### PR TITLE
alerts: fix ability to navigate back to the active alerts tab

### DIFF
--- a/web/src/app/actions/alerts.js
+++ b/web/src/app/actions/alerts.js
@@ -5,8 +5,19 @@ export const SET_ALERTS_ACTION_COMPLETE = 'SET_ALERTS_ACTION_COMPLETE'
 
 // setAlertsStatusFilter will set the current alert status filter.
 // A falsy value will result in the default (active) being set.
+// active: null
+// unacknowledged
+// acknowledged
+// closed
+// all
 export function setAlertsStatusFilter(type) {
-  return setURLParam('filter', type && type !== 'active' ? type : null)
+  let val = null
+  if (type && type !== 'active') {
+    // active is the default, so when type is null it will show the "active" tab
+    val = type
+  }
+
+  return setURLParam('filter', val)
 }
 
 // setAlertsAllServicesFilter will set the alert list to include all services.

--- a/web/src/app/actions/main.js
+++ b/web/src/app/actions/main.js
@@ -23,8 +23,8 @@ export function resetURLParams(...keys) {
 }
 
 const sanitizeParam = value => {
-  if (value === true) value = '1'
-  if (value === false) value = ''
+  if (value === true) value = '1' // explicitly true
+  if (!value) value = '' // any falsey value
   if (!Array.isArray(value)) return value.trim()
 
   let filtered = value.filter(v => v)

--- a/web/src/app/alerts/components/AlertsListControls.js
+++ b/web/src/app/alerts/components/AlertsListControls.js
@@ -21,9 +21,12 @@ const tabs = ['active', 'unacknowledged', 'acknowledged', 'closed', 'all']
 )
 export default class AlertsListControls extends React.PureComponent {
   render() {
+    let currTab = tabs.indexOf(this.props.filter)
+    if (currTab === -1) currTab = 0 // handle jargon input from url params
+
     return (
       <Tabs
-        value={tabs.indexOf(this.props.filter)}
+        value={currTab}
         onChange={(e, idx) => this.props.setAlertsStatusFilter(tabs[idx])}
         centered
         indicatorColor='primary'


### PR DESCRIPTION
Previously the ability to navigate back to the Active tab on the alerts page (from another tab, such as Closed) was not working. This PR addresses this issue, as well as defaults to the Active tab if the URL parameter is for `filter` is anything but `unacknowledged`, `acknowledged`, `closed`, or `all`.