### PR TITLE
alerts: address mobile alerts controls bottom margin

### DIFF
--- a/web/src/app/alerts/components/CheckedAlertsFormControl.js
+++ b/web/src/app/alerts/components/CheckedAlertsFormControl.js
@@ -85,7 +85,7 @@ const styles = theme => ({
   },
   stickyLarge: {
     ...stickyBase,
-    marginBottom: '0.75em', // push list down below box shadow
+    marginBottom: '0.5em', // push list down below box shadow
     marginTop: '-1em',
     top: 64,
   },


### PR DESCRIPTION
This PR adjusts the bottom padding on the mobile alerts screen such that the main alerts list is no longer cut off at the top.

- Increases bottom margin of controls for xs-md screens from `0.75em` to `2.5em`
- Decreases bottom margin for lg-xl screens from `0.75em` to `0.5em` (less whitespace in-between the controls and list)
- Adjusts leftmost whitespace width of the checkbox controls such that the control lines up with the alerts list checkboxes