### PR TITLE
container: fix default listen address

### DIFF
--- a/devtools/ci/dockerfiles/goalert/Dockerfile
+++ b/devtools/ci/dockerfiles/goalert/Dockerfile
@@ -2,3 +2,4 @@ FROM alpine
 RUN apk --no-cache add tzdata ca-certificates
 COPY goalert /usr/bin/
 CMD ["/usr/bin/goalert"]
+ENV GOALERT_LISTEN :8081


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [X] Identified the issue which this PR solves.
- [X] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [X] Code builds clean without any errors or warnings.
- [X] Added appropriate tests for any new functionality.
- [X] All new and existing tests passed.
- [X] Added comments in the code, where necessary.
- [X] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Update the default bind address from localhost to wildcard in the goalert/Dockerfile.

Depending on docker/environment configuration, mapping ports to localhost (within the container) may not work, giving users "connection refused" errors when using the container as documented.

This PR sets the default address for the container to the wildcard address (within the container) on the same port, resolving the issue.
