### PR TITLE
contactmethod: allow UK (+44) numbers

### DIFF
--- a/notification/twilio/validation.go
+++ b/notification/twilio/validation.go
@@ -82,7 +82,7 @@ func validSID(n string) string {
 // Supported Country Codes
 // +1 = USA, +91 = India
 func supportedCountryCode(n string) bool {
-	if strings.HasPrefix(n, "+1") || strings.HasPrefix(n, "+91") {
+	if strings.HasPrefix(n, "+1") || strings.HasPrefix(n, "+91") || strings.HasPrefix(n, "+44") {
 		return true
 	}
 	return false

--- a/notification/twilio/validation.go
+++ b/notification/twilio/validation.go
@@ -80,7 +80,7 @@ func validSID(n string) string {
 }
 
 // Supported Country Codes
-// +1 = USA, +91 = India
+// +1 = USA, +91 = India, +44 = United Kingdom
 func supportedCountryCode(n string) bool {
 	if strings.HasPrefix(n, "+1") || strings.HasPrefix(n, "+91") || strings.HasPrefix(n, "+44") {
 		return true

--- a/validation/validate/phone_test.go
+++ b/validation/validate/phone_test.go
@@ -25,6 +25,7 @@ func TestPhone(t *testing.T) {
 		"+919632040000",
 		"+17734562190",
 		"+916301210000",
+		"+447480809090",
 	}
 	for _, number := range valid {
 		check(number, true)
@@ -33,6 +34,7 @@ func TestPhone(t *testing.T) {
 	invalid := []string{
 		"+10633453456",
 		"+15555555555",
+		"+4474808090",
 	}
 	for _, number := range invalid {
 		check(number, false)

--- a/web/src/app/contact-methods/components/ContactMethodForm.js
+++ b/web/src/app/contact-methods/components/ContactMethodForm.js
@@ -49,6 +49,11 @@ const countryCodeOptions = [
     value: '+91',
     length: 10,
   },
+  {
+    label: '+44 (United Kingdom)',
+    value: '+44',
+    length: 10,
+  },
 ]
 
 const fieldStyle = {

--- a/web/src/app/contact-methods/components/VerificationForm.js
+++ b/web/src/app/contact-methods/components/VerificationForm.js
@@ -37,6 +37,9 @@ function formatNumber(n) {
   }
   if (n.startsWith('+91')) {
     return `+91-${n.slice(3, 5)}-${n.slice(5, 8)}-${n.slice(8)}`
+  }
+  if (n.startsWith('+44')) {
+    return `+44 ${n.slice(3, 7)} ${n.slice(7)}`
   } else {
     return <span>{n}</span>
   }

--- a/web/src/app/users/UserContactMethodForm.js
+++ b/web/src/app/users/UserContactMethodForm.js
@@ -69,6 +69,7 @@ export default class UserContactMethodForm extends React.PureComponent {
             >
               <MenuItem value='+1'>+1 (USA)</MenuItem>
               <MenuItem value='+91'>+91 (India)</MenuItem>
+              <MenuItem value='+44'>+44 (UK)</MenuItem>
             </TextField>
           </Grid>
           <Grid item xs={12} sm={12} md={6}>

--- a/web/src/app/users/util.js
+++ b/web/src/app/users/util.js
@@ -20,6 +20,9 @@ export function formatPhoneNumber(n) {
   if (n.startsWith('+91')) {
     return `+91 ${n.slice(3, 5)} ${n.slice(5, 9)} ${n.slice(9)}`
   }
+  if (n.startsWith('+44')) {
+    return `+44 ${n.slice(3, 7)} ${n.slice(7)}`
+  }
 
   return n
 }
@@ -48,7 +51,7 @@ export function sortContactMethods(cm) {
 }
 
 export function getCountryCode(phone) {
-  return ['+1', '+91'].find(cc => phone.startsWith(cc))
+  return ['+1', '+91', '+44'].find(cc => phone.startsWith(cc))
 }
 
 export function stripCountryCode(phone) {

--- a/web/src/app/users/util.test.js
+++ b/web/src/app/users/util.test.js
@@ -12,6 +12,9 @@ test('formatPhoneNumber', () => {
   expect(formatPhoneNumber('+911400000000')).toBe('+91 14 0000 0000')
   expect(formatPhoneNumber('+911401234567')).toBe('+91 14 0123 4567')
   expect(formatPhoneNumber('+911409876543')).toBe('+91 14 0987 6543')
+  expect(formatPhoneNumber('+447700000000')).toBe('+44 7700 000000')
+  expect(formatPhoneNumber('+447701234567')).toBe('+44 7701 234567')
+  expect(formatPhoneNumber('+447709876543')).toBe('+44 7709 876543')
 })
 
 test('formatNotificationRule', () => {
@@ -43,6 +46,13 @@ test('formatNotificationRule', () => {
       value: '+911400000000',
     }),
   ).toBe('After 1 minute notify me via VOICE at +91 14 0000 0000 (myPhone)')
+  expect(
+    formatNotificationRule(5, {
+      type: 'VOICE',
+      name: 'myPhone',
+      value: '+447700000000',
+    }),
+  ).toBe('After 5 minutes notify me via VOICE at +44 7700 000000 (myPhone)')
 })
 
 test('getCountryCode', () => {
@@ -52,6 +62,9 @@ test('getCountryCode', () => {
   expect(getCountryCode('+911400000000')).toBe('+91')
   expect(getCountryCode('+911401234567')).toBe('+91')
   expect(getCountryCode('+911409876543')).toBe('+91')
+  expect(getCountryCode('+447700000000')).toBe('+44')
+  expect(getCountryCode('+447701234567')).toBe('+44')
+  expect(getCountryCode('+447709876543')).toBe('+44')
 })
 
 test('stripCountryCode', () => {
@@ -61,4 +74,7 @@ test('stripCountryCode', () => {
   expect(stripCountryCode('+911400000000')).toBe('1400000000')
   expect(stripCountryCode('+911401234567')).toBe('1401234567')
   expect(stripCountryCode('+911409876543')).toBe('1409876543')
+  expect(stripCountryCode('+447700000000')).toBe('7700000000')
+  expect(stripCountryCode('+447701234567')).toBe('7701234567')
+  expect(stripCountryCode('+447709876543')).toBe('7709876543')
 })


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [X] Identified the issue which this PR solves.
- [X] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [X] Code builds clean without any errors or warnings.
- [X] Added appropriate tests for any new functionality.
- [X] All new and existing tests passed.
- [X] Added comments in the code, where necessary.
- [X] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Allow for Mobile numbers from the UK (+44) to be used in GoAlert.

**Which issue(s) this PR fixes:**
Only US and Indian numbers are avaliable at the moment, we need to be able to use UK based numbers for alerting 

Fixes #21

**Describe any introduced user-facing changes:**
Users can now select a UK phone number when creating a new contact method