### PR TITLE
slack/testing: make fake slack creds look more fake

### DIFF
--- a/devtools/runjson/ci-cypress.json
+++ b/devtools/runjson/ci-cypress.json
@@ -23,9 +23,9 @@
     "Name": "Slack",
     "Command": [
       "bin/mockslack",
-      "-client-id=555449060693.555449060694",
-      "-client-secret=52fdfc072182654f163f5f0f9a621d72",
-      "-access-token=xoxp-555449060693-555449060694-587071460694-9566c74d10037c4d7bbb0407d1e2c649",
+      "-client-id=000000000000.000000000000",
+      "-client-secret=00000000000000000000000000000000",
+      "-access-token=xoxp-000000000000-000000000000-000000000000-00000000000000000000000000000000",
       "-prefix=/slack",
       "-single-user=bob",
       "-addr=localhost:3046"

--- a/devtools/runjson/localdev-cypress-prod.json
+++ b/devtools/runjson/localdev-cypress-prod.json
@@ -42,9 +42,9 @@
     "Watch": true,
     "Command": [
       "bin/mockslack",
-      "-client-id=555449060693.555449060694",
-      "-client-secret=52fdfc072182654f163f5f0f9a621d72",
-      "-access-token=xoxp-555449060693-555449060694-587071460694-9566c74d10037c4d7bbb0407d1e2c649",
+      "-client-id=000000000000.000000000000",
+      "-client-secret=00000000000000000000000000000000",
+      "-access-token=xoxp-000000000000-000000000000-000000000000-00000000000000000000000000000000",
       "-prefix=/slack",
       "-single-user=bob",
       "-addr=localhost:3046"

--- a/devtools/runjson/localdev-cypress.json
+++ b/devtools/runjson/localdev-cypress.json
@@ -56,9 +56,9 @@
     "Watch": true,
     "Command": [
       "bin/mockslack",
-      "-client-id=555449060693.555449060694",
-      "-client-secret=52fdfc072182654f163f5f0f9a621d72",
-      "-access-token=xoxp-555449060693-555449060694-587071460694-9566c74d10037c4d7bbb0407d1e2c649",
+      "-client-id=000000000000.000000000000",
+      "-client-secret=00000000000000000000000000000000",
+      "-access-token=xoxp-000000000000-000000000000-000000000000-00000000000000000000000000000000",
       "-prefix=/slack",
       "-single-user=bob",
       "-addr=localhost:3046"

--- a/web/src/cypress/support/config.ts
+++ b/web/src/cypress/support/config.ts
@@ -128,10 +128,10 @@ function resetConfig(): Cypress.Chainable<Config> {
     General: { PublicURL: base },
     Slack: {
       Enable: true,
-      ClientID: '555449060693.555449060694',
-      ClientSecret: '52fdfc072182654f163f5f0f9a621d72',
+      ClientID: '000000000000.000000000000',
+      ClientSecret: '00000000000000000000000000000000',
       AccessToken:
-        'xoxp-555449060693-555449060694-587071460694-9566c74d10037c4d7bbb0407d1e2c649',
+        'xoxp-000000000000-000000000000-000000000000-00000000000000000000000000000000',
     },
   })
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [X] Identified the issue which this PR solves.
- [X] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [X] Code builds clean without any errors or warnings.
- [X] Added appropriate tests for any new functionality.
- [X] All new and existing tests passed.
- [X] Added comments in the code, where necessary.
- [X] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
The fake credentials used for running tests against the mock Slack server look real (in fact they are probably indistinguishable). The values being used were randomly generated at some point by the mock server with the default seed value.

This PR replaces them with ones that are zeroed out, hopefully making it apparent that they are dummy values. :)
