### PR TITLE
slack: accept tokens with 10-digit sections

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -161,10 +161,10 @@ func (cfg Config) PublicURL() string {
 var (
 	mailgunKeyRx = regexp.MustCompile(`^key-[0-9a-f]{32}$`)
 
-	slackClientIDRx        = regexp.MustCompile(`^[0-9]{12}\.[0-9]{12}$`)
+	slackClientIDRx        = regexp.MustCompile(`^[0-9]{10,12}\.[0-9]{10,12}$`)
 	slackClientSecretRx    = regexp.MustCompile(`^[0-9a-f]{32}$`)
-	slackUserAccessTokenRx = regexp.MustCompile(`^xoxp-[0-9]{12}-[0-9]{12}-[0-9]{12}-[0-9a-f]{32}$`)
-	slackBotAccessTokenRx  = regexp.MustCompile(`^xoxb-[0-9]{12}-[0-9]{12}-[0-9A-Za-z]{24}$`)
+	slackUserAccessTokenRx = regexp.MustCompile(`^xoxp-[0-9]{10,12}-[0-9]{10,12}-[0-9]{10,12}-[0-9a-f]{32}$`)
+	slackBotAccessTokenRx  = regexp.MustCompile(`^xoxb-[0-9]{10,12}-[0-9]{10,12}-[0-9A-Za-z]{24}$`)
 
 	twilioAccountSIDRx = regexp.MustCompile(`^AC[0-9a-f]{32}$`)
 	twilioAuthTokenRx  = regexp.MustCompile(`^[0-9a-f]{32}$`)

--- a/devtools/mockslack/validate.go
+++ b/devtools/mockslack/validate.go
@@ -8,5 +8,5 @@ var (
 	scopeRx           = regexp.MustCompile(`^[a-z]+(:[a-z]+)*$`)
 	clientIDRx        = regexp.MustCompile(`^[0-9]{12}.[0-9]{12}$`)
 	clientSecretRx    = regexp.MustCompile(`^[a-z0-9]{32}$`)
-	userAccessTokenRx = regexp.MustCompile(`^xoxp-[0-9]{12}-[0-9]{12}-[0-9]{12}-[a-z0-9]{32}$`)
+	userAccessTokenRx = regexp.MustCompile(`^xoxp-[0-9]{10,12}-[0-9]{10,12}-[0-9]{10,12}-[a-z0-9]{32}$`)
 )


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [X] Identified the issue which this PR solves.
- [X] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [X] Code builds clean without any errors or warnings.
- [X] Added appropriate tests for any new functionality.
- [X] All new and existing tests passed.
- [X] Added comments in the code, where necessary.
- [X] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**

Some Slack tokens have an alternate numeric section consisting of 10-digits instead of 12. This PR updates the validation regex to accept between 10 and 12, allowing both formats.

**Which issue(s) this PR fixes:**
Fixes #33
