### PR TITLE
config: loosen key validation & guide updates 

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -159,10 +159,10 @@ The **API Key** may be found under the **Security** section in the Mailgun websi
 
 To configure Mailgun to forward to GoAlert:
 
-1. Go to **Routes**
+1. Go to **Receiving**
 1. Click **Create Route**
 1. Set **Expression Type** to `Match Recipient`
-1. Set **Recipient** to `*@<Mailgun.Email Domain>`
+1. Set **Recipient** to `.*@<Mailgun.Email Domain>`
 1. Check **Forward**
 1. In the forward box, enter `<General.Public URL>/api/v2/mailgun/incoming`
 1. Click **Create Route**

--- a/graphql2/mapconfig.go
+++ b/graphql2/mapconfig.go
@@ -38,7 +38,7 @@ func MapConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "Slack.Enable", Type: ConfigTypeBoolean, Description: "", Value: fmt.Sprintf("%t", cfg.Slack.Enable)},
 		{ID: "Slack.ClientID", Type: ConfigTypeString, Description: "", Value: cfg.Slack.ClientID},
 		{ID: "Slack.ClientSecret", Type: ConfigTypeString, Description: "", Value: cfg.Slack.ClientSecret, Password: true},
-		{ID: "Slack.AccessToken", Type: ConfigTypeString, Description: "Slack app OAuth access token.", Value: cfg.Slack.AccessToken, Password: true},
+		{ID: "Slack.AccessToken", Type: ConfigTypeString, Description: "Slack app bot user OAuth access token (should start with xoxb-).", Value: cfg.Slack.AccessToken, Password: true},
 		{ID: "Twilio.Enable", Type: ConfigTypeBoolean, Description: "Enables sending and processing of Voice and SMS messages through the Twilio notification provider.", Value: fmt.Sprintf("%t", cfg.Twilio.Enable)},
 		{ID: "Twilio.AccountSID", Type: ConfigTypeString, Description: "", Value: cfg.Twilio.AccountSID},
 		{ID: "Twilio.AuthToken", Type: ConfigTypeString, Description: "The primary Auth Token for Twilio. Must be primary (not secondary) for request valiation.", Value: cfg.Twilio.AuthToken, Password: true},

--- a/validation/validate/ascii.go
+++ b/validation/validate/ascii.go
@@ -1,0 +1,34 @@
+package validate
+
+import (
+	"strconv"
+	"unicode"
+
+	"github.com/target/goalert/validation"
+)
+
+// ASCII will validate that the passed value is an ASCII string within the given length values.
+func ASCII(fname, val string, minLen, maxLen int) error {
+	l := len(val)
+	if minLen > 1 && l < minLen {
+		return validation.NewFieldError(fname, "must be at least "+strconv.Itoa(minLen)+" characters")
+	} else if minLen == 1 && l < minLen {
+		return validation.NewFieldError(fname, "must not be empty")
+	}
+	if l > maxLen {
+		return validation.NewFieldError(fname, "cannot exceed "+strconv.Itoa(maxLen)+" characters")
+	}
+
+	for _, r := range val {
+		if r >= 32 && r <= 126 {
+			continue
+		}
+		if unicode.IsPrint(r) {
+			return validation.NewFieldError(fname, "invalid character '"+string(r)+"'")
+		}
+		return validation.NewFieldError(fname, "invalid character 0x"+strconv.Itoa(int(r)))
+
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [X] Identified the issue which this PR solves.
- [X] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [X] Code builds clean without any errors or warnings.
- [X] Added appropriate tests for any new functionality.
- [X] All new and existing tests passed.
- [X] Added comments in the code, where necessary.
- [X] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR loosens the validation requirements for things like client IDs, API keys, etc.. that come from external systems and stored in config. Previously config validation would match against strict regular expressions.

Since GoAlert doesn't actually parse or otherwise require specific formats, this only caused confusion as the external systems could provide/change said formats making it impossible for GoAlert to be configured correctly until a code fix/regex update was deployed.

Additionally, the Getting Started guide was updated for the new Mailgun UI.

**Which issue(s) this PR fixes:**
Closes #43 

**Describe any introduced user-facing changes:**
Client IDs, secrets, API keys (e.g. Mailgun, Slack) are now only required to be <128 ASCII characters without formatting requirements.

This means GoAlert only validates these values in the way that they are used by GoAlert, as arbitrary strings.

