### PR TITLE
http: request queue and timeouts

### DIFF
--- a/app/concurrencylimiter.go
+++ b/app/concurrencylimiter.go
@@ -40,17 +40,31 @@ func (list *pendingList) newReq() *pendingReq {
 
 	return req
 }
+
 func (list *pendingList) remove(req *pendingReq) bool {
+	if req == nil || list == nil {
+		return false
+	}
+
+	defer func() { req.prev, req.next = nil, nil }()
+
 	if list.head == req {
 		list.head = req.next
+		if list.head != nil {
+			list.head.prev = nil
+		}
+		if list.tail == req {
+			list.tail = nil
+		}
 		return true
 	}
 
 	if list.tail == req {
 		list.tail = req.prev
-		if req.prev != nil {
-			req.prev.next = nil
+		if list.tail != nil {
+			list.tail.next = nil
 		}
+
 		return true
 	}
 
@@ -66,15 +80,12 @@ func (list *pendingList) remove(req *pendingReq) bool {
 }
 
 func (list *pendingList) pop() *pendingReq {
-	if list == nil || list.head == nil {
+	if list == nil {
 		return nil
 	}
 
 	req := list.head
-	list.head, req.next = req.next, nil
-	if list.head != nil {
-		list.head.prev = nil
-	}
+	list.remove(req)
 
 	return req
 }

--- a/app/concurrencylimiter.go
+++ b/app/concurrencylimiter.go
@@ -3,70 +3,130 @@ package app
 import (
 	"context"
 	"sync"
+
+	"github.com/pkg/errors"
 )
+
+var errQueueFull = errors.New("queue full")
 
 // concurrencyLimiter is a locking mechanism that allows setting a limit
 // on the number of simultaneous locks for a given arbitrary ID.
 type concurrencyLimiter struct {
-	max     int
-	count   map[string]int
-	pending map[string]chan struct{}
+	maxLock    int
+	maxQueue   int
+	lockCount  map[string]int
+	queueCount map[string]int
+	pending    map[string]*pendingList
 
 	mx sync.Mutex
 }
+type pendingReq struct {
+	lockCh     chan bool
+	prev, next *pendingReq
+}
+type pendingList struct{ head, tail *pendingReq }
 
-func newConcurrencyLimiter(max int) *concurrencyLimiter {
+func newConcurrencyLimiter(maxLock, maxQueue int) *concurrencyLimiter {
 	return &concurrencyLimiter{
-		max:     max,
-		count:   make(map[string]int, 100),
-		pending: make(map[string]chan struct{}),
+		maxLock:    maxLock,
+		maxQueue:   maxQueue,
+		lockCount:  make(map[string]int, 100),
+		queueCount: make(map[string]int, 100),
+		pending:    make(map[string]*pendingList, 100),
 	}
 }
 
 // Lock will acquire a lock for the given ID. It may return an err
 // if the context expires before the lock is given.
-func (l *concurrencyLimiter) Lock(ctx context.Context, id string) error {
-	for {
-		l.mx.Lock()
-		n := l.count[id]
-		if n < l.max {
-			l.count[id] = n + 1
-			l.mx.Unlock()
-			return nil
-		}
+func (l *concurrencyLimiter) Lock(ctx context.Context, id string) (err error) {
+	l.mx.Lock()
+	c := l.lockCount[id]
+	if c < l.maxLock {
+		l.lockCount[id] = c + 1
+		l.mx.Unlock()
+		return nil
+	}
 
-		ch := l.pending[id]
-		if ch == nil {
-			ch = make(chan struct{})
-			l.pending[id] = ch
+	list := l.pending[id]
+	if list == nil {
+		list = &pendingList{}
+		l.pending[id] = list
+	}
+
+	if l.queueCount[id] == l.maxQueue {
+		l.mx.Unlock()
+		return errQueueFull
+	}
+
+	// need to queue
+	req := &pendingReq{
+		lockCh: make(chan bool),
+		prev:   list.tail,
+	}
+	if list.head == nil {
+		list.head, list.tail = req, req
+	} else {
+		list.tail.next = req
+		list.tail = req
+	}
+	l.queueCount[id]++
+	l.mx.Unlock()
+
+	cancel := func() {
+		close(req.lockCh)
+		l.mx.Lock()
+		if req.prev != nil {
+			req.prev.next = req.next
+		}
+		if req.next != nil {
+			l.queueCount[id]--
+			req.next.prev = req.prev
+		}
+		if list.head == req {
+			list.head = req.next
+		}
+		if list.tail == req {
+			list.tail = req.prev
 		}
 		l.mx.Unlock()
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ch:
-		}
 	}
+	select {
+	case <-ctx.Done():
+		cancel()
+		return ctx.Err()
+	case req.lockCh <- true:
+	}
+
+	return nil
 }
 
 // Unlock releases a lock for the given ID. It panics
 // if there are no remaining locks.
 func (l *concurrencyLimiter) Unlock(id string) {
 	l.mx.Lock()
-	defer l.mx.Unlock()
-	n := l.count[id]
-	n--
-	if n < 0 {
-		panic("not locked: " + id)
+	if l.lockCount[id] == 0 {
+		l.mx.Unlock()
+		panic("not locked")
 	}
-	if n == 0 {
-		delete(l.count, id)
-	} else {
-		l.count[id] = n
+	list := l.pending[id]
+	if list == nil || list.head == nil {
+		l.lockCount[id]--
+		l.mx.Unlock()
+		return
 	}
-	ch := l.pending[id]
-	if ch != nil {
-		delete(l.pending, id)
-		close(ch)
+
+	for list.head != nil {
+		head := list.head
+		list.head = head.next
+		list.head.prev = nil
+		head.next = nil
+		l.queueCount[id]--
+		if <-head.lockCh {
+			// keep lock count
+			l.mx.Unlock()
+			return
+		}
 	}
+	l.lockCount[id]--
+	l.mx.Unlock()
 }

--- a/app/concurrencylimiter_test.go
+++ b/app/concurrencylimiter_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestConcurrencyLimiter(t *testing.T) {
-	lim := newConcurrencyLimiter(2)
+	lim := newConcurrencyLimiter(2, 10)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	err := lim.Lock(ctx, "foo")

--- a/app/concurrencylimiter_test.go
+++ b/app/concurrencylimiter_test.go
@@ -8,6 +8,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestPendingList(t *testing.T) {
+	list := &pendingList{}
+
+	r1 := list.newReq()
+	assert.Equal(t, r1, list.pop())
+
+	r2 := list.newReq()
+	assert.Equal(t, r2, list.pop())
+	assert.Nil(t, list.head)
+	assert.Nil(t, list.tail)
+
+	assert.Nil(t, list.pop())
+
+	r3 := list.newReq()
+	r4 := list.newReq()
+	r5 := list.newReq()
+
+	assert.True(t, list.remove(r4))
+	assert.Nil(t, r4.prev)
+	assert.Nil(t, r4.next)
+	assert.False(t, list.remove(r4))
+
+	assert.Equal(t, r3, list.pop())
+	assert.Equal(t, r5, list.pop())
+	assert.Nil(t, list.head)
+	assert.Nil(t, list.tail)
+}
+
 func TestConcurrencyLimiter(t *testing.T) {
 	t.Run("lock count", func(t *testing.T) {
 		lim := newConcurrencyLimiter(2, 10)

--- a/app/concurrencylimiter_test.go
+++ b/app/concurrencylimiter_test.go
@@ -3,40 +3,81 @@ package app
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestConcurrencyLimiter(t *testing.T) {
-	lim := newConcurrencyLimiter(2, 10)
+	t.Run("lock count", func(t *testing.T) {
+		lim := newConcurrencyLimiter(2, 10)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	err := lim.Lock(ctx, "foo")
-	assert.Nil(t, err)
+		ctx, cancel := context.WithCancel(context.Background())
+		err := lim.Lock(ctx, "foo")
+		assert.Nil(t, err)
 
-	err = lim.Lock(ctx, "foo")
-	assert.Nil(t, err)
+		err = lim.Lock(ctx, "foo")
+		assert.Nil(t, err)
 
-	err = lim.Lock(ctx, "bar")
-	assert.Nil(t, err)
+		err = lim.Lock(ctx, "bar")
+		assert.Nil(t, err)
 
-	cancel()
-	err = lim.Lock(ctx, "foo")
-	assert.Error(t, err, "context canceled")
+		cancel()
+		err = lim.Lock(ctx, "foo")
+		assert.Error(t, err, "context canceled")
 
-	lim.Unlock("bar")
-	err = lim.Lock(ctx, "foo")
-	assert.Error(t, err, "context canceled")
-
-	assert.Panics(t, func() {
-		// unlock twice (only locked once)
 		lim.Unlock("bar")
+		err = lim.Lock(ctx, "foo")
+		assert.Error(t, err, "context canceled")
+
+		assert.Panics(t, func() {
+			// unlock twice (only locked once)
+			lim.Unlock("bar")
+		})
+
+		lim.Unlock("foo")
+		ctx, cancel = context.WithCancel(context.Background())
+		err = lim.Lock(ctx, "foo")
+		assert.Nil(t, err)
+
+		cancel()
+		assert.Equal(t, 2, lim.lockCount["foo"])
+		assert.Equal(t, 0, lim.lockCount["bar"])
 	})
 
-	lim.Unlock("foo")
-	ctx, cancel = context.WithCancel(context.Background())
-	err = lim.Lock(ctx, "foo")
-	assert.Nil(t, err)
+	t.Run("queue", func(t *testing.T) {
+		lim := newConcurrencyLimiter(1, 3)
+		ctx := context.Background()
 
-	cancel()
+		gotLockCh := make(chan struct{})
+		lock := func() { lim.Lock(ctx, "foo"); gotLockCh <- struct{}{} }
+		for i := 0; i < 4; i++ {
+			go lock()
+		}
+		<-gotLockCh
+		assert.Equal(t, 1, lim.lockCount["foo"])
+		time.Sleep(time.Millisecond) // ensure other goroutines have a chance to fill the queue
+		assert.Error(t, lim.Lock(ctx, "foo"))
+		assert.Equal(t, 3, lim.queueCount["foo"])
+
+		lim.Unlock("foo")
+		go lock()
+
+		<-gotLockCh
+		lim.Unlock("foo")
+
+		<-gotLockCh
+		lim.Unlock("foo")
+
+		<-gotLockCh
+		lim.Unlock("foo")
+
+		<-gotLockCh
+		lim.Unlock("foo")
+
+		assert.Equal(t, 0, lim.lockCount["foo"])
+		assert.Equal(t, 0, lim.queueCount["foo"])
+
+		assert.Nil(t, lim.Lock(ctx, "foo"))
+	})
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [X] Identified the issue which this PR solves.
- [X] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [X] Code builds clean without any errors or warnings.
- [X] Added appropriate tests for any new functionality.
- [X] All new and existing tests passed.
- [X] Added comments in the code, where necessary.
- [X] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR introduces request queueing to the concurrency limiter.

The concurrency limiter was designed to limit the number of simultaneous integration keys, service, and/or user-requests that are processed concurrently per-instance.

The present-day implementation limits concurrency, effectively isolating busy consumers, but all "pending" requests are then processed in random order. This results in latency spikes under load (per individual key) and 502 responses due to "backend timeout".

This change introduces a FIFO queue for all pending requests instead of the random group.
- For requests beyond the maximum (250 per key), they are immediately returned with status code 429 (too many requests)
- Requests stuck in the queue for longer than 25s are also returned with 429

Rejected requests are still scoped per integration key/service/user as before but will now allow a distinction between actual hung requests and throttling.

**Describe any introduced API changes:**
Throttled requests will now return status code 429 instead of timing out and returning 502.
