### PR TITLE
dev: change `smoketest` dep from `generate` to `install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ graphql2/generated.go: graphql2/schema.graphql graphql2/gqlgen.yml
 generate:
 	go generate ./...
 
-smoketest: generate bin/goalert
+smoketest: install bin/goalert
 	(cd smoketest && go test -timeout 20m)
 
 test-migrations: migrate/inline_data_gen.go bin/goalert


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [X] Identified the issue which this PR solves.
- [X] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [X] Code builds clean without any errors or warnings.
- [X] Added appropriate tests for any new functionality.
- [X] All new and existing tests passed.
- [X] Added comments in the code, where necessary.
- [X] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This updates `make smoketest` to depend on `install` instead of `generate`.

**Which issue(s) this PR fixes:**
Closes #51 

**Additional Info:**
Internally the smoketests use the installed binary, and generate is already done as-needed when the `install` task is run. So this will also result in preventing the accidental running of smoketests against outdated code.
