### PR TITLE
contact methods: hide reactivate button on mobile/always have option within other actions

### DIFF
--- a/web/src/app/users/UserContactMethodList.js
+++ b/web/src/app/users/UserContactMethodList.js
@@ -4,6 +4,7 @@ import Query from '../util/Query'
 import gql from 'graphql-tag'
 import FlatList from '../lists/FlatList'
 import { Button, Card, CardHeader, Grid, IconButton } from '@material-ui/core'
+import withWidth, { isWidthUp } from '@material-ui/core/withWidth'
 import { formatCMValue, sortContactMethods } from './util'
 import OtherActions from '../util/OtherActions'
 import UserContactMethodDeleteDialog from './UserContactMethodDeleteDialog'
@@ -50,7 +51,7 @@ const useStyles = makeStyles(theme => {
   })
 })
 
-export default function UserContactMethodList(props) {
+function UserContactMethodList(props) {
   const classes = useStyles()
 
   const [showVerifyDialogByID, setShowVerifyDialogByID] = useState(null)
@@ -99,6 +100,11 @@ export default function UserContactMethodList(props) {
             },
           }),
       })
+    } else {
+      actions.push({
+        label: 'Reactivate',
+        onClick: () => setShowVerifyDialogByID(cm.id),
+      })
     }
 
     return actions
@@ -107,7 +113,7 @@ export default function UserContactMethodList(props) {
   function getSecondaryAction(cm) {
     return (
       <Grid container spacing={2} className={classes.actionGrid}>
-        {cm.disabled && !props.readOnly && (
+        {cm.disabled && !props.readOnly && isWidthUp('md', props.width) && (
           <Grid item>
             <Button
               aria-label='Reactivate contact method'
@@ -192,6 +198,8 @@ export default function UserContactMethodList(props) {
     />
   )
 }
+
+export default withWidth()(UserContactMethodList)
 
 UserContactMethodList.propTypes = {
   userID: p.string.isRequired,


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Hides the `Reactivate` button on mobile as it overlaps ListItem text.

**Additional Info:**
Adds a reactivate button the a contact method's other actions menu if disabled, regardless of the current breakpoint.
