### PR TITLE
ui: grid item container consistency

### DIFF
--- a/web/src/app/admin/AdminConfig.js
+++ b/web/src/app/admin/AdminConfig.js
@@ -89,7 +89,8 @@ export default class AdminConfig extends React.PureComponent {
           {groups.map((groupID, index) => (
             <Grid
               key={index}
-              item
+              container // contains title above card/card itself
+              item // for each admin config section
               xs={12}
               className={this.props.classes.gridItem}
             >

--- a/web/src/app/admin/AdminConfig.js
+++ b/web/src/app/admin/AdminConfig.js
@@ -83,7 +83,7 @@ export default class AdminConfig extends React.PureComponent {
       <React.Fragment>
         <Grid
           container
-          spacing={3}
+          spacing={2}
           className={this.props.classes.gridContainer}
         >
           {groups.map((groupID, index) => (

--- a/web/src/app/admin/AdminConfig.js
+++ b/web/src/app/admin/AdminConfig.js
@@ -89,7 +89,6 @@ export default class AdminConfig extends React.PureComponent {
           {groups.map((groupID, index) => (
             <Grid
               key={index}
-              container
               item
               xs={12}
               className={this.props.classes.gridItem}

--- a/web/src/app/alerts/components/AlertsList.js
+++ b/web/src/app/alerts/components/AlertsList.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import Card from '@material-ui/core/Card'
 import InfoIcon from '@material-ui/icons/Info'
 import List from '@material-ui/core/List'
-import Grid from '@material-ui/core/Grid'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 import Snackbar from '@material-ui/core/Snackbar'
@@ -325,31 +324,23 @@ export default class AlertsList extends Component {
           serviceID={serviceID}
           transition={fullScreen && (showFavoritesWarning || actionComplete)}
         />
-        <Grid item container>
-          <Grid item container>
-            <Card style={{ width: '100%' }}>
-              <Hidden mdDown>
-                <AlertsListControls />
-              </Hidden>
-              <List
-                id='alerts-list'
-                style={{ padding: 0 }}
-                data-cy='alerts-list'
-              >
-                <InfiniteScroll
-                  next={() => loadMore(this.getQueryData(offset))}
-                  dataLength={len}
-                  hasMore={hasMore}
-                  loader={null}
-                  scrollThreshold={(len - 20) / len}
-                  style={{ overflow: 'hidden' }}
-                >
-                  {content}
-                </InfiniteScroll>
-              </List>
-            </Card>
-          </Grid>
-        </Grid>
+        <Card style={{ width: '100%' }}>
+          <Hidden mdDown>
+            <AlertsListControls />
+          </Hidden>
+          <List id='alerts-list' style={{ padding: 0 }} data-cy='alerts-list'>
+            <InfiniteScroll
+              next={() => loadMore(this.getQueryData(offset))}
+              dataLength={len}
+              hasMore={hasMore}
+              loader={null}
+              scrollThreshold={(len - 20) / len}
+              style={{ overflow: 'hidden' }}
+            >
+              {content}
+            </InfiniteScroll>
+          </List>
+        </Card>
       </React.Fragment>
     )
   }

--- a/web/src/app/alerts/components/CheckedAlertsFormControl.js
+++ b/web/src/app/alerts/components/CheckedAlertsFormControl.js
@@ -360,7 +360,7 @@ export default class CheckedAlertsFormControl extends Component {
           open={actionComplete}
           updateMessage={updateMessage}
         />
-        <Grid item container className={containerClass}>
+        <Grid container className={containerClass}>
           <Grid item className={classes.whitespace} />
           <Grid item>
             <Checkbox

--- a/web/src/app/details/DetailsPage.js
+++ b/web/src/app/details/DetailsPage.js
@@ -123,7 +123,7 @@ export default class DetailsPage extends React.PureComponent {
       classes,
     } = this.props
     return (
-      <Grid item container>
+      <Grid container>
         <Grid item xs={12} className={classes.spacing}>
           <Card>
             <CardContent>

--- a/web/src/app/escalation-policies/PolicyStepForm.js
+++ b/web/src/app/escalation-policies/PolicyStepForm.js
@@ -119,7 +119,7 @@ export default class PolicyStepForm extends React.Component {
 
     return (
       <FormContainer {...this.props}>
-        <Grid container spacing={3}>
+        <Grid container spacing={2}>
           <Grid item xs={12}>
             <Config>
               {cfg => (

--- a/web/src/app/lists/PaginatedList.js
+++ b/web/src/app/lists/PaginatedList.js
@@ -64,7 +64,7 @@ class PaginationControls extends React.PureComponent {
 
     return (
       <React.Fragment>
-        <Grid container item justify='flex-end' className={classes.controls}>
+        <Grid container justify='flex-end' className={classes.controls}>
           <Grid item>
             <IconButton
               title='back page'

--- a/web/src/app/schedules/ScheduleAssignedToList.js
+++ b/web/src/app/schedules/ScheduleAssignedToList.js
@@ -3,7 +3,7 @@ import p from 'prop-types'
 import gql from 'graphql-tag'
 import Query from '../util/Query'
 import FlatList from '../lists/FlatList'
-import { Grid, Card } from '@material-ui/core'
+import Card from '@material-ui/core/Card'
 
 const query = gql`
   query($id: ID!) {
@@ -33,17 +33,15 @@ export default class ScheduleAssignedToList extends React.PureComponent {
   }
   renderList({ data }) {
     return (
-      <Grid item container>
-        <Card style={{ width: '100%' }}>
-          <FlatList
-            items={data.schedule.assignedTo.map(t => ({
-              title: t.name,
-              url: `/escalation-policies/${t.id}`,
-            }))}
-            emptyMessage='This schedule is not assigned to any escalation policies.'
-          />
-        </Card>
-      </Grid>
+      <Card style={{ width: '100%' }}>
+        <FlatList
+          items={data.schedule.assignedTo.map(t => ({
+            title: t.name,
+            url: `/escalation-policies/${t.id}`,
+          }))}
+          emptyMessage='This schedule is not assigned to any escalation policies.'
+        />
+      </Card>
     )
   }
 }

--- a/web/src/app/schedules/ScheduleForm.js
+++ b/web/src/app/schedules/ScheduleForm.js
@@ -24,33 +24,35 @@ export default class ScheduleForm extends React.PureComponent {
   render() {
     return (
       <FormContainer optionalLabels {...this.props}>
-        <Grid item container>
-          <FormField
-            fullWidth
-            component={TextField}
-            name='name'
-            label='Name'
-            required
-          />
-        </Grid>
-        <Grid item container>
-          <FormField
-            fullWidth
-            component={TextField}
-            multiline
-            name='description'
-            label='Description'
-          />
-        </Grid>
-        <Grid item container>
-          <FormField
-            fullWidth
-            component={TimeZoneSelect}
-            name='time-zone'
-            fieldName='timeZone'
-            label='Time Zone'
-            required
-          />
+        <Grid container spacing={2}>
+          <Grid item xs={12}>
+            <FormField
+              fullWidth
+              component={TextField}
+              name='name'
+              label='Name'
+              required
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <FormField
+              fullWidth
+              component={TextField}
+              multiline
+              name='description'
+              label='Description'
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <FormField
+              fullWidth
+              component={TimeZoneSelect}
+              name='time-zone'
+              fieldName='timeZone'
+              label='Time Zone'
+              required
+            />
+          </Grid>
         </Grid>
       </FormContainer>
     )

--- a/web/src/app/schedules/ScheduleOverrideList.js
+++ b/web/src/app/schedules/ScheduleOverrideList.js
@@ -133,44 +133,40 @@ export default class ScheduleOverrideList extends React.PureComponent {
             onClick={variant => this.setState({ create: variant })}
           />
         </PageActions>
-        <Grid item container>
-          <QueryList
-            headerNote={note}
-            noSearch
-            noPlaceholder
-            query={query}
-            mapDataNode={n => ({
-              title: n.addUser ? n.addUser.name : n.removeUser.name,
-              subText: subText(n),
-              icon: (
-                <UserAvatar
-                  userID={n.addUser ? n.addUser.id : n.removeUser.id}
-                />
-              ),
-              action: (
-                <OtherActions
-                  actions={[
-                    {
-                      label: 'Edit',
-                      onClick: () => this.setState({ editID: n.id }),
-                    },
-                    {
-                      label: 'Delete',
-                      onClick: () => this.setState({ deleteID: n.id }),
-                    },
-                  ]}
-                />
-              ),
-            })}
-            variables={{
-              input: {
-                scheduleID: this.props.scheduleID,
-                start: this.props.showPast ? null : new Date().toISOString(),
-                filterAnyUserID: this.props.userFilter,
-              },
-            }}
-          />
-        </Grid>
+        <QueryList
+          headerNote={note}
+          noSearch
+          noPlaceholder
+          query={query}
+          mapDataNode={n => ({
+            title: n.addUser ? n.addUser.name : n.removeUser.name,
+            subText: subText(n),
+            icon: (
+              <UserAvatar userID={n.addUser ? n.addUser.id : n.removeUser.id} />
+            ),
+            action: (
+              <OtherActions
+                actions={[
+                  {
+                    label: 'Edit',
+                    onClick: () => this.setState({ editID: n.id }),
+                  },
+                  {
+                    label: 'Delete',
+                    onClick: () => this.setState({ deleteID: n.id }),
+                  },
+                ]}
+              />
+            ),
+          })}
+          variables={{
+            input: {
+              scheduleID: this.props.scheduleID,
+              start: this.props.showPast ? null : new Date().toISOString(),
+              filterAnyUserID: this.props.userFilter,
+            },
+          }}
+        />
         {this.state.create && (
           <ScheduleOverrideCreateDialog
             scheduleID={this.props.scheduleID}

--- a/web/src/app/util/FilterContainer.js
+++ b/web/src/app/util/FilterContainer.js
@@ -12,6 +12,10 @@ import { FilterList } from '@material-ui/icons'
 
 const style = theme => {
   return {
+    actions: {
+      display: 'flex',
+      justifyContent: 'flex-end',
+    },
     overflow: {
       overflow: 'visible',
     },
@@ -35,7 +39,7 @@ export default class FilterContainer extends React.PureComponent {
 
   renderContent() {
     return (
-      <Grid item container spacing={3} className={this.props.classes.container}>
+      <Grid container spacing={3} className={this.props.classes.container}>
         <Grid
           item
           container
@@ -45,7 +49,7 @@ export default class FilterContainer extends React.PureComponent {
         >
           {this.props.children}
         </Grid>
-        <Grid item container justify='flex-end' xs={12}>
+        <Grid item xs={12} className={this.props.classes.actions}>
           {this.props.onReset && (
             <Button onClick={this.props.onReset}>Reset</Button>
           )}

--- a/web/src/app/util/FilterContainer.js
+++ b/web/src/app/util/FilterContainer.js
@@ -39,7 +39,7 @@ export default class FilterContainer extends React.PureComponent {
 
   renderContent() {
     return (
-      <Grid container spacing={3} className={this.props.classes.container}>
+      <Grid container spacing={2} className={this.props.classes.container}>
         <Grid
           item
           container

--- a/web/src/app/wizard/WizardForm.js
+++ b/web/src/app/wizard/WizardForm.js
@@ -52,7 +52,7 @@ export default class WizardForm extends React.PureComponent {
 
     return (
       <FormContainer optionalLabels {...this.props}>
-        <Grid container spacing={3}>
+        <Grid container spacing={2}>
           <Grid item className={classes.stepItem}>
             <StepIcon icon='1' />
           </Grid>


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR removes any inconsistencies between `Grid` components being rendered with both the `item` and `container` properties, when in most use cases it should be one or the other. In some cases here, a grid was not needed at all has been subsequently removed.

**Additional Info:**
Also updates the few places where we use `spacing={3}` to `spacing={2}`, which is what we mainly use across GoAlert.