### PR TITLE
profile: contact method management fixes

### DIFF
--- a/graphql2/graphqlapp/contactmethod.go
+++ b/graphql2/graphqlapp/contactmethod.go
@@ -71,9 +71,6 @@ func (m *Mutation) CreateUserContactMethod(ctx context.Context, input graphql2.C
 }
 
 func (m *Mutation) UpdateUserContactMethod(ctx context.Context, input graphql2.UpdateUserContactMethodInput) (bool, error) {
-	if input.Value != nil {
-		return false, validation.NewFieldError("Value", "changing contact method value is not allowed")
-	}
 
 	err := withContextTx(ctx, m.DB, func(ctx context.Context, tx *sql.Tx) error {
 		cm, err := m.CMStore.FindOneTx(ctx, tx, input.ID)
@@ -82,6 +79,9 @@ func (m *Mutation) UpdateUserContactMethod(ctx context.Context, input graphql2.U
 		}
 		if input.Name != nil {
 			cm.Name = *input.Name
+		}
+		if input.Value != nil {
+			cm.Value = *input.Value
 		}
 
 		return m.CMStore.UpdateTx(ctx, tx, cm)

--- a/graphql2/graphqlapp/contactmethod.go
+++ b/graphql2/graphqlapp/contactmethod.go
@@ -71,6 +71,10 @@ func (m *Mutation) CreateUserContactMethod(ctx context.Context, input graphql2.C
 }
 
 func (m *Mutation) UpdateUserContactMethod(ctx context.Context, input graphql2.UpdateUserContactMethodInput) (bool, error) {
+	if input.Value != nil {
+		return false, validation.NewFieldError("Value", "changing contact method value is not allowed")
+	}
+
 	err := withContextTx(ctx, m.DB, func(ctx context.Context, tx *sql.Tx) error {
 		cm, err := m.CMStore.FindOneTx(ctx, tx, input.ID)
 		if err != nil {
@@ -79,12 +83,7 @@ func (m *Mutation) UpdateUserContactMethod(ctx context.Context, input graphql2.U
 		if input.Name != nil {
 			cm.Name = *input.Name
 		}
-		if input.Value != nil {
-			if *input.Value != cm.Value {
-				cm.Disabled = true
-			}
-			cm.Value = *input.Value
-		}
+
 		return m.CMStore.UpdateTx(ctx, tx, cm)
 	})
 	return err == nil, err

--- a/web/src/app/dialogs/FormDialog.js
+++ b/web/src/app/dialogs/FormDialog.js
@@ -49,6 +49,7 @@ export default class FormDialog extends React.PureComponent {
     errors: p.arrayOf(
       p.shape({
         message: p.string.isRequired,
+        nonSubmit: p.bool, // indicates that it is a non-submit related error
       }),
     ),
 
@@ -196,7 +197,7 @@ export default class FormDialog extends React.PureComponent {
           Cancel
         </Button>
         <LoadingButton
-          attemptCount={errors.length ? 1 : 0}
+          attemptCount={errors.filter(e => !e.nonSubmit).length ? 1 : 0}
           buttonText={confirm ? 'Confirm' : 'Submit'}
           color='primary'
           loading={loading}

--- a/web/src/app/users/UserContactMethodEditDialog.js
+++ b/web/src/app/users/UserContactMethodEditDialog.js
@@ -7,7 +7,7 @@ import { fieldErrors, nonFieldErrors } from '../util/errutil'
 import FormDialog from '../dialogs/FormDialog'
 import UserContactMethodForm from './UserContactMethodForm'
 import Query from '../util/Query'
-import { omit } from 'lodash-es'
+import { pick } from 'lodash-es'
 
 const query = gql`
   query($id: ID!) {
@@ -79,9 +79,9 @@ export default class UserContactMethodEditDialog extends React.PureComponent {
         onSubmit={() => {
           return commit({
             variables: {
-              // removing field 'type' from value for mutation
+              // only pass 'name'
               input: {
-                ...omit(this.state.value, 'type'),
+                ...pick(this.state.value, 'name'),
                 id: this.props.contactMethodID,
               },
             },

--- a/web/src/app/users/UserContactMethodForm.js
+++ b/web/src/app/users/UserContactMethodForm.js
@@ -71,15 +71,18 @@ export default class UserContactMethodForm extends React.PureComponent {
               type='tel'
               component={TextField}
               mapOnChangeValue={cleanValue}
+              disabled={this.props.edit}
             />
-            <Typography
-              variant='caption'
-              component='p'
-              id='countryCodeIndicator'
-            >
-              Please provide your country code e.g. +1 (USA), +91 (India) +44
-              (UK)
-            </Typography>
+            {!this.props.edit && (
+              <Typography
+                variant='caption'
+                component='p'
+                id='countryCodeIndicator'
+              >
+                Please provide your country code e.g. +1 (USA), +91 (India) +44
+                (UK)
+              </Typography>
+            )}
           </Grid>
         </Grid>
       </FormContainer>

--- a/web/src/app/users/UserContactMethodForm.js
+++ b/web/src/app/users/UserContactMethodForm.js
@@ -32,6 +32,15 @@ export default class UserContactMethodForm extends React.PureComponent {
   }
 
   render() {
+    const cleanValue = val => {
+      val = val.replace(/[^0-9]/g, '')
+
+      if (!val) {
+        return ''
+      }
+
+      return '+' + val
+    }
     return (
       <FormContainer {...this.props} optionalLabels>
         <Grid container spacing={2}>
@@ -61,6 +70,7 @@ export default class UserContactMethodForm extends React.PureComponent {
               label='Phone Number'
               type='tel'
               component={TextField}
+              mapOnChangeValue={cleanValue}
             />
             <Typography
               variant='caption'

--- a/web/src/app/users/UserContactMethodVerificationDialog.js
+++ b/web/src/app/users/UserContactMethodVerificationDialog.js
@@ -70,7 +70,11 @@ export default function UserContactMethodVerificationDialog(props) {
               caption={caption}
               loading={loading}
               errors={
-                sendError ? [{ message: sendError }] : nonFieldErrors(error)
+                sendError
+                  ? [{ message: sendError, nonSubmit: true }].concat(
+                      nonFieldErrors(error),
+                    )
+                  : nonFieldErrors(error)
               }
               data-cy='verify-form'
               onClose={props.onClose}

--- a/web/src/app/users/UserContactMethodVerificationDialog.js
+++ b/web/src/app/users/UserContactMethodVerificationDialog.js
@@ -24,9 +24,8 @@ const contactMethodQuery = gql`
   query($id: ID!) {
     userContactMethod(id: $id) {
       id
-      name
       type
-      value
+      formattedValue
     }
   }
 `

--- a/web/src/app/users/UserContactMethodVerificationForm.js
+++ b/web/src/app/users/UserContactMethodVerificationForm.js
@@ -42,12 +42,16 @@ export default function UserContactMethodVerificationForm(props) {
   })
 
   function sendAndCatch() {
+    // Clear error on new actions.
+    props.setSendError(null)
     sendCode().catch(err => props.setSendError(err.message))
   }
 
-  // componentDidMount
+  // Attempt to send a code on load, but it's ok if it fails.
+  //
+  // We only want to display an error in response to a user action.
   useEffect(() => {
-    sendAndCatch()
+    sendCode().catch(() => {})
   }, [])
 
   return (

--- a/web/src/cypress/integration/profile.ts
+++ b/web/src/cypress/integration/profile.ts
@@ -66,8 +66,6 @@ function testProfile(screen: ScreenFormat) {
     })
     it('should allow editing', () => {
       const name = 'SM CM ' + c.word({ length: 8 })
-      const value = '763' + c.integer({ min: 3000000, max: 3999999 })
-      const usCountryCode = '+1'
       cy.get('ul[data-cy=contact-methods]')
         .contains('li', cm.name)
         .find('button[data-cy=other-actions]')
@@ -76,18 +74,12 @@ function testProfile(screen: ScreenFormat) {
       cy.get('input[name=name]')
         .clear()
         .type(name)
-      cy.get('input[name=value]')
-        .clear()
-        .type(usCountryCode + value)
       cy.get('button[type=submit]').click()
 
       cy.get('ul[data-cy=contact-methods]').should(
         'contain',
         `${name} (${cm.type})`,
       )
-      cy.get('ul[data-cy="contact-methods"]')
-        .contains('li', `${name} (${cm.type})`)
-        .find(`button[data-cy='cm-disabled']`)
     })
     it('should allow deleting', () => {
       cy.get('ul[data-cy=contact-methods]')


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [X] Identified the issue which this PR solves.
- [X] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [X] Code builds clean without any errors or warnings.
- [X] Added appropriate tests for any new functionality.
- [X] All new and existing tests passed.
- [X] Added comments in the code, where necessary.
- [X] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes issues around contact method management in preparation for the next release.

**Which issue(s) this PR fixes:**
- Fixes "A verification code has been sent to undefined" message for new contact methods
- Fixes a regression that prevented pasting pre-formatted numbers into the contact method field
- Fixes the "too many messages" error when opening the reactivate dialog
- Fixes the "Retry" button appearing in the reactivate dialog when it had not been submitted

**Describe any introduced user-facing changes:**
It is no longer possible to edit a contact method value. This was done to ensure consistency in logs and verification.

![image](https://user-images.githubusercontent.com/595010/61478449-246ec980-a957-11e9-993e-66ada5134382.png)

