### PR TITLE
dialogs: fix cases where errors were not displayed

### DIFF
--- a/web/src/app/dialogs/FormDialog.js
+++ b/web/src/app/dialogs/FormDialog.js
@@ -30,8 +30,9 @@ const styles = theme => {
       display: 'flex',
       flexDirection: 'column',
     },
-    noGrow: {
+    errorContainer: {
       flexGrow: 0,
+      overflowY: 'visible',
     },
   }
 }
@@ -165,7 +166,7 @@ export default class FormDialog extends React.PureComponent {
   renderErrors = () => {
     return this.props.errors.map((err, idx) => (
       <DialogContentError
-        className={this.props.classes.noGrow}
+        className={this.props.classes.errorContainer}
         error={err.message || err}
         key={idx}
         noPadding

--- a/web/src/app/services/ServiceDeleteDialog.js
+++ b/web/src/app/services/ServiceDeleteDialog.js
@@ -128,7 +128,7 @@ export default class ServiceDeleteDialog extends React.PureComponent {
           <DeleteForm
             epName={svcData.escalationPolicy.name}
             error={
-              fieldErrors(error).find(f => f.field === 'escalationPolicyId') &&
+              fieldErrors(error).find(f => f.field === 'escalationPolicyID') &&
               'Escalation policy is currently in use.'
             }
             onChange={deleteEP => this.setState({ deleteEP })}


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [X] Identified the issue which this PR solves.
- [X] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [X] Code builds clean without any errors or warnings.
- [X] Added appropriate tests for any new functionality.
- [X] All new and existing tests passed.
- [X] Added comments in the code, where necessary.
- [X] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This fixes a couple of issues where error messages were not displayed in dialogs.

**Which issue(s) this PR fixes:**
- Delete service errors not displaying
- Long dialogs didn't show any error messages

**Additional Context**
- The service dialog issue was due to the field `escalationPolicyID` not matching `escalationPolicyId` (capitalization).
- The other dialogs were actually rendering the errors, but the error sections were collapsed into a scrollable container rather than expanding the dialog content (which scrolls already).