### PR TITLE
search: focus fix

### DIFF
--- a/web/src/app/util/Search.js
+++ b/web/src/app/util/Search.js
@@ -1,33 +1,21 @@
-import React, { Component } from 'react'
-import { PropTypes as p } from 'prop-types'
+import React, { useState, useEffect } from 'react'
 import AppBar from '@material-ui/core/AppBar'
 import Hidden from '@material-ui/core/Hidden'
 import IconButton from '@material-ui/core/IconButton'
 import Slide from '@material-ui/core/Slide'
 import TextField from '@material-ui/core/TextField'
 import Toolbar from '@material-ui/core/Toolbar'
-import withStyles from '@material-ui/core/styles/withStyles'
 import { Close as CloseIcon, Search as SearchIcon } from '@material-ui/icons'
 import { styles } from '../styles/materialStyles'
-import { connect } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { searchSelector } from '../selectors/url'
 import { setURLParam } from '../actions/main'
-import { debounce } from 'lodash-es'
 import { DEBOUNCE_DELAY } from '../config'
+import { makeStyles } from '@material-ui/core'
 
-const mapDispatchToProps = dispatch => {
-  return {
-    setSearch: debounce(
-      value => dispatch(setURLParam('search', value)),
-      DEBOUNCE_DELAY,
-    ),
-  }
-}
-const mapStateToProps = state => {
-  return {
-    search: searchSelector(state),
-  }
-}
+const useStyles = makeStyles(theme => {
+  return { searchFieldBox: styles(theme).searchFieldBox }
+})
 
 /*
  * Renders a search bar that will fix to the top right of the screen (in the app bar)
@@ -36,35 +24,32 @@ const mapStateToProps = state => {
  * a new appbar will display that contains a search field to use.
  *
  * On a larger screen, the field will always be present to use in the app bar.
- *
- * Uncontrolled component with a key. If the component detects that the search
- * URL parameter has been reset, it will reset the search param's state as well.
- * i.e. this component's location key changes and will remount a new version of itself.
- *
- * A search function is provided for components that need tracking of the search
- * in Redux (for cache updates, queries, etc).
  */
-@withStyles(styles)
-@connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)
-export default class Search extends Component {
-  static propTypes = {
-    setSearch: p.func.isRequired, // used for redux updates
-    search: p.string.isRequired, // initial value of search param, if given
-  }
+export default function Search() {
+  const searchParam = useSelector(searchSelector)
+  const dispatch = useDispatch()
+  const setSearchParam = value => dispatch(setURLParam('search', value))
+  const classes = useStyles()
+  const [search, setSearch] = useState(searchParam)
+  const [showMobile, setShowMobile] = useState(false)
 
-  state = {
-    showMobile: false,
-  }
+  // If the page search param changes, we update state directly.
+  useEffect(() => {
+    setSearch(searchParam)
+  }, [searchParam])
 
-  renderTextField = extraProps => {
-    const { classes, search } = this.props
+  // When typing, we setup a debounce before updating the URL.
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setSearchParam(search)
+    }, DEBOUNCE_DELAY)
 
+    return () => clearTimeout(t)
+  }, [search])
+
+  function renderTextField(extraProps) {
     return (
       <TextField
-        key={search}
         InputProps={{
           disableUnderline: true,
           classes: {
@@ -72,28 +57,28 @@ export default class Search extends Component {
           },
         }}
         placeholder='Search'
-        onChange={e => this.props.setSearch(e.target.value)}
-        defaultValue={search}
+        onChange={e => setSearch(e.target.value)}
+        value={search}
         {...extraProps}
       />
     )
   }
 
-  renderMobileSearch() {
+  function renderMobile() {
     return (
-      <Hidden mdUp>
+      <React.Fragment>
         <IconButton
           key='search-icon'
           color='inherit'
           aria-label='Search'
           data-cy='open-search'
-          onClick={() => this.setState({ showMobile: true })}
+          onClick={() => setShowMobile(true)}
         >
           <SearchIcon />
         </IconButton>
         <Slide
           key='search-field'
-          in={this.state.showMobile}
+          in={showMobile}
           direction='down'
           mountOnEnter
           unmountOnExit
@@ -105,30 +90,24 @@ export default class Search extends Component {
             <Toolbar>
               <IconButton
                 color='inherit'
-                onClick={() => this.setState({ showMobile: false })}
+                onClick={() => setShowMobile(false)}
                 aria-label='Cancel'
                 data-cy='close-search'
               >
                 <CloseIcon />
               </IconButton>
-              {this.renderTextField({ style: { flex: 1 } })}
+              {renderTextField({ style: { flex: 1 } })}
             </Toolbar>
           </AppBar>
         </Slide>
-      </Hidden>
-    )
-  }
-
-  renderDesktopSearch() {
-    return <Hidden smDown>{this.renderTextField()}</Hidden>
-  }
-
-  render() {
-    return (
-      <React.Fragment>
-        {this.renderDesktopSearch()}
-        {this.renderMobileSearch()}
       </React.Fragment>
     )
   }
+
+  return (
+    <React.Fragment>
+      <Hidden smDown>{renderTextField()}</Hidden>
+      <Hidden mdUp>{renderMobile()}</Hidden>
+    </React.Fragment>
+  )
 }

--- a/web/src/app/util/Search.js
+++ b/web/src/app/util/Search.js
@@ -31,7 +31,7 @@ export default function Search() {
   const setSearchParam = value => dispatch(setURLParam('search', value))
   const classes = useStyles()
   const [search, setSearch] = useState(searchParam)
-  const [showMobile, setShowMobile] = useState(false)
+  const [showMobile, setShowMobile] = useState(Boolean(search))
 
   // If the page search param changes, we update state directly.
   useEffect(() => {
@@ -78,7 +78,7 @@ export default function Search() {
         </IconButton>
         <Slide
           key='search-field'
-          in={showMobile}
+          in={showMobile || Boolean(search)}
           direction='down'
           mountOnEnter
           unmountOnExit
@@ -90,7 +90,11 @@ export default function Search() {
             <Toolbar>
               <IconButton
                 color='inherit'
-                onClick={() => setShowMobile(false)}
+                onClick={() => {
+                  // cancel search and close the bar
+                  setSearch('')
+                  setShowMobile(false)
+                }}
                 aria-label='Cancel'
                 data-cy='close-search'
               >

--- a/web/src/cypress/support/page-nav.ts
+++ b/web/src/cypress/support/page-nav.ts
@@ -11,7 +11,7 @@ function pageNav(s: string, skipClick?: boolean): Cypress.Chainable {
     expect(format, 'app bar format').to.be.oneOf(['mobile', 'wide'])
 
     if (format === 'mobile') {
-      cy.get('button[data-cy=nav-menu-icon]').click()
+      cy.get('button[data-cy=nav-menu-icon]').click({ force: true }) // since we're running tests, it's ok if it's already open
     }
     if (skipClick) {
       cy.get('ul[data-cy=nav-list]').contains('a', s)

--- a/web/src/cypress/support/page-search.ts
+++ b/web/src/cypress/support/page-search.ts
@@ -15,18 +15,12 @@ function pageSearch(s: string): Cypress.Chainable {
     if (format === 'mobile') {
       cy.get('@container')
         .find('button[data-cy=open-search]')
-        .click()
+        .click({ force: true }) // since we're running tests, it's ok if it is already open
     }
 
     cy.get('@container')
       .find('input')
       .type(`{selectall}${s}{enter}`)
-
-    if (format === 'mobile') {
-      cy.get('@container')
-        .find('button[data-cy=close-search]')
-        .click()
-    }
   })
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [X] Identified the issue which this PR solves.
- [X] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [X] Code builds clean without any errors or warnings.
- [X] Added appropriate tests for any new functionality.
- [X] All new and existing tests passed.
- [X] Added comments in the code, where necessary.
- [X] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes focus issues regarding the search bar on mobile and desktop.

Additionally, it ensures that the search string is visible on mobile if results are being filtered.

**Which issue(s) this PR fixes:**
- Unable to type in search bar without losing focus

**Describe any introduced user-facing changes:**
- When canceling the mobile search bar, the search state is cleared
- When loading the page, if a search is present, the mobile search bar is shown

**Additional Context**
The `Search` component was converted to React Hooks.
