### PR TITLE
ui: firefox support for schedule calendars

### DIFF
--- a/web/src/app/schedules/ScheduleCalendar.js
+++ b/web/src/app/schedules/ScheduleCalendar.js
@@ -13,6 +13,7 @@ import ScheduleOverrideCreateDialog from './ScheduleOverrideCreateDialog'
 import { resetURLParams, setURLParam } from '../actions'
 import { urlParamSelector } from '../selectors'
 import { DateTime, Interval } from 'luxon'
+import { theme } from '../mui'
 
 const localizer = BigCalendar.momentLocalizer(moment)
 
@@ -185,9 +186,6 @@ export default class ScheduleCalendar extends React.PureComponent {
   render() {
     const { classes, shifts, start, weekly } = this.props
 
-    // fill available doesn't work in weekly view
-    const height = weekly ? '100%' : '-webkit-fill-available'
-
     return (
       <React.Fragment>
         <Typography variant='caption' color='textSecondary'>
@@ -202,7 +200,11 @@ export default class ScheduleCalendar extends React.PureComponent {
               date={new Date(start)}
               localizer={localizer}
               events={this.getCalEvents(shifts)}
-              style={{ height, font: '-webkit-control' }}
+              style={{
+                height: weekly ? '100%' : '45rem',
+                fontFamily: theme.typography.body2.fontFamily,
+                fontSize: theme.typography.body2.fontSize,
+              }}
               tooltipAccessor={() => null}
               views={['month', 'week']}
               view={weekly ? 'week' : 'month'}


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Closes #35. This PR fixes an issue where the height and font were set with the `webkit` vendor prefix, which Firefox does not support. These values are now represented using our `theme` from material-ui, and `rem` for the height.