### PR TITLE
cypress: fix pagination tests

### DIFF
--- a/web/src/app/actions/main.js
+++ b/web/src/app/actions/main.js
@@ -13,13 +13,22 @@ export function resetURLParams(...keys) {
     keys.forEach(key => {
       q.delete(key)
     })
-    if (q.sort) q.sort()
 
-    const search = q.toString()
-    dispatch(
-      replace(state.router.location.pathname + (search ? '?' + search : '')),
-    )
+    setSearchStr(dispatch, state, q)
   }
+}
+
+const setSearchStr = (dispatch, state, searchParams) => {
+  if (searchParams.sort) searchParams.sort()
+  let newSearch = searchParams.toString()
+  newSearch = newSearch ? '?' + newSearch : ''
+
+  const { search, pathname, hash } = state.router.location
+  if (newSearch === search) {
+    // no action for no param change
+    return
+  }
+  dispatch(replace(pathname + newSearch + hash))
 }
 
 const sanitizeParam = value => {
@@ -61,12 +70,8 @@ export function setURLParam(name, _value, _default) {
     } else {
       q.delete(name)
     }
-    if (q.sort) q.sort()
 
-    const search = q.toString()
-    dispatch(
-      replace(state.router.location.pathname + (search ? '?' + search : '')),
-    )
+    setSearchStr(dispatch, state, q)
   }
 }
 

--- a/web/src/app/lists/QueryList.js
+++ b/web/src/app/lists/QueryList.js
@@ -8,6 +8,7 @@ import { connect } from 'react-redux'
 import { searchSelector } from '../selectors'
 import Query from '../util/Query'
 import { fieldAlias } from '../util/graphql'
+import Spinner from '../loading/components/Spinner'
 
 const mapStateToProps = state => ({
   search: searchSelector(state),
@@ -95,6 +96,10 @@ export default class QueryList extends React.PureComponent {
         loadMore = this.buildFetchMore(fetchMore, data.data.pageInfo.endCursor)
       }
     }
+
+    // react-router initializes without a key sometimes, need to wait for it to "correct"
+    if (!this.props.routeKey) return <Spinner />
+
     return (
       <PaginatedList
         {...listProps}

--- a/web/src/app/lists/QueryList.js
+++ b/web/src/app/lists/QueryList.js
@@ -8,7 +8,6 @@ import { connect } from 'react-redux'
 import { searchSelector } from '../selectors'
 import Query from '../util/Query'
 import { fieldAlias } from '../util/graphql'
-import Spinner from '../loading/components/Spinner'
 
 const mapStateToProps = state => ({
   search: searchSelector(state),
@@ -96,9 +95,6 @@ export default class QueryList extends React.PureComponent {
         loadMore = this.buildFetchMore(fetchMore, data.data.pageInfo.endCursor)
       }
     }
-
-    // react-router initializes without a key sometimes, need to wait for it to "correct"
-    if (!this.props.routeKey) return <Spinner />
 
     return (
       <PaginatedList

--- a/web/src/app/lists/QueryList.js
+++ b/web/src/app/lists/QueryList.js
@@ -11,6 +11,7 @@ import { fieldAlias } from '../util/graphql'
 
 const mapStateToProps = state => ({
   search: searchSelector(state),
+  routeKey: state.router.location.key,
 })
 
 @connect(mapStateToProps)
@@ -44,6 +45,7 @@ export default class QueryList extends React.PureComponent {
 
     // provided by redux
     search: p.string,
+    routeKey: p.string,
   }
 
   static defaultProps = {
@@ -96,7 +98,7 @@ export default class QueryList extends React.PureComponent {
     return (
       <PaginatedList
         {...listProps}
-        key={this.props.search}
+        key={this.props.routeKey}
         items={items}
         loadMore={loadMore}
         isLoading={loading}

--- a/web/src/cypress/support/fail-fast.ts
+++ b/web/src/cypress/support/fail-fast.ts
@@ -10,7 +10,7 @@ before(function() {
 
 // Fail-fast-single-file
 afterEach(function() {
-  if (this.currentTest.state === 'failed') {
+  if (this.currentTest && this.currentTest.state === 'failed') {
     cy.setCookie('has-failed-test', 'true')
     CY.runner.stop()
   }

--- a/web/src/package.json
+++ b/web/src/package.json
@@ -89,7 +89,7 @@
     "mdi-material-ui": "6.0.0",
     "moment": "^2.22.2",
     "react": "16.8.6",
-    "react-apollo": "2.5.6",
+    "react-apollo": "2.5.8",
     "react-beautiful-dnd": "11.0.4",
     "react-big-calendar": "0.21.0",
     "react-count-down": "^1.1.0",

--- a/web/src/package.json
+++ b/web/src/package.json
@@ -126,7 +126,7 @@
     "chance": "^1.0.16",
     "css-loader": "1.0.1",
     "cssnano": "^4.1.7",
-    "cypress": "3.3.2",
+    "cypress": "3.4.1",
     "eslint": "^5.9.0",
     "eslint-config-prettier": "5.0.0",
     "eslint-config-standard": "^12.0.0",

--- a/web/src/yarn.lock
+++ b/web/src/yarn.lock
@@ -9276,12 +9276,13 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-apollo@2.5.6:
-  version "2.5.6"
-  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.6.tgz#98a59d0eea31432ed001e6a033e11a58139ffc31"
-  integrity sha512-WWX5UykTtmW6+awjqEsSWSdvVyZv/vsavUgpdI4ddn4CBdz47INC+iTdJBnYaUFMB24GmqjFFSoSd98gu1xqKA==
+react-apollo@2.5.8:
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.8.tgz#c7a593b027efeefdd8399885e0ac6bec3b32623c"
+  integrity sha512-60yOQrnNosxU/tRbOxGDaYNLFcOKmQqxHPhxyvKTlGIaF/rRCXQRKixUgWVffpEupSHHD7psY5k5ZOuZsdsSGQ==
   dependencies:
     apollo-utilities "^1.3.0"
+    fast-json-stable-stringify "^2.0.0"
     hoist-non-react-statics "^3.3.0"
     lodash.isequal "^4.5.0"
     prop-types "^15.7.2"

--- a/web/src/yarn.lock
+++ b/web/src/yarn.lock
@@ -3617,10 +3617,10 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
-cypress@*, cypress@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.3.2.tgz#105d9283c747884d534b88a8e6c857d977887024"
-  integrity sha512-d2gFX0KBBdNfMMZ/ud9ouNqjDtMM3Tf5Z50hkl8Ldb8T+jKc7RLFo/4FjMu9i28T2x+50Sx8sN/kLzxr2oeWNg==
+cypress@*, cypress@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.4.1.tgz#ca2e4e9864679da686c6a6189603efd409664c30"
+  integrity sha512-1HBS7t9XXzkt6QHbwfirWYty8vzxNMawGj1yI+Fu6C3/VZJ8UtUngMW6layqwYZzLTZV8tiDpdCNBypn78V4Dg==
   dependencies:
     "@cypress/listr-verbose-renderer" "0.4.1"
     "@cypress/xvfb" "1.2.4"
@@ -3637,18 +3637,17 @@ cypress@*, cypress@3.3.2:
     extract-zip "1.6.7"
     fs-extra "5.0.0"
     getos "3.1.1"
-    glob "7.1.3"
     is-ci "1.2.1"
     is-installed-globally "0.1.0"
     lazy-ass "1.6.0"
     listr "0.12.0"
-    lodash "4.17.11"
+    lodash "4.17.15"
     log-symbols "2.2.0"
     minimist "1.2.0"
     moment "2.24.0"
     ramda "0.24.1"
     request "2.88.0"
-    request-progress "0.4.0"
+    request-progress "3.0.0"
     supports-color "5.5.0"
     tmp "0.1.0"
     url "0.11.0"
@@ -5158,7 +5157,7 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
 
-glob@7.1.3, glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   dependencies:
@@ -7239,9 +7238,10 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.17.11, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@~4.17.10:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+lodash@4.17.15, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@~4.17.10:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-symbols@2.2.0, log-symbols@^2.2.0:
   version "2.2.0"
@@ -7802,10 +7802,6 @@ no-case@^2.2.0:
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
   dependencies:
     lower-case "^1.1.1"
-
-node-eta@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/node-eta/-/node-eta-0.1.1.tgz#4066109b39371c761c72b7ebda9a9ea0a5de121f"
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -9837,12 +9833,12 @@ replace-ext@1.0.0, replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
-request-progress@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/request-progress/-/request-progress-0.4.0.tgz#c1954e39086aa85269c5660bcee0142a6a70d7e7"
+request-progress@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/request-progress/-/request-progress-3.0.0.tgz#4ca754081c7fec63f505e4faa825aa06cd669dbe"
+  integrity sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=
   dependencies:
-    node-eta "^0.1.1"
-    throttleit "^0.0.2"
+    throttleit "^1.0.0"
 
 request-promise-core@1.1.2:
   version "1.1.2"
@@ -11018,9 +11014,10 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
-throttleit@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-0.0.2.tgz#cfedf88e60c00dd9697b61fdd2a8343a9b680eaf"
+throttleit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.0.tgz#9e785836daf46743145a5984b6268d828528ac6c"
+  integrity sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=
 
 through2@^2.0.0:
   version "2.0.5"


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [X] Identified the issue which this PR solves.
- [X] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [X] Code builds clean without any errors or warnings.
- [X] Added appropriate tests for any new functionality.
- [X] All new and existing tests passed.
- [X] Added comments in the code, where necessary.
- [X] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes the pagination Cypress tests.

The issue was actually a bug, if you were on any page past the first, and clicked on a nav link the page would be stuck in a loading state.

For example:
1. Click on rotations
1. Navigate to the next page
1. Click the rotations link again
1. Observe broken list

**Additional Info:**
The fix was to change the `PaginatedList` key value from the search param to the router location key (which updates on any navigation change). In doing so discovered that the search bar was causing a double-page-navigation on load which caused intermittent failures. That was fixed by updating the URL actions to only dispatch a navigation action if the parameter changes.

Also:
- Updated `cypress` to 3.4.1, resolving the lodash warning
- Updated `react-apollo`
