### PR TITLE
ui: padding consistency around rotation participants and service on-call user lists

### DIFF
--- a/web/src/app/rotations/RotationUserList.js
+++ b/web/src/app/rotations/RotationUserList.js
@@ -5,7 +5,6 @@ import { graphql2Client } from '../apollo'
 import FlatList from '../lists/FlatList'
 import Query from '../util/Query'
 import Card from '@material-ui/core/Card'
-import CardContent from '@material-ui/core/CardContent'
 import CardHeader from '@material-ui/core/CardHeader'
 import { reorderList, calcNewActiveIndex } from './util'
 import { Mutation } from 'react-apollo'
@@ -67,13 +66,11 @@ export default class RotationUserList extends React.PureComponent {
             component='h3'
             title='Users'
           />
-          <CardContent>
-            <Query
-              query={rotationUsersQuery}
-              render={({ data }) => this.renderMutation(data)}
-              variables={{ id: this.props.rotationID }}
-            />
-          </CardContent>
+          <Query
+            query={rotationUsersQuery}
+            render={({ data }) => this.renderMutation(data)}
+            variables={{ id: this.props.rotationID }}
+          />
         </Card>
         {this.state.deleteIndex !== null && (
           <RotationUserDeleteDialog

--- a/web/src/app/services/components/OnCallForService.js
+++ b/web/src/app/services/components/OnCallForService.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import { PropTypes as p } from 'prop-types'
 import Card from '@material-ui/core/Card'
-import CardContent from '@material-ui/core/CardContent'
 import CardHeader from '@material-ui/core/CardHeader'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
@@ -117,7 +116,7 @@ export default class OnCallForService extends Component {
           component='h3'
           title='On Call Users'
         />
-        <CardContent>{content}</CardContent>
+        {content}
       </Card>
     )
   }


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [X] Identified the issue which this PR solves.
- [X] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [X] Code builds clean without any errors or warnings.
- [X] Added appropriate tests for any new functionality.
- [X] All new and existing tests passed.
- [X] Added comments in the code, where necessary.
- [X] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR removes padding on a service's on-call users list to match schedule assignments, alerts, and contact methods. Also removes the padding for a rotation's participants list.

**Screenshots:**
Before:
![image](https://user-images.githubusercontent.com/31386843/62317899-3d4fa280-b460-11e9-8073-d36bb4f65ebf.png)

After:
![image](https://user-images.githubusercontent.com/31386843/62317821-18f3c600-b460-11e9-9722-43689723571a.png)
