### PR TITLE
ui: adjust form dialog spacing

### DIFF
--- a/web/src/app/dialogs/components/DialogTitleWrapper.js
+++ b/web/src/app/dialogs/components/DialogTitleWrapper.js
@@ -104,8 +104,7 @@ export default class DialogTitleWrapper extends Component {
       return (
         <React.Fragment>
           <DialogTitle className={classes.wideScreenTitle} key='title'>
-            {' '}
-            {title}{' '}
+            {title}
           </DialogTitle>
           {subtitle}
           {menu}

--- a/web/src/app/dialogs/components/DialogTitleWrapper.js
+++ b/web/src/app/dialogs/components/DialogTitleWrapper.js
@@ -15,6 +15,16 @@ const styles = theme => {
   const { topRightActions } = globalStyles(theme)
 
   return {
+    appBar: {
+      marginBottom: '1em',
+    },
+    appBarTitle: {
+      fontSize: '1.2em',
+      flex: 1,
+    },
+    subtitle: {
+      overflowY: 'unset',
+    },
     topRightActions,
     wideScreenTitle: {
       paddingBottom: 0,
@@ -73,7 +83,7 @@ export default class DialogTitleWrapper extends Component {
     let subtitle
     if (subTitle) {
       subtitle = (
-        <DialogContent style={{ overflowY: 'unset' }}>
+        <DialogContent className={classes.subtitle}>
           <Typography variant='subtitle1' component='p'>
             {subTitle}
           </Typography>
@@ -84,13 +94,10 @@ export default class DialogTitleWrapper extends Component {
     if (fullScreen) {
       return (
         <React.Fragment>
-          <AppBar position='sticky' style={{ marginBottom: '1em' }}>
+          <AppBar position='sticky' className={classes.appBar}>
             <Toolbar>
               {closeButton}
-              <Typography
-                color='inherit'
-                style={{ fontSize: '1.2em', flex: 1 }}
-              >
+              <Typography color='inherit' className={classes.appBarTitle}>
                 {title}
               </Typography>
               {toolbarItems}

--- a/web/src/app/dialogs/components/DialogTitleWrapper.js
+++ b/web/src/app/dialogs/components/DialogTitleWrapper.js
@@ -8,8 +8,19 @@ import Typography from '@material-ui/core/Typography'
 import withStyles from '@material-ui/core/styles/withStyles'
 import CloseIcon from '@material-ui/icons/Close'
 import DropDownMenu from '../../dialogs/components/DropDownMenu'
-import { styles } from '../../styles/materialStyles'
+import { styles as globalStyles } from '../../styles/materialStyles'
 import { DialogContent } from '@material-ui/core'
+
+const styles = theme => {
+  const { topRightActions } = globalStyles(theme)
+
+  return {
+    topRightActions,
+    wideScreenTitle: {
+      paddingBottom: 0,
+    },
+  }
+}
 
 /**
  * Renders a fullscreen dialog with an app bar if on a small
@@ -59,6 +70,17 @@ export default class DialogTitleWrapper extends Component {
       )
     }
 
+    let subtitle
+    if (subTitle) {
+      subtitle = (
+        <DialogContent style={{ overflowY: 'unset' }}>
+          <Typography variant='subtitle1' component='p'>
+            {subTitle}
+          </Typography>
+        </DialogContent>
+      )
+    }
+
     if (fullScreen) {
       return (
         <React.Fragment>
@@ -75,23 +97,17 @@ export default class DialogTitleWrapper extends Component {
               {menu}
             </Toolbar>
           </AppBar>
-          <DialogContent style={{ overflowY: 'unset' }}>
-            <Typography variant='subtitle1' component='p'>
-              {subTitle}
-            </Typography>
-          </DialogContent>
+          {subtitle}
         </React.Fragment>
       )
     } else {
       return (
         <React.Fragment>
-          <DialogTitle key='title'> {title} </DialogTitle>
-          <DialogContent style={{ overflowY: 'unset' }}>
-            <Typography variant='subtitle1' component='p'>
-              {subTitle}
-            </Typography>
-          </DialogContent>
-
+          <DialogTitle className={classes.wideScreenTitle} key='title'>
+            {' '}
+            {title}{' '}
+          </DialogTitle>
+          {subtitle}
           {menu}
         </React.Fragment>
       )


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This is a small PR that adjusts the padding of form dialogs such that extra whitespace isn't rendered if a subtitle isn't present, as well as removes the bottom padding on the dialog title headers so it doesn't feel like there is lots of empty space between the title and the content.