### PR TITLE
hooks: add useConfigValue hook

### DIFF
--- a/web/src/app/users/UserContactMethodVerificationDialog.js
+++ b/web/src/app/users/UserContactMethodVerificationDialog.js
@@ -5,7 +5,7 @@ import gql from 'graphql-tag'
 import Query from '../util/Query'
 import { fieldErrors, nonFieldErrors } from '../util/errutil'
 import UserContactMethodVerificationForm from './UserContactMethodVerificationForm'
-import { useConfig } from '../util/RequireConfig'
+import { useConfigValue } from '../util/RequireConfig'
 import { useMutation } from '@apollo/react-hooks'
 
 /*
@@ -47,13 +47,12 @@ export default function UserContactMethodVerificationDialog(props) {
     refetchQueries: ['cmList'],
     onCompleted: props.onClose,
   })
-  const config = useConfig()
+  const [fromNumber] = useConfigValue('Twilio.FromNumber')
 
   // dialog rendered that handles rendering the verification form
   function renderDialog(cm) {
     const { loading, error } = status
     const fieldErrs = fieldErrors(error)
-    const fromNumber = config['Twilio.FromNumber']
 
     let caption = null
     if (fromNumber && cm.type === 'SMS') {

--- a/web/src/app/util/RequireConfig.js
+++ b/web/src/app/util/RequireConfig.js
@@ -72,7 +72,7 @@ function isTrue(value) {
 }
 
 const mapConfig = value =>
-  _.chain(value.config)
+  _.chain(value)
     .groupBy('id')
     .mapValues(v => parseValue(v[0].type, v[0].value))
     .value()

--- a/web/src/app/util/RequireConfig.js
+++ b/web/src/app/util/RequireConfig.js
@@ -99,6 +99,18 @@ export function useConfig() {
   return mapConfig(useContext(ConfigContext).config)
 }
 
+// useConfigValue will return an array of config values
+// for the provided fields.
+//
+// Example:
+// ```js
+// const [mailgun, slack] = useConfigValue('Mailgun.Enable', 'Slack.Enable')
+// ```
+export function useConfigValue(...fields) {
+  const config = useConfig()
+  return fields.map(f => config[f])
+}
+
 export class Config extends React.PureComponent {
   render() {
     return (


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [X] Identified the issue which this PR solves.
- [X] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [X] Code builds clean without any errors or warnings.
- [X] Added appropriate tests for any new functionality.
- [X] All new and existing tests passed.
- [X] Added comments in the code, where necessary.
- [X] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Adds a new hook `useConfigValue` that is a bit more natural to use than the raw `useConfig` hook.

Usage:
```js
  const [fromNumber] = useConfigValue('Twilio.FromNumber')
```

**Additional Info:**
- also fixes `mapConfig`
