### PR TITLE
db: retry on connection failure

### DIFF
--- a/retry/do.go
+++ b/retry/do.go
@@ -2,11 +2,11 @@ package retry
 
 import (
 	"context"
-	"github.com/target/goalert/util/log"
 	"math/rand"
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/target/goalert/util/log"
 )
 
 var _fib = []int{0, 1}
@@ -77,5 +77,12 @@ func FibBackoff(d time.Duration) Option {
 		}
 		time.Sleep(time.Duration(fib(a))*d + time.Duration(rand.Intn(100)-50)*time.Millisecond)
 		return true
+	}
+}
+
+// Context will allow retry to continue until the context is cancelled.
+func Context(ctx context.Context) Option {
+	return func(a int, _ error) bool {
+		return ctx.Err() == nil
 	}
 }

--- a/sqltrace/connector.go
+++ b/sqltrace/connector.go
@@ -3,7 +3,9 @@ package sqltrace
 import (
 	"context"
 	"database/sql/driver"
+	"time"
 
+	"github.com/target/goalert/retry"
 	"go.opencensus.io/trace"
 )
 
@@ -15,7 +17,17 @@ type _Connector struct {
 }
 
 func (c *_Connector) Connect(ctx context.Context) (driver.Conn, error) {
-	conn, err := c.dbc.Connect(ctx)
+	var conn driver.Conn
+	var err error
+	err = retry.DoTemporaryError(func(_ int) error {
+		conn, err = c.dbc.Connect(ctx)
+		return err
+	},
+		retry.Log(ctx),
+		retry.Context(ctx),
+		retry.Limit(10),
+		retry.FibBackoff(time.Second/2),
+	)
 	return &_Conn{conn: conn, drv: c.drv, attrs: c.attrs}, err
 }
 func (c *_Connector) Driver() driver.Driver {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [X] Identified the issue which this PR solves.
- [X] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [X] Code builds clean without any errors or warnings.
- [X] Added appropriate tests for any new functionality.
- [X] All new and existing tests passed.
- [X] Added comments in the code, where necessary.
- [X] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR updates the DB driver wrapper to retry connecting to the DB when the connection attempt fails. It also updates the health check to ignore DB state (as UI can and should still be served).
