### PR TITLE
ui: mobile card padding fix

### DIFF
--- a/web/src/app/main/NewApp.js
+++ b/web/src/app/main/NewApp.js
@@ -35,6 +35,7 @@ const styles = theme => ({
   },
   main: {
     width: '100%',
+    padding: '10px',
   },
   appBar: {
     zIndex: theme.zIndex.drawer + 1,


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [X] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
added padding to the main tag for cards to not appear cutoff on moble.

**Screenshots:**
![image](https://user-images.githubusercontent.com/29063970/62713128-d4b57800-b9c1-11e9-9e2a-a704ff0ce44c.png)
![image](https://user-images.githubusercontent.com/29063970/62713134-d717d200-b9c1-11e9-977c-640f092d406c.png)



