### PR TITLE
ui: fix alignment of "Provided by Gravatar" under user profile avatar

### DIFF
--- a/web/src/app/users/UserDetails.js
+++ b/web/src/app/users/UserDetails.js
@@ -134,7 +134,11 @@ export default class UserDetails extends React.PureComponent {
               />
               <Typography
                 variant='caption'
-                style={{ textAlign: 'center', paddingTop: '0.5em' }}
+                style={{
+                  textAlign: 'center',
+                  paddingTop: '0.5em',
+                  display: 'block',
+                }}
               >
                 Provided by{' '}
                 <a href='https://gravatar.com' target='_blank'>


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [X] Identified the issue which this PR solves.
- [X] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [X] Code builds clean without any errors or warnings.
- [X] Added appropriate tests for any new functionality.
- [X] All new and existing tests passed.
- [X] Added comments in the code, where necessary.
- [X] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes the "Provided by Gravatar" text so that it is centered under the profile avatar at all breakpoints.

**Which issue(s) this PR fixes:**
The position of the text caption under the current user's profile avatar was misaligned at different breakpoints, as seen in the provided before/after screenshots.

**Screenshots:**
Before:
<img src="https://user-images.githubusercontent.com/31386843/62712627-d16dbc80-b9c0-11e9-9b5f-d2c5a493bb2b.png" width="60%" alt="before"/>
<br>
After:
<img src="https://user-images.githubusercontent.com/31386843/62712513-99667980-b9c0-11e9-85fe-43c50809c489.png" width="60%" alt="after"/>