### PR TITLE
ui: fix 'optional' text align on escalation policy step form

### DIFF
--- a/web/src/app/escalation-policies/PolicyStepForm.js
+++ b/web/src/app/escalation-policies/PolicyStepForm.js
@@ -32,6 +32,7 @@ const styles = {
     backgroundColor: '#cd1831',
   },
   optional: {
+    float: 'left',
     textAlign: 'left',
   },
   label: {


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [X] Identified the issue which this PR solves.
- [X] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [X] Code builds clean without any errors or warnings.
- [X] Added appropriate tests for any new functionality.
- [X] All new and existing tests passed.
- [X] Added comments in the code, where necessary.
- [X] Ran `make check` to catch common errors. Fixed any that came up.

**Which issue(s) this PR fixes:**
This PR fixes the 'optional' text field on escalation policy step form so that it is left-aligned under the preceding text.

**Screenshots:**
Before:
<img src="https://user-images.githubusercontent.com/31386843/62716769-4ee8fb00-b9c8-11e9-9925-ba217bfe87f4.png" alt="before create" width="70%"/>
<img src="https://user-images.githubusercontent.com/31386843/62716925-91aad300-b9c8-11e9-869d-7aca6c118c90.png" alt="before edit" width="70%"/>
<hr/>
After:
<img src="https://user-images.githubusercontent.com/31386843/62716605-07fb0580-b9c8-11e9-96e8-0dbc9b5cd4a3.png" alt="after create" width="70%"/>
<img src="https://user-images.githubusercontent.com/31386843/62717112-eb130200-b9c8-11e9-8e75-fc41787b4107.png" alt="after edit" width="70%"/>
