### PR TITLE
ci: only add screenshots and videos to debug tgz

### DIFF
--- a/devtools/ci/tasks/scripts/test-integration.sh
+++ b/devtools/ci/tasks/scripts/test-integration.sh
@@ -17,7 +17,7 @@ then
   DEBUG_SUFFIX=mobile
 fi
 
-trap "tar czf ../../debug/debug-$(date +%Y%m%d%H%M%S)-$COMMIT-$DEBUG_SUFFIX.tgz -C .. goalert" EXIT
+trap "tar czf ../../debug/debug-$(date +%Y%m%d%H%M%S)-$COMMIT-$DEBUG_SUFFIX.tgz cypress/screenshots cypress/videos" EXIT
 
 mockslack \
   -client-id=000000000000.000000000000 \


### PR DESCRIPTION
<!-- Thank you for your contribution to Goalert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Update browser debug tgz files to only include screenshots and videos.
