### PR TITLE
cypress: more assertions for admin and page search tests

### DIFF
--- a/web/src/app/admin/AdminConfirmDialog.js
+++ b/web/src/app/admin/AdminConfirmDialog.js
@@ -72,7 +72,7 @@ export default class AdminConfirmDialog extends React.PureComponent {
         form={
           <List data-cy='confirmation-diff'>
             {changes.map(c => (
-              <ListItem divider key={c.id} data-cy={c.id}>
+              <ListItem divider key={c.id} data-cy={'diff-' + c.id}>
                 <ListItemText
                   disableTypography
                   secondary={

--- a/web/src/app/admin/AdminConfirmDialog.js
+++ b/web/src/app/admin/AdminConfirmDialog.js
@@ -70,9 +70,9 @@ export default class AdminConfirmDialog extends React.PureComponent {
           })),
         )}
         form={
-          <List>
+          <List data-cy='confirmation-diff'>
             {changes.map(c => (
-              <ListItem divider key={c.id}>
+              <ListItem divider key={c.id} data-cy={c.id}>
                 <ListItemText
                   disableTypography
                   secondary={

--- a/web/src/cypress/integration/admin.ts
+++ b/web/src/cypress/integration/admin.ts
@@ -32,27 +32,37 @@ function testAdmin(screen: ScreenFormat) {
       const newVal = 'http://' + c.domain()
       cy.get('input[name="General.PublicURL"]')
         .clear()
+        .should('be.empty')
         .type(newVal)
+        .should('have.value', newVal)
       cy.get('button[data-cy="save"]').click()
+
+      // save dialog
       cy.get('p[data-cy="old"]').should('contain', cfg.General.PublicURL)
       cy.get('p[data-cy="new"]').should('contain', newVal)
       cy.get('button[type="submit"]')
         .contains('Confirm')
         .click()
       cy.get('div[role="document"]').should('not.exist') // dialog should close
+
       cy.get('input[name="General.PublicURL"]').should('have.value', newVal)
     })
 
     it('should set a config value', () => {
       const newVal = c.domain()
-      cy.get('input[name="Mailgun.EmailDomain"]').type(newVal)
+      cy.get('input[name="Mailgun.EmailDomain"]')
+        .type(newVal)
+        .should('have.value', newVal)
       cy.get('button[data-cy="save"]').click()
+
+      // save dialog
       cy.get('p[data-cy="old"]').should('not.exist')
       cy.get('p[data-cy="new"]').should('contain', newVal)
       cy.get('button[type="submit"]')
         .contains('Confirm')
         .click()
       cy.get('div[role="document"]').should('not.exist') // dialog should close
+
       cy.get('input[name="Mailgun.EmailDomain"]').should('have.value', newVal)
     })
 
@@ -63,23 +73,31 @@ function testAdmin(screen: ScreenFormat) {
       cy.get('input[name="General.PublicURL"]')
         .clear()
         .type(newVal1)
-      cy.get('input[name="Mailgun.EmailDomain"]').type(newVal2)
+        .should('have.value', newVal1)
+      cy.get('input[name="Mailgun.EmailDomain"]')
+        .type(newVal2)
+        .should('have.value', newVal2)
       cy.get('button[data-cy="save"]').click()
 
+      // save dialog
       cy.get('li')
+        .should('be.visible')
         .contains('General.PublicURL')
         .siblings('p[data-cy="old"]')
         .should('contain', cfg.General.PublicURL)
       cy.get('li')
+        .should('be.visible')
         .contains('General.PublicURL')
         .siblings('p[data-cy="new"]')
         .should('contain', newVal1)
 
       cy.get('li')
+        .should('be.visible')
         .contains('Mailgun.EmailDomain')
         .siblings('p[data-cy="old"]')
         .should('not.exist') // not set in beforeEach
       cy.get('li')
+        .should('be.visible')
         .contains('Mailgun.EmailDomain')
         .siblings('p[data-cy="new"]')
         .should('contain', newVal2)
@@ -94,36 +112,62 @@ function testAdmin(screen: ScreenFormat) {
     })
 
     it('should delete a config value', () => {
-      cy.get('input[name="General.PublicURL"]').clear()
+      cy.get('input[name="General.PublicURL"]')
+        .clear()
+        .should('be.empty')
       cy.get('button[data-cy="save"]').click()
+
+      // save dialog
       cy.get('p[data-cy="old"]').should('contain', cfg.General.PublicURL)
       cy.get('p[data-cy="new"]').should('not.exist')
       cy.get('button[type="submit"]')
         .contains('Confirm')
         .click()
       cy.get('div[role="document"]').should('not.exist') // dialog should close
+
       cy.get('input[name="General.PublicURL"]').should('have.value', '')
     })
 
     it('should cancel changing a config value', () => {
       const newVal = c.domain()
+
       cy.get('input[name="General.PublicURL"]')
         .clear()
+        .should('be.empty')
         .type(newVal)
+        .should('have.value', newVal)
       cy.get('button[data-cy="save"]').click()
+
+      // save dialog
       cy.get('p[data-cy="old"]').should('contain', cfg.General.PublicURL)
       cy.get('p[data-cy="new"]').should('contain', newVal)
       cy.get('button[type="button"]')
         .contains('Cancel')
         .click()
       cy.get('div[role="document"]').should('not.exist') // dialog should close
+
+      // value typed in
+      cy.get('input[name="General.PublicURL"]').should('have.value', newVal)
+      // reload page
+      cy.reload()
+      // since cancelled, data should be the same as before
+      cy.get('input[name="General.PublicURL"]').should(
+        'have.value',
+        cfg.General.PublicURL,
+      )
     })
 
     it('should reset pending config value changes', () => {
+      const domain1 = c.domain()
+      const domain2 = c.domain()
       cy.get('input[name="General.PublicURL"]')
         .clear()
-        .type(c.domain())
-      cy.get('input[name="Mailgun.EmailDomain"]').type(c.domain())
+        .should('be.empty')
+        .type(domain1)
+        .should('have.value', domain1)
+      cy.get('input[name="Mailgun.EmailDomain"]')
+        .type(domain2)
+        .should('have.value', domain2)
 
       cy.get('button[data-cy="reset"]').click()
 
@@ -137,12 +181,15 @@ function testAdmin(screen: ScreenFormat) {
     it('should update a boolean toggle field', () => {
       cy.get('input[name="Twilio.Enable"]').click()
       cy.get('button[data-cy="save"]').click()
+
+      // save dialog
       cy.get('p[data-cy="old"]').should('contain', 'false')
       cy.get('p[data-cy="new"]').should('contain', 'true')
       cy.get('button[type="submit"]')
         .contains('Confirm')
         .click()
       cy.get('div[role="document"]').should('not.exist') // dialog should close
+
       cy.get('input[name="Twilio.Enable"]').should('have.value', 'true')
     })
 
@@ -153,16 +200,22 @@ function testAdmin(screen: ScreenFormat) {
 
       cy.get('input[name="Auth.RefererURLs-new-item"]')
         .clear()
+        .should('be.empty')
         .type(domain1)
+        .should('have.value', domain1)
       cy.get('input[name="Auth.RefererURLs-new-item"]')
         .clear()
+        .should('be.empty')
         .type(domain2)
+        .should('have.value', domain2)
       cy.get('input[name="Auth.RefererURLs-new-item"]')
         .clear()
+        .should('be.empty')
         .type(domain3)
-
+        .should('have.value', domain3)
       cy.get('button[data-cy="save"]').click()
-      // cy.get('p[data-cy="old"]').should('contain', url)
+
+      // save dialog
       cy.get('p[data-cy="new"]').should(
         'contain',
         domain1 + ', ' + domain2 + ', ' + domain3,
@@ -171,6 +224,7 @@ function testAdmin(screen: ScreenFormat) {
         .contains('Confirm')
         .click()
       cy.get('div[role="document"]').should('not.exist') // dialog should close
+
       cy.get('input[name="Auth.RefererURLs-0"]').should('have.value', domain1)
       cy.get('input[name="Auth.RefererURLs-1"]').should('have.value', domain2)
       cy.get('input[name="Auth.RefererURLs-2"]').should('have.value', domain3)
@@ -181,14 +235,19 @@ function testAdmin(screen: ScreenFormat) {
       const newKey = 'key-' + c.string({ length: 32, pool: '0123456789abcdef' })
       cy.get('input[name="Mailgun.APIKey"]')
         .clear()
+        .should('be.empty')
         .type(newKey)
+        .should('have.value', newKey)
       cy.get('button[data-cy="save"]').click()
+
+      // save dialog
       cy.get('p[data-cy="old"]').should('contain', cfg.Mailgun.APIKey)
       cy.get('p[data-cy="new"]').should('contain', newKey)
       cy.get('button[type="submit"]')
         .contains('Confirm')
         .click()
       cy.get('div[role="document"]').should('not.exist') // dialog should close
+
       cy.get('input[name="Mailgun.APIKey"]').should('have.value', newKey)
     })
   })

--- a/web/src/cypress/integration/admin.ts
+++ b/web/src/cypress/integration/admin.ts
@@ -40,7 +40,7 @@ function testAdmin(screen: ScreenFormat) {
 
       // save dialog
       cy.get(
-        'ul[data-cy="confirmation-diff"] li[data-cy="General.PublicURL"] p[data-cy="old"]',
+        'ul[data-cy="confirmation-diff"] li[data-cy="diff-General.PublicURL"] p[data-cy="old"]',
       )
         .should('contain', cfg.General.PublicURL)
         .siblings('p[data-cy="new"]')
@@ -63,10 +63,10 @@ function testAdmin(screen: ScreenFormat) {
 
       // save dialog
       cy.get(
-        'ul[data-cy="confirmation-diff"] li[data-cy="Mailgun.EmailDomain"] p[data-cy="old"]',
+        'ul[data-cy="confirmation-diff"] li[data-cy="diff-Mailgun.EmailDomain"] p[data-cy="old"]',
       ).should('not.exist')
       cy.get(
-        'ul[data-cy="confirmation-diff"] li[data-cy="Mailgun.EmailDomain"] p[data-cy="new"]',
+        'ul[data-cy="confirmation-diff"] li[data-cy="diff-Mailgun.EmailDomain"] p[data-cy="new"]',
       ).should('contain', newVal)
       cy.get('button[type="submit"]')
         .contains('Confirm')
@@ -91,18 +91,18 @@ function testAdmin(screen: ScreenFormat) {
 
       // save dialog
       cy.get(
-        'ul[data-cy="confirmation-diff"] li[data-cy="General.PublicURL"] p[data-cy="old"]',
+        'ul[data-cy="confirmation-diff"] li[data-cy="diff-General.PublicURL"] p[data-cy="old"]',
       )
         .should('contain', cfg.General.PublicURL)
         .siblings('p[data-cy="new"]')
         .should('contain', newVal1)
 
       cy.get(
-        'ul[data-cy="confirmation-diff"] li[data-cy="Mailgun.EmailDomain"] p[data-cy="old"]',
+        'ul[data-cy="confirmation-diff"] li[data-cy="diff-Mailgun.EmailDomain"] p[data-cy="old"]',
       ).should('not.exist') // not set in beforeEach
 
       cy.get(
-        'ul[data-cy="confirmation-diff"] li[data-cy="Mailgun.EmailDomain"] p[data-cy="new"]',
+        'ul[data-cy="confirmation-diff"] li[data-cy="diff-Mailgun.EmailDomain"] p[data-cy="new"]',
       ).should('contain', newVal2)
 
       cy.get('button[type="submit"]')
@@ -122,7 +122,7 @@ function testAdmin(screen: ScreenFormat) {
 
       // save dialog
       cy.get(
-        'ul[data-cy="confirmation-diff"] li[data-cy="General.PublicURL"] p[data-cy="old"]',
+        'ul[data-cy="confirmation-diff"] li[data-cy="diff-General.PublicURL"] p[data-cy="old"]',
       )
         .should('contain', cfg.General.PublicURL)
         .siblings('p[data-cy="new"]')
@@ -147,7 +147,7 @@ function testAdmin(screen: ScreenFormat) {
 
       // save dialog
       cy.get(
-        'ul[data-cy="confirmation-diff"] li[data-cy="General.PublicURL"] p[data-cy="old"]',
+        'ul[data-cy="confirmation-diff"] li[data-cy="diff-General.PublicURL"] p[data-cy="old"]',
       )
         .should('contain', cfg.General.PublicURL)
         .siblings('p[data-cy="new"]')
@@ -196,7 +196,7 @@ function testAdmin(screen: ScreenFormat) {
 
       // save dialog
       cy.get(
-        'ul[data-cy="confirmation-diff"] li[data-cy="Twilio.Enable"] p[data-cy="old"]',
+        'ul[data-cy="confirmation-diff"] li[data-cy="diff-Twilio.Enable"] p[data-cy="old"]',
       )
         .should('contain', 'false')
         .siblings('p[data-cy="new"]')
@@ -233,10 +233,10 @@ function testAdmin(screen: ScreenFormat) {
 
       // save dialog
       cy.get(
-        'ul[data-cy="confirmation-diff"] li[data-cy="Auth.RefererURLs"] p[data-cy="old"]',
+        'ul[data-cy="confirmation-diff"] li[data-cy="diff-Auth.RefererURLs"] p[data-cy="old"]',
       ).should('not.exist')
       cy.get(
-        'ul[data-cy="confirmation-diff"] li[data-cy="Auth.RefererURLs"] p[data-cy="new"]',
+        'ul[data-cy="confirmation-diff"] li[data-cy="diff-Auth.RefererURLs"] p[data-cy="new"]',
       ).should('contain', `${domain1}, ${domain2}, ${domain3}`)
       cy.get('button[type="submit"]')
         .contains('Confirm')
@@ -261,7 +261,7 @@ function testAdmin(screen: ScreenFormat) {
 
       // save dialog
       cy.get(
-        'ul[data-cy="confirmation-diff"] li[data-cy="Mailgun.APIKey"] p[data-cy="old"]',
+        'ul[data-cy="confirmation-diff"] li[data-cy="diff-Mailgun.APIKey"] p[data-cy="old"]',
       )
         .should('contain', cfg.Mailgun.APIKey)
         .siblings('p[data-cy="new"]')

--- a/web/src/cypress/integration/admin.ts
+++ b/web/src/cypress/integration/admin.ts
@@ -39,8 +39,12 @@ function testAdmin(screen: ScreenFormat) {
       cy.get('button[data-cy="save"]').click()
 
       // save dialog
-      cy.get('p[data-cy="old"]').should('contain', cfg.General.PublicURL)
-      cy.get('p[data-cy="new"]').should('contain', newVal)
+      cy.get(
+        'ul[data-cy="confirmation-diff"] li[data-cy="General.PublicURL"] p[data-cy="old"]',
+      )
+        .should('contain', cfg.General.PublicURL)
+        .siblings('p[data-cy="new"]')
+        .should('contain', newVal)
       cy.get('button[type="submit"]')
         .contains('Confirm')
         .click()
@@ -58,8 +62,12 @@ function testAdmin(screen: ScreenFormat) {
       cy.get('button[data-cy="save"]').click()
 
       // save dialog
-      cy.get('p[data-cy="old"]').should('not.exist')
-      cy.get('p[data-cy="new"]').should('contain', newVal)
+      cy.get(
+        'ul[data-cy="confirmation-diff"] li[data-cy="Mailgun.EmailDomain"] p[data-cy="old"]',
+      ).should('not.exist')
+      cy.get(
+        'ul[data-cy="confirmation-diff"] li[data-cy="Mailgun.EmailDomain"] p[data-cy="new"]',
+      ).should('contain', newVal)
       cy.get('button[type="submit"]')
         .contains('Confirm')
         .click()
@@ -82,27 +90,20 @@ function testAdmin(screen: ScreenFormat) {
       cy.get('button[data-cy="save"]').click()
 
       // save dialog
-      cy.get('li')
-        .should('be.visible')
-        .contains('General.PublicURL')
-        .siblings('p[data-cy="old"]')
+      cy.get(
+        'ul[data-cy="confirmation-diff"] li[data-cy="General.PublicURL"] p[data-cy="old"]',
+      )
         .should('contain', cfg.General.PublicURL)
-      cy.get('li')
-        .should('be.visible')
-        .contains('General.PublicURL')
         .siblings('p[data-cy="new"]')
         .should('contain', newVal1)
 
-      cy.get('li')
-        .should('be.visible')
-        .contains('Mailgun.EmailDomain')
-        .siblings('p[data-cy="old"]')
-        .should('not.exist') // not set in beforeEach
-      cy.get('li')
-        .should('be.visible')
-        .contains('Mailgun.EmailDomain')
-        .siblings('p[data-cy="new"]')
-        .should('contain', newVal2)
+      cy.get(
+        'ul[data-cy="confirmation-diff"] li[data-cy="Mailgun.EmailDomain"] p[data-cy="old"]',
+      ).should('not.exist') // not set in beforeEach
+
+      cy.get(
+        'ul[data-cy="confirmation-diff"] li[data-cy="Mailgun.EmailDomain"] p[data-cy="new"]',
+      ).should('contain', newVal2)
 
       cy.get('button[type="submit"]')
         .contains('Confirm')
@@ -120,8 +121,12 @@ function testAdmin(screen: ScreenFormat) {
       cy.get('button[data-cy="save"]').click()
 
       // save dialog
-      cy.get('p[data-cy="old"]').should('contain', cfg.General.PublicURL)
-      cy.get('p[data-cy="new"]').should('not.exist')
+      cy.get(
+        'ul[data-cy="confirmation-diff"] li[data-cy="General.PublicURL"] p[data-cy="old"]',
+      )
+        .should('contain', cfg.General.PublicURL)
+        .siblings('p[data-cy="new"]')
+        .should('not.exist')
       cy.get('button[type="submit"]')
         .contains('Confirm')
         .click()
@@ -141,8 +146,12 @@ function testAdmin(screen: ScreenFormat) {
       cy.get('button[data-cy="save"]').click()
 
       // save dialog
-      cy.get('p[data-cy="old"]').should('contain', cfg.General.PublicURL)
-      cy.get('p[data-cy="new"]').should('contain', newVal)
+      cy.get(
+        'ul[data-cy="confirmation-diff"] li[data-cy="General.PublicURL"] p[data-cy="old"]',
+      )
+        .should('contain', cfg.General.PublicURL)
+        .siblings('p[data-cy="new"]')
+        .should('contain', newVal)
       cy.get('button[type="button"]')
         .contains('Cancel')
         .click()
@@ -186,8 +195,12 @@ function testAdmin(screen: ScreenFormat) {
       cy.get('button[data-cy="save"]').click()
 
       // save dialog
-      cy.get('p[data-cy="old"]').should('contain', 'false')
-      cy.get('p[data-cy="new"]').should('contain', 'true')
+      cy.get(
+        'ul[data-cy="confirmation-diff"] li[data-cy="Twilio.Enable"] p[data-cy="old"]',
+      )
+        .should('contain', 'false')
+        .siblings('p[data-cy="new"]')
+        .should('contain', 'true')
       cy.get('button[type="submit"]')
         .contains('Confirm')
         .click()
@@ -219,10 +232,12 @@ function testAdmin(screen: ScreenFormat) {
       cy.get('button[data-cy="save"]').click()
 
       // save dialog
-      cy.get('p[data-cy="new"]').should(
-        'contain',
-        domain1 + ', ' + domain2 + ', ' + domain3,
-      )
+      cy.get(
+        'ul[data-cy="confirmation-diff"] li[data-cy="Auth.RefererURLs"] p[data-cy="old"]',
+      ).should('not.exist')
+      cy.get(
+        'ul[data-cy="confirmation-diff"] li[data-cy="Auth.RefererURLs"] p[data-cy="new"]',
+      ).should('contain', `${domain1}, ${domain2}, ${domain3}`)
       cy.get('button[type="submit"]')
         .contains('Confirm')
         .click()
@@ -245,8 +260,12 @@ function testAdmin(screen: ScreenFormat) {
       cy.get('button[data-cy="save"]').click()
 
       // save dialog
-      cy.get('p[data-cy="old"]').should('contain', cfg.Mailgun.APIKey)
-      cy.get('p[data-cy="new"]').should('contain', newKey)
+      cy.get(
+        'ul[data-cy="confirmation-diff"] li[data-cy="Mailgun.APIKey"] p[data-cy="old"]',
+      )
+        .should('contain', cfg.Mailgun.APIKey)
+        .siblings('p[data-cy="new"]')
+        .should('contain', newKey)
       cy.get('button[type="submit"]')
         .contains('Confirm')
         .click()

--- a/web/src/cypress/integration/admin.ts
+++ b/web/src/cypress/integration/admin.ts
@@ -30,6 +30,7 @@ function testAdmin(screen: ScreenFormat) {
 
     it('should update a config value', () => {
       const newVal = 'http://' + c.domain()
+
       cy.get('input[name="General.PublicURL"]')
         .clear()
         .should('be.empty')
@@ -50,6 +51,7 @@ function testAdmin(screen: ScreenFormat) {
 
     it('should set a config value', () => {
       const newVal = c.domain()
+
       cy.get('input[name="Mailgun.EmailDomain"]')
         .type(newVal)
         .should('have.value', newVal)
@@ -160,6 +162,7 @@ function testAdmin(screen: ScreenFormat) {
     it('should reset pending config value changes', () => {
       const domain1 = c.domain()
       const domain2 = c.domain()
+
       cy.get('input[name="General.PublicURL"]')
         .clear()
         .should('be.empty')
@@ -233,6 +236,7 @@ function testAdmin(screen: ScreenFormat) {
 
     it('should update a password field', () => {
       const newKey = 'key-' + c.string({ length: 32, pool: '0123456789abcdef' })
+
       cy.get('input[name="Mailgun.APIKey"]')
         .clear()
         .should('be.empty')

--- a/web/src/cypress/support/page-search.ts
+++ b/web/src/cypress/support/page-search.ts
@@ -16,7 +16,9 @@ function pageSearch(s: string): Cypress.Chainable {
       }) // since we're running tests, it's ok if it is already open
     }
 
-    cy.get('[data-cy=app-bar] input').type(`{selectall}${s}`)
+    cy.get('[data-cy=app-bar] input')
+      .type(`{selectall}${s}`)
+      .should('have.value', s)
   })
 }
 

--- a/web/src/cypress/support/page-search.ts
+++ b/web/src/cypress/support/page-search.ts
@@ -6,21 +6,17 @@ declare namespace Cypress {
 }
 
 function pageSearch(s: string): Cypress.Chainable {
-  cy.get('[data-cy=app-bar]').as('container')
-
-  return cy.get('@container').then(el => {
+  return cy.get('[data-cy=app-bar]').then(el => {
     const format: 'mobile' | 'wide' = el.data('cy-format')
     expect(format, 'header format').to.be.oneOf(['mobile', 'wide'])
 
     if (format === 'mobile') {
-      cy.get('@container')
-        .find('button[data-cy=open-search]')
-        .click({ force: true }) // since we're running tests, it's ok if it is already open
+      cy.get('[data-cy=app-bar] button[data-cy=open-search]').click({
+        force: true,
+      }) // since we're running tests, it's ok if it is already open
     }
 
-    cy.get('@container')
-      .find('input')
-      .type(`{selectall}${s}{enter}`)
+    cy.get('[data-cy=app-bar] input').type(`{selectall}${s}`)
   })
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adds more assertions (e.g. `cy.get('x').should('have.value', val)`) such that retry logic is hardened as cypress navigates throughout the page.