### PR TITLE
heartbeat: adjust heartbeat endpoint to only allow POST requests

### DIFF
--- a/genericapi/handler.go
+++ b/genericapi/handler.go
@@ -47,6 +47,10 @@ func (h *Handler) ServeUserAvatar(w http.ResponseWriter, req *http.Request) {
 // ServeHeartbeatCheck serves the heartbeat check-in endpoint.
 func (h *Handler) ServeHeartbeatCheck(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	if r.Method != "POST" {
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
 
 	parts := strings.Split(r.URL.Path, "/")
 	monitorID := parts[len(parts)-1]


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Our heartbeat endpoint was allowing all HTTP methods on `/api/v2/heartbeat/` -- this change is to enforce allowing `POST` requests only.  If request method is not `POST`, client will receive a `HTTP 405 Method Not Allowed` status code as response.