### PR TITLE
ui: add href to ChevronRight button on details pages

### DIFF
--- a/web/src/app/details/DetailsPage.js
+++ b/web/src/app/details/DetailsPage.js
@@ -91,7 +91,7 @@ export default class DetailsPage extends React.PureComponent {
           primaryTypographyProps={{ variant: 'h5' }}
         />
         <ListItemSecondaryAction>
-          <IconButton>
+          <IconButton component={Link} to={absURL(url)}>
             <ChevronRight />
           </IconButton>
         </ListItemSecondaryAction>


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Adds link / href to the `ChevronRight` icon that is displayed on Details Pages.  Currently, clicking directly on this button doesn't actually do anything.
