### PR TITLE
apollo: add old client to serviceAlerts

### DIFF
--- a/web/src/app/dialogs/components/ConfirmationDialog.js
+++ b/web/src/app/dialogs/components/ConfirmationDialog.js
@@ -11,6 +11,7 @@ import LoadingButton from '../../loading/components/LoadingButton'
 import { styles } from '../../styles/materialStyles'
 import DialogContentError from './DialogContentError'
 import { Mutation } from 'react-apollo'
+import { LegacyGraphQLClient } from '../../apollo'
 
 @withStyles(styles)
 export default class ConfirmationDialog extends Component {
@@ -98,6 +99,7 @@ export default class ConfirmationDialog extends Component {
       <Mutation
         key='mutation-form'
         mutation={mutation}
+        client={LegacyGraphQLClient}
         refetchQueries={this.props.refetchQueries}
         update={(cache, { data }) => {
           this.setState({ loading: false })


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adds the old client to ack all/close all functionality for service alerts.


