### PR TITLE
services: convert ServiceDeleteDialog to hooks

### DIFF
--- a/web/src/app/services/ServiceDeleteDialog.js
+++ b/web/src/app/services/ServiceDeleteDialog.js
@@ -62,14 +62,18 @@ export default function ServiceDeleteDialog({ serviceID, onClose }) {
   })
   const input = [{ type: 'service', id: serviceID }]
   const dispatch = useDispatch()
+  const refetch = ['servicesQuery']
   const [deleteService, { loading, error }] = useMutation(mutation, {
     variables: { input },
+    awaitRefetchQueries: true,
+    refetchQueries: refetch,
     onCompleted: () => dispatch(push('/services')),
   })
 
   if (dataLoading) return <Spinner />
 
   if (deleteEP) {
+    refetch.push('epsQuery')
     input.push({
       type: 'escalationPolicy',
       id: data.service.escalationPolicyID,

--- a/web/src/app/services/ServiceDeleteDialog.js
+++ b/web/src/app/services/ServiceDeleteDialog.js
@@ -1,43 +1,39 @@
-import React from 'react'
+import React, { useState } from 'react'
 import p from 'prop-types'
-
+import { useDispatch } from 'react-redux'
 import gql from 'graphql-tag'
-import { Mutation } from 'react-apollo'
+import { useQuery, useMutation } from 'react-apollo'
 import { fieldErrors, nonFieldErrors } from '../util/errutil'
 import Checkbox from '@material-ui/core/Checkbox'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import FormControl from '@material-ui/core/FormControl'
 import FormHelperText from '@material-ui/core/FormHelperText'
-import { Redirect } from 'react-router-dom'
-import Query from '../util/Query'
-
 import FormDialog from '../dialogs/FormDialog'
+import Spinner from '../loading/components/Spinner'
+import { push } from 'connected-react-router'
 
-class DeleteForm extends React.PureComponent {
-  static propTypes = {
-    epName: p.string.isRequired,
-    error: p.string,
-    value: p.bool,
-    onChange: p.func.isRequired,
-  }
-
-  render() {
-    return (
-      <FormControl error={Boolean(this.props.error)} style={{ width: '100%' }}>
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={this.props.value}
-              onChange={e => this.props.onChange(e.target.checked)}
-              value='delete-escalation-policy'
-            />
-          }
-          label={`Also delete escalation policy: ${this.props.epName}`}
-        />
-        <FormHelperText>{this.props.error}</FormHelperText>
-      </FormControl>
-    )
-  }
+function DeleteForm({ epName, error, value, onChange }) {
+  return (
+    <FormControl error={Boolean(error)} style={{ width: '100%' }}>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={value}
+            onChange={e => onChange(e.target.checked)}
+            value='delete-escalation-policy'
+          />
+        }
+        label={`Also delete escalation policy: ${epName}`}
+      />
+      <FormHelperText>{error}</FormHelperText>
+    </FormControl>
+  )
+}
+DeleteForm.propTypes = {
+  epName: p.string.isRequired,
+  error: p.string,
+  value: p.bool,
+  onChange: p.func.isRequired,
 }
 
 const query = gql`
@@ -59,85 +55,52 @@ const mutation = gql`
   }
 `
 
-export default class ServiceDeleteDialog extends React.PureComponent {
-  static propTypes = {
-    serviceID: p.string.isRequired,
-    onClose: p.func,
+export default function ServiceDeleteDialog({ serviceID, onClose }) {
+  const [deleteEP, setDeleteEP] = useState(true)
+  const { data, loading: dataLoading } = useQuery(query, {
+    variables: { id: serviceID },
+  })
+  const input = [{ type: 'service', id: serviceID }]
+  const dispatch = useDispatch()
+  const [deleteService, { loading, error }] = useMutation(mutation, {
+    variables: { input },
+    onCompleted: () => dispatch(push('/services')),
+  })
+
+  if (dataLoading) return <Spinner />
+
+  if (deleteEP) {
+    input.push({
+      type: 'escalationPolicy',
+      id: data.service.escalationPolicyID,
+    })
   }
 
-  state = {
-    deleteEP: true,
-  }
-
-  renderQuery() {
-    return (
-      <Query
-        noPoll
-        query={query}
-        variables={{ id: this.props.serviceID }}
-        render={({ data }) => this.renderMutation(data.service)}
-      />
-    )
-  }
-
-  renderMutation(svcData) {
-    return (
-      <Mutation mutation={mutation}>
-        {(commit, status) => this.renderDialog(svcData, commit, status)}
-      </Mutation>
-    )
-  }
-
-  renderDialog = (svcData, commit, mutStatus) => {
-    const { loading, error, data } = mutStatus
-    if (data && data.deleteAll) {
-      return <Redirect push to={`/services`} />
-    }
-
-    return (
-      <FormDialog
-        title='Are you sure?'
-        confirm
-        subTitle={`This will delete the service: ${svcData.name}`}
-        caption='Deleting a service will also delete all associated integration keys and alerts.'
-        loading={loading}
-        errors={nonFieldErrors(error)}
-        onClose={this.props.onClose}
-        onSubmit={() => {
-          const input = [
-            {
-              type: 'service',
-              id: this.props.serviceID,
-            },
-          ]
-          if (this.state.deleteEP) {
-            input.push({
-              type: 'escalationPolicy',
-              id: svcData.escalationPolicyID,
-            })
+  return (
+    <FormDialog
+      title='Are you sure?'
+      confirm
+      subTitle={`This will delete the service: ${data.service.name}`}
+      caption='Deleting a service will also delete all associated integration keys and alerts.'
+      loading={loading}
+      errors={nonFieldErrors(error)}
+      onClose={onClose}
+      onSubmit={() => deleteService()}
+      form={
+        <DeleteForm
+          epName={data.service.escalationPolicy.name}
+          error={
+            fieldErrors(error).find(f => f.field === 'escalationPolicyID') &&
+            'Escalation policy is currently in use.'
           }
-          return commit({
-            variables: {
-              input,
-            },
-          })
-        }}
-        form={
-          <DeleteForm
-            epName={svcData.escalationPolicy.name}
-            error={
-              fieldErrors(error).find(f => f.field === 'escalationPolicyID') &&
-              'Escalation policy is currently in use.'
-            }
-            onChange={deleteEP => this.setState({ deleteEP })}
-            value={this.state.deleteEP}
-          />
-        }
-      />
-    )
-  }
-
-  render() {
-    return this.renderQuery()
-  }
+          onChange={deleteEP => setDeleteEP(deleteEP)}
+          value={deleteEP}
+        />
+      }
+    />
+  )
+}
+ServiceDeleteDialog.propTypes = {
+  serviceID: p.string.isRequired,
+  onClose: p.func,
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Converts the `ServiceDeleteDialog` to hooks

- Fixes a race condition where deleting a service results in a not-found page instead of redirecting to the list page.