### PR TITLE
apollo: set default options

### DIFF
--- a/web/src/app/admin/AdminConfirmDialog.js
+++ b/web/src/app/admin/AdminConfirmDialog.js
@@ -30,7 +30,6 @@ export default class AdminConfirmDialog extends React.PureComponent {
       <Mutation
         mutation={mutation}
         onCompleted={this.props.onComplete}
-        awaitRefetchQueries
         refetchQueries={['getConfig']}
       >
         {(commit, status) => this.renderConfirm(commit, status)}

--- a/web/src/app/apollo.js
+++ b/web/src/app/apollo.js
@@ -8,6 +8,7 @@ import { toIdValue } from 'apollo-utilities'
 import { authLogout } from './actions'
 
 import reduxStore from './reduxStore'
+import { POLL_INTERVAL } from './config'
 
 let pendingMutations = 0
 window.onbeforeunload = function(e) {
@@ -132,4 +133,8 @@ cache = new InMemoryCache({
 export const GraphQLClient = new ApolloClient({
   link: graphql2Link,
   cache,
+  defaultOptions: {
+    query: { fetchPolicy: 'cache-and-network', pollInterval: POLL_INTERVAL },
+    mutate: { awaitRefetchQueries: true },
+  },
 })

--- a/web/src/app/apollo.js
+++ b/web/src/app/apollo.js
@@ -130,11 +130,16 @@ cache = new InMemoryCache({
   },
 })
 
+const queryOpts = { fetchPolicy: 'cache-and-network' }
+if (new URLSearchParams(location.search).get('poll') !== '0') {
+  queryOpts.pollInterval = POLL_INTERVAL
+}
+
 export const GraphQLClient = new ApolloClient({
   link: graphql2Link,
   cache,
   defaultOptions: {
-    query: { fetchPolicy: 'cache-and-network', pollInterval: POLL_INTERVAL },
+    query: queryOpts,
     mutate: { awaitRefetchQueries: true },
   },
 })

--- a/web/src/app/escalation-policies/PolicyDeleteDialog.js
+++ b/web/src/app/escalation-policies/PolicyDeleteDialog.js
@@ -15,7 +15,6 @@ const mutation = gql`
 export default function PolicyDeleteDialog(props) {
   const dispatch = useDispatch()
   const [deletePolicy, deletePolicyStatus] = useMutation(mutation, {
-    awaitRefetchQueries: true,
     refetchQueries: ['epsQuery'],
     variables: {
       input: [

--- a/web/src/app/escalation-policies/PolicyEditDialog.js
+++ b/web/src/app/escalation-policies/PolicyEditDialog.js
@@ -40,7 +40,6 @@ export default class PolicyEditDialog extends PureComponent {
       <Mutation
         mutation={mutation}
         onCompleted={this.props.onClose}
-        awaitRefetchQueries
         refetchQueries={() => [
           {
             query,

--- a/web/src/app/escalation-policies/PolicyStepCreateDialog.js
+++ b/web/src/app/escalation-policies/PolicyStepCreateDialog.js
@@ -112,7 +112,6 @@ export default class PolicyStepCreateDialog extends React.Component {
     return (
       <Mutation
         mutation={mutation}
-        awaitRefetchQueries
         refetchQueries={() => [
           {
             query: refetchQuery,

--- a/web/src/app/escalation-policies/PolicyStepEditDialog.js
+++ b/web/src/app/escalation-policies/PolicyStepEditDialog.js
@@ -98,7 +98,6 @@ export default class PolicyStepEditDialog extends React.Component {
     return (
       <Mutation
         mutation={mutation}
-        awaitRefetchQueries
         refetchQueries={() => ['stepsQuery']}
         onCompleted={this.props.onClose}
       >

--- a/web/src/app/rotations/RotationAddUserDialog.js
+++ b/web/src/app/rotations/RotationAddUserDialog.js
@@ -30,11 +30,7 @@ export default class RotationAddUserDialog extends React.Component {
     }
 
     return (
-      <Mutation
-        mutation={mutation}
-        awaitRefetchQueries
-        refetchQueries={() => ['rotationUsers']}
-      >
+      <Mutation mutation={mutation} refetchQueries={() => ['rotationUsers']}>
         {(commit, status) => this.renderDialog(defaultValue, commit, status)}
       </Mutation>
     )

--- a/web/src/app/rotations/RotationEditDialog.js
+++ b/web/src/app/rotations/RotationEditDialog.js
@@ -53,7 +53,6 @@ export default class RotationEditDialog extends React.PureComponent {
       <Mutation
         mutation={mutation}
         onCompleted={this.props.onClose}
-        awaitRefetchQueries
         refetchQueries={['rotationDetails']}
       >
         {(...args) => this.renderForm(data, ...args)}

--- a/web/src/app/rotations/RotationSetActiveDialog.js
+++ b/web/src/app/rotations/RotationSetActiveDialog.js
@@ -45,7 +45,6 @@ export default class RotationSetActiveDialog extends React.PureComponent {
       <Mutation
         mutation={mutation}
         onCompleted={this.props.onClose}
-        awaitRefetchQueries
         refetchQueries={['rotationDetails']}
       >
         {commit => this.renderDialog(data, commit)}

--- a/web/src/app/rotations/RotationUserDeleteDialog.js
+++ b/web/src/app/rotations/RotationUserDeleteDialog.js
@@ -46,7 +46,6 @@ export default class RotationUserDeleteDialog extends React.PureComponent {
       <Mutation
         mutation={mutation}
         onCompleted={this.props.onClose}
-        awaitRefetchQueries
         refetchQueries={['rotationUsers']}
       >
         {commit => this.renderDialog(data, commit)}

--- a/web/src/app/schedules/ScheduleEditDialog.js
+++ b/web/src/app/schedules/ScheduleEditDialog.js
@@ -45,7 +45,6 @@ export default class ScheduleEditDialog extends React.PureComponent {
     return (
       <Mutation
         mutation={mutation}
-        awaitRefetchQueries
         onCompleted={this.props.onClose}
         refetchQueries={() => [
           {

--- a/web/src/app/schedules/ScheduleOverrideCreateDialog.js
+++ b/web/src/app/schedules/ScheduleOverrideCreateDialog.js
@@ -79,7 +79,6 @@ export default class ScheduleOverrideCreateDialog extends React.PureComponent {
           'scheduleCalendarShifts',
           'scheduleOverrides',
         ]}
-        awaitRefetchQueries
       >
         {this.renderDialog}
       </Mutation>

--- a/web/src/app/schedules/ScheduleOverrideDeleteDialog.js
+++ b/web/src/app/schedules/ScheduleOverrideDeleteDialog.js
@@ -59,7 +59,6 @@ export default class ScheduleOverrideDeleteDialog extends React.PureComponent {
         mutation={mutation}
         onCompleted={this.props.onClose}
         refetchQueries={['scheduleOverrides']}
-        awaitRefetchQueries
       >
         {(commit, status) => this.renderDialog(data, commit, status)}
       </Mutation>

--- a/web/src/app/schedules/ScheduleOverrideEditDialog.js
+++ b/web/src/app/schedules/ScheduleOverrideEditDialog.js
@@ -58,7 +58,6 @@ export default class ScheduleOverrideEditDialog extends React.PureComponent {
         mutation={mutation}
         onCompleted={this.props.onClose}
         refetchQueries={['scheduleShifts', 'scheduleOverrides']}
-        awaitRefetchQueries
       >
         {(commit, status) => this.renderDialog(data, commit, status)}
       </Mutation>

--- a/web/src/app/schedules/ScheduleRuleCreateDialog.js
+++ b/web/src/app/schedules/ScheduleRuleCreateDialog.js
@@ -38,7 +38,6 @@ export default class ScheduleRuleCreateDialog extends React.PureComponent {
         mutation={mutation}
         onCompleted={this.props.onClose}
         refetchQueries={['scheduleRules']}
-        awaitRefetchQueries
       >
         {this.renderDialog}
       </Mutation>

--- a/web/src/app/schedules/ScheduleRuleDeleteDialog.js
+++ b/web/src/app/schedules/ScheduleRuleDeleteDialog.js
@@ -55,7 +55,6 @@ export default class ScheduleRuleDeleteDialog extends React.PureComponent {
         mutation={mutation}
         onCompleted={this.props.onClose}
         refetchQueries={['scheduleRules']}
-        awaitRefetchQueries
       >
         {(commit, status) => this.renderDialog(data, commit, status)}
       </Mutation>

--- a/web/src/app/schedules/ScheduleRuleEditDialog.js
+++ b/web/src/app/schedules/ScheduleRuleEditDialog.js
@@ -67,7 +67,6 @@ export default class ScheduleRuleEditDialog extends React.Component {
         mutation={mutation}
         onCompleted={this.props.onClose}
         refetchQueries={['scheduleRules']}
-        awaitRefetchQueries
       >
         {(commit, status) => this.renderDialog(data, commit, status)}
       </Mutation>

--- a/web/src/app/services/HeartbeatMonitorCreateDialog.js
+++ b/web/src/app/services/HeartbeatMonitorCreateDialog.js
@@ -20,7 +20,6 @@ export default function HeartbeatMonitorCreateDialog(props) {
   const [value, setValue] = useState({ name: '', timeoutMinutes: 15 })
   const [createHeartbeat, { loading, error }] = useMutation(createMutation, {
     refetchQueries: props.refetchQueries,
-    awaitRefetchQueries: true,
     variables: {
       input: {
         name: value.name,

--- a/web/src/app/services/HeartbeatMonitorDeleteDialog.js
+++ b/web/src/app/services/HeartbeatMonitorDeleteDialog.js
@@ -24,7 +24,6 @@ const mutation = gql`
 export default function HeartbeatMonitorDeleteDialog(props) {
   const [deleteHeartbeat, { loading, error }] = useMutation(mutation, {
     refetchQueries: props.refetchQueries,
-    awaitRefetchQueries: true,
     variables: { id: props.monitorID },
   })
 

--- a/web/src/app/services/HeartbeatMonitorEditDialog.js
+++ b/web/src/app/services/HeartbeatMonitorEditDialog.js
@@ -51,7 +51,6 @@ function HeartbeatMonitorEditDialogContent({ props, data }) {
   })
   const [update, { loading, error }] = useMutation(mutation, {
     refetchQueries: props.refetchQueries,
-    awaitRefetchQueries: Boolean(props.refetchQueries),
     onCompleted: props.onClose,
     variables: {
       input: { id: props.monitorID, ...value },

--- a/web/src/app/services/ServiceDeleteDialog.js
+++ b/web/src/app/services/ServiceDeleteDialog.js
@@ -65,7 +65,6 @@ export default function ServiceDeleteDialog({ serviceID, onClose }) {
   const refetch = ['servicesQuery']
   const [deleteService, { loading, error }] = useMutation(mutation, {
     variables: { input },
-    awaitRefetchQueries: true,
     refetchQueries: refetch,
     onCompleted: () => dispatch(push('/services')),
   })

--- a/web/src/app/services/ServiceEditDialog.js
+++ b/web/src/app/services/ServiceEditDialog.js
@@ -65,7 +65,6 @@ export default class ServiceEditDialog extends React.PureComponent {
       <Mutation
         mutation={mutation}
         onCompleted={this.props.onClose}
-        awaitRefetchQueries
         refetchQueries={() => [
           {
             query,

--- a/web/src/app/users/UserContactMethodCreateDialog.js
+++ b/web/src/app/users/UserContactMethodCreateDialog.js
@@ -26,7 +26,6 @@ export default function UserContactMethodCreateDialog(props) {
 
   const [createCM, createCMStatus] = useMutation(createMutation, {
     refetchQueries: ['nrList', 'cmList'],
-    awaitRefetchQueries: true,
     onCompleted: result => {
       props.onClose({ contactMethodID: result.createUserContactMethod.id })
     },

--- a/web/src/app/users/UserContactMethodDeleteDialog.js
+++ b/web/src/app/users/UserContactMethodDeleteDialog.js
@@ -21,7 +21,6 @@ export default class UserContactMethodDeleteDialog extends React.PureComponent {
       <Mutation
         mutation={mutation}
         onCompleted={this.props.onClose}
-        awaitRefetchQueries
         refetchQueries={['nrList', 'cmList']}
       >
         {(commit, status) => this.renderDialog(commit, status)}

--- a/web/src/app/users/UserContactMethodEditDialog.js
+++ b/web/src/app/users/UserContactMethodEditDialog.js
@@ -52,7 +52,6 @@ export default class UserContactMethodEditDialog extends React.PureComponent {
     return (
       <Mutation
         mutation={mutation}
-        awaitRefetchQueries
         refetchQueries={['cmList']}
         onCompleted={this.props.onClose}
       >

--- a/web/src/app/users/UserContactMethodVerificationDialog.js
+++ b/web/src/app/users/UserContactMethodVerificationDialog.js
@@ -43,7 +43,6 @@ export default function UserContactMethodVerificationDialog(props) {
         code: value.code,
       },
     },
-    awaitRefetchQueries: true,
     refetchQueries: ['cmList'],
     onCompleted: props.onClose,
   })

--- a/web/src/app/users/UserNotificationRuleCreateDialog.js
+++ b/web/src/app/users/UserNotificationRuleCreateDialog.js
@@ -34,7 +34,6 @@ export default class UserNotificationRuleCreateDialog extends React.PureComponen
     return (
       <Mutation
         mutation={createMutation}
-        awaitRefetchQueries
         refetchQueries={['nrList']}
         onCompleted={this.props.onClose}
       >

--- a/web/src/app/users/UserNotificationRuleDeleteDialog.js
+++ b/web/src/app/users/UserNotificationRuleDeleteDialog.js
@@ -19,7 +19,6 @@ export default class UserNotificationRuleDeleteDialog extends React.PureComponen
     return (
       <Mutation
         mutation={mutation}
-        awaitRefetchQueries
         refetchQueries={['nrList']}
         onCompleted={this.props.onClose}
       >

--- a/web/src/app/util/QuerySetFavoriteButton.js
+++ b/web/src/app/util/QuerySetFavoriteButton.js
@@ -69,11 +69,7 @@ export function QuerySetFavoriteButton(props) {
 
 function renderMutation(isFavorite, id, typeName) {
   return (
-    <Mutation
-      mutation={mutation}
-      awaitRefetchQueries
-      refetchQueries={[`${typeName}FavQuery`]}
-    >
+    <Mutation mutation={mutation} refetchQueries={[`${typeName}FavQuery`]}>
       {mutation => renderSetFavButton(isFavorite, mutation, id, typeName)}
     </Mutation>
   )


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR updates the default apollo client to `awaitRefetchQueries` by default (no effect if `refetchQueries` are not set), set a default `pollInterval` and use `cache-and-network` as the default `fetchPolicy`

The values provided are the ones used by our `Query` component.