### PR TITLE
patch: on delete race condition fixes

### DIFF
--- a/web/src/app/admin/AdminConfirmDialog.js
+++ b/web/src/app/admin/AdminConfirmDialog.js
@@ -30,7 +30,6 @@ export default class AdminConfirmDialog extends React.PureComponent {
       <Mutation
         mutation={mutation}
         onCompleted={this.props.onComplete}
-        awaitRefetchQueries
         refetchQueries={['getConfig']}
       >
         {(commit, status) => this.renderConfirm(commit, status)}

--- a/web/src/app/apollo.js
+++ b/web/src/app/apollo.js
@@ -8,6 +8,7 @@ import { toIdValue } from 'apollo-utilities'
 import { authLogout } from './actions'
 
 import reduxStore from './reduxStore'
+import { POLL_INTERVAL } from './config'
 
 let pendingMutations = 0
 window.onbeforeunload = function(e) {
@@ -129,7 +130,16 @@ cache = new InMemoryCache({
   },
 })
 
+const queryOpts = { fetchPolicy: 'cache-and-network' }
+if (new URLSearchParams(location.search).get('poll') !== '0') {
+  queryOpts.pollInterval = POLL_INTERVAL
+}
+
 export const GraphQLClient = new ApolloClient({
   link: graphql2Link,
   cache,
+  defaultOptions: {
+    query: queryOpts,
+    mutate: { awaitRefetchQueries: true },
+  },
 })

--- a/web/src/app/escalation-policies/PolicyDeleteDialog.js
+++ b/web/src/app/escalation-policies/PolicyDeleteDialog.js
@@ -15,7 +15,6 @@ const mutation = gql`
 export default function PolicyDeleteDialog(props) {
   const dispatch = useDispatch()
   const [deletePolicy, deletePolicyStatus] = useMutation(mutation, {
-    awaitRefetchQueries: true,
     refetchQueries: ['epsQuery'],
     variables: {
       input: [

--- a/web/src/app/escalation-policies/PolicyEditDialog.js
+++ b/web/src/app/escalation-policies/PolicyEditDialog.js
@@ -40,7 +40,6 @@ export default class PolicyEditDialog extends PureComponent {
       <Mutation
         mutation={mutation}
         onCompleted={this.props.onClose}
-        awaitRefetchQueries
         refetchQueries={() => [
           {
             query,

--- a/web/src/app/escalation-policies/PolicyStepCreateDialog.js
+++ b/web/src/app/escalation-policies/PolicyStepCreateDialog.js
@@ -112,7 +112,6 @@ export default class PolicyStepCreateDialog extends React.Component {
     return (
       <Mutation
         mutation={mutation}
-        awaitRefetchQueries
         refetchQueries={() => [
           {
             query: refetchQuery,

--- a/web/src/app/escalation-policies/PolicyStepEditDialog.js
+++ b/web/src/app/escalation-policies/PolicyStepEditDialog.js
@@ -98,7 +98,6 @@ export default class PolicyStepEditDialog extends React.Component {
     return (
       <Mutation
         mutation={mutation}
-        awaitRefetchQueries
         refetchQueries={() => ['stepsQuery']}
         onCompleted={this.props.onClose}
       >

--- a/web/src/app/rotations/RotationAddUserDialog.js
+++ b/web/src/app/rotations/RotationAddUserDialog.js
@@ -30,11 +30,7 @@ export default class RotationAddUserDialog extends React.Component {
     }
 
     return (
-      <Mutation
-        mutation={mutation}
-        awaitRefetchQueries
-        refetchQueries={() => ['rotationUsers']}
-      >
+      <Mutation mutation={mutation} refetchQueries={() => ['rotationUsers']}>
         {(commit, status) => this.renderDialog(defaultValue, commit, status)}
       </Mutation>
     )

--- a/web/src/app/rotations/RotationEditDialog.js
+++ b/web/src/app/rotations/RotationEditDialog.js
@@ -53,7 +53,6 @@ export default class RotationEditDialog extends React.PureComponent {
       <Mutation
         mutation={mutation}
         onCompleted={this.props.onClose}
-        awaitRefetchQueries
         refetchQueries={['rotationDetails']}
       >
         {(...args) => this.renderForm(data, ...args)}

--- a/web/src/app/rotations/RotationSetActiveDialog.js
+++ b/web/src/app/rotations/RotationSetActiveDialog.js
@@ -45,7 +45,6 @@ export default class RotationSetActiveDialog extends React.PureComponent {
       <Mutation
         mutation={mutation}
         onCompleted={this.props.onClose}
-        awaitRefetchQueries
         refetchQueries={['rotationDetails']}
       >
         {commit => this.renderDialog(data, commit)}

--- a/web/src/app/rotations/RotationUserDeleteDialog.js
+++ b/web/src/app/rotations/RotationUserDeleteDialog.js
@@ -46,7 +46,6 @@ export default class RotationUserDeleteDialog extends React.PureComponent {
       <Mutation
         mutation={mutation}
         onCompleted={this.props.onClose}
-        awaitRefetchQueries
         refetchQueries={['rotationUsers']}
       >
         {commit => this.renderDialog(data, commit)}

--- a/web/src/app/schedules/ScheduleEditDialog.js
+++ b/web/src/app/schedules/ScheduleEditDialog.js
@@ -45,7 +45,6 @@ export default class ScheduleEditDialog extends React.PureComponent {
     return (
       <Mutation
         mutation={mutation}
-        awaitRefetchQueries
         onCompleted={this.props.onClose}
         refetchQueries={() => [
           {

--- a/web/src/app/schedules/ScheduleOverrideCreateDialog.js
+++ b/web/src/app/schedules/ScheduleOverrideCreateDialog.js
@@ -79,7 +79,6 @@ export default class ScheduleOverrideCreateDialog extends React.PureComponent {
           'scheduleCalendarShifts',
           'scheduleOverrides',
         ]}
-        awaitRefetchQueries
       >
         {this.renderDialog}
       </Mutation>

--- a/web/src/app/schedules/ScheduleOverrideDeleteDialog.js
+++ b/web/src/app/schedules/ScheduleOverrideDeleteDialog.js
@@ -59,7 +59,6 @@ export default class ScheduleOverrideDeleteDialog extends React.PureComponent {
         mutation={mutation}
         onCompleted={this.props.onClose}
         refetchQueries={['scheduleOverrides']}
-        awaitRefetchQueries
       >
         {(commit, status) => this.renderDialog(data, commit, status)}
       </Mutation>

--- a/web/src/app/schedules/ScheduleOverrideEditDialog.js
+++ b/web/src/app/schedules/ScheduleOverrideEditDialog.js
@@ -58,7 +58,6 @@ export default class ScheduleOverrideEditDialog extends React.PureComponent {
         mutation={mutation}
         onCompleted={this.props.onClose}
         refetchQueries={['scheduleShifts', 'scheduleOverrides']}
-        awaitRefetchQueries
       >
         {(commit, status) => this.renderDialog(data, commit, status)}
       </Mutation>

--- a/web/src/app/schedules/ScheduleRuleCreateDialog.js
+++ b/web/src/app/schedules/ScheduleRuleCreateDialog.js
@@ -38,7 +38,6 @@ export default class ScheduleRuleCreateDialog extends React.PureComponent {
         mutation={mutation}
         onCompleted={this.props.onClose}
         refetchQueries={['scheduleRules']}
-        awaitRefetchQueries
       >
         {this.renderDialog}
       </Mutation>

--- a/web/src/app/schedules/ScheduleRuleDeleteDialog.js
+++ b/web/src/app/schedules/ScheduleRuleDeleteDialog.js
@@ -55,7 +55,6 @@ export default class ScheduleRuleDeleteDialog extends React.PureComponent {
         mutation={mutation}
         onCompleted={this.props.onClose}
         refetchQueries={['scheduleRules']}
-        awaitRefetchQueries
       >
         {(commit, status) => this.renderDialog(data, commit, status)}
       </Mutation>

--- a/web/src/app/schedules/ScheduleRuleEditDialog.js
+++ b/web/src/app/schedules/ScheduleRuleEditDialog.js
@@ -67,7 +67,6 @@ export default class ScheduleRuleEditDialog extends React.Component {
         mutation={mutation}
         onCompleted={this.props.onClose}
         refetchQueries={['scheduleRules']}
-        awaitRefetchQueries
       >
         {(commit, status) => this.renderDialog(data, commit, status)}
       </Mutation>

--- a/web/src/app/services/HeartbeatMonitorCreateDialog.js
+++ b/web/src/app/services/HeartbeatMonitorCreateDialog.js
@@ -20,7 +20,6 @@ export default function HeartbeatMonitorCreateDialog(props) {
   const [value, setValue] = useState({ name: '', timeoutMinutes: 15 })
   const [createHeartbeat, { loading, error }] = useMutation(createMutation, {
     refetchQueries: props.refetchQueries,
-    awaitRefetchQueries: true,
     variables: {
       input: {
         name: value.name,

--- a/web/src/app/services/HeartbeatMonitorDeleteDialog.js
+++ b/web/src/app/services/HeartbeatMonitorDeleteDialog.js
@@ -24,7 +24,6 @@ const mutation = gql`
 export default function HeartbeatMonitorDeleteDialog(props) {
   const [deleteHeartbeat, { loading, error }] = useMutation(mutation, {
     refetchQueries: props.refetchQueries,
-    awaitRefetchQueries: true,
     variables: { id: props.monitorID },
   })
 

--- a/web/src/app/services/HeartbeatMonitorEditDialog.js
+++ b/web/src/app/services/HeartbeatMonitorEditDialog.js
@@ -51,7 +51,6 @@ function HeartbeatMonitorEditDialogContent({ props, data }) {
   })
   const [update, { loading, error }] = useMutation(mutation, {
     refetchQueries: props.refetchQueries,
-    awaitRefetchQueries: Boolean(props.refetchQueries),
     onCompleted: props.onClose,
     variables: {
       input: { id: props.monitorID, ...value },

--- a/web/src/app/services/ServiceDeleteDialog.js
+++ b/web/src/app/services/ServiceDeleteDialog.js
@@ -1,43 +1,39 @@
-import React from 'react'
+import React, { useState } from 'react'
 import p from 'prop-types'
-
+import { useDispatch } from 'react-redux'
 import gql from 'graphql-tag'
-import { Mutation } from 'react-apollo'
+import { useQuery, useMutation } from 'react-apollo'
 import { fieldErrors, nonFieldErrors } from '../util/errutil'
 import Checkbox from '@material-ui/core/Checkbox'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import FormControl from '@material-ui/core/FormControl'
 import FormHelperText from '@material-ui/core/FormHelperText'
-import { Redirect } from 'react-router-dom'
-import Query from '../util/Query'
-
 import FormDialog from '../dialogs/FormDialog'
+import Spinner from '../loading/components/Spinner'
+import { push } from 'connected-react-router'
 
-class DeleteForm extends React.PureComponent {
-  static propTypes = {
-    epName: p.string.isRequired,
-    error: p.string,
-    value: p.bool,
-    onChange: p.func.isRequired,
-  }
-
-  render() {
-    return (
-      <FormControl error={Boolean(this.props.error)} style={{ width: '100%' }}>
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={this.props.value}
-              onChange={e => this.props.onChange(e.target.checked)}
-              value='delete-escalation-policy'
-            />
-          }
-          label={`Also delete escalation policy: ${this.props.epName}`}
-        />
-        <FormHelperText>{this.props.error}</FormHelperText>
-      </FormControl>
-    )
-  }
+function DeleteForm({ epName, error, value, onChange }) {
+  return (
+    <FormControl error={Boolean(error)} style={{ width: '100%' }}>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={value}
+            onChange={e => onChange(e.target.checked)}
+            value='delete-escalation-policy'
+          />
+        }
+        label={`Also delete escalation policy: ${epName}`}
+      />
+      <FormHelperText>{error}</FormHelperText>
+    </FormControl>
+  )
+}
+DeleteForm.propTypes = {
+  epName: p.string.isRequired,
+  error: p.string,
+  value: p.bool,
+  onChange: p.func.isRequired,
 }
 
 const query = gql`
@@ -59,85 +55,56 @@ const mutation = gql`
   }
 `
 
-export default class ServiceDeleteDialog extends React.PureComponent {
-  static propTypes = {
-    serviceID: p.string.isRequired,
-    onClose: p.func,
+export default function ServiceDeleteDialog({ serviceID, onClose }) {
+  const [deleteEP, setDeleteEP] = useState(true)
+  const { data, loading: dataLoading } = useQuery(query, {
+    variables: { id: serviceID },
+  })
+  const input = [{ type: 'service', id: serviceID }]
+  const dispatch = useDispatch()
+  const refetch = ['servicesQuery']
+  const [deleteService, { loading, error }] = useMutation(mutation, {
+    variables: { input },
+    awaitRefetchQueries: true,
+    refetchQueries: refetch,
+    onCompleted: () => dispatch(push('/services')),
+  })
+
+  if (dataLoading) return <Spinner />
+
+  if (deleteEP) {
+    refetch.push('epsQuery')
+    input.push({
+      type: 'escalationPolicy',
+      id: data.service.escalationPolicyID,
+    })
   }
 
-  state = {
-    deleteEP: true,
-  }
-
-  renderQuery() {
-    return (
-      <Query
-        noPoll
-        query={query}
-        variables={{ id: this.props.serviceID }}
-        render={({ data }) => this.renderMutation(data.service)}
-      />
-    )
-  }
-
-  renderMutation(svcData) {
-    return (
-      <Mutation mutation={mutation}>
-        {(commit, status) => this.renderDialog(svcData, commit, status)}
-      </Mutation>
-    )
-  }
-
-  renderDialog = (svcData, commit, mutStatus) => {
-    const { loading, error, data } = mutStatus
-    if (data && data.deleteAll) {
-      return <Redirect push to={`/services`} />
-    }
-
-    return (
-      <FormDialog
-        title='Are you sure?'
-        confirm
-        subTitle={`This will delete the service: ${svcData.name}`}
-        caption='Deleting a service will also delete all associated integration keys and alerts.'
-        loading={loading}
-        errors={nonFieldErrors(error)}
-        onClose={this.props.onClose}
-        onSubmit={() => {
-          const input = [
-            {
-              type: 'service',
-              id: this.props.serviceID,
-            },
-          ]
-          if (this.state.deleteEP) {
-            input.push({
-              type: 'escalationPolicy',
-              id: svcData.escalationPolicyID,
-            })
+  return (
+    <FormDialog
+      title='Are you sure?'
+      confirm
+      subTitle={`This will delete the service: ${data.service.name}`}
+      caption='Deleting a service will also delete all associated integration keys and alerts.'
+      loading={loading}
+      errors={nonFieldErrors(error)}
+      onClose={onClose}
+      onSubmit={() => deleteService()}
+      form={
+        <DeleteForm
+          epName={data.service.escalationPolicy.name}
+          error={
+            fieldErrors(error).find(f => f.field === 'escalationPolicyID') &&
+            'Escalation policy is currently in use.'
           }
-          return commit({
-            variables: {
-              input,
-            },
-          })
-        }}
-        form={
-          <DeleteForm
-            epName={svcData.escalationPolicy.name}
-            error={
-              fieldErrors(error).find(f => f.field === 'escalationPolicyID') &&
-              'Escalation policy is currently in use.'
-            }
-            onChange={deleteEP => this.setState({ deleteEP })}
-            value={this.state.deleteEP}
-          />
-        }
-      />
-    )
-  }
-
-  render() {
-    return this.renderQuery()
-  }
+          onChange={deleteEP => setDeleteEP(deleteEP)}
+          value={deleteEP}
+        />
+      }
+    />
+  )
+}
+ServiceDeleteDialog.propTypes = {
+  serviceID: p.string.isRequired,
+  onClose: p.func,
 }

--- a/web/src/app/services/ServiceDeleteDialog.js
+++ b/web/src/app/services/ServiceDeleteDialog.js
@@ -65,7 +65,6 @@ export default function ServiceDeleteDialog({ serviceID, onClose }) {
   const refetch = ['servicesQuery']
   const [deleteService, { loading, error }] = useMutation(mutation, {
     variables: { input },
-    awaitRefetchQueries: true,
     refetchQueries: refetch,
     onCompleted: () => dispatch(push('/services')),
   })

--- a/web/src/app/services/ServiceEditDialog.js
+++ b/web/src/app/services/ServiceEditDialog.js
@@ -65,7 +65,6 @@ export default class ServiceEditDialog extends React.PureComponent {
       <Mutation
         mutation={mutation}
         onCompleted={this.props.onClose}
-        awaitRefetchQueries
         refetchQueries={() => [
           {
             query,

--- a/web/src/app/users/UserContactMethodCreateDialog.js
+++ b/web/src/app/users/UserContactMethodCreateDialog.js
@@ -26,7 +26,6 @@ export default function UserContactMethodCreateDialog(props) {
 
   const [createCM, createCMStatus] = useMutation(createMutation, {
     refetchQueries: ['nrList', 'cmList'],
-    awaitRefetchQueries: true,
     onCompleted: result => {
       props.onClose({ contactMethodID: result.createUserContactMethod.id })
     },

--- a/web/src/app/users/UserContactMethodDeleteDialog.js
+++ b/web/src/app/users/UserContactMethodDeleteDialog.js
@@ -21,7 +21,6 @@ export default class UserContactMethodDeleteDialog extends React.PureComponent {
       <Mutation
         mutation={mutation}
         onCompleted={this.props.onClose}
-        awaitRefetchQueries
         refetchQueries={['nrList', 'cmList']}
       >
         {(commit, status) => this.renderDialog(commit, status)}

--- a/web/src/app/users/UserContactMethodEditDialog.js
+++ b/web/src/app/users/UserContactMethodEditDialog.js
@@ -52,7 +52,6 @@ export default class UserContactMethodEditDialog extends React.PureComponent {
     return (
       <Mutation
         mutation={mutation}
-        awaitRefetchQueries
         refetchQueries={['cmList']}
         onCompleted={this.props.onClose}
       >

--- a/web/src/app/users/UserContactMethodVerificationDialog.js
+++ b/web/src/app/users/UserContactMethodVerificationDialog.js
@@ -43,7 +43,6 @@ export default function UserContactMethodVerificationDialog(props) {
         code: value.code,
       },
     },
-    awaitRefetchQueries: true,
     refetchQueries: ['cmList'],
     onCompleted: props.onClose,
   })

--- a/web/src/app/users/UserNotificationRuleCreateDialog.js
+++ b/web/src/app/users/UserNotificationRuleCreateDialog.js
@@ -34,7 +34,6 @@ export default class UserNotificationRuleCreateDialog extends React.PureComponen
     return (
       <Mutation
         mutation={createMutation}
-        awaitRefetchQueries
         refetchQueries={['nrList']}
         onCompleted={this.props.onClose}
       >

--- a/web/src/app/users/UserNotificationRuleDeleteDialog.js
+++ b/web/src/app/users/UserNotificationRuleDeleteDialog.js
@@ -19,7 +19,6 @@ export default class UserNotificationRuleDeleteDialog extends React.PureComponen
     return (
       <Mutation
         mutation={mutation}
-        awaitRefetchQueries
         refetchQueries={['nrList']}
         onCompleted={this.props.onClose}
       >

--- a/web/src/app/util/QuerySetFavoriteButton.js
+++ b/web/src/app/util/QuerySetFavoriteButton.js
@@ -69,11 +69,7 @@ export function QuerySetFavoriteButton(props) {
 
 function renderMutation(isFavorite, id, typeName) {
   return (
-    <Mutation
-      mutation={mutation}
-      awaitRefetchQueries
-      refetchQueries={[`${typeName}FavQuery`]}
-    >
+    <Mutation mutation={mutation} refetchQueries={[`${typeName}FavQuery`]}>
       {mutation => renderSetFavButton(isFavorite, mutation, id, typeName)}
     </Mutation>
   )


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes a race condition when deleting an escalation policy, service, rotation, or a schedule. Currently, if the Apollo cache is updated faster than the page rerenders the dialog component, the broken page will then be rendered instead saying that the EP does not exist, because the <Redirect /> component did not have a chance to be rendered/executed.

Now, instead of rendering the <Redirect /> component, an action will be dispatched when the mutation completes successfully that will redirect back to the list.

**Additional Info:**
- Converts components to hooks
- Adds default values for `awaitrefetchqueries`, `fetchPolicy`, and `pollInterval` when the apollo client is initialized
