### PR TITLE
migrate: use connection string instead of *sql.DB

### DIFF
--- a/app/cmd.go
+++ b/app/cmd.go
@@ -99,12 +99,13 @@ var RootCmd = &cobra.Command{
 		u.RawQuery = q.Encode()
 		cfg.DBURL = u.String()
 
+		s := time.Now()
 		n, err := migrate.ApplyAll(log.EnableDebug(ctx), cfg.DBURL)
 		if err != nil {
 			return errors.Wrap(err, "apply migrations")
 		}
 		if n > 0 {
-			log.Logf(ctx, "Applied %d migrations.", n)
+			log.Logf(ctx, "Applied %d migrations in %s.", n, time.Since(s))
 		}
 
 		dbc, err := wrappedDriver.OpenConnector(cfg.DBURL)

--- a/app/cmd.go
+++ b/app/cmd.go
@@ -99,6 +99,14 @@ var RootCmd = &cobra.Command{
 		u.RawQuery = q.Encode()
 		cfg.DBURL = u.String()
 
+		n, err := migrate.ApplyAll(log.EnableDebug(ctx), cfg.DBURL)
+		if err != nil {
+			return errors.Wrap(err, "apply migrations")
+		}
+		if n > 0 {
+			log.Logf(ctx, "Applied %d migrations.", n)
+		}
+
 		dbc, err := wrappedDriver.OpenConnector(cfg.DBURL)
 		if err != nil {
 			return errors.Wrap(err, "connect to postgres")
@@ -289,17 +297,12 @@ Migration: %s (#%d)
 			if err != nil {
 				return err
 			}
-			db, err := sql.Open("postgres", c.DBURL)
-			if err != nil {
-				return errors.Wrap(err, "connect to postgres")
-			}
-			defer db.Close()
 
 			ctx := context.Background()
 			down := viper.GetString("down")
 			up := viper.GetString("up")
 			if down != "" {
-				n, err := migrate.Down(ctx, db, down)
+				n, err := migrate.Down(ctx, c.DBURL, down)
 
 				if err != nil {
 					return errors.Wrap(err, "apply DOWN migrations")
@@ -310,7 +313,7 @@ Migration: %s (#%d)
 			}
 
 			if up != "" || down == "" {
-				n, err := migrate.Up(ctx, db, up)
+				n, err := migrate.Up(ctx, c.DBURL, up)
 
 				if err != nil {
 					return errors.Wrap(err, "apply UP migrations")

--- a/app/startup.go
+++ b/app/startup.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/target/goalert/app/lifecycle"
-	"github.com/target/goalert/migrate"
 	"github.com/target/goalert/notification"
 	"github.com/target/goalert/retry"
 	"github.com/target/goalert/util/log"
@@ -51,17 +50,6 @@ func (app *App) startup(ctx context.Context) error {
 		}
 
 		return err
-	})
-
-	app.initStartup(ctx, "Startup.MigrateDB", func(ctx context.Context) error {
-		n, err := migrate.ApplyAll(log.EnableDebug(ctx), app.db)
-		if err != nil {
-			return errors.Wrap(err, "apply migrations")
-		}
-		if n > 0 {
-			log.Logf(ctx, "Applied %d migrations.", n)
-		}
-		return nil
 	})
 
 	app.notificationManager = notification.NewManager()

--- a/devtools/resetdb/main.go
+++ b/devtools/resetdb/main.go
@@ -499,12 +499,12 @@ func recreateDB() error {
 	return err
 }
 
-func resetDB(db *sql.DB) error {
+func resetDB(url string) error {
 	var err error
 	if flag.Arg(0) != "" {
-		_, err = migrate.Up(context.Background(), db, flag.Arg(0))
+		_, err = migrate.Up(context.Background(), url, flag.Arg(0))
 	} else {
-		_, err = migrate.ApplyAll(context.Background(), db)
+		_, err = migrate.ApplyAll(context.Background(), url)
 	}
 	return err
 }
@@ -525,7 +525,7 @@ func doMigrations(skipMigrate *bool) error {
 		return nil
 	}
 
-	err = resetDB(db)
+	err = resetDB("user=goalert dbname=goalert sslmode=disable")
 	if err != nil {
 		return errors.Wrap(err, "perform migration after resettting")
 	}

--- a/smoketest/migrations_test.go
+++ b/smoketest/migrations_test.go
@@ -545,13 +545,7 @@ func TestMigrations(t *testing.T) {
 	}
 	defer db.Exec("drop database " + pgx.Identifier([]string{dbName}).Sanitize())
 
-	db, err = sql.Open("pgx", harness.DBURL(dbName))
-	if err != nil {
-		t.Fatal("failed to open created db:", err)
-	}
-	defer db.Close()
-
-	n, err := migrate.Up(context.Background(), db, start)
+	n, err := migrate.Up(context.Background(), harness.DBURL(dbName), start)
 	if err != nil {
 		t.Fatal("failed to apply initial migrations:", err)
 	}
@@ -582,7 +576,7 @@ func TestMigrations(t *testing.T) {
 
 	names = names[idx:]
 	if skipTo {
-		n, err := migrate.Up(context.Background(), db, env)
+		n, err := migrate.Up(context.Background(), harness.DBURL(dbName), env)
 		if err != nil {
 			t.Fatal("failed to apply skip migrations:", err)
 		}
@@ -644,7 +638,7 @@ func TestMigrations(t *testing.T) {
 			ctx := context.Background()
 
 			orig := snapshot(t, migrationName)
-			n, err = migrate.Up(ctx, db, migrationName)
+			n, err = migrate.Up(ctx, harness.DBURL(dbName), migrationName)
 			if err != nil {
 				t.Fatalf("failed to apply UP migration: %v", err)
 			}
@@ -653,7 +647,7 @@ func TestMigrations(t *testing.T) {
 			}
 			applied = true
 			upSnap := snapshot(t, migrationName)
-			_, err = migrate.Down(ctx, db, lastMigrationName)
+			_, err = migrate.Down(ctx, harness.DBURL(dbName), lastMigrationName)
 			if err != nil {
 				t.Fatalf("failed to apply DOWN migration: %v", err)
 			}
@@ -663,7 +657,7 @@ func TestMigrations(t *testing.T) {
 				t.Fatalf("DOWN migration did not restore previous schema")
 			}
 
-			_, err = migrate.Up(ctx, db, migrationName)
+			_, err = migrate.Up(ctx, harness.DBURL(dbName), migrationName)
 			if err != nil {
 				t.Fatalf("failed to apply UP migration (2nd time): %v", err)
 			}
@@ -674,7 +668,7 @@ func TestMigrations(t *testing.T) {
 			}
 		})
 		if !pass && !applied {
-			n, err = migrate.Up(context.Background(), db, migrationName)
+			n, err = migrate.Up(context.Background(), harness.DBURL(dbName), migrationName)
 			if err != nil || n == 0 {
 				t.Fatalf("failed to apply UP migration; abort")
 			}

--- a/switchover/dbsync/shell.go
+++ b/switchover/dbsync/shell.go
@@ -55,17 +55,12 @@ func RunShell(oldURL, newURL string) error {
 	}
 
 	fmt.Println("Applying migrations to next-db...")
-	dbNew, err := sql.Open("pgx", newURL)
-	if err != nil {
-		return errors.Wrap(err, "open next-DB")
-	}
-	_, err = migrate.ApplyAll(ctx, dbNew)
+	_, err = migrate.ApplyAll(ctx, newURL)
 	if err != nil {
 		return errors.Wrap(err, "migrate next-DB")
 	}
-	dbNew.Close()
 
-	dbNew, err = sql.Open("pgx", newURL)
+	dbNew, err := sql.Open("pgx", newURL)
 	if err != nil {
 		return errors.Wrap(err, "open next-DB")
 	}

--- a/util/sqlutil/listener.go
+++ b/util/sqlutil/listener.go
@@ -111,7 +111,13 @@ func (l *Listener) run(ctx context.Context) {
 			return
 		default:
 		}
-		l.errCh <- l.handleNotifications(ctx)
+		err := l.handleNotifications(ctx)
+		if err == context.Canceled {
+			err = nil
+		}
+		if err != nil {
+			l.errCh <- err
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR updates the migrate package to operate on a connection string and use pgx directly instead of `*sql.DB`. This ensures that GoAlert establishes it's connection pool *after* any new types/tables have been created.

**Which issue(s) this PR fixes:**
- Fixes an issue where migrations would fail to apply during engine cycles

