### PR TITLE
smoketest: fix ep action limit flakyness

### DIFF
--- a/escalation/store.go
+++ b/escalation/store.go
@@ -3,6 +3,7 @@ package escalation
 import (
 	"context"
 	"database/sql"
+
 	"github.com/target/goalert/util/sqlutil"
 
 	alertlog "github.com/target/goalert/alert/log"
@@ -175,8 +176,8 @@ func NewDB(ctx context.Context, db *sql.DB, cfg Config) (*DB, error) {
 		deletePolicy: p.P(`DELETE FROM escalation_policies WHERE id = any($1)`),
 
 		addStepTarget: p.P(`
-			INSERT INTO escalation_policy_actions (escalation_policy_step_id, user_id, schedule_id, rotation_id, channel_id)
-			VALUES ($1, $2, $3, $4, $5)
+			INSERT INTO escalation_policy_actions (id, escalation_policy_step_id, user_id, schedule_id, rotation_id, channel_id)
+			VALUES ($1, $2, $3, $4, $5, $6)
 			ON CONFLICT DO NOTHING
 		`),
 		deleteStepTarget: p.P(`
@@ -292,7 +293,7 @@ func validStepTarget(tgt assignment.Target) error {
 	)
 }
 
-func tgtFields(id string, tgt assignment.Target) []interface{} {
+func tgtFields(id string, tgt assignment.Target, insert bool) []interface{} {
 	var usr, sched, rot, ch sql.NullString
 	switch tgt.TargetType() {
 	case assignment.TargetTypeUser:
@@ -307,6 +308,16 @@ func tgtFields(id string, tgt assignment.Target) []interface{} {
 	case assignment.TargetTypeNotificationChannel:
 		ch.Valid = true
 		ch.String = tgt.TargetID()
+	}
+	if insert {
+		return []interface{}{
+			uuid.NewV4().String(),
+			id,
+			usr,
+			sched,
+			rot,
+			ch,
+		}
 	}
 	return []interface{}{
 		id,
@@ -350,7 +361,7 @@ func (db *DB) FindManyPolicies(ctx context.Context, ids []string) ([]Policy, err
 	return result, nil
 }
 
-func (db *DB) _updateStepTarget(ctx context.Context, stepID string, tgt assignment.Target, stmt *sql.Stmt) error {
+func (db *DB) _updateStepTarget(ctx context.Context, stepID string, tgt assignment.Target, stmt *sql.Stmt, insert bool) error {
 	err := validate.Many(
 		validate.UUID("StepID", stepID),
 		validStepTarget(tgt),
@@ -362,7 +373,7 @@ func (db *DB) _updateStepTarget(ctx context.Context, stepID string, tgt assignme
 	if err != nil {
 		return err
 	}
-	_, err = stmt.ExecContext(ctx, tgtFields(stepID, tgt)...)
+	_, err := stmt.ExecContext(ctx, tgtFields(stepID, tgt, insert)...)
 	if err == sql.ErrNoRows {
 		err = nil
 	}
@@ -397,7 +408,7 @@ func (db *DB) lookupSlackChannel(ctx context.Context, tx *sql.Tx, stepID, slackC
 }
 
 func (db *DB) AddStepTarget(ctx context.Context, stepID string, tgt assignment.Target) error {
-	return db._updateStepTarget(ctx, stepID, tgt, db.addStepTarget)
+	return db._updateStepTarget(ctx, stepID, tgt, db.addStepTarget, true)
 }
 
 func (db *DB) AddStepTargetTx(ctx context.Context, tx *sql.Tx, stepID string, tgt assignment.Target) error {
@@ -408,11 +419,11 @@ func (db *DB) AddStepTargetTx(ctx context.Context, tx *sql.Tx, stepID string, tg
 			return err
 		}
 	}
-	return db._updateStepTarget(ctx, stepID, tgt, tx.StmtContext(ctx, db.addStepTarget))
+	return db._updateStepTarget(ctx, stepID, tgt, tx.StmtContext(ctx, db.addStepTarget), true)
 }
 
 func (db *DB) DeleteStepTarget(ctx context.Context, stepID string, tgt assignment.Target) error {
-	return db._updateStepTarget(ctx, stepID, tgt, db.deleteStepTarget)
+	return db._updateStepTarget(ctx, stepID, tgt, db.deleteStepTarget, false)
 }
 
 func (db *DB) DeleteStepTargetTx(ctx context.Context, tx *sql.Tx, stepID string, tgt assignment.Target) error {
@@ -423,7 +434,7 @@ func (db *DB) DeleteStepTargetTx(ctx context.Context, tx *sql.Tx, stepID string,
 			return err
 		}
 	}
-	return db._updateStepTarget(ctx, stepID, tgt, tx.StmtContext(ctx, db.deleteStepTarget))
+	return db._updateStepTarget(ctx, stepID, tgt, tx.StmtContext(ctx, db.deleteStepTarget), false)
 }
 
 func (db *DB) FindAllStepTargets(ctx context.Context, stepID string) ([]assignment.Target, error) {

--- a/escalation/store.go
+++ b/escalation/store.go
@@ -178,7 +178,6 @@ func NewDB(ctx context.Context, db *sql.DB, cfg Config) (*DB, error) {
 		addStepTarget: p.P(`
 			INSERT INTO escalation_policy_actions (id, escalation_policy_step_id, user_id, schedule_id, rotation_id, channel_id)
 			VALUES ($1, $2, $3, $4, $5, $6)
-			ON CONFLICT DO NOTHING
 		`),
 		deleteStepTarget: p.P(`
 			DELETE FROM escalation_policy_actions
@@ -373,7 +372,7 @@ func (db *DB) _updateStepTarget(ctx context.Context, stepID string, tgt assignme
 	if err != nil {
 		return err
 	}
-	_, err := stmt.ExecContext(ctx, tgtFields(stepID, tgt, insert)...)
+	_, err = stmt.ExecContext(ctx, tgtFields(stepID, tgt, insert)...)
 	if err == sql.ErrNoRows {
 		err = nil
 	}

--- a/smoketest/systemlimits_test.go
+++ b/smoketest/systemlimits_test.go
@@ -3,13 +3,14 @@ package smoketest
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/target/goalert/limit"
-	"github.com/target/goalert/smoketest/harness"
 	"sort"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/target/goalert/limit"
+	"github.com/target/goalert/smoketest/harness"
 )
 
 // TestSystemLimits tests that limits are enforced if configured.
@@ -214,28 +215,6 @@ func TestSystemLimits(t *testing.T) {
 	)
 
 	actUsersList := []string{h.UUID("ep_act_user1"), h.UUID("ep_act_user2"), h.UUID("ep_act_user3"), h.UUID("ep_act_user4")}
-	actUsers := func(n int) string {
-		return fmt.Sprintf(`"%s"`, strings.Join(actUsersList[:n], `","`))
-	}
-	doTest(
-		limit.EPActionsPerStep,
-		"actions",
-		func(n int) string {
-			return fmt.Sprintf(`mutation{createOrUpdateEscalationPolicyStep(input:{id:"%s", escalation_policy_id: "%s", delay_minutes: 15, schedule_ids: [], user_ids: [%s]}){escalation_policy_step{id}}}`,
-				h.UUID("act_ep_step"),
-				h.UUID("act_ep"),
-				actUsers(n),
-			)
-		},
-		func(n int, _ string) string {
-			return fmt.Sprintf(`mutation{createOrUpdateEscalationPolicyStep(input:{id:"%s", escalation_policy_id: "%s", delay_minutes: 15, schedule_ids: [], user_ids: [%s]}){escalation_policy_step{id}}}`,
-				h.UUID("act_ep_step"),
-				h.UUID("act_ep"),
-				actUsers(n),
-			)
-		},
-		nil,
-	)
 	doTest(
 		limit.EPActionsPerStep,
 		"actions",


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR moves UUID generation for EP step actions to the app layer (rather than from Postgres) as the latter, using `gen_random_uuid()` can return the same value multiple times on some systems.

It was found because the EP method to add a new target had `ON CONFLICT DO NOTHING` which would swallow the duplicate primary key error when an error was expected as part of the system-limits test.
