### PR TITLE
schedules: pass schedule ID to tz filter

### DIFF
--- a/web/src/app/schedules/ScheduleRuleForm.js
+++ b/web/src/app/schedules/ScheduleRuleForm.js
@@ -21,7 +21,6 @@ import { startCase } from 'lodash-es'
 import { Add, Trash } from '../icons'
 import { TimePicker } from '@material-ui/pickers'
 import { ScheduleTZFilter } from './ScheduleTZFilter'
-import { oneOfShape } from '../util/propTypes'
 import Query from '../util/Query'
 import gql from 'graphql-tag'
 import { connect } from 'react-redux'
@@ -109,11 +108,7 @@ export default class ScheduleRuleForm extends React.PureComponent {
     targetType: p.oneOf(['rotation', 'user']).isRequired,
     targetDisabled: p.bool,
 
-    // one of scheduleID or scheduleTimeZone must be specified
-    tz: oneOfShape({
-      scheduleID: p.string,
-      scheduleTimeZone: p.string,
-    }),
+    scheduleID: p.string.isRequired,
 
     value: p.shape({
       targetID: p.string.isRequired,
@@ -129,9 +124,6 @@ export default class ScheduleRuleForm extends React.PureComponent {
   }
 
   render() {
-    if (this.props.scheduleTimeZone) {
-      return this.renderForm(this.props.scheduleTimeZone)
-    }
     return (
       <Query
         query={query}

--- a/web/src/app/schedules/ScheduleRuleList.js
+++ b/web/src/app/schedules/ScheduleRuleList.js
@@ -111,7 +111,7 @@ export default class ScheduleRuleList extends React.PureComponent {
         <PageActions>
           <FilterContainer onReset={() => this.props.resetFilter()}>
             <Grid item xs={12}>
-              <ScheduleTZFilter scheduleTimeZone={timeZone} />
+              <ScheduleTZFilter scheduleID={this.props.scheduleID} />
             </Grid>
           </FilterContainer>
           <SpeedDial

--- a/web/src/app/schedules/ScheduleTZFilter.js
+++ b/web/src/app/schedules/ScheduleTZFilter.js
@@ -4,7 +4,6 @@ import { urlParamSelector } from '../selectors'
 import { setURLParam } from '../actions'
 import gql from 'graphql-tag'
 import { FormControlLabel, Switch } from '@material-ui/core'
-import { oneOfShape } from '../util/propTypes'
 import { useQuery } from 'react-apollo'
 import { useSelector, useDispatch } from 'react-redux'
 
@@ -54,11 +53,7 @@ export function ScheduleTZFilter(props) {
 ScheduleTZFilter.propTypes = {
   label: p.func,
 
-  // one of scheduleID or scheduleTimeZone must be specified
-  _tz: oneOfShape({
-    scheduleID: p.string,
-    scheduleTimeZone: p.string,
-  }),
+  scheduleID: p.string.isRequired,
 
   // provided by connect
   zone: p.string,


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes a regression that broke the TZ filter on the schedule assignments page.
