### PR TITLE
schedules: switch to hooks

### DIFF
--- a/web/src/app/details/DetailsPage.js
+++ b/web/src/app/details/DetailsPage.js
@@ -1,9 +1,8 @@
 import React from 'react'
 import p from 'prop-types'
-import { connect } from 'react-redux'
 import { absURLSelector } from '../selectors/url'
 import statusStyles from '../util/statusStyles'
-import withStyles from '@material-ui/core/styles/withStyles'
+import { makeStyles } from '@material-ui/core/styles'
 import Card from '@material-ui/core/Card'
 import CardContent from '@material-ui/core/CardContent'
 import Grid from '@material-ui/core/Grid'
@@ -16,9 +15,10 @@ import ListItemText from '@material-ui/core/ListItemText'
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
 import IconButton from '@material-ui/core/IconButton'
 import Markdown from '../util/Markdown'
+import { useSelector } from 'react-redux'
 
-const styles = theme => ({
-  ...statusStyles,
+const useLinkStyles = makeStyles(() => statusStyles)
+const useStyles = makeStyles(theme => ({
   spacing: {
     '&:not(:first-child)': {
       marginTop: 8,
@@ -35,132 +35,111 @@ const styles = theme => ({
   mainHeading: {
     fontSize: '1.5rem',
   },
-})
+}))
 
-const mapStateToProps = state => {
-  return {
-    absURL: absURLSelector(state),
+function DetailsLink({ url, label, status, subText }) {
+  const absURL = useSelector(absURLSelector)
+  const classes = useLinkStyles()
+
+  let itemClass = classes.noStatus
+  switch (status) {
+    case 'ok':
+      itemClass = classes.statusOK
+      break
+    case 'warn':
+      itemClass = classes.statusWarning
+      break
+    case 'err':
+      itemClass = classes.statusError
+      break
   }
+
+  return (
+    <ListItem component={Link} to={absURL(url)} button className={itemClass}>
+      <ListItemText
+        secondary={subText}
+        primary={label}
+        primaryTypographyProps={{ variant: 'h5' }}
+      />
+      <ListItemSecondaryAction>
+        <IconButton component={Link} to={absURL(url)}>
+          <ChevronRight />
+        </IconButton>
+      </ListItemSecondaryAction>
+    </ListItem>
+  )
+}
+DetailsLink.propTypes = {
+  label: p.string.isRequired,
+  url: p.string.isRequired,
+  status: p.oneOf(['ok', 'warn', 'err']),
+  subText: p.node,
 }
 
-@withStyles(styles)
-@connect(mapStateToProps)
-export default class DetailsPage extends React.PureComponent {
-  static propTypes = {
-    title: p.string.isRequired,
-    details: p.string.isRequired,
+export default function DetailsPage(props) {
+  const classes = useStyles()
 
-    icon: p.node,
-    links: p.arrayOf(
-      p.shape({
-        label: p.string.isRequired,
-        url: p.string.isRequired,
-        status: p.oneOf(['ok', 'warn', 'err']),
-        subText: p.node,
-      }),
-    ),
+  const { title, details, icon, titleFooter, pageFooter } = props
 
-    titleFooter: p.any,
-    pageFooter: p.any,
-  }
-
-  renderLink = ({ url, label, status, subText }, idx) => {
-    const { classes, absURL } = this.props
-    let itemClass = classes.noStatus
-    switch (status) {
-      case 'ok':
-        itemClass = classes.statusOK
-        break
-      case 'warn':
-        itemClass = classes.statusWarning
-        break
-      case 'err':
-        itemClass = classes.statusError
-        break
-    }
-
-    return (
-      <ListItem
-        key={idx}
-        component={Link}
-        to={absURL(url)}
-        button
-        className={itemClass}
-      >
-        <ListItemText
-          secondary={subText}
-          primary={label}
-          primaryTypographyProps={{ variant: 'h5' }}
-        />
-        <ListItemSecondaryAction>
-          <IconButton component={Link} to={absURL(url)}>
-            <ChevronRight />
-          </IconButton>
-        </ListItemSecondaryAction>
-      </ListItem>
-    )
-  }
-
-  renderLinks() {
-    const { links } = this.props
-
-    if (!links || !links.length) return null
-
-    return (
-      <Grid item xs={12} className={this.props.classes.spacing}>
+  let links = null
+  if (props.links && props.links.length) {
+    links = (
+      <Grid item xs={12} className={classes.spacing}>
         <Card>
-          <List>{links.map(this.renderLink)}</List>
+          <List>
+            {props.links.map((li, idx) => (
+              <DetailsLink key={idx} {...li} />
+            ))}
+          </List>
         </Card>
       </Grid>
     )
   }
 
-  render() {
-    const {
-      title,
-      details,
-      icon,
-      titleFooter,
-      pageFooter,
-      classes,
-    } = this.props
-    return (
-      <Grid container>
-        <Grid item xs={12} className={classes.spacing}>
-          <Card>
-            <CardContent>
-              {icon && <div className={classes.iconContainer}>{icon}</div>}
+  return (
+    <Grid container>
+      <Grid item xs={12} className={classes.spacing}>
+        <Card>
+          <CardContent>
+            {icon && <div className={classes.iconContainer}>{icon}</div>}
+            <Typography
+              data-cy='details-heading'
+              className={classes.mainHeading}
+              component='h2'
+            >
+              {title}
+            </Typography>
+            <Typography data-cy='details' variant='subtitle1' component='div'>
+              <Markdown value={details} />
+            </Typography>
+            {titleFooter && (
               <Typography
-                data-cy='details-heading'
-                className={classes.mainHeading}
-                component='h2'
+                component='div'
+                variant='subtitle1'
+                data-cy='title-footer'
               >
-                {title}
+                {titleFooter}
               </Typography>
-              <Typography data-cy='details' variant='subtitle1' component='div'>
-                <Markdown value={details} />
-              </Typography>
-              {titleFooter && (
-                <Typography
-                  component='div'
-                  variant='subtitle1'
-                  data-cy='title-footer'
-                >
-                  {titleFooter}
-                </Typography>
-              )}
-            </CardContent>
-          </Card>
-        </Grid>
-
-        {this.renderLinks()}
-
-        {pageFooter && (
-          <Grid item xs={12} className={classes.spacing}>
-            {pageFooter}
-          </Grid>
-        )}
+            )}
+          </CardContent>
+        </Card>
       </Grid>
-    )
-  }
+      {links}
+      {pageFooter && (
+        <Grid item xs={12} className={classes.spacing}>
+          {pageFooter}
+        </Grid>
+      )}
+    </Grid>
+  )
+}
+DetailsPage.propTypes = {
+  title: p.string.isRequired,
+  details: p.string.isRequired,
+
+  icon: p.node,
+  links: p.arrayOf(p.shape(DetailsLink.propTypes)),
+
+  titleFooter: p.any,
+  pageFooter: p.any,
 }

--- a/web/src/app/schedules/ScheduleDeleteDialog.js
+++ b/web/src/app/schedules/ScheduleDeleteDialog.js
@@ -1,10 +1,8 @@
 import React from 'react'
 import p from 'prop-types'
-
 import gql from 'graphql-tag'
 import { useQuery, useMutation } from '@apollo/react-hooks'
-import { push } from 'connected-react-router'
-import { useDispatch } from 'react-redux'
+import { get } from 'lodash-es'
 import FormDialog from '../dialogs/FormDialog'
 import Spinner from '../loading/components/Spinner'
 
@@ -23,13 +21,11 @@ const mutation = gql`
 `
 
 export default function ScheduleDeleteDialog(props) {
-  const dispatch = useDispatch()
   const { data, loading: dataLoading } = useQuery(query, {
     onClose: p.func,
     variables: { id: props.scheduleID },
   })
   const [deleteSchedule, deleteScheduleStatus] = useMutation(mutation, {
-    refetchQueries: ['schedulesQuery'],
     variables: {
       input: [
         {
@@ -38,7 +34,6 @@ export default function ScheduleDeleteDialog(props) {
         },
       ],
     },
-    onCompleted: () => dispatch(push('/schedules')),
   })
 
   if (dataLoading) return <Spinner />
@@ -47,7 +42,7 @@ export default function ScheduleDeleteDialog(props) {
     <FormDialog
       title='Are you sure?'
       confirm
-      subTitle={`This will delete the schedule: ${data.schedule.name}`}
+      subTitle={`This will delete the schedule: ${get(data, 'schedule.name')}`}
       caption='Deleting a schedule will also delete all associated rules and overrides.'
       loading={deleteScheduleStatus.loading}
       errors={deleteScheduleStatus.error ? [deleteScheduleStatus.error] : []}

--- a/web/src/app/schedules/ScheduleDetails.js
+++ b/web/src/app/schedules/ScheduleDetails.js
@@ -1,11 +1,10 @@
-import React from 'react'
+import React, { useState } from 'react'
 import p from 'prop-types'
 import gql from 'graphql-tag'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import Grid from '@material-ui/core/Grid'
 import Switch from '@material-ui/core/Switch'
 import DetailsPage from '../details/DetailsPage'
-import Query from '../util/Query'
 import { UserSelect } from '../selection'
 import FilterContainer from '../util/FilterContainer'
 import PageActions from '../util/PageActions'
@@ -13,10 +12,12 @@ import OtherActions from '../util/OtherActions'
 import ScheduleEditDialog from './ScheduleEditDialog'
 import ScheduleDeleteDialog from './ScheduleDeleteDialog'
 import ScheduleCalendarQuery from './ScheduleCalendarQuery'
-import { urlParamSelector } from '../selectors'
-import { resetURLParams, setURLParam } from '../actions'
-import { connect } from 'react-redux'
+import { Redirect } from 'react-router-dom'
+import { useURLParam, useResetURLParams } from '../actions'
 import { QuerySetFavoriteButton } from '../util/QuerySetFavoriteButton'
+import { useQuery } from 'react-apollo'
+import Spinner from '../loading/components/Spinner'
+import { ObjectNotFound, GenericError } from '../error-pages'
 
 const query = gql`
   query($id: ID!) {
@@ -28,127 +29,92 @@ const query = gql`
     }
   }
 `
-const partialQuery = gql`
-  query($id: ID!) {
-    schedule(id: $id) {
-      id
-      name
-      description
-      isFavorite
-    }
-  }
-`
 
-const mapStateToProps = state => ({
-  userFilter: urlParamSelector(state)('userFilter', []),
-  activeOnly: urlParamSelector(state)('activeOnly', false),
-})
+export default function ScheduleDetails({ scheduleID }) {
+  const [userFilter, setUserFilter] = useURLParam('userFilter', [])
+  const [activeOnly, setActiveOnly] = useURLParam('activeOnly', false)
+  const [showEdit, setShowEdit] = useState(false)
+  const [showDelete, setShowDelete] = useState(false)
+  const resetFilter = useResetURLParams(
+    'userFilter',
+    'start',
+    'activeOnly',
+    'tz',
+    'duration',
+  )
+  const { data: _data, loading, error } = useQuery(query, {
+    variables: { id: scheduleID },
+  })
 
-const mapDispatchToProps = dispatch => {
-  return {
-    setUserFilter: value => dispatch(setURLParam('userFilter', value)),
-    setActiveOnly: value => dispatch(setURLParam('activeOnly', value)),
-    resetFilter: () =>
-      dispatch(
-        resetURLParams('userFilter', 'start', 'activeOnly', 'tz', 'duration'),
-      ),
-  }
-}
+  if (loading) return <Spinner />
+  if (error) return <GenericError error={error.message} />
 
-@connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)
-export default class ScheduleDetails extends React.PureComponent {
-  static propTypes = {
-    scheduleID: p.string.isRequired,
-  }
+  const data = _data.schedule
+  if (!data)
+    return showDelete ? <Redirect to='/schedules' push /> : <ObjectNotFound />
 
-  state = {
-    edit: false,
-    delete: false,
-  }
-
-  render() {
-    return (
-      <Query
-        query={query}
-        partialQuery={partialQuery}
-        variables={{ id: this.props.scheduleID }}
-        render={({ data }) => this.renderPage(data.schedule)}
-      />
-    )
-  }
-
-  renderPage = data => {
-    return (
-      <React.Fragment>
-        <PageActions>
-          <QuerySetFavoriteButton scheduleID={data.id} />
-          <FilterContainer onReset={() => this.props.resetFilter()}>
-            <Grid item xs={12}>
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={this.props.activeOnly}
-                    onChange={e => this.props.setActiveOnly(e.target.checked)}
-                    value='activeOnly'
-                  />
-                }
-                label='Active shifts only'
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <UserSelect
-                label='Filter users...'
-                multiple
-                value={this.props.userFilter}
-                onChange={this.props.setUserFilter}
-              />
-            </Grid>
-          </FilterContainer>
-          <OtherActions
-            actions={[
-              {
-                label: 'Edit Schedule',
-                onClick: () => this.setState({ edit: true }),
-              },
-              {
-                label: 'Delete Schedule',
-                onClick: () => this.setState({ delete: true }),
-              },
-            ]}
-          />
-        </PageActions>
-        <DetailsPage
-          title={data.name}
-          details={data.description}
-          titleFooter={
-            <React.Fragment>Time Zone: {data.timeZone}</React.Fragment>
-          }
-          links={[
-            { label: 'Assignments', url: 'assignments' },
-            { label: 'Escalation Policies', url: 'escalation-policies' },
-            { label: 'Overrides', url: 'overrides' },
-            { label: 'Shifts', url: 'shifts' },
-          ]}
-          pageFooter={
-            <ScheduleCalendarQuery scheduleID={this.props.scheduleID} />
-          }
+  return (
+    <React.Fragment>
+      {showEdit && (
+        <ScheduleEditDialog
+          scheduleID={scheduleID}
+          onClose={() => setShowEdit(false)}
         />
-        {this.state.edit && (
-          <ScheduleEditDialog
-            scheduleID={this.props.scheduleID}
-            onClose={() => this.setState({ edit: false })}
-          />
-        )}
-        {this.state.delete && (
-          <ScheduleDeleteDialog
-            scheduleID={this.props.scheduleID}
-            onClose={() => this.setState({ delete: false })}
-          />
-        )}
-      </React.Fragment>
-    )
-  }
+      )}
+      {showDelete && (
+        <ScheduleDeleteDialog
+          scheduleID={scheduleID}
+          onClose={() => setShowDelete(false)}
+        />
+      )}
+      <PageActions>
+        <QuerySetFavoriteButton scheduleID={scheduleID} />
+        <FilterContainer onReset={resetFilter}>
+          <Grid item xs={12}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={activeOnly}
+                  onChange={e => setActiveOnly(e.target.checked)}
+                  value='activeOnly'
+                />
+              }
+              label='Active shifts only'
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <UserSelect
+              label='Filter users...'
+              multiple
+              value={userFilter}
+              onChange={setUserFilter}
+            />
+          </Grid>
+        </FilterContainer>
+        <OtherActions
+          actions={[
+            { label: 'Edit Schedule', onClick: () => setShowEdit(true) },
+            { label: 'Delete Schedule', onClick: () => setShowDelete(true) },
+          ]}
+        />
+      </PageActions>
+      <DetailsPage
+        title={data.name}
+        details={data.description}
+        titleFooter={
+          <React.Fragment>Time Zone: {data.timeZone}</React.Fragment>
+        }
+        links={[
+          { label: 'Assignments', url: 'assignments' },
+          { label: 'Escalation Policies', url: 'escalation-policies' },
+          { label: 'Overrides', url: 'overrides' },
+          { label: 'Shifts', url: 'shifts' },
+        ]}
+        pageFooter={<ScheduleCalendarQuery scheduleID={scheduleID} />}
+      />
+    </React.Fragment>
+  )
+}
+ScheduleDetails.propTypes = {
+  scheduleID: p.string.isRequired,
 }

--- a/web/src/app/util/SetFavoriteButton.js
+++ b/web/src/app/util/SetFavoriteButton.js
@@ -3,13 +3,18 @@ import p from 'prop-types'
 import IconButton from '@material-ui/core/IconButton'
 import FavoriteFilledIcon from '@material-ui/icons/Star'
 import FavoriteBorderIcon from '@material-ui/icons/StarBorder'
+import Spinner from '../loading/components/Spinner'
 
-export function SetFavoriteButton({ typeName, isFavorite, onSubmit }) {
+export function SetFavoriteButton({ typeName, isFavorite, loading, onClick }) {
+  let icon = isFavorite ? <FavoriteFilledIcon /> : <FavoriteBorderIcon />
+  if (loading) {
+    icon = <Spinner />
+  }
   return (
     <form
       onSubmit={e => {
         e.preventDefault()
-        onSubmit()
+        onClick()
       }}
     >
       <IconButton
@@ -22,7 +27,7 @@ export function SetFavoriteButton({ typeName, isFavorite, onSubmit }) {
         color='inherit'
         data-cy='set-fav'
       >
-        {isFavorite ? <FavoriteFilledIcon /> : <FavoriteBorderIcon />}
+        {icon}
       </IconButton>
     </form>
   )
@@ -32,4 +37,5 @@ SetFavoriteButton.propTypes = {
   typeName: p.oneOf(['rotation', 'service', 'schedule']),
   onSubmit: p.func,
   isFavorite: p.bool,
+  loading: p.bool,
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR converts the schedule details page to hooks, as well as the favorite button and `DetailsPage` component.

Schedule tests should pass with this PR.

**Out of Scope**
- tests for other details pages may still fail until they are updated