### PR TITLE
engine/cleanup: option to clear old alerts

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,10 @@ type Config struct {
 		DisableLabelCreation   bool   `public:"true" info:"Disables the ability to create new labels for services."`
 	}
 
+	Maintenance struct {
+		AlertCleanupDays int `public:"true" info:"Closed alerts will be deleted after this many days (0 means disable cleanup)."`
+	}
+
 	Auth struct {
 		RefererURLs  []string `info:"Allowed referer URLs for auth and redirects."`
 		DisableBasic bool     `public:"true" info:"Disallow username/password login."`
@@ -201,6 +205,7 @@ func (cfg Config) Validate() error {
 		validateKey("GitHub.ClientID", cfg.GitHub.ClientID),
 		validateKey("GitHub.ClientSecret", cfg.GitHub.ClientSecret),
 		validateKey("Slack.AccessToken", cfg.Slack.AccessToken),
+		validate.Range("Maintenance.AlertCleanupDays", cfg.Maintenance.AlertCleanupDays, 0, 9000),
 	)
 
 	if cfg.OIDC.IssuerURL != "" {

--- a/engine/cleanupmanager/db.go
+++ b/engine/cleanupmanager/db.go
@@ -3,8 +3,8 @@ package cleanupmanager
 import (
 	"context"
 	"database/sql"
+
 	"github.com/target/goalert/engine/processinglock"
-	"github.com/target/goalert/keyring"
 	"github.com/target/goalert/util"
 )
 
@@ -13,17 +13,14 @@ type DB struct {
 	db   *sql.DB
 	lock *processinglock.Lock
 
-	keys keyring.Keys
-
-	orphanSlackChan *sql.Stmt
-	deleteChan      *sql.Stmt
+	cleanupAlerts *sql.Stmt
 }
 
 // Name returns the name of the module.
 func (db *DB) Name() string { return "Engine.CleanupManager" }
 
 // NewDB creates a new DB.
-func NewDB(ctx context.Context, db *sql.DB, keys keyring.Keys) (*DB, error) {
+func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 	lock, err := processinglock.NewLock(ctx, db, processinglock.Config{
 		Version: 1,
 		Type:    processinglock.TypeCleanup,
@@ -38,19 +35,6 @@ func NewDB(ctx context.Context, db *sql.DB, keys keyring.Keys) (*DB, error) {
 		db:   db,
 		lock: lock,
 
-		keys: keys,
-
-		orphanSlackChan: p.P(`
-			select
-				id, meta->>'tok'
-			from notification_channels
-			where
-				type = 'SLACK' and
-				id not in (select channel_id from escalation_policy_actions where channel_id notnull)
-			order by created_at
-			limit 15
-			for update skip locked
-		`),
-		deleteChan: p.P(`delete from notification_channels where id = any($1)`),
+		cleanupAlerts: p.P(`delete from alerts where id = any(select id from alerts where status = 'closed' AND created_at < (now() - $1::interval) order by id limit 100 for update)`),
 	}, p.Err
 }

--- a/engine/cleanupmanager/update.go
+++ b/engine/cleanupmanager/update.go
@@ -2,11 +2,11 @@ package cleanupmanager
 
 import (
 	"context"
+
+	"github.com/jackc/pgx/pgtype"
+	"github.com/target/goalert/config"
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/util/log"
-	"github.com/target/goalert/util/sqlutil"
-	"net/http"
-	"net/url"
 )
 
 // UpdateAll will update the state of all active escalation policies.
@@ -28,34 +28,15 @@ func (db *DB) update(ctx context.Context) error {
 	}
 	defer tx.Rollback()
 
-	rows, err := tx.StmtContext(ctx, db.orphanSlackChan).QueryContext(ctx)
-	if err != nil {
-		return err
-	}
-	defer rows.Close()
-
-	var toDelete sqlutil.UUIDArray
-	for rows.Next() {
-		var id, token string
-		err = rows.Scan(&id, &token)
+	cfg := config.FromContext(ctx)
+	if cfg.Maintenance.AlertCleanupDays > 0 {
+		var dur pgtype.Interval
+		dur.Days = int32(cfg.Maintenance.AlertCleanupDays)
+		dur.Status = pgtype.Present
+		_, err = db.cleanupAlerts.ExecContext(ctx, &dur)
 		if err != nil {
 			return err
 		}
-		log.Debugf(ctx, "cleanup notification channel %s", id)
-		data, _, err := db.keys.Decrypt([]byte(token))
-		if err != nil {
-			return err
-		}
-
-		// TODO: implement retry/backoff logic?
-		go http.Get("https://slack.com/api/auth.revoke?token=" + url.QueryEscape(string(data)))
-
-		toDelete = append(toDelete, id)
-	}
-
-	_, err = tx.StmtContext(ctx, db.deleteChan).ExecContext(ctx, toDelete)
-	if err != nil {
-		return err
 	}
 
 	return tx.Commit()

--- a/engine/cleanupmanager/update.go
+++ b/engine/cleanupmanager/update.go
@@ -28,6 +28,11 @@ func (db *DB) update(ctx context.Context) error {
 	}
 	defer tx.Rollback()
 
+	_, err = tx.StmtContext(ctx, db.setTimeout).ExecContext(ctx)
+	if err != nil {
+		return err
+	}
+
 	cfg := config.FromContext(ctx)
 	if cfg.Maintenance.AlertCleanupDays > 0 {
 		var dur pgtype.Interval

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/target/goalert/alert"
 	"github.com/target/goalert/app/lifecycle"
+	"github.com/target/goalert/engine/cleanupmanager"
 	"github.com/target/goalert/engine/escalationmanager"
 	"github.com/target/goalert/engine/heartbeatmanager"
 	"github.com/target/goalert/engine/message"
@@ -119,10 +120,10 @@ func NewEngine(ctx context.Context, db *sql.DB, c *Config) (*Engine, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "heartbeat processing backend")
 	}
-	// cleanMgr, err := cleanupmanager.NewDB(ctx, db, c.CredKeyring)
-	// if err != nil {
-	// 	return nil, errors.Wrap(err, "cleanup backend")
-	// }
+	cleanMgr, err := cleanupmanager.NewDB(ctx, db)
+	if err != nil {
+		return nil, errors.Wrap(err, "cleanup backend")
+	}
 
 	p.modules = []updater{
 		rotMgr,
@@ -132,7 +133,7 @@ func NewEngine(ctx context.Context, db *sql.DB, c *Config) (*Engine, error) {
 		statMgr,
 		verifyMgr,
 		hbMgr,
-		// cleanMgr,
+		cleanMgr,
 	}
 
 	p.msg, err = message.NewDB(ctx, db, &message.Config{

--- a/graphql2/mapconfig.go
+++ b/graphql2/mapconfig.go
@@ -4,6 +4,7 @@ package graphql2
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/target/goalert/config"
@@ -17,6 +18,7 @@ func MapConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "General.GoogleAnalyticsID", Type: ConfigTypeString, Description: "", Value: cfg.General.GoogleAnalyticsID},
 		{ID: "General.NotificationDisclaimer", Type: ConfigTypeString, Description: "Disclaimer text for receiving pre-recorded notifications (appears on profile page).", Value: cfg.General.NotificationDisclaimer},
 		{ID: "General.DisableLabelCreation", Type: ConfigTypeBoolean, Description: "Disables the ability to create new labels for services.", Value: fmt.Sprintf("%t", cfg.General.DisableLabelCreation)},
+		{ID: "Maintenance.AlertCleanupDays", Type: ConfigTypeInteger, Description: "Closed alerts will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.AlertCleanupDays)},
 		{ID: "Auth.RefererURLs", Type: ConfigTypeStringList, Description: "Allowed referer URLs for auth and redirects.", Value: strings.Join(cfg.Auth.RefererURLs, "\n")},
 		{ID: "Auth.DisableBasic", Type: ConfigTypeBoolean, Description: "Disallow username/password login.", Value: fmt.Sprintf("%t", cfg.Auth.DisableBasic)},
 		{ID: "GitHub.Enable", Type: ConfigTypeBoolean, Description: "Enable GitHub authentication.", Value: fmt.Sprintf("%t", cfg.GitHub.Enable)},
@@ -54,6 +56,7 @@ func MapPublicConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "General.GoogleAnalyticsID", Type: ConfigTypeString, Description: "", Value: cfg.General.GoogleAnalyticsID},
 		{ID: "General.NotificationDisclaimer", Type: ConfigTypeString, Description: "Disclaimer text for receiving pre-recorded notifications (appears on profile page).", Value: cfg.General.NotificationDisclaimer},
 		{ID: "General.DisableLabelCreation", Type: ConfigTypeBoolean, Description: "Disables the ability to create new labels for services.", Value: fmt.Sprintf("%t", cfg.General.DisableLabelCreation)},
+		{ID: "Maintenance.AlertCleanupDays", Type: ConfigTypeInteger, Description: "Closed alerts will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.AlertCleanupDays)},
 		{ID: "Auth.DisableBasic", Type: ConfigTypeBoolean, Description: "Disallow username/password login.", Value: fmt.Sprintf("%t", cfg.Auth.DisableBasic)},
 		{ID: "GitHub.Enable", Type: ConfigTypeBoolean, Description: "Enable GitHub authentication.", Value: fmt.Sprintf("%t", cfg.GitHub.Enable)},
 		{ID: "OIDC.Enable", Type: ConfigTypeBoolean, Description: "Enable OpenID Connect authentication.", Value: fmt.Sprintf("%t", cfg.OIDC.Enable)},
@@ -73,6 +76,16 @@ func ApplyConfigValues(cfg config.Config, vals []ConfigValueInput) (config.Confi
 			return nil
 		}
 		return strings.Split(v, "\n")
+	}
+	parseInt := func(id, v string) (int, error) {
+		if v == "" {
+			return 0, nil
+		}
+		val, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return 0, validation.NewFieldError("\""+id+"\".Value", "integer value invalid: "+err.Error())
+		}
+		return int(val), nil
 	}
 	parseBool := func(id, v string) (bool, error) {
 		switch v {
@@ -98,6 +111,12 @@ func ApplyConfigValues(cfg config.Config, vals []ConfigValueInput) (config.Confi
 				return cfg, err
 			}
 			cfg.General.DisableLabelCreation = val
+		case "Maintenance.AlertCleanupDays":
+			val, err := parseInt(v.ID, v.Value)
+			if err != nil {
+				return cfg, err
+			}
+			cfg.Maintenance.AlertCleanupDays = val
 		case "Auth.RefererURLs":
 			cfg.Auth.RefererURLs = parseStringList(v.Value)
 		case "Auth.DisableBasic":


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adds the config value `Maintenance.AlertCleanupDays`. Alerts that are closed, that were created more than `Maintenance.AlertCleanupDays` days prior, will be deleted in increments of 100.

This will cause data for the alert, sent messages, logs/responses, to all be purged from the DB.

100 each cyle can handle roughly 72k alerts per hour with one engine instance running. There is a limit of 3 seconds to the query in the cleanup module, though observed times were around 50ms, max of 400ms with large datasets.

The default behavior is no cleanup (same as today) so this change should be safe to all existing configurations. Admins will need to manually set a retention period to enable this feature.

**Out of Scope**
- In the future, a strategy could be implemented to allow archiving data. With this change, DB snapshots/backups will still contain the data should it need to be revisited.