### PR TITLE
Remove country code

### DIFF
--- a/notification/twilio/sms.go
+++ b/notification/twilio/sms.go
@@ -17,8 +17,7 @@ import (
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/retry"
 	"github.com/target/goalert/util/log"
-	"github.com/target/goalert/validation"
-	"github.com/ttacon/libphonenumber"
+	"github.com/target/goalert/validation/validate"
 
 	"github.com/pkg/errors"
 )
@@ -87,13 +86,9 @@ func (s *SMS) Send(ctx context.Context, msg notification.Message) (*notification
 		return nil, errors.Errorf("unsupported destination type %s; expected SMS", msg.Destination().Type)
 	}
 	destNumber := msg.Destination().Value
-	d, err := libphonenumber.Parse(destNumber, "")
+	err := validate.Phone("destNumber", destNumber)
 	if err != nil {
-		return nil, validation.NewFieldError(destNumber, fmt.Sprintf("must be a valid number: %s", err.Error()))
-	}
-
-	if !libphonenumber.IsValidNumber(d) {
-		return nil, validation.NewFieldError(destNumber, "must be a valid number")
+		return nil, errors.Wrap(err, "must be a valid number")
 	}
 
 	if destNumber == cfg.Twilio.FromNumber {

--- a/notification/twilio/validation.go
+++ b/notification/twilio/validation.go
@@ -3,11 +3,11 @@ package twilio
 import (
 	"context"
 	"crypto/hmac"
-	"github.com/target/goalert/config"
-	"github.com/target/goalert/util/log"
 	"net/http"
 	"regexp"
-	"strings"
+
+	"github.com/target/goalert/config"
+	"github.com/target/goalert/util/log"
 
 	"github.com/pkg/errors"
 )
@@ -77,13 +77,4 @@ func validSID(n string) string {
 	}
 
 	return n
-}
-
-// Supported Country Codes
-// +1 = USA, +91 = India, +44 = United Kingdom
-func supportedCountryCode(n string) bool {
-	if strings.HasPrefix(n, "+1") || strings.HasPrefix(n, "+91") || strings.HasPrefix(n, "+44") {
-		return true
-	}
-	return false
 }

--- a/notification/twilio/voice.go
+++ b/notification/twilio/voice.go
@@ -22,8 +22,7 @@ import (
 	"github.com/target/goalert/retry"
 	"github.com/target/goalert/util/errutil"
 	"github.com/target/goalert/util/log"
-	"github.com/target/goalert/validation"
-	"github.com/ttacon/libphonenumber"
+	"github.com/target/goalert/validation/validate"
 )
 
 // CallType indicates a supported Twilio voice call type.
@@ -209,14 +208,9 @@ func (v *Voice) Send(ctx context.Context, msg notification.Message) (*notificati
 		return nil, errors.New("Twilio provider is disabled")
 	}
 	toNumber := msg.Destination().Value
-
-	t, err := libphonenumber.Parse(toNumber, "")
+	err := validate.Phone("toNumber", toNumber)
 	if err != nil {
-		return nil, validation.NewFieldError(toNumber, fmt.Sprintf("must be a valid number: %s", err.Error()))
-	}
-
-	if !libphonenumber.IsValidNumber(t) {
-		return nil, validation.NewFieldError(toNumber, "must be a valid number")
+		return nil, errors.Wrap(err, "must be a valid number")
 	}
 
 	if toNumber == cfg.Twilio.FromNumber {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR removes country code validation for a contact number in GoAlert.
As a result, all valid international phone numbers will now be accepted by GoAlert. 
Users should confirm with their provider for actual delivery of notifications to those phone numbers.

**Out of Scope:**
GoAlert will accept any valid phone numbers as contact methods. But the delivery of notifications to international phone numbers depends on the settings at the provider's side.
