### PR TITLE
go: update build-env to use Go 1.13.1

### DIFF
--- a/devtools/ci/dockerfiles/build-env/Dockerfile
+++ b/devtools/ci/dockerfiles/build-env/Dockerfile
@@ -1,2 +1,2 @@
-FROM golang:1.13.0-alpine
+FROM golang:1.13.1-alpine
 RUN apk --no-cache add git nodejs yarn make postgresql-client


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Updates the version of Go in the build-env container to 1.13.1
