### PR TITLE
Fixing spinner css to be responsive to center

### DIFF
--- a/web/src/app/loading/components/Spinner.js
+++ b/web/src/app/loading/components/Spinner.js
@@ -50,7 +50,14 @@ export default class Spinner extends React.PureComponent {
     if (this.props.delayMs && !this.state.spin) return null
 
     return (
-      <div style={{ position: 'absolute', top: '50%', left: '50%' }}>
+      <div
+        style={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+        }}
+      >
         <CircularProgress />
       </div>
     )


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [ ] All new and existing tests passed.
- [ ] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Spinner when loading is now centered on all devices.