### PR TITLE
form dialogs: revert to old content padding

### DIFF
--- a/web/src/app/dialogs/FormDialog.js
+++ b/web/src/app/dialogs/FormDialog.js
@@ -25,6 +25,9 @@ const styles = theme => {
     form: {
       height: '100%', // pushes caption to bottom if room is available
     },
+    dialogContent: {
+      padding: 0,
+    },
     formContainer: {
       width: '100%',
       height: '100%',
@@ -125,7 +128,7 @@ export default class FormDialog extends React.PureComponent {
           title={title}
           subTitle={subTitle}
         />
-        <DialogContent>
+        <DialogContent className={classes.dialogContent}>
           <Form
             id='dialog-form'
             className={classes.formContainer}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Previously we weren't using padding around the form in our form dialogs. With the addition of dialog content on our forms, the padding has changed from what it was originally designed as. This PR keeps the content (needed for proper overflow scrolling), but removes the padding.