### PR TITLE
remotemonitor/monitor: WrapValidation before TrimPrefix

### DIFF
--- a/remotemonitor/monitor.go
+++ b/remotemonitor/monitor.go
@@ -3,8 +3,6 @@ package remotemonitor
 import (
 	"context"
 	"fmt"
-	"github.com/target/goalert/config"
-	"github.com/target/goalert/notification/twilio"
 	"io"
 	"log"
 	"net"
@@ -12,6 +10,9 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/target/goalert/config"
+	"github.com/target/goalert/notification/twilio"
 )
 
 // Monitor will check for functionality and communication between itself and one or more instances.
@@ -50,7 +51,11 @@ func NewMonitor(cfg Config) (*Monitor, error) {
 	if err != nil {
 		return nil, err
 	}
-	h := twilio.WrapValidation(m, m.tw)
+	h := twilio.WrapValidation(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		req.URL.Path = strings.TrimPrefix(req.URL.Path, u.Path)
+
+		m.ServeHTTP(w, req)
+	}), m.tw)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, req *http.Request) { io.WriteString(w, "ok") })
 	m.appCfg.General.PublicURL = cfg.PublicURL
@@ -58,11 +63,7 @@ func NewMonitor(cfg Config) (*Monitor, error) {
 	m.appCfg.Twilio.AccountSID = cfg.Twilio.AccountSID
 	m.appCfg.Twilio.AuthToken = cfg.Twilio.AuthToken
 	m.appCfg.Twilio.FromNumber = cfg.Twilio.FromNumber
-	mux.Handle("/", twilio.WrapHeaderHack(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		req.URL.Path = strings.TrimPrefix(req.URL.Path, u.Path)
-
-		h.ServeHTTP(w, req)
-	})))
+	mux.Handle("/", twilio.WrapHeaderHack(h))
 	m.srv = &http.Server{
 		Handler:           config.Handler(mux, config.Static(m.appCfg)),
 		IdleTimeout:       15 * time.Second,


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Fixes bug that caused Twilio request validation for the remote-monitor to fail -- this PR reorders operations so that `WrapValidation` occurs before `TrimPrefix`
