### PR TITLE
graphql: fix alerts query pagination

### DIFF
--- a/alert/search.go
+++ b/alert/search.go
@@ -3,12 +3,13 @@ package alert
 import (
 	"context"
 	"database/sql"
+	"strconv"
+	"text/template"
+
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/search"
 	"github.com/target/goalert/util/sqlutil"
 	"github.com/target/goalert/validation/validate"
-	"strconv"
-	"text/template"
 
 	"github.com/pkg/errors"
 )
@@ -27,7 +28,7 @@ type SearchOptions struct {
 	After SearchCursor `json:"a,omitempty"`
 
 	// Omit specifies a list of alert IDs to exclude from the results.
-	Omit []int
+	Omit []int `json:"o,omitempty"`
 
 	// Limit restricts the maximum number of rows returned. Default is 50.
 	// Note: Limit is applied AFTER AfterID is taken into account.
@@ -72,7 +73,7 @@ var searchTemplate = template.Must(template.New("search").Parse(`
 	{{ if .After.ID }}
 		AND (
 			a.status > :afterStatus::enum_alert_status OR
-			(a.status = :afterStatus::enum_alert_status AND a.id < :afterID
+			(a.status = :afterStatus::enum_alert_status AND a.id < :afterID)
 		)
 	{{ end }}
 	ORDER BY status, id DESC

--- a/graphql2/graphqlapp/alert.go
+++ b/graphql2/graphqlapp/alert.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/target/goalert/alert"
-	"github.com/target/goalert/alert/log"
+	alertlog "github.com/target/goalert/alert/log"
 	"github.com/target/goalert/assignment"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/permission"
@@ -140,6 +140,8 @@ func (q *Query) Alerts(ctx context.Context, opts *graphql2.AlertSearchOptions) (
 	}
 	conn.Nodes = alerts
 	if len(alerts) > 0 {
+		s.After.ID = conn.Nodes[len(conn.Nodes)-1].ID
+		s.After.Status = conn.Nodes[len(conn.Nodes)-1].Status
 		cur, err := search.Cursor(s)
 		if err != nil {
 			return nil, errors.Wrap(err, "serialize cursor")


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes pagination on the `alerts` query by setting the `After` cursor data and fixing a syntax error in the query.