### PR TITLE
ep repeat count never negative

### DIFF
--- a/devtools/resetdb/datagen.go
+++ b/devtools/resetdb/datagen.go
@@ -218,7 +218,7 @@ func (d *datagen) NewEP() {
 		ID:          gofakeit.UUID(),
 		Name:        d.ids.Gen(idName("Policy")),
 		Description: gofakeit.Sentence(rand.Intn(10) + 3),
-		Repeat:      rand.Intn(5) - 1,
+		Repeat:      rand.Intn(5),
 	})
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR makes changes to our regendb randomly generated seed data code. It makes sure there are never any escalation policies that have a repeat count of -1.

