### PR TITLE
smoketest/harness: ensure harness datagen always returns unique values

### DIFF
--- a/smoketest/harness/datagen.go
+++ b/smoketest/harness/datagen.go
@@ -64,13 +64,13 @@ func (d *DataGen) Get(id string) string {
 func (d *DataGen) GetWithArg(arg, id string) string {
 	d.mx.Lock()
 	defer d.mx.Unlock()
-	if id == "" {
-		return d.g.Generate(arg)
-	}
 	key := dataGenKey{arg: arg, id: id}
 	val := dataGenKey{arg: arg, id: ""}
 	var ok bool
-	val.id, ok = d.data[key]
+	if id != "" {
+		// only return previous value if given an ID
+		val.id, ok = d.data[key]
+	}
 	if !ok {
 		val.id = d.g.Generate(arg)
 		for d.uniq[val] {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This fixes a bug where repeat values could be returned from datagen methods on occasion, causing failing tests.
