### PR TITLE
ui/service: don't show page spinner if partially loaded

### DIFF
--- a/web/src/app/services/ServiceDetails.js
+++ b/web/src/app/services/ServiceDetails.js
@@ -77,7 +77,7 @@ export default function ServiceDetails({ serviceID }) {
     returnPartialData: true,
   })
 
-  if (loading) return <Spinner />
+  if (loading && !data) return <Spinner />
   if (error) return <GenericError error={error.message} />
 
   if (!_.get(data, 'service.id')) {

--- a/web/src/app/services/ServiceDetails.js
+++ b/web/src/app/services/ServiceDetails.js
@@ -77,7 +77,7 @@ export default function ServiceDetails({ serviceID }) {
     returnPartialData: true,
   })
 
-  if (loading && !data) return <Spinner />
+  if (loading && !_.get(data, 'service.id')) return <Spinner />
   if (error) return <GenericError error={error.message} />
 
   if (!_.get(data, 'service.id')) {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes a bug where a blank details page is displayed when navigating from the services list.
