### PR TITLE
schedule/rotation: fix endtime calculation bug

### DIFF
--- a/schedule/rotation/rotation.go
+++ b/schedule/rotation/rotation.go
@@ -87,10 +87,10 @@ func (r Rotation) EndTime(t time.Time) time.Time {
 				cTime = addHoursAlwaysInc(cTime, -r.ShiftLength)
 			}
 		case TypeWeekly, TypeDaily:
-			// while cTime (rotation start) is before t
+			// while cTime (rotation start) is after t
 			for cTime.After(t) {
 				last = cTime
-				// getting end of shift
+				// getting next end of shift
 				cTime = cTime.AddDate(0, 0, -r.ShiftLength)
 			}
 		default:

--- a/schedule/rotation/rotation.go
+++ b/schedule/rotation/rotation.go
@@ -87,7 +87,6 @@ func (r Rotation) EndTime(t time.Time) time.Time {
 				cTime = addHoursAlwaysInc(cTime, -r.ShiftLength)
 			}
 		case TypeWeekly, TypeDaily:
-			// while cTime (rotation start) is after t
 			for cTime.After(t) {
 				last = cTime
 				// getting next end of shift
@@ -101,12 +100,10 @@ func (r Rotation) EndTime(t time.Time) time.Time {
 
 	switch r.Type {
 	case TypeHourly:
-		// while cTime (rotation start) is before t
 		for !cTime.After(t) {
 			cTime = addHoursAlwaysInc(cTime, r.ShiftLength)
 		}
 	case TypeWeekly, TypeDaily:
-		// while cTime (rotation start) is before t
 		for !cTime.After(t) {
 			// getting end of shift
 			cTime = cTime.AddDate(0, 0, r.ShiftLength)

--- a/schedule/rotation/rotation_test.go
+++ b/schedule/rotation/rotation_test.go
@@ -1,6 +1,7 @@
 package rotation
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 )
@@ -165,6 +166,36 @@ func TestRotation_Normalize(t *testing.T) {
 	for _, r := range invalid {
 		test(false, r)
 	}
+}
+
+func TestRotation_FutureStart(t *testing.T) {
+	rot := Rotation{
+		Type:        TypeDaily,
+		ShiftLength: 1,
+
+		// StartTime and EndTime should work correctly even if Start
+		// is in the future.
+		Start: time.Date(2019, 0, 10, 0, 0, 0, 0, time.UTC),
+	}
+
+	assert.Equal(t, time.Date(2019, 0, 6, 0, 0, 0, 0, time.UTC),
+		rot.EndTime(time.Date(2019, 0, 5, 0, 0, 0, 0, time.UTC)),
+	)
+	assert.Equal(t, time.Date(2019, 0, 5, 0, 0, 0, 0, time.UTC),
+		rot.StartTime(time.Date(2019, 0, 5, 0, 0, 0, 0, time.UTC)),
+	)
+	assert.Equal(t, time.Date(2019, 0, 4, 0, 0, 0, 0, time.UTC),
+		rot.StartTime(time.Date(2019, 0, 5, 0, 0, 0, -1, time.UTC)),
+	)
+	assert.Equal(t, time.Date(2019, 0, 11, 0, 0, 0, 0, time.UTC),
+		rot.EndTime(time.Date(2019, 0, 10, 0, 0, 0, 0, time.UTC)),
+	)
+	assert.Equal(t, time.Date(2019, 0, 10, 0, 0, 0, 0, time.UTC),
+		rot.StartTime(time.Date(2019, 0, 10, 0, 0, 0, 0, time.UTC)),
+	)
+	assert.Equal(t, time.Date(2019, 0, 9, 0, 0, 0, 0, time.UTC),
+		rot.StartTime(time.Date(2019, 0, 10, 0, 0, 0, -1, time.UTC)),
+	)
 }
 
 func TestRotation_StartTime(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes a bug in `Rotation.EndTime` that would return an incorrect value causing an infinite loop in some cases.

**Additional Info:**
When it comes to rotations we use a single timestamp and timezone to denote when the "rotating" begins.

For weekly and daily this is how a rotation at 8 pm keeps its meaning across timezone boundaries. Additionally, changing the timezone of the rotation won't "lose its place" because it's evaluated as "what time was it, at this moment, in that timezone".

When dealing with rotations we have one method that does most of the heavy lifting `EndTime`. It takes a single argument, `t`, any timestamp, and will output the time at which a rotation shift would be over, for whatever shift is active at `t`.

There is also a `StartTime` method, which just calculates the `EndTime` and subtracts 1 shift from it.

---

When calculating schedules for who is on-call at any given time, there is a method that uses this, named `UserID`, which takes a timestamp `t` and returns the user who would be active at that time.

To do this, it will walk the rotation forward or backward to find the correct shift. It will advance the rotation until `EndTime` is *after* `t` or roll it back until `StartTime` is *before* `t`.

---

The loop bug found was that if the rotations configured `Start` time is *after* the `t` argument to `EndTime`, it will return the `Start` value.

When mixed with the on-call code, that meant that the `EndTime` would be in the future, and the `StartTime` would always be 1 shift length behind `EndTime`. This caused the `UserID` method to infinitely "rollback" the rotation since every time it rolled back it would actually get the same value.

---

Viewing a schedule where an assigned rotation's `Start` value is > 1 shift length past the current time would cause it to loop infinitely.

