### PR TITLE
cypress: use whitelist instead of preserveOnce

### DIFF
--- a/web/src/cypress/support/index.ts
+++ b/web/src/cypress/support/index.ts
@@ -15,6 +15,9 @@
 
 import 'cypress-plugin-retries'
 Cypress.env('RETRIES', 2)
+Cypress.Cookies.defaults({
+  whitelist: 'goalert_session.2',
+})
 
 import './alert'
 import './service'

--- a/web/src/cypress/support/util.ts
+++ b/web/src/cypress/support/util.ts
@@ -76,7 +76,6 @@ export function testScreen(
     if (!skipLogin) {
       before(() => cy.resetConfig()[adminLogin ? 'adminLogin' : 'login']())
       it(adminLogin ? 'admin login' : 'login', () => {}) // required due to mocha skip bug
-      beforeEach(() => Cypress.Cookies.preserveOnce('goalert_session.2'))
     }
     describe(screenName(), () => fn(screen()))
   })


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR replaces the `preserveOnce` inside `beforeEach` by whitelisting the session cookie.
