### PR TITLE
ui/details: use partial query for schedule/rotation initial render

### DIFF
--- a/web/src/app/rotations/RotationDetails.js
+++ b/web/src/app/rotations/RotationDetails.js
@@ -19,11 +19,16 @@ import Spinner from '../loading/components/Spinner'
 import { ObjectNotFound, GenericError } from '../error-pages'
 
 const query = gql`
+  fragment TitleQuery on Rotation {
+    id
+    name
+    description
+  }
+
   query rotationDetails($id: ID!) {
     rotation(id: $id) {
-      id
-      name
-      description
+      ...TitleQuery
+
       activeUserIndex
       userIDs
       type
@@ -41,11 +46,12 @@ export default function RotationDetails({ rotationID }) {
 
   const { data: _data, loading, error } = useQuery(query, {
     variables: { id: rotationID },
+    returnPartialData: true,
   })
 
   const data = _.get(_data, 'rotation', null)
 
-  if (loading) return <Spinner />
+  if (loading && !data) return <Spinner />
   if (error) return <GenericError error={error.message} />
 
   if (!data)

--- a/web/src/app/rotations/util.js
+++ b/web/src/app/rotations/util.js
@@ -75,6 +75,8 @@ export function formatWeeklySummary(shiftLength, start, tz) {
 export function handoffSummary(rotation) {
   const tz = rotation.timeZone
 
+  if (!tz) return 'Loading handoff information...'
+
   let details = ''
   switch (rotation.type) {
     case 'hourly':

--- a/web/src/app/schedules/ScheduleDetails.js
+++ b/web/src/app/schedules/ScheduleDetails.js
@@ -22,11 +22,14 @@ import Spinner from '../loading/components/Spinner'
 import { ObjectNotFound, GenericError } from '../error-pages'
 
 const query = gql`
-  query($id: ID!) {
+  fragment TitleQuery on Schedule {
+    id
+    name
+    description
+  }
+  query scheduleDetailsQuery($id: ID!) {
     schedule(id: $id) {
-      id
-      name
-      description
+      ...TitleQuery
       timeZone
     }
   }
@@ -48,11 +51,12 @@ export default function ScheduleDetails({ scheduleID }) {
 
   const { data: _data, loading, error } = useQuery(query, {
     variables: { id: scheduleID },
+    returnPartialData: true,
   })
 
   const data = _.get(_data, 'schedule', null)
 
-  if (loading) return <Spinner />
+  if (loading && !data) return <Spinner />
   if (error) return <GenericError error={error.message} />
 
   if (!data) {
@@ -108,7 +112,9 @@ export default function ScheduleDetails({ scheduleID }) {
         title={data.name}
         details={data.description}
         titleFooter={
-          <React.Fragment>Time Zone: {data.timeZone}</React.Fragment>
+          <React.Fragment>
+            Time Zone: {data.timeZone || 'Loading...'}
+          </React.Fragment>
         }
         links={[
           { label: 'Assignments', url: 'assignments' },


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This updates `ScheduleDetails` and `RotationDetails` so they can render immediately (i.e. from the list page) with cached data while fetching additional information on the page. It fixes the page flicker to make them behave like service and EP details pages.

**Describe any introduced user-facing changes:**
Schedule and rotation details pages should render immediately when coming from the list page, even when on a slow network or device.