### PR TITLE
ui: fix input label shrinking bug

### DIFF
--- a/web/src/app/forms/FormField.js
+++ b/web/src/app/forms/FormField.js
@@ -109,10 +109,11 @@ export class FormField extends React.PureComponent {
       ...otherFieldProps
     } = this.props
 
-    const InputLabelProps = {
+    let InputLabelProps = {
       required: required && !optionalLabels,
       ..._inputProps,
     }
+    if (this.props.value) InputLabelProps = { ...InputLabelProps, shrink: true }
 
     const baseLabel = typeof _label === 'string' ? _label : startCase(name)
     const label =
@@ -174,7 +175,6 @@ export class FormField extends React.PureComponent {
 
     if (render) return render(props)
     const Component = component
-    if (props.value) props.InputLabelProps = { shrink: true }
 
     return (
       <FormControl fullWidth={props.fullWidth} error={Boolean(props.error)}>

--- a/web/src/app/forms/FormField.js
+++ b/web/src/app/forms/FormField.js
@@ -109,11 +109,11 @@ export class FormField extends React.PureComponent {
       ...otherFieldProps
     } = this.props
 
-    let InputLabelProps = {
+    const InputLabelProps = {
       required: required && !optionalLabels,
+      shrink: Boolean(this.props.value),
       ..._inputProps,
     }
-    if (this.props.value) InputLabelProps = { ...InputLabelProps, shrink: true }
 
     const baseLabel = typeof _label === 'string' ? _label : startCase(name)
     const label =

--- a/web/src/app/forms/FormField.js
+++ b/web/src/app/forms/FormField.js
@@ -174,6 +174,7 @@ export class FormField extends React.PureComponent {
 
     if (render) return render(props)
     const Component = component
+    if (props.value) props.InputLabelProps = { shrink: true }
 
     return (
       <FormControl fullWidth={props.fullWidth} error={Boolean(props.error)}>

--- a/web/src/app/forms/FormField.js
+++ b/web/src/app/forms/FormField.js
@@ -5,7 +5,7 @@ import FormControl from '@material-ui/core/FormControl'
 import FormHelperText from '@material-ui/core/FormHelperText'
 import FormLabel from '@material-ui/core/FormLabel'
 import { get, isEmpty, startCase } from 'lodash-es'
-import hasValue from '../util/hasValue'
+import shrinkWorkaround from '../util/shrinkWorkaround'
 
 import { FormContainerContext } from './context'
 
@@ -128,7 +128,7 @@ export class FormField extends React.PureComponent {
 
     const InputLabelProps = {
       required: required && !optionalLabels,
-      shrink: hasValue(props.value),
+      ...shrinkWorkaround(props.value),
       ..._inputProps,
     }
 

--- a/web/src/app/forms/FormField.js
+++ b/web/src/app/forms/FormField.js
@@ -109,12 +109,6 @@ export class FormField extends React.PureComponent {
       ...otherFieldProps
     } = this.props
 
-    const InputLabelProps = {
-      required: required && !optionalLabels,
-      shrink: Boolean(this.props.value),
-      ..._inputProps,
-    }
-
     const baseLabel = typeof _label === 'string' ? _label : startCase(name)
     const label =
       !required && optionalLabels ? baseLabel + ' (optional)' : baseLabel
@@ -129,6 +123,11 @@ export class FormField extends React.PureComponent {
       error: errors.find(err => err.field === (errorName || fieldName)),
       hint,
       value: mapValue(get(value, fieldName)),
+    }
+    const InputLabelProps = {
+      required: required && !optionalLabels,
+      shrink: Boolean(props.value),
+      ..._inputProps,
     }
 
     let getValueOf = e => (e && e.target ? e.target.value : e)

--- a/web/src/app/forms/FormField.js
+++ b/web/src/app/forms/FormField.js
@@ -5,6 +5,7 @@ import FormControl from '@material-ui/core/FormControl'
 import FormHelperText from '@material-ui/core/FormHelperText'
 import FormLabel from '@material-ui/core/FormLabel'
 import { get, isEmpty, startCase } from 'lodash-es'
+import hasValue from '../util/hasValue'
 
 import { FormContainerContext } from './context'
 
@@ -124,9 +125,10 @@ export class FormField extends React.PureComponent {
       hint,
       value: mapValue(get(value, fieldName)),
     }
+
     const InputLabelProps = {
       required: required && !optionalLabels,
-      shrink: Boolean(props.value),
+      shrink: hasValue(props.value),
       ..._inputProps,
     }
 

--- a/web/src/app/selection/MaterialSelect.js
+++ b/web/src/app/selection/MaterialSelect.js
@@ -3,7 +3,7 @@ import { PropTypes as p } from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
 import Select from 'react-select'
 import { components, styles } from './MaterialSelectComponents'
-import hasValue from '../util/hasValue'
+import shrinkWorkaround from '../util/shrinkWorkaround'
 
 const valueShape = p.shape({
   label: p.string.isRequired,
@@ -54,7 +54,7 @@ export default class MaterialSelect extends Component {
     } = this.props
 
     const InputLabelProps = {
-      shrink: hasValue(this.props.value),
+      ...shrinkWorkaround(this.props.value),
       ..._InputLabelProps,
     }
 

--- a/web/src/app/selection/MaterialSelect.js
+++ b/web/src/app/selection/MaterialSelect.js
@@ -52,8 +52,10 @@ export default class MaterialSelect extends Component {
       ...props
     } = this.props
 
-    let InputLabelProps = _InputLabelProps
-    if (this.props.value) InputLabelProps = { ...InputLabelProps, shrink: true }
+    const InputLabelProps = {
+      shrink: Boolean(this.props.value),
+      ..._InputLabelProps,
+    }
 
     const selectStyles = {
       input: base => ({

--- a/web/src/app/selection/MaterialSelect.js
+++ b/web/src/app/selection/MaterialSelect.js
@@ -47,10 +47,13 @@ export default class MaterialSelect extends Component {
       label,
       name,
       placeholder,
-      InputLabelProps,
+      InputLabelProps: _InputLabelProps,
 
       ...props
     } = this.props
+
+    let InputLabelProps = _InputLabelProps
+    if (this.props.value) InputLabelProps = { ...InputLabelProps, shrink: true }
 
     const selectStyles = {
       input: base => ({

--- a/web/src/app/selection/MaterialSelect.js
+++ b/web/src/app/selection/MaterialSelect.js
@@ -3,6 +3,7 @@ import { PropTypes as p } from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
 import Select from 'react-select'
 import { components, styles } from './MaterialSelectComponents'
+import hasValue from '../util/hasValue'
 
 const valueShape = p.shape({
   label: p.string.isRequired,
@@ -53,7 +54,7 @@ export default class MaterialSelect extends Component {
     } = this.props
 
     const InputLabelProps = {
-      shrink: Boolean(this.props.value),
+      shrink: hasValue(this.props.value),
       ..._InputLabelProps,
     }
 

--- a/web/src/app/util/hasValue.js
+++ b/web/src/app/util/hasValue.js
@@ -1,0 +1,7 @@
+// cast as a Boolean unless candidate is an Array
+export default function hasValue(candidate) {
+  if (Array.isArray(candidate)) {
+    return candidate.length > 0
+  }
+  return Boolean(candidate)
+}

--- a/web/src/app/util/hasValue.js
+++ b/web/src/app/util/hasValue.js
@@ -1,7 +1,0 @@
-// cast as a Boolean unless candidate is an Array
-export default function hasValue(candidate) {
-  if (Array.isArray(candidate)) {
-    return candidate.length > 0
-  }
-  return Boolean(candidate)
-}

--- a/web/src/app/util/shrinkWorkaround.js
+++ b/web/src/app/util/shrinkWorkaround.js
@@ -1,5 +1,6 @@
 import _ from 'lodash-es'
-// fixes bug in material where non-empty values
+
+// shrinkWorkaround fixes bug in material where non-empty values
 // fail to trigger the label text to shrink.
 //
 // Usage:

--- a/web/src/app/util/shrinkWorkaround.js
+++ b/web/src/app/util/shrinkWorkaround.js
@@ -1,0 +1,13 @@
+import _ from 'lodash-es'
+// fixes bug in material where non-empty values
+// fail to trigger the label text to shrink.
+//
+// Usage:
+// const InputProps = {
+//  ...otherInputProps,
+//  ...shrinkWorkaround(value)
+// }
+export default function shrinkWorkaround(value) {
+  if (_.isEmpty(value) && !_.isNumber(value)) return {}
+  return { shrink: true }
+}


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Added fix for input labels that would overlap in text fields that had autofilled values.

**Screenshots:**
<img width="486" alt="Screen Shot 2019-11-18 at 2 27 49 PM" src="https://user-images.githubusercontent.com/17692467/71109279-7b88fc80-218a-11ea-8dbb-b9d58ca6321f.png">

**Additional Info**
Link to documentation in material ui for this fix:
https://material-ui.com/components/text-fields/#shrink
