### PR TITLE
ui/calendar: replace invalid `mini` prop with `size`

### DIFF
--- a/web/src/app/schedules/CalendarEventWrapper.js
+++ b/web/src/app/schedules/CalendarEventWrapper.js
@@ -107,7 +107,7 @@ export default class CalendarEventWrapper extends Component {
             <Button
               className={classes.button}
               data-cy='replace-override'
-              mini
+              size='small'
               onClick={() => this.handleShowOverrideForm('replace')}
               variant='outlined'
             >


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.
