### PR TITLE
refetch: fix auth issues in admin tests

### DIFF
--- a/web/src/app/util/promiseBatch.js
+++ b/web/src/app/util/promiseBatch.js
@@ -27,6 +27,25 @@ function start() {
   return [current.promise, current.done]
 }
 
+function _finally(fn) {
+  return this.then(
+    val => {
+      const v = () => val
+      return Promise.resolve(fn()).then(v, v)
+    },
+    err => {
+      const e = () => Promise.reject(err)
+      return Promise.resolve(fn()).then(e, e)
+    },
+  )
+}
+
+// polyfill finally
+if (!Promise.prototype.finally) {
+  // eslint-disable-next-line
+  Object.defineProperty(Promise.prototype, 'finally', { value: _finally })
+}
+
 // promiseBatch will wrap a promise so that it resolves at the same time as any
 // others within the delay.
 export default function promiseBatch(p) {

--- a/web/src/cypress/support/login.ts
+++ b/web/src/cypress/support/login.ts
@@ -22,37 +22,27 @@ function login(
   }
 
   if (tokenOnly) {
-    return cy.getCookie('goalert_session.2').then(sess => {
-      const oldValue = sess && sess.value
-
-      return cy
-        .clearCookie('goalert_session.2')
-        .request({
-          url: '/api/v2/identity/providers/basic?noRedirect=1',
-          method: 'POST',
-          form: true, // indicates the body should be form urlencoded and sets Content-Type: application/x-www-form-urlencoded headers
-          body: {
-            username,
-            password,
-          },
-          followRedirect: false,
-          headers: {
-            referer: Cypress.config('baseUrl'),
-          },
-        })
-        .then(res => {
-          if (oldValue) {
-            return cy
-              .setCookie('goalert_session.2', oldValue, { path: '/' })
-              .then(() => res.body)
-          }
-          return res.body
-        })
-    })
+    return cy
+      .request({
+        url: '/api/v2/identity/providers/basic?noRedirect=1',
+        method: 'POST',
+        form: true, // indicates the body should be form urlencoded and sets Content-Type: application/x-www-form-urlencoded headers
+        body: {
+          username,
+          password,
+        },
+        followRedirect: false,
+        headers: {
+          referer: Cypress.config('baseUrl'),
+          Cookie: '',
+        },
+      })
+      .then(res => {
+        return res.body
+      })
   }
 
   return cy
-    .clearCookie('goalert_session.2')
     .request({
       url: '/api/v2/identity/providers/basic',
       method: 'POST',
@@ -64,6 +54,7 @@ function login(
       followRedirect: false,
       headers: {
         referer: Cypress.config('baseUrl'),
+        Cookie: '',
       },
     })
     .then(res => {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adds a polyfill for the `finally` method of promises and removes the use of `setCookie`, `getCookie`, and `clearCookie` that were causing issues for admin tests.