### PR TITLE
refetch: fix electron crash

### DIFF
--- a/web/src/app/config/index.js
+++ b/web/src/app/config/index.js
@@ -11,3 +11,4 @@ export const DEFAULT_SPIN_WAIT_MS = 1500
 export const DEBOUNCE_DELAY = 250
 
 export const CREATE_ALERT_LIMIT = 35
+export const BATCH_DELAY = 10

--- a/web/src/app/rotations/RotationDetails.js
+++ b/web/src/app/rotations/RotationDetails.js
@@ -19,7 +19,7 @@ import Spinner from '../loading/components/Spinner'
 import { ObjectNotFound, GenericError } from '../error-pages'
 
 const query = gql`
-  fragment TitleQuery on Rotation {
+  fragment RotationTitleQuery on Rotation {
     id
     name
     description
@@ -27,7 +27,7 @@ const query = gql`
 
   query rotationDetails($id: ID!) {
     rotation(id: $id) {
-      ...TitleQuery
+      ...RotationTitleQuery
 
       activeUserIndex
       userIDs

--- a/web/src/app/schedules/ScheduleDetails.js
+++ b/web/src/app/schedules/ScheduleDetails.js
@@ -22,14 +22,14 @@ import Spinner from '../loading/components/Spinner'
 import { ObjectNotFound, GenericError } from '../error-pages'
 
 const query = gql`
-  fragment TitleQuery on Schedule {
+  fragment ScheduleTitleQuery on Schedule {
     id
     name
     description
   }
   query scheduleDetailsQuery($id: ID!) {
     schedule(id: $id) {
-      ...TitleQuery
+      ...ScheduleTitleQuery
       timeZone
     }
   }

--- a/web/src/app/services/ServiceDetails.js
+++ b/web/src/app/services/ServiceDetails.js
@@ -16,7 +16,7 @@ import { GenericError, ObjectNotFound } from '../error-pages'
 import ServiceOnCallList from './ServiceOnCallList'
 
 const query = gql`
-  fragment TitleQuery on Service {
+  fragment ServiceTitleQuery on Service {
     id
     name
     description
@@ -24,7 +24,7 @@ const query = gql`
 
   query serviceDetailsQuery($serviceID: ID!) {
     service(id: $serviceID) {
-      ...TitleQuery
+      ...ServiceTitleQuery
       ep: escalationPolicy {
         id
         name

--- a/web/src/app/util/promiseBatch.js
+++ b/web/src/app/util/promiseBatch.js
@@ -1,54 +1,62 @@
-const BATCH_DELAY = 10
+import { BATCH_DELAY } from '../config'
 
-let current, timeout
-function Batch(initActive = 0) {
-  this._active = initActive
-  this.promise = new Promise(resolve => {
-    this._resolve = resolve
-  })
-  this.start = () => {
-    this._active++
-  }
-  this.done = () => {
-    this._active--
-    if (this._active === 0) this._resolve()
-  }
-}
+function _finally(p, fn) {
+  if (p.finally) return p.finally(fn)
 
-function start() {
-  if (!current) current = new Batch(1)
-  current.start()
-  clearTimeout(timeout)
-  const done = current.done
-  timeout = setTimeout(() => {
-    current = null
-    done()
-  }, BATCH_DELAY)
-  return [current.promise, current.done]
-}
-
-function _finally(fn) {
-  return this.then(
+  // fallback to manual implementation
+  return p.then(
     val => {
       const v = () => val
-      return Promise.resolve(fn()).then(v, v)
+      return Promise.resolve()
+        .then(fn)
+        .then(v)
     },
     err => {
       const e = () => Promise.reject(err)
-      return Promise.resolve(fn()).then(e, e)
+      return Promise.resolve()
+        .then(fn)
+        .then(e)
     },
   )
 }
 
-// polyfill finally
-if (!Promise.prototype.finally) {
-  // eslint-disable-next-line
-  Object.defineProperty(Promise.prototype, 'finally', { value: _finally })
+// BatchPromise allows batching promises together so they resolve at the same time.
+// It differes from Promise.all and Promise.allSettled in that you can add
+// additional promises after creation.
+class BatchPromise {
+  _p = new Promise(resolve => {
+    this._resolveP = resolve
+  })
+
+  _unresolvedCount = 1 // start with +1 for the timer
+
+  resolveOne = () => {
+    this._unresolvedCount--
+    if (this._unresolvedCount === 0) this._resolveP()
+    return this._p
+  }
+
+  addPromise = p => {
+    this._unresolvedCount++
+    return _finally(p, this.resolveOne)
+  }
 }
 
-// promiseBatch will wrap a promise so that it resolves at the same time as any
-// others within the delay.
-export default function promiseBatch(p) {
-  const [wait, done] = start()
-  return p.finally(done).finally(() => wait)
+let currentBatch, t
+function batchReset() {
+  currentBatch.resolveOne()
+  currentBatch = null
+}
+
+// promiseBatch will return a new Promise that will resolve after all Promises
+// that were provided during the debounce (ms) delay.
+export default function promiseBatch(p, debounce = BATCH_DELAY) {
+  if (!currentBatch) {
+    currentBatch = new BatchPromise()
+  }
+
+  clearTimeout(t)
+  t = setTimeout(batchReset, debounce)
+
+  return currentBatch.addPromise(p)
 }


### PR DESCRIPTION
**Description:**
This PR fixes an issue triggered by mutating `Promise.prototype.finally` to polyfill missing functionality in Electron. When running tests, Electron would crash while the polyfill was in effect.

Additionally, the `promiseBatch` code was refactored to be easier to understand and maintain.


