### PR TITLE
ui: Convert ScheduleOverrideCreateDialog to hooks

### DIFF
--- a/web/src/app/schedules/ScheduleOverrideCreateDialog.js
+++ b/web/src/app/schedules/ScheduleOverrideCreateDialog.js
@@ -72,7 +72,7 @@ export default function ScheduleOverrideCreateDialog(props) {
           disabled={loading}
           errors={fieldErrors(error)}
           value={value}
-          onChange={newValue => setValue({ ...value, ...newValue })}
+          onChange={newValue => setValue(newValue)}
         />
       }
     />

--- a/web/src/app/schedules/ScheduleOverrideCreateDialog.js
+++ b/web/src/app/schedules/ScheduleOverrideCreateDialog.js
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { useState } from 'react'
 import p from 'prop-types'
-import { Mutation } from 'react-apollo'
+import { useMutation } from 'react-apollo'
 import FormDialog from '../dialogs/FormDialog'
 import { DateTime } from 'luxon'
 import ScheduleOverrideForm from './ScheduleOverrideForm'
@@ -33,79 +33,64 @@ const mutation = gql`
   }
 `
 
-export default class ScheduleOverrideCreateDialog extends React.PureComponent {
-  static propTypes = {
-    scheduleID: p.string.isRequired,
-    variant: p.oneOf(['add', 'remove', 'replace']).isRequired,
-    onClose: p.func,
-    defaultValue: p.shape({
-      addUserID: p.string,
-      removeUserID: p.string,
-      start: p.string,
-      end: p.string,
-    }),
-  }
+export default function ScheduleOverrideCreateDialog(props) {
+  const [value, setValue] = useState({
+    addUserID: '',
+    removeUserID: '',
+    start: DateTime.local()
+      .startOf('hour')
+      .toISO(),
+    end: DateTime.local()
+      .startOf('hour')
+      .plus({ hours: 8 })
+      .toISO(),
+    ...props.defaultValue,
+  })
 
-  static defaultProps = {
-    defaultValue: {},
-  }
-
-  constructor(props) {
-    super(props)
-
-    this.state = {
-      value: {
-        addUserID: '',
-        removeUserID: '',
-        start: DateTime.local()
-          .startOf('hour')
-          .toISO(),
-        end: DateTime.local()
-          .startOf('hour')
-          .plus({ hours: 8 })
-          .toISO(),
-        ...props.defaultValue,
+  const [mutate, { loading, error }] = useMutation(mutation, {
+    variables: {
+      input: {
+        ...value,
+        scheduleID: props.scheduleID,
       },
-    }
-  }
+    },
+    onCompleted: props.onClose,
+  })
 
-  render() {
-    return (
-      <Mutation mutation={mutation} onCompleted={this.props.onClose}>
-        {this.renderDialog}
-      </Mutation>
-    )
-  }
+  return (
+    <FormDialog
+      onClose={props.onClose}
+      title={copyText[props.variant].title}
+      subTitle={copyText[props.variant].desc}
+      errors={nonFieldErrors(error)}
+      onSubmit={mutate}
+      form={
+        <ScheduleOverrideForm
+          add={props.variant !== 'remove'}
+          remove={props.variant !== 'add'}
+          scheduleID={props.scheduleID}
+          disabled={loading}
+          errors={fieldErrors(error)}
+          value={value}
+          onChange={newValue => setValue({ ...value, ...newValue })}
+        />
+      }
+    />
+  )
+}
 
-  renderDialog = (commit, status) => {
-    return (
-      <FormDialog
-        onClose={this.props.onClose}
-        title={copyText[this.props.variant].title}
-        subTitle={copyText[this.props.variant].desc}
-        errors={nonFieldErrors(status.error)}
-        onSubmit={() =>
-          commit({
-            variables: {
-              input: {
-                ...this.state.value,
-                scheduleID: this.props.scheduleID,
-              },
-            },
-          })
-        }
-        form={
-          <ScheduleOverrideForm
-            add={this.props.variant !== 'remove'}
-            remove={this.props.variant !== 'add'}
-            scheduleID={this.props.scheduleID}
-            disabled={status.loading}
-            errors={fieldErrors(status.error)}
-            value={this.state.value}
-            onChange={value => this.setState({ value })}
-          />
-        }
-      />
-    )
-  }
+ScheduleOverrideCreateDialog.defaultProps = {
+  defaultValue: {},
+}
+
+ScheduleOverrideCreateDialog.propTypes = {
+  scheduleID: p.string.isRequired,
+  variant: p.oneOf(['add', 'remove', 'replace']).isRequired,
+  onClose: p.func,
+  defaultValue: p.shape({
+    addUserID: p.string,
+    removeUserID: p.string,
+    start: p.string,
+    end: p.string,
+  }),
 }

--- a/web/src/app/schedules/ScheduleOverrideCreateDialog.js
+++ b/web/src/app/schedules/ScheduleOverrideCreateDialog.js
@@ -63,7 +63,7 @@ export default function ScheduleOverrideCreateDialog(props) {
       title={copyText[props.variant].title}
       subTitle={copyText[props.variant].desc}
       errors={nonFieldErrors(error)}
-      onSubmit={mutate}
+      onSubmit={() => mutate()}
       form={
         <ScheduleOverrideForm
           add={props.variant !== 'remove'}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Additional Info:**
Calendar schedule pages are lagging, including dialogs. Converted the dialogs to hooks, but didn't gain any significant improvement in perf