### PR TITLE
cypress: Increase timeout when closing dialogs

### DIFF
--- a/web/src/cypress/support/dialog.ts
+++ b/web/src/cypress/support/dialog.ts
@@ -54,8 +54,8 @@ function dialogFinish(s: string): Cypress.Chainable {
       const id = el.data('cyGu')
       return cy
         .dialogClick(s)
-        .get(`[data-cy-gu=${id}]`, { timeout: 10000 })
-        .should('not.exist')
+        .get(`[data-cy-gu=${id}]`)
+        .should('not.exist', { timeout: 15000 })
     })
 }
 

--- a/web/src/cypress/support/dialog.ts
+++ b/web/src/cypress/support/dialog.ts
@@ -54,7 +54,7 @@ function dialogFinish(s: string): Cypress.Chainable {
       const id = el.data('cyGu')
       return cy
         .dialogClick(s)
-        .get(`[data-cy-gu=${id}]`)
+        .get(`[data-cy-gu=${id}]`, { timeout: 10000 })
         .should('not.exist')
     })
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Increases timeout on commands in `dialogFinish()` from 4000 (default) to 10000

**Which issue(s) this PR fixes:**
Addresses flakey build in #326
