### PR TITLE
ui: Always allow clearing of select input fields

### DIFF
--- a/web/src/app/escalation-policies/PolicyForm.js
+++ b/web/src/app/escalation-policies/PolicyForm.js
@@ -4,6 +4,7 @@ import Grid from '@material-ui/core/Grid'
 import TextField from '@material-ui/core/TextField'
 import { FormContainer, FormField } from '../forms'
 import MaterialSelect from '../selection/MaterialSelect'
+import _ from 'lodash-es'
 
 export default class PolicyForm extends PureComponent {
   static propTypes = {
@@ -73,7 +74,7 @@ export default class PolicyForm extends PureComponent {
                 { label: '5', value: '5' },
               ]}
               required
-              value={this.props.value.repeat.value}
+              value={_.get(this.props.value, 'repeat.value')}
             />
           </Grid>
         </Grid>

--- a/web/src/app/selection/MaterialSelect.js
+++ b/web/src/app/selection/MaterialSelect.js
@@ -88,7 +88,7 @@ export default class MaterialSelect extends Component {
           }}
           name={name}
           classes={classes}
-          isClearable={!required}
+          isClearable
           isDisabled={disabled}
           isMulti={multiple}
           value={value}

--- a/web/src/cypress/integration/materialselect.ts
+++ b/web/src/cypress/integration/materialselect.ts
@@ -1,0 +1,74 @@
+import { Chance } from 'chance'
+import { testScreen } from '../support'
+
+const c = new Chance()
+
+testScreen('MaterialSelect', testMaterialSelect)
+
+function testMaterialSelect(screen: ScreenFormat) {
+  describe('Clearable fields', () => {
+    let ep: EP
+    let svc: Service
+
+    before(() => {
+      cy.createEP().then(e => {
+        ep = e
+      })
+      cy.createService().then(e => {
+        svc = e
+      })
+    })
+
+    it('should clear required fields', () => {
+      cy.visit(`/escalation-policies/${ep.id}`)
+      const name = 'SM EP ' + c.word({ length: 7 })
+      const description = c.word({ length: 9 })
+      const repeat = c.integer({ min: 0, max: 5 }).toString()
+
+      cy.pageAction('Edit Escalation Policy')
+      cy.dialogTitle('Edit Escalation Policy')
+
+      //fill name and descr, but clear repeat; expect validation error
+      cy.dialogForm({ name, description, repeat: null })
+      cy.dialogClick('Submit')
+      cy.dialogContains('Required field')
+
+      // fill in repeat; expect success
+      cy.dialogForm({ repeat })
+      cy.dialogFinish('Submit')
+
+      // old name and descr should not be present
+      cy.get('body')
+        .should('not.contain', ep.name)
+        .should('not.contain', ep.description)
+
+      // new ones should
+      cy.get('body')
+        .should('contain', name)
+        .should('contain', description)
+    })
+
+    it('should clear optional fields', () => {
+      cy.visit('/services')
+      const name = 'SM Svc ' + c.word({ length: 8 })
+      const description = c.word({ length: 10 })
+
+      cy.pageFab()
+      cy.dialogForm({
+        name,
+        'escalation-policy': svc.ep.name,
+        description,
+      })
+
+      cy.dialogForm({
+        'escalation-policy': null,
+      })
+      cy.dialogFinish('Submit')
+
+      // should be on details page
+      cy.get('body')
+        .should('contain', name)
+        .should('contain', description)
+    })
+  })
+}

--- a/web/src/cypress/integration/rotations.ts
+++ b/web/src/cypress/integration/rotations.ts
@@ -54,9 +54,11 @@ function testRotations(screen: ScreenFormat) {
             description,
             timeZone: tz,
             type,
-            dayOfWeek: type === 'Weekly' ? start.weekdayLong : null,
             shiftLength: shiftLength.toString(),
           })
+          if (type === 'Weekly') {
+            cy.dialogForm({ dayOfWeek: start.weekdayLong })
+          }
           cy.dialogFinish('Submit')
 
           // should be on details page


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Describe any introduced user-facing changes:**
Users will now be able to clear select fields, even if they are required by the form. (The form still won't submit when the fields are empty).
