### PR TITLE
ui/ServiceAlerts: wrap call to mutate in onSubmit handler

### DIFF
--- a/web/src/app/services/components/ServiceAlerts.js
+++ b/web/src/app/services/components/ServiceAlerts.js
@@ -82,7 +82,7 @@ export default function ServiceAlerts(props) {
           confirm
           subTitle={`This will ${alertStatus} all the alerts for this service.`}
           caption='This will stop all notifications from being sent out for all alerts with this service.'
-          onSubmit={mutate}
+          onSubmit={() => mutate()}
           loading={loading}
           onClose={() => setShowDialog(false)}
         />


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
`onSubmit` is an event handler that will pass in arguments not meant for mutate, and we don't want it to interpret the return value of mutate.
