### PR TITLE
ci: make check will fail if cypress version mismatch

### DIFF
--- a/devtools/ci/dockerfiles/cypress-env/Dockerfile
+++ b/devtools/ci/dockerfiles/cypress-env/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/included:3.4.1
+FROM cypress/included:3.8.1
 ENTRYPOINT [ "/bin/sh" ]
 RUN apt-get update && apt-get install -y --no-install-recommends postgresql postgresql-contrib && rm -rf /var/lib/apt/lists/*
 ENV PGDATA=/var/lib/postgresql/data PGUSER=postgres DB_URL=postgresql://postgres@

--- a/devtools/ci/tasks/scripts/codecheck.sh
+++ b/devtools/ci/tasks/scripts/codecheck.sh
@@ -19,3 +19,11 @@ then
 	exit 1
 fi
 
+# assert Cypress versions are identical
+PKG_JSON_VER=$(grep '"cypress":' web/src/package.json | awk -F '"' '{print $4}')
+DOCKERFILE_VER=$(grep 'FROM cypress/included:' devtools/ci/dockerfiles/cypress-env/Dockerfile | awk -F ':' '{print $2}')
+if [ "$PKG_JSON_VER" != "$DOCKERFILE_VER" ]; then
+  echo "Cypress versions do not match:"
+  echo "package.json: ${PKG_JSON_VER} - Dockerfile: ${DOCKERFILE_VER}"
+  exit 1
+fi


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adjusts `codecheck.sh` (which is called by `make check`) so an error occurs if Cypress versions are not set with the same version in both:
`web/src/package.json`
and
`devtools/ci/dockerfiles/cypress-env/Dockerfile`