### PR TITLE
ui: set fixed size on loading spinner

### DIFF
--- a/web/src/app/loading/components/Spinner.js
+++ b/web/src/app/loading/components/Spinner.js
@@ -59,7 +59,7 @@ export default class Spinner extends React.PureComponent {
 
     return (
       <span style={style}>
-        <CircularProgress size={this.props.text ? '1em' : null} />
+        <CircularProgress size={this.props.text ? '1em' : '5em'} />
         &nbsp;{this.props.text}
       </span>
     )

--- a/web/src/app/loading/components/Spinner.js
+++ b/web/src/app/loading/components/Spinner.js
@@ -59,7 +59,7 @@ export default class Spinner extends React.PureComponent {
 
     return (
       <span style={style}>
-        <CircularProgress size={this.props.text ? '1em' : '5em'} />
+        <CircularProgress size={this.props.text ? '1em' : '40px'} />
         &nbsp;{this.props.text}
       </span>
     )


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Loading spinners weren't styled correctly in Firefox. This change has been tested for compatibility in Chrome, Firefox, and Safari.

**Describe any introduced user-facing changes:**
Loading spinners will be a fixed height on all devices.

