### PR TITLE
ui: migrate from moment to luxon

### DIFF
--- a/web/src/app/alerts/components/AlertsListDataWrapper.js
+++ b/web/src/app/alerts/components/AlertsListDataWrapper.js
@@ -5,7 +5,7 @@ import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
 import Typography from '@material-ui/core/Typography'
-import moment from 'moment'
+import { DateTime } from 'luxon'
 import withStyles from '@material-ui/core/styles/withStyles'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
@@ -48,26 +48,6 @@ export default class AlertsListDataWrapper extends Component {
   static propTypes = {
     alert: p.object.isRequired,
     onServicePage: p.bool,
-  }
-
-  componentWillMount() {
-    moment.updateLocale('en', {
-      relativeTime: {
-        future: 'in %s',
-        past: '%s ago',
-        s: '< 1m',
-        m: '1m',
-        mm: '%dm',
-        h: '1h',
-        hh: '%dh',
-        d: '1d',
-        dd: '%dd',
-        M: '1mo',
-        MM: '%dmo',
-        y: '1y',
-        yy: '%dy',
-      },
-    })
   }
 
   componentWillReceiveProps(nextProps, nextContext) {
@@ -154,9 +134,9 @@ export default class AlertsListDataWrapper extends Component {
         <ListItemSecondaryAction>
           <ListItemText disableTypography>
             <Typography variant='caption'>
-              {moment(alert.created_at)
-                .local()
-                .fromNow()}
+              {DateTime.fromISO(alert.created_at)
+                .toLocal()
+                .toRelative({ style: 'narrow' })}
             </Typography>
           </ListItemText>
         </ListItemSecondaryAction>

--- a/web/src/app/alerts/components/AlertsListDataWrapper.js
+++ b/web/src/app/alerts/components/AlertsListDataWrapper.js
@@ -5,7 +5,6 @@ import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
 import Typography from '@material-ui/core/Typography'
-import { DateTime } from 'luxon'
 import withStyles from '@material-ui/core/styles/withStyles'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
@@ -13,6 +12,7 @@ import { setCheckedAlerts } from '../../actions'
 import { bindActionCreators } from 'redux'
 import statusStyles from '../../util/statusStyles'
 import { alertFilterSelector } from '../../selectors'
+import { formatTimeSince } from '../../util/timeFormat'
 
 const styles = {
   checkBox: {
@@ -134,9 +134,7 @@ export default class AlertsListDataWrapper extends Component {
         <ListItemSecondaryAction>
           <ListItemText disableTypography>
             <Typography variant='caption'>
-              {DateTime.fromISO(alert.created_at)
-                .toLocal()
-                .toRelative({ style: 'narrow' })}
+              {formatTimeSince(alert.created_at)}
             </Typography>
           </ListItemText>
         </ListItemSecondaryAction>

--- a/web/src/app/schedules/CalendarEventWrapper.js
+++ b/web/src/app/schedules/CalendarEventWrapper.js
@@ -99,7 +99,7 @@ export default class CalendarEventWrapper extends Component {
     const { classes, event } = this.props
 
     let overrideCtrls = null
-    if (DateTime.fromJSDate(event.end).toUTC() > DateTime.utc()) {
+    if (DateTime.fromJSDate(event.end) > DateTime.utc()) {
       overrideCtrls = (
         <React.Fragment>
           <Grid item className={classes.buttonContainer}>

--- a/web/src/app/schedules/CalendarEventWrapper.js
+++ b/web/src/app/schedules/CalendarEventWrapper.js
@@ -7,7 +7,6 @@ import RemoveIcon from '@material-ui/icons/Delete'
 import Tooltip from '@material-ui/core/Tooltip'
 import withStyles from '@material-ui/core/styles/withStyles'
 import { connect } from 'react-redux'
-import moment from 'moment'
 import { urlParamSelector } from '../selectors'
 import { DateTime, Duration } from 'luxon'
 
@@ -100,7 +99,7 @@ export default class CalendarEventWrapper extends Component {
     const { classes, event } = this.props
 
     let overrideCtrls = null
-    if (moment(event.end).isAfter(moment())) {
+    if (DateTime.fromJSDate(event.end).toUTC() > DateTime.utc()) {
       overrideCtrls = (
         <React.Fragment>
           <Grid item className={classes.buttonContainer}>
@@ -128,12 +127,13 @@ export default class CalendarEventWrapper extends Component {
       )
     }
 
+    const formatJSDate = JSDate =>
+      DateTime.fromJSDate(JSDate).toLocaleString(DateTime.DATETIME_FULL)
+
     return (
       <Grid container spacing={1}>
         <Grid item xs={12}>
-          {moment(event.start).format('LLL')}
-          {' – '}
-          {moment(event.end).format('LLL')}
+          {`${formatJSDate(event.start)}  –  ${formatJSDate(event.end)}`}
         </Grid>
         {overrideCtrls}
       </Grid>

--- a/web/src/app/schedules/CalendarToolbar.js
+++ b/web/src/app/schedules/CalendarToolbar.js
@@ -8,7 +8,7 @@ import {
   makeStyles,
   Typography,
 } from '@material-ui/core'
-import moment from 'moment'
+import { DateTime } from 'luxon'
 import { urlParamSelector } from '../selectors'
 
 const useStyles = makeStyles(theme => ({
@@ -52,26 +52,25 @@ export default function CalendarToolbar(props) {
   const weekly = urlParams('weekly', false)
 
   const handleTodayClick = e => {
-    props.onNavigate(e, moment().toDate())
+    props.onNavigate(e, DateTime.local().toJSDate())
   }
 
   const handleBackClick = e => {
-    const nextDate = weekly
-      ? moment(date)
-          .clone()
-          .subtract(1, 'week')
-      : moment(date)
-          .clone()
-          .subtract(1, 'month')
+    const timeUnit = weekly ? { weeks: 1 } : { months: 1 }
+    const nextDate = DateTime.fromJSDate(date)
+      .minus(timeUnit)
+      .toJSDate()
 
-    props.onNavigate(e, nextDate.toDate())
+    props.onNavigate(e, nextDate)
   }
 
   const handleNextClick = e => {
-    // either month or week
-    const dateCopy = moment(date).clone()
-    const nextDate = weekly ? dateCopy.add(1, 'week') : dateCopy.add(1, 'month')
-    props.onNavigate(e, nextDate.toDate())
+    const timeUnit = weekly ? { weeks: 1 } : { months: 1 }
+    const nextDate = DateTime.fromJSDate(date)
+      .plus(timeUnit)
+      .toJSDate()
+
+    props.onNavigate(e, nextDate)
   }
 
   const handleMonthViewClick = () => {

--- a/web/src/app/schedules/ScheduleCalendar.js
+++ b/web/src/app/schedules/ScheduleCalendar.js
@@ -138,7 +138,7 @@ export default class ScheduleCalendar extends React.PureComponent {
     } else if (nextView === 'week' && prevStartMonth !== currMonth) {
       this.props.setWeekly(true)
       this.props.setStart(
-        DateTime.fromJSDate(this.props.start)
+        DateTime.fromISO(this.props.start)
           .toLocal()
           .startOf('month')
           .toUTC()

--- a/web/src/app/schedules/ScheduleCalendar.js
+++ b/web/src/app/schedules/ScheduleCalendar.js
@@ -4,8 +4,7 @@ import Card from '@material-ui/core/Card'
 import Typography from '@material-ui/core/Typography'
 import withStyles from '@material-ui/core/styles/withStyles'
 import { connect } from 'react-redux'
-import moment from 'moment'
-import { Calendar, momentLocalizer } from 'react-big-calendar'
+import { Calendar } from 'react-big-calendar'
 import '../../node_modules/react-big-calendar/lib/css/react-big-calendar.css'
 import CalendarEventWrapper from './CalendarEventWrapper'
 import CalendarToolbar from './CalendarToolbar'
@@ -14,8 +13,10 @@ import { resetURLParams, setURLParam } from '../actions'
 import { urlParamSelector } from '../selectors'
 import { DateTime, Interval } from 'luxon'
 import { theme } from '../mui'
+import { getLuxonStartOfWeek, getLuxonEndOfWeek } from '../util/luxon-helpers'
+import LuxonLocalizer from '../util/LuxonLocalizer'
 
-const localizer = momentLocalizer(moment)
+const localizer = LuxonLocalizer(DateTime, { firstDayOfWeek: 0 })
 
 const styles = {
   calendarContainer: {
@@ -29,17 +30,22 @@ const mapStateToProps = state => {
   const start = urlParamSelector(state)(
     'start',
     weekly
-      ? moment()
-          .startOf('week')
-          .toISOString()
-      : moment()
+      ? getLuxonStartOfWeek()
+          .toUTC()
+          .toISO()
+      : DateTime.local()
           .startOf('month')
-          .toISOString(),
+          .toUTC()
+          .toISO(),
   )
 
-  const end = moment(start)
-    .add(1, weekly ? 'week' : 'month')
-    .toISOString()
+  const timeUnit = weekly ? { weeks: 1 } : { months: 1 }
+
+  const end = DateTime.fromISO(start)
+    .toLocal()
+    .plus(timeUnit)
+    .toUTC()
+    .toISO()
 
   return {
     start,
@@ -86,17 +92,17 @@ export default class ScheduleCalendar extends React.PureComponent {
   handleCalNavigate = nextDate => {
     if (this.props.weekly) {
       this.props.setStart(
-        moment(nextDate)
-          .startOf('week')
-          .startOf('day')
-          .toISOString(),
+        getLuxonStartOfWeek(nextDate)
+          .toUTC()
+          .toISO(),
       )
     } else {
       this.props.setStart(
-        moment(nextDate)
+        DateTime.fromJSDate(nextDate)
+          .toLocal()
           .startOf('month')
-          .startOf('day')
-          .toISOString(),
+          .toUTC()
+          .toISO(),
       )
     }
   }
@@ -116,26 +122,27 @@ export default class ScheduleCalendar extends React.PureComponent {
    */
   handleViewChange = nextView => {
     const start = this.props.start
-    const prevStartMonth = moment(start).month()
-    const currMonth = moment().month()
+    const prevStartMonth = DateTime.fromISO(start).toLocal().month
+    const currMonth = DateTime.local().month
 
     // if viewing the current month, show the current week
     if (nextView === 'week' && prevStartMonth === currMonth) {
       this.props.setWeekly(true)
       this.props.setStart(
-        moment()
-          .startOf('week')
-          .toISOString(),
+        getLuxonStartOfWeek()
+          .toUTC()
+          .toISO(),
       )
 
       // if not on the current month, show the first week of the month
     } else if (nextView === 'week' && prevStartMonth !== currMonth) {
       this.props.setWeekly(true)
       this.props.setStart(
-        moment(this.props.start)
+        DateTime.fromJSDate(this.props.start)
+          .toLocal()
           .startOf('month')
-          .startOf('week')
-          .toISOString(),
+          .toUTC()
+          .toISO(),
       )
 
       // go from week to monthly view
@@ -145,10 +152,11 @@ export default class ScheduleCalendar extends React.PureComponent {
       this.props.setWeekly(false)
 
       this.props.setStart(
-        moment(start)
-          .endOf('week')
+        getLuxonEndOfWeek(new Date(start))
+          .toLocal()
           .startOf('month')
-          .toISOString(),
+          .toUTC()
+          .toISO(),
       )
     }
   }
@@ -171,7 +179,11 @@ export default class ScheduleCalendar extends React.PureComponent {
    * the default light blue
    */
   dayPropGetter = date => {
-    if (moment(date).isSame(moment(), 'd')) {
+    if (
+      DateTime.fromJSDate(date)
+        .toLocal()
+        .hasSame(DateTime.local(), 'day')
+    ) {
       return {
         style: {
           backgroundColor: '#FFECEC',

--- a/web/src/app/schedules/ScheduleCalendar.js
+++ b/web/src/app/schedules/ScheduleCalendar.js
@@ -13,7 +13,7 @@ import { resetURLParams, setURLParam } from '../actions'
 import { urlParamSelector } from '../selectors'
 import { DateTime, Interval } from 'luxon'
 import { theme } from '../mui'
-import { getLuxonStartOfWeek, getLuxonEndOfWeek } from '../util/luxon-helpers'
+import { getStartOfWeek, getEndOfWeek } from '../util/luxon-helpers'
 import LuxonLocalizer from '../util/LuxonLocalizer'
 
 const localizer = LuxonLocalizer(DateTime, { firstDayOfWeek: 0 })
@@ -30,7 +30,7 @@ const mapStateToProps = state => {
   const start = urlParamSelector(state)(
     'start',
     weekly
-      ? getLuxonStartOfWeek()
+      ? getStartOfWeek()
           .toUTC()
           .toISO()
       : DateTime.local()
@@ -92,7 +92,7 @@ export default class ScheduleCalendar extends React.PureComponent {
   handleCalNavigate = nextDate => {
     if (this.props.weekly) {
       this.props.setStart(
-        getLuxonStartOfWeek(nextDate)
+        getStartOfWeek(DateTime.fromJSDate(nextDate))
           .toUTC()
           .toISO(),
       )
@@ -129,7 +129,7 @@ export default class ScheduleCalendar extends React.PureComponent {
     if (nextView === 'week' && prevStartMonth === currMonth) {
       this.props.setWeekly(true)
       this.props.setStart(
-        getLuxonStartOfWeek()
+        getStartOfWeek()
           .toUTC()
           .toISO(),
       )
@@ -152,7 +152,7 @@ export default class ScheduleCalendar extends React.PureComponent {
       this.props.setWeekly(false)
 
       this.props.setStart(
-        getLuxonEndOfWeek(new Date(start))
+        getEndOfWeek(DateTime.fromJSDate(new Date(start)))
           .toLocal()
           .startOf('month')
           .toUTC()

--- a/web/src/app/schedules/ScheduleCalendarQuery.js
+++ b/web/src/app/schedules/ScheduleCalendarQuery.js
@@ -5,7 +5,8 @@ import ScheduleCalendar from './ScheduleCalendar'
 import { urlParamSelector } from '../selectors'
 import { connect } from 'react-redux'
 import withWidth, { isWidthDown } from '@material-ui/core/withWidth/index'
-import moment from 'moment/moment'
+import { getLuxonStartOfWeek } from '../util/luxon-helpers'
+import { DateTime } from 'luxon'
 
 const query = gql`
   query scheduleCalendarShifts(
@@ -34,17 +35,19 @@ const mapStateToProps = state => {
   const start = urlParamSelector(state)(
     'start',
     weekly
-      ? moment()
-          .startOf('week')
-          .toISOString()
-      : moment()
+      ? getLuxonStartOfWeek()
+          .toUTC()
+          .toISO()
+      : DateTime.utc()
           .startOf('month')
-          .toISOString(),
+          .toISO(),
   )
 
-  const end = moment(start)
-    .add(1, weekly ? 'week' : 'month')
-    .toISOString()
+  const unitToAdd = weekly ? { weeks: 1 } : { months: 1 }
+  const end = DateTime.fromISO(start)
+    .plus(unitToAdd)
+    .toUTC()
+    .toISO()
 
   return {
     start,

--- a/web/src/app/schedules/ScheduleCalendarQuery.js
+++ b/web/src/app/schedules/ScheduleCalendarQuery.js
@@ -38,8 +38,9 @@ const mapStateToProps = state => {
       ? getLuxonStartOfWeek()
           .toUTC()
           .toISO()
-      : DateTime.utc()
+      : DateTime.local()
           .startOf('month')
+          .toUTC()
           .toISO(),
   )
 

--- a/web/src/app/schedules/ScheduleCalendarQuery.js
+++ b/web/src/app/schedules/ScheduleCalendarQuery.js
@@ -5,7 +5,7 @@ import ScheduleCalendar from './ScheduleCalendar'
 import { urlParamSelector } from '../selectors'
 import { connect } from 'react-redux'
 import withWidth, { isWidthDown } from '@material-ui/core/withWidth/index'
-import { getLuxonStartOfWeek } from '../util/luxon-helpers'
+import { getStartOfWeek } from '../util/luxon-helpers'
 import { DateTime } from 'luxon'
 
 const query = gql`
@@ -35,7 +35,7 @@ const mapStateToProps = state => {
   const start = urlParamSelector(state)(
     'start',
     weekly
-      ? getLuxonStartOfWeek()
+      ? getStartOfWeek()
           .toUTC()
           .toISO()
       : DateTime.local()

--- a/web/src/app/util/CountDown.js
+++ b/web/src/app/util/CountDown.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { PropTypes as p } from 'prop-types'
 import withStyles from '@material-ui/core/styles/withStyles'
-import moment from 'moment'
+import { DateTime } from 'luxon'
 import { styles } from '../styles/materialStyles'
 
 export function formatTimeRemaining(
@@ -68,7 +68,8 @@ export default class CountDown extends Component {
     super(props)
 
     this.state = {
-      timeRemaining: moment(props.end).unix() - moment(Date.now()).unix(),
+      timeRemaining:
+        DateTime.fromISO(props.end).toSeconds() - DateTime.local().toSeconds(),
     }
   }
 
@@ -108,7 +109,8 @@ export default class CountDown extends Component {
       if (this.state.timeRemaining > 0) {
         this.setState({
           timeRemaining:
-            moment(this.props.end).unix() - moment(Date.now()).unix(),
+            DateTime.fromISO(this.props.end).toSeconds() -
+            DateTime.local().toSeconds(),
         })
       }
     }, 1000)

--- a/web/src/app/util/LuxonLocalizer.js
+++ b/web/src/app/util/LuxonLocalizer.js
@@ -1,0 +1,60 @@
+import * as dates from 'react-big-calendar/lib/utils/dates'
+import { DateLocalizer } from 'react-big-calendar/lib/localizer'
+
+const dateRangeFormat = ({ start, end }, culture, local) =>
+  `${local.format(start, 'D', culture)} — ${local.format(end, 'D', culture)}`
+
+const timeRangeFormat = ({ start, end }, culture, local) =>
+  `${local.format(start, 't', culture)} — ${local.format(end, 't', culture)}`
+
+const timeRangeStartFormat = ({ start }, culture, local) =>
+  `${local.format(start, 't', culture)} — `
+
+const timeRangeEndFormat = ({ end }, culture, local) =>
+  ` — ${local.format(end, 't', culture)}`
+
+const weekRangeFormat = ({ start, end }, culture, local) =>
+  `${local.format(start, 'MMMM dd', culture)} — ${local.format(
+    end,
+    dates.eq(start, end, 'month') ? 'dd' : 'MMMM dd',
+    culture,
+  )}`
+
+export const formats = {
+  dateFormat: 'dd',
+  dayFormat: 'dd EEE',
+  weekdayFormat: 'ccc',
+
+  selectRangeFormat: timeRangeFormat,
+  eventTimeRangeFormat: timeRangeFormat,
+  eventTimeRangeStartFormat: timeRangeStartFormat,
+  eventTimeRangeEndFormat: timeRangeEndFormat,
+
+  timeGutterFormat: 't',
+
+  monthHeaderFormat: 'MMMM yyyy',
+  dayHeaderFormat: 'dddd MMM dd',
+  dayRangeHeaderFormat: weekRangeFormat,
+  agendaHeaderFormat: dateRangeFormat,
+
+  agendaDateFormat: 'EEE MMM dd',
+  agendaTimeFormat: 't',
+  agendaTimeRangeFormat: timeRangeFormat,
+}
+
+const LuxonLocalizer = function(DateTime, { firstDayOfWeek }) {
+  const locale = (d, c) => (c ? d.reconfigure(c) : d)
+
+  return new DateLocalizer({
+    formats,
+    firstOfWeek() {
+      return firstDayOfWeek
+    },
+
+    format(value, format, culture) {
+      return locale(DateTime.fromJSDate(value), culture).toFormat(format)
+    },
+  })
+}
+
+export default LuxonLocalizer

--- a/web/src/app/util/LuxonLocalizer.js
+++ b/web/src/app/util/LuxonLocalizer.js
@@ -33,11 +33,11 @@ export const formats = {
   timeGutterFormat: 't',
 
   monthHeaderFormat: 'MMMM yyyy',
-  dayHeaderFormat: 'dddd MMM dd',
+  dayHeaderFormat: 'cccc MMM dd',
   dayRangeHeaderFormat: weekRangeFormat,
   agendaHeaderFormat: dateRangeFormat,
 
-  agendaDateFormat: 'EEE MMM dd',
+  agendaDateFormat: 'ccc MMM dd',
   agendaTimeFormat: 't',
   agendaTimeRangeFormat: timeRangeFormat,
 }

--- a/web/src/app/util/luxon-helpers.js
+++ b/web/src/app/util/luxon-helpers.js
@@ -1,0 +1,33 @@
+import { DateTime } from 'luxon'
+
+// getLuxonStartOfWeek
+// Given a JS Date object, this yields a DateTime object set to the previous Sunday at 12am.
+// If no date is provided, default to now
+// This is excluded from Luxon core since certain countries start the week on Saturday or Sunday
+// Conventionally, weeks start on a Monday
+export function getLuxonStartOfWeek(JSDate = new Date()) {
+  // 1-based i.e. [Mon=1, Tues=2, ... Sat=6, Sun=7]
+  const _weekdayIndex = DateTime.fromJSDate(JSDate).toLocal().weekday
+  const weekdayIndex = _weekdayIndex === 7 ? 0 : _weekdayIndex
+
+  return DateTime.fromJSDate(JSDate)
+    .toLocal()
+    .minus({
+      days: weekdayIndex,
+    })
+    .startOf('day')
+}
+
+// getLuxonEndOfWeek
+export function getLuxonEndOfWeek(JSDate = new Date()) {
+  // 1-based i.e. [Mon=1, Tues=2, ... Sat=6, Sun=7]
+  const _weekdayIndex = DateTime.fromJSDate(JSDate).toLocal().weekday
+  const weekdayIndex = _weekdayIndex === 7 ? 0 : _weekdayIndex
+
+  return DateTime.fromJSDate(JSDate)
+    .toLocal()
+    .plus({
+      days: 6 - weekdayIndex,
+    })
+    .endOf('day')
+}

--- a/web/src/app/util/luxon-helpers.js
+++ b/web/src/app/util/luxon-helpers.js
@@ -1,16 +1,16 @@
 import { DateTime } from 'luxon'
 
-// getLuxonStartOfWeek
-// Given a JS Date object, this yields a DateTime object set to the previous Sunday at 12am.
+// getStartOfWeek
+// Given a luxon DateTime, this yields a luxon DateTime set to the previous Sunday at 12am.
 // If no date is provided, default to now
 // This is excluded from Luxon core since certain countries start the week on Saturday or Sunday
-// Conventionally, weeks start on a Monday
-export function getLuxonStartOfWeek(JSDate = new Date()) {
+// (Conventionally, weeks start on a Monday)
+export function getStartOfWeek(luxonDateTime = DateTime.local()) {
   // 1-based i.e. [Mon=1, Tues=2, ... Sat=6, Sun=7]
-  const _weekdayIndex = DateTime.fromJSDate(JSDate).toLocal().weekday
+  const _weekdayIndex = luxonDateTime.toLocal().weekday
   const weekdayIndex = _weekdayIndex === 7 ? 0 : _weekdayIndex
 
-  return DateTime.fromJSDate(JSDate)
+  return luxonDateTime
     .toLocal()
     .minus({
       days: weekdayIndex,
@@ -18,13 +18,13 @@ export function getLuxonStartOfWeek(JSDate = new Date()) {
     .startOf('day')
 }
 
-// getLuxonEndOfWeek
-export function getLuxonEndOfWeek(JSDate = new Date()) {
+// getEndOfWeek
+export function getEndOfWeek(luxonDateTime = DateTime.local()) {
   // 1-based i.e. [Mon=1, Tues=2, ... Sat=6, Sun=7]
-  const _weekdayIndex = DateTime.fromJSDate(JSDate).toLocal().weekday
+  const _weekdayIndex = luxonDateTime.toLocal().weekday
   const weekdayIndex = _weekdayIndex === 7 ? 0 : _weekdayIndex
 
-  return DateTime.fromJSDate(JSDate)
+  return luxonDateTime
     .toLocal()
     .plus({
       days: 6 - weekdayIndex,

--- a/web/src/app/util/luxon-helpers.test.js
+++ b/web/src/app/util/luxon-helpers.test.js
@@ -20,22 +20,22 @@ test('it should yield 12am on Sunday of the week of the date given', () => {
   const result2 = getNativeStartOfWeek()
   expect(result1.toMillis()).toBe(result2.getTime())
 
-  const davidsBirthday = new Date('November 26, 1997 03:24:00') // wednesday
-  const startOfDavidsWeek = new Date('November 23, 1997 00:00:00')
-  expect(getLuxonStartOfWeek(davidsBirthday).toMillis()).toBe(
-    startOfDavidsWeek.getTime(),
+  const randomWednesday = new Date('November 26, 1997 03:24:00')
+  const startOfRandomWednesdaysWeek = new Date('November 23, 1997 00:00:00')
+  expect(getLuxonStartOfWeek(randomWednesday).toMillis()).toBe(
+    startOfRandomWednesdaysWeek.getTime(),
   )
 
-  const katiesBirthday = new Date('December 15, 1996 03:24:30') // sunday
-  const startOfKatiesWeek = new Date('December 15, 1996 00:00:00')
-  expect(getLuxonStartOfWeek(katiesBirthday).toMillis()).toBe(
-    startOfKatiesWeek.getTime(),
+  const randomSunday = new Date('December 15, 1996 03:24:30')
+  const startOfRandomSundaysWeek = new Date('December 15, 1996 00:00:00')
+  expect(getLuxonStartOfWeek(randomSunday).toMillis()).toBe(
+    startOfRandomSundaysWeek.getTime(),
   )
 
-  const cooksBirthday = new Date('September 1, 2018 12:24:30') // saturday
-  const startOfCooksWeek = new Date('August 26, 2018 00:00:00')
-  expect(getLuxonStartOfWeek(cooksBirthday).toMillis()).toBe(
-    startOfCooksWeek.getTime(),
+  const randomSaturday = new Date('September 1, 2018 12:24:30')
+  const startOfRandomSaturdaysWeek = new Date('August 26, 2018 00:00:00')
+  expect(getLuxonStartOfWeek(randomSaturday).toMillis()).toBe(
+    startOfRandomSaturdaysWeek.getTime(),
   )
 
   const midnight = new Date('January 19, 2020 00:00:00') // 12am sunday
@@ -48,22 +48,22 @@ test('it should yield almost midnight on Saturday of the week of the date given'
   const result2 = getNativeEndOfWeek()
   expect(result1.toMillis()).toBe(result2.getTime())
 
-  const davidsBirthday = new Date('November 26, 1997 03:24:00') // wednesday
-  const endOfDavidsWeek = new Date('November 29, 1997 23:59:59:999')
-  expect(getLuxonEndOfWeek(davidsBirthday).toMillis()).toBe(
-    endOfDavidsWeek.getTime(),
+  const randomWednesday = new Date('November 26, 1997 03:24:00')
+  const endOfRandomWednesdaysWeek = new Date('November 29, 1997 23:59:59:999')
+  expect(getLuxonEndOfWeek(randomWednesday).toMillis()).toBe(
+    endOfRandomWednesdaysWeek.getTime(),
   )
 
-  const katiesBirthday = new Date('December 15, 1996 03:24:30') // sunday
-  const endOfKatiesWeek = new Date('December 21, 1996 23:59:59:999')
-  expect(getLuxonEndOfWeek(katiesBirthday).toMillis()).toBe(
-    endOfKatiesWeek.getTime(),
+  const randomSunday = new Date('December 15, 1996 03:24:30')
+  const endOfRandomSundaysWeek = new Date('December 21, 1996 23:59:59:999')
+  expect(getLuxonEndOfWeek(randomSunday).toMillis()).toBe(
+    endOfRandomSundaysWeek.getTime(),
   )
 
-  const cooksBirthday = new Date('September 1, 2018 12:24:30') // saturday
-  const endOfCooksWeek = new Date('September 1, 2018 23:59:59:999')
-  expect(getLuxonEndOfWeek(cooksBirthday).toMillis()).toBe(
-    endOfCooksWeek.getTime(),
+  const randomSaturday = new Date('September 1, 2018 12:24:30')
+  const endOfRandomSaturdaysWeek = new Date('September 1, 2018 23:59:59:999')
+  expect(getLuxonEndOfWeek(randomSaturday).toMillis()).toBe(
+    endOfRandomSaturdaysWeek.getTime(),
   )
 
   const almostMidnight = new Date('January 18, 2020 23:59:59:999') // saturday

--- a/web/src/app/util/luxon-helpers.test.js
+++ b/web/src/app/util/luxon-helpers.test.js
@@ -1,4 +1,5 @@
-import { getLuxonStartOfWeek, getLuxonEndOfWeek } from './luxon-helpers'
+import { getStartOfWeek, getEndOfWeek } from './luxon-helpers'
+import { DateTime } from 'luxon'
 
 const getNativeStartOfWeek = (dt = new Date()) => {
   const weekdayIndex = dt.getDay() // Sun - Sat : 0 - 6
@@ -16,58 +17,72 @@ const getNativeEndOfWeek = (dt = new Date()) => {
 
 test('it should yield 12am on Sunday of the week of the date given', () => {
   // get beginning of today's week
-  const result1 = getLuxonStartOfWeek()
+  const result1 = getStartOfWeek()
   const result2 = getNativeStartOfWeek()
   expect(result1.toMillis()).toBe(result2.getTime())
 
-  const randomWednesday = new Date('November 26, 1997 03:24:00')
+  const randomWednesday = DateTime.fromJSDate(
+    new Date('November 26, 1997 03:24:00'),
+  )
   const startOfRandomWednesdaysWeek = new Date('November 23, 1997 00:00:00')
-  expect(getLuxonStartOfWeek(randomWednesday).toMillis()).toBe(
+  expect(getStartOfWeek(randomWednesday).toMillis()).toBe(
     startOfRandomWednesdaysWeek.getTime(),
   )
 
-  const randomSunday = new Date('December 15, 1996 03:24:30')
+  const randomSunday = DateTime.fromJSDate(
+    new Date('December 15, 1996 03:24:30'),
+  )
   const startOfRandomSundaysWeek = new Date('December 15, 1996 00:00:00')
-  expect(getLuxonStartOfWeek(randomSunday).toMillis()).toBe(
+  expect(getStartOfWeek(randomSunday).toMillis()).toBe(
     startOfRandomSundaysWeek.getTime(),
   )
 
-  const randomSaturday = new Date('September 1, 2018 12:24:30')
+  const randomSaturday = DateTime.fromJSDate(
+    new Date('September 1, 2018 12:24:30'),
+  )
   const startOfRandomSaturdaysWeek = new Date('August 26, 2018 00:00:00')
-  expect(getLuxonStartOfWeek(randomSaturday).toMillis()).toBe(
+  expect(getStartOfWeek(randomSaturday).toMillis()).toBe(
     startOfRandomSaturdaysWeek.getTime(),
   )
 
   const midnight = new Date('January 19, 2020 00:00:00') // 12am sunday
-  expect(getLuxonStartOfWeek(midnight).toMillis()).toBe(midnight.getTime())
+  expect(getStartOfWeek(DateTime.fromJSDate(midnight)).toMillis()).toBe(
+    midnight.getTime(),
+  )
 })
 
 test('it should yield almost midnight on Saturday of the week of the date given', () => {
   // get end of today's week
-  const result1 = getLuxonEndOfWeek()
+  const result1 = getEndOfWeek()
   const result2 = getNativeEndOfWeek()
   expect(result1.toMillis()).toBe(result2.getTime())
 
-  const randomWednesday = new Date('November 26, 1997 03:24:00')
+  const randomWednesday = DateTime.fromJSDate(
+    new Date('November 26, 1997 03:24:00'),
+  )
   const endOfRandomWednesdaysWeek = new Date('November 29, 1997 23:59:59:999')
-  expect(getLuxonEndOfWeek(randomWednesday).toMillis()).toBe(
+  expect(getEndOfWeek(randomWednesday).toMillis()).toBe(
     endOfRandomWednesdaysWeek.getTime(),
   )
 
-  const randomSunday = new Date('December 15, 1996 03:24:30')
+  const randomSunday = DateTime.fromJSDate(
+    new Date('December 15, 1996 03:24:30'),
+  )
   const endOfRandomSundaysWeek = new Date('December 21, 1996 23:59:59:999')
-  expect(getLuxonEndOfWeek(randomSunday).toMillis()).toBe(
+  expect(getEndOfWeek(randomSunday).toMillis()).toBe(
     endOfRandomSundaysWeek.getTime(),
   )
 
-  const randomSaturday = new Date('September 1, 2018 12:24:30')
+  const randomSaturday = DateTime.fromJSDate(
+    new Date('September 1, 2018 12:24:30'),
+  )
   const endOfRandomSaturdaysWeek = new Date('September 1, 2018 23:59:59:999')
-  expect(getLuxonEndOfWeek(randomSaturday).toMillis()).toBe(
+  expect(getEndOfWeek(randomSaturday).toMillis()).toBe(
     endOfRandomSaturdaysWeek.getTime(),
   )
 
   const almostMidnight = new Date('January 18, 2020 23:59:59:999') // saturday
-  expect(getLuxonEndOfWeek(almostMidnight).toMillis()).toBe(
+  expect(getEndOfWeek(DateTime.fromJSDate(almostMidnight)).toMillis()).toBe(
     almostMidnight.getTime(),
   )
 })

--- a/web/src/app/util/luxon-helpers.test.js
+++ b/web/src/app/util/luxon-helpers.test.js
@@ -1,0 +1,73 @@
+import { getLuxonStartOfWeek, getLuxonEndOfWeek } from './luxon-helpers'
+
+const getNativeStartOfWeek = (dt = new Date()) => {
+  const weekdayIndex = dt.getDay() // Sun - Sat : 0 - 6
+  const sunday = new Date(new Date(dt).setDate(dt.getDate() - weekdayIndex))
+  return new Date(new Date(sunday).setHours(0, 0, 0, 0))
+}
+
+const getNativeEndOfWeek = (dt = new Date()) => {
+  const weekdayIndex = dt.getDay() // Sun - Sat : 0 - 6
+  const saturday = new Date(
+    new Date(dt).setDate(dt.getDate() + (6 - weekdayIndex)),
+  )
+  return new Date(new Date(saturday).setHours(23, 59, 59, 999))
+}
+
+test('it should yield 12am on Sunday of the week of the date given', () => {
+  // get beginning of today's week
+  const result1 = getLuxonStartOfWeek()
+  const result2 = getNativeStartOfWeek()
+  expect(result1.toMillis()).toBe(result2.getTime())
+
+  const davidsBirthday = new Date('November 26, 1997 03:24:00') // wednesday
+  const startOfDavidsWeek = new Date('November 23, 1997 00:00:00')
+  expect(getLuxonStartOfWeek(davidsBirthday).toMillis()).toBe(
+    startOfDavidsWeek.getTime(),
+  )
+
+  const katiesBirthday = new Date('December 15, 1996 03:24:30') // sunday
+  const startOfKatiesWeek = new Date('December 15, 1996 00:00:00')
+  expect(getLuxonStartOfWeek(katiesBirthday).toMillis()).toBe(
+    startOfKatiesWeek.getTime(),
+  )
+
+  const cooksBirthday = new Date('September 1, 2018 12:24:30') // saturday
+  const startOfCooksWeek = new Date('August 26, 2018 00:00:00')
+  expect(getLuxonStartOfWeek(cooksBirthday).toMillis()).toBe(
+    startOfCooksWeek.getTime(),
+  )
+
+  const midnight = new Date('January 19, 2020 00:00:00') // 12am sunday
+  expect(getLuxonStartOfWeek(midnight).toMillis()).toBe(midnight.getTime())
+})
+
+test('it should yield almost midnight on Saturday of the week of the date given', () => {
+  // get end of today's week
+  const result1 = getLuxonEndOfWeek()
+  const result2 = getNativeEndOfWeek()
+  expect(result1.toMillis()).toBe(result2.getTime())
+
+  const davidsBirthday = new Date('November 26, 1997 03:24:00') // wednesday
+  const endOfDavidsWeek = new Date('November 29, 1997 23:59:59:999')
+  expect(getLuxonEndOfWeek(davidsBirthday).toMillis()).toBe(
+    endOfDavidsWeek.getTime(),
+  )
+
+  const katiesBirthday = new Date('December 15, 1996 03:24:30') // sunday
+  const endOfKatiesWeek = new Date('December 21, 1996 23:59:59:999')
+  expect(getLuxonEndOfWeek(katiesBirthday).toMillis()).toBe(
+    endOfKatiesWeek.getTime(),
+  )
+
+  const cooksBirthday = new Date('September 1, 2018 12:24:30') // saturday
+  const endOfCooksWeek = new Date('September 1, 2018 23:59:59:999')
+  expect(getLuxonEndOfWeek(cooksBirthday).toMillis()).toBe(
+    endOfCooksWeek.getTime(),
+  )
+
+  const almostMidnight = new Date('January 18, 2020 23:59:59:999') // saturday
+  expect(getLuxonEndOfWeek(almostMidnight).toMillis()).toBe(
+    almostMidnight.getTime(),
+  )
+})

--- a/web/src/cypress/integration/scheduleCalendar.ts
+++ b/web/src/cypress/integration/scheduleCalendar.ts
@@ -15,6 +15,12 @@ const weekHeaderFormat = (t: DateTime) => {
   )
 }
 
+const weekSpansTwoMonths = (t: DateTime) => {
+  const start = t.startOf('week').minus({ day: 1 })
+  const end = t.endOf('week').minus({ day: 1 })
+  return start.month !== end.month
+}
+
 function testCalendar(screen: ScreenFormat) {
   if (screen !== 'widescreen') return
 
@@ -113,13 +119,15 @@ function testCalendar(screen: ScreenFormat) {
     )
   })
 
-  it.skip('should switch between weekly and monthly views', () => {
+  it('should switch between weekly and monthly views', () => {
+    // defaults to current month
     cy.get('button[data-cy="show-month"]').should('be.disabled')
     cy.get('[data-cy="calendar-header"]').should(
       'contain',
       monthHeaderFormat(now),
     )
 
+    // click weekly
     cy.get('button[data-cy="show-week"]').click()
     cy.get('button[data-cy="show-week"]').should('be.disabled')
     cy.get('[data-cy="calendar-header"]').should(
@@ -127,11 +135,14 @@ function testCalendar(screen: ScreenFormat) {
       weekHeaderFormat(now),
     )
 
+    // go from week to monthly view
+    // e.g. if navigating to an overlap of two months such as
+    // Jan 27 - Feb 2, show the latter month (February)
     cy.get('button[data-cy="show-month"]').click()
     cy.get('button[data-cy="show-month"]').should('be.disabled')
     cy.get('[data-cy="calendar-header"]').should(
       'contain',
-      monthHeaderFormat(now),
+      monthHeaderFormat(now.plus({ months: weekSpansTwoMonths(now) ? 1 : 0 })),
     )
   })
 

--- a/web/src/cypress/integration/scheduleCalendar.ts
+++ b/web/src/cypress/integration/scheduleCalendar.ts
@@ -10,7 +10,7 @@ const weekHeaderFormat = (t: DateTime) => {
   const end = t.endOf('week').minus({ day: 1 })
 
   return (
-    start.toFormat('MMMM dd – ') +
+    start.toFormat('MMMM dd — ') +
     end.toFormat(end.month === start.month ? 'dd' : 'MMMM dd')
   )
 }

--- a/web/src/package.json
+++ b/web/src/package.json
@@ -89,7 +89,6 @@
     "mdi-material-ui": "6.10.0",
     "modernizr": "3.8.0",
     "modernizr-loader": "1.0.1",
-    "moment": "2.24.0",
     "react": "16.12.0",
     "react-apollo": "3.1.3",
     "react-beautiful-dnd": "12.2.0",

--- a/web/src/webpack.dll.config.js
+++ b/web/src/webpack.dll.config.js
@@ -16,7 +16,6 @@ module.exports = {
       '@material-ui/lab',
       '@material-ui/pickers',
       'luxon',
-      'moment',
       'lodash-es',
       'apollo-client',
       'apollo-link',


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.


**Description:**
Migrates any use of the datetime formatter Moment to use Luxon which is much smaller in bundle size. (Although Moment is a dependency of cypress; thus `yarn.lock` remains unchanged).

**User-facing Changes:**
`CalendarEventWrapper.js` now includes timezone

Before:
<img width="331" alt="Screen Shot 2020-01-22 at 3 08 40 PM" src="https://user-images.githubusercontent.com/17692467/72934423-2dd35700-3d29-11ea-8d92-027a2d4a20dc.png">
After:
<img width="316" alt="Screen Shot 2020-01-22 at 3 08 57 PM" src="https://user-images.githubusercontent.com/17692467/72934422-2dd35700-3d29-11ea-822b-2b9070be4fc7.png">


