### PR TITLE
ui/alerts: Give visual separation between alert service name and summary

### DIFF
--- a/web/src/app/alerts/components/AlertsListDataWrapper.js
+++ b/web/src/app/alerts/components/AlertsListDataWrapper.js
@@ -25,6 +25,9 @@ const styles = {
   listItem: {
     width: '100%',
   },
+  summaryText: {
+    marginLeft: '0.5em',
+  },
   ...statusStyles,
 }
 
@@ -145,9 +148,11 @@ export default class AlertsListDataWrapper extends Component {
             {alert.status.toUpperCase()}
           </Typography>
           {onServicePage ? null : (
-            <Typography variant='caption'>{alert.service.name}</Typography>
+            <Typography variant='caption'>
+              {alert.service.name + ':'}
+            </Typography>
           )}
-          <Typography variant='caption' noWrap>
+          <Typography variant='caption' noWrap className={classes.summaryText}>
             {alert.summary}
           </Typography>
         </ListItemText>


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [ ] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [ ] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Adds a left margin to the alert summary

**Describe any introduced user-facing changes:**
Before:
<img width="520" alt="Screen Shot 2020-01-22 at 4 04 17 PM" src="https://user-images.githubusercontent.com/17692467/72938606-df29bb00-3d30-11ea-92d7-c0a8fdb5f3b4.png">


After:
<img width="530" alt="Screen Shot 2020-01-22 at 4 03 49 PM" src="https://user-images.githubusercontent.com/17692467/72938605-df29bb00-3d30-11ea-8fe1-0c569c0df652.png">
