### PR TITLE
deps: disable dependabot Go config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,7 +10,3 @@ update_configs:
       - match:
           dependency_name: "react-infinite-scroll-component"
           version_requirement: "<=5.0.3"
-
-  - package_manager: "go:modules"
-    directory: "/"
-    update_schedule: "daily"


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This makes Dependabot stop watching our Go modules. Our CI was failing due to a few known issues, but before GitHub fixes them, we are disabling it.