### PR TITLE
ui: require input when adding user to rotation

### DIFF
--- a/web/src/app/rotations/UserForm.js
+++ b/web/src/app/rotations/UserForm.js
@@ -26,6 +26,7 @@ export default class UserForm extends React.Component {
             label='Select User(s)'
             multiple
             name='users'
+            required
             value={this.props.value.users}
           />
         </Grid>


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Currently, a user can submit the Add User form without selecting a user. We provide a cancel button if they don't wish to add a user.
