### PR TITLE
cypress: fix flaky test; replace override requires unique users

### DIFF
--- a/web/src/cypress/integration/scheduleCalendar.ts
+++ b/web/src/cypress/integration/scheduleCalendar.ts
@@ -169,10 +169,12 @@ function testCalendar(screen: ScreenFormat) {
     })
   })
 
-  it('should create a replace override from a shift tooltip', () => {
+  it.only('should create a replace override from a shift tooltip', () => {
     const name = rot.users[0].name.split(' ')[0]
 
     cy.fixture('users').then(users => {
+      let addUserName = users[0].name
+      if (rot.users[0].id === users[0].id) addUserName = users[1].name
       cy.get('[data-cy=calendar]')
         .should('contain', name)
         .contains('div', name)
@@ -180,7 +182,7 @@ function testCalendar(screen: ScreenFormat) {
       cy.get('div[data-cy="shift-tooltip"]').should('be.visible')
       cy.get('button[data-cy="replace-override"]').click()
       cy.dialogTitle('Replace a User')
-      cy.dialogForm({ addUserID: users[0].name })
+      cy.dialogForm({ addUserID: addUserName })
       cy.dialogFinish('Submit')
     })
   })

--- a/web/src/cypress/integration/scheduleCalendar.ts
+++ b/web/src/cypress/integration/scheduleCalendar.ts
@@ -169,7 +169,7 @@ function testCalendar(screen: ScreenFormat) {
     })
   })
 
-  it.only('should create a replace override from a shift tooltip', () => {
+  it('should create a replace override from a shift tooltip', () => {
     const name = rot.users[0].name.split(' ')[0]
 
     cy.fixture('users').then(users => {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
It "should create a replace override from a shift tooltip", but the replacer must be different than the replacee. We ensure this by verifying the replacer has a different user id.