### PR TITLE
smoketests: migrate queries to use GraphQL 2

### DIFF
--- a/smoketest/deleteescalationpolicy_test.go
+++ b/smoketest/deleteescalationpolicy_test.go
@@ -2,8 +2,9 @@ package smoketest
 
 import (
 	"fmt"
-	"github.com/target/goalert/smoketest/harness"
 	"testing"
+
+	"github.com/target/goalert/smoketest/harness"
 )
 
 // TestDeleteEscalationPolicy tests that it is possible to delete an escalation policy
@@ -25,7 +26,7 @@ func TestDeleteEscalationPolicy(t *testing.T) {
 	defer h.Close()
 
 	doQL := func(query string) {
-		g := h.GraphQLQuery(query)
+		g := h.GraphQLQuery2(query)
 		for _, err := range g.Errors {
 			t.Error("GraphQL Error:", err.Message)
 		}
@@ -37,9 +38,7 @@ func TestDeleteEscalationPolicy(t *testing.T) {
 
 	doQL(fmt.Sprintf(`
 		mutation {
-			deleteEscalationPolicy(input:{id: "%s"}) {
-				deleted_id
-			}
+			deleteAll(input:{id: "%s", type: escalationPolicy})
 		}
 	`, h.UUID("ep1")))
 }

--- a/smoketest/deleterotation_test.go
+++ b/smoketest/deleterotation_test.go
@@ -2,8 +2,9 @@ package smoketest
 
 import (
 	"fmt"
-	"github.com/target/goalert/smoketest/harness"
 	"testing"
+
+	"github.com/target/goalert/smoketest/harness"
 )
 
 // TestDeleteRotation tests that it is possible to delete a rotation with participants
@@ -30,7 +31,7 @@ func TestDeleteRotation(t *testing.T) {
 	defer h.Close()
 
 	doQL := func(query string) {
-		g := h.GraphQLQuery(query)
+		g := h.GraphQLQuery2(query)
 		for _, err := range g.Errors {
 			t.Error("GraphQL Error:", err.Message)
 		}
@@ -42,9 +43,7 @@ func TestDeleteRotation(t *testing.T) {
 
 	doQL(fmt.Sprintf(`
 		mutation {
-			deleteRotation(input:{id: "%s"}) {
-				deleted_id
-			}
+			deleteAll(input:{id: "%s", type: rotation})
 		}
 	`, h.UUID("r1")))
 }

--- a/smoketest/graphqlalert_test.go
+++ b/smoketest/graphqlalert_test.go
@@ -194,12 +194,13 @@ func TestGraphQLAlert(t *testing.T) {
 		mutation {
 			createEscalationPolicyStep(input:{
 				delayMinutes: 60,
-				escalationPolicyID: "%s"
+				escalationPolicyID: "%s",
+				targets: [{id: "%s", type: user}, {id: "%s", type: schedule}]
 			}){
 				id
 			}
 		}
-	`, esc.CreateEscalationPolicy.ID), &step)
+	`, esc.CreateEscalationPolicy.ID, uid2, sched.CreateSchedule.ID), &step)
 	var svc struct{ CreateService struct{ ID string } }
 	doQL(fmt.Sprintf(`
 		mutation {

--- a/smoketest/graphqlalert_test.go
+++ b/smoketest/graphqlalert_test.go
@@ -67,7 +67,10 @@ func TestGraphQLAlert(t *testing.T) {
 			ID string
 		}
 	}
-	doQL(fmt.Sprintf(`
+
+	createCM := func(userID, phone string, cm interface{}) harness.TwilioExpectedMessage {
+		t.Helper()
+		doQL(fmt.Sprintf(`
 		mutation {
 			createUserContactMethod(input:{
 				userID: "%s",
@@ -78,80 +81,57 @@ func TestGraphQLAlert(t *testing.T) {
 				id
 			}
 		}
-	`, uid1, phone1), &cm1)
-	doQL(fmt.Sprintf(`
-		mutation {
-			createUserContactMethod(input:{
-				userID: "%s",
-				name: "default",
-				type: SMS,
-				value: "%s"
-			}) {
-				id
-			}
-		}
-	`, uid2, phone2), &cm2)
+    `, userID, phone), cm)
+		return h.Twilio().Device(phone).ExpectSMS("verification")
+	}
 
-	doQL(fmt.Sprintf(`
+	msg1 := createCM(uid1, phone1, &cm1)
+	msg2 := createCM(uid2, phone2, &cm2)
+
+	sendCMVerification := func(cmID string) {
+		doQL(fmt.Sprintf(`
 		mutation {
 			sendContactMethodVerification(input:{
 				contactMethodID: "%s"
 			})
 		}
-	`, cm1.CreateUserContactMethod.ID), nil)
+	`, cmID), nil)
+	}
 
-	doQL(fmt.Sprintf(`
-		mutation {
-			sendContactMethodVerification(input:{
-				contactMethodID: "%s"
-			})
-		}
-	`, cm2.CreateUserContactMethod.ID), nil)
+	sendCMVerification(cm1.CreateUserContactMethod.ID)
+	sendCMVerification(cm2.CreateUserContactMethod.ID)
 
-	tw := h.Twilio()
-	d1 := tw.Device(phone1)
-	d2 := tw.Device(phone2)
+	h.Twilio().WaitAndAssert() // wait for code, ensure no notifications went out
 
-	msg1 := d1.ExpectSMS("verification")
-	msg2 := d2.ExpectSMS("verification")
-	tw.WaitAndAssert() // wait for code, and ensure no notifications went out
-
-	codeStr1 := strings.Map(func(r rune) rune {
+	digits := func(r rune) rune {
 		if r >= '0' && r <= '9' {
 			return r
 		}
 		return -1
-	}, msg1.Body())
+	}
 
-	codeStr2 := strings.Map(func(r rune) rune {
-		if r >= '0' && r <= '9' {
-			return r
-		}
-		return -1
-	}, msg2.Body())
+	codeStr1 := strings.Map(digits, msg1.Body())
+	codeStr2 := strings.Map(digits, msg2.Body())
 
 	code1, _ := strconv.Atoi(codeStr1)
 	code2, _ := strconv.Atoi(codeStr2)
 
-	doQL(fmt.Sprintf(`
+	verifyCM := func(cmID string, code int) {
+		doQL(fmt.Sprintf(`
 		mutation {
 			verifyContactMethod(input:{
 				contactMethodID:  "%s",
 				code: %d
 			})
 		}
-	`, cm1.CreateUserContactMethod.ID, code1), nil)
+	`, cmID, code), nil)
+	}
 
-	doQL(fmt.Sprintf(`
-		mutation {
-			verifyContactMethod(input:{
-				contactMethodID:  "%s",
-				code: %d
-			})
-		}
-	`, cm2.CreateUserContactMethod.ID, code2), nil)
+	verifyCM(cm1.CreateUserContactMethod.ID, code1)
+	verifyCM(cm2.CreateUserContactMethod.ID, code2)
 
-	doQL(fmt.Sprintf(`
+	createUserNR := func(userID string, cmID string) {
+		doQL(fmt.Sprintf(`
 		mutation {
 			createUserNotificationRule(input:{
 				userID: "%s",
@@ -162,20 +142,11 @@ func TestGraphQLAlert(t *testing.T) {
 			}
 		}
 	
-	`, uid1, cm1.CreateUserContactMethod.ID), nil)
+	`, userID, cmID), nil)
+	}
 
-	doQL(fmt.Sprintf(`
-		mutation {
-			createUserNotificationRule(input:{
-				userID: "%s",
-				contactMethodID: "%s",
-				delayMinutes: 0
-			}){
-				id
-			}
-		}
-	
-	`, uid2, cm2.CreateUserContactMethod.ID), nil)
+	createUserNR(uid1, cm1.CreateUserContactMethod.ID)
+	createUserNR(uid2, cm2.CreateUserContactMethod.ID)
 
 	var sched struct {
 		CreateSchedule struct {

--- a/smoketest/graphqlalert_test.go
+++ b/smoketest/graphqlalert_test.go
@@ -64,8 +64,8 @@ func TestGraphQLAlert(t *testing.T) {
 
 	var cm1, cm2 struct {
 		CreateUserContactMethod struct {
-			ID string `json:"id"`
-		} `json:"createUserContactMethod"`
+			ID string
+		}
 	}
 	doQL(fmt.Sprintf(`
 		mutation {

--- a/smoketest/graphqlservicelabels_test.go
+++ b/smoketest/graphqlservicelabels_test.go
@@ -2,8 +2,9 @@ package smoketest
 
 import (
 	"fmt"
-	"github.com/target/goalert/smoketest/harness"
 	"testing"
+
+	"github.com/target/goalert/smoketest/harness"
 )
 
 // TestGraphQLServiceLabels tests that labels for services can be created
@@ -31,7 +32,7 @@ func TestGraphQLServiceLabels(t *testing.T) {
 	defer h.Close()
 
 	doQL := func(query string) {
-		g := h.GraphQLQuery(query)
+		g := h.GraphQLQuery2(query)
 		for _, err := range g.Errors {
 			t.Error("GraphQL Error:", err.Message)
 		}
@@ -44,14 +45,14 @@ func TestGraphQLServiceLabels(t *testing.T) {
 	// Edit label
 	doQL(fmt.Sprintf(`
 		mutation {
-			setLabel(input:{ target_type: service ,target_id: "%s", key: "%s", value: "%s" }) 
+			setLabel(input:{ target: {type: service , id: "%s"}, key: "%s", value: "%s" }) 
 		}
 	`, h.UUID("sid"), "foo/bar", "editedvalue"))
 
 	// Delete label
 	doQL(fmt.Sprintf(`
 		mutation {
-			setLabel(input:{ target_type: service ,target_id: "%s", key: "%s", value: "%s" }) 
+			setLabel(input:{ target: {type: service , id: "%s"}, key: "%s", value: "%s" }) 
 		}
 	`, h.UUID("sid"), "foo/bar", ""))
 

--- a/smoketest/graphqlupdaterotation_test.go
+++ b/smoketest/graphqlupdaterotation_test.go
@@ -103,6 +103,7 @@ func TestGraphQLUpdateRotation(t *testing.T) {
 				start: "1997-11-26T12:08:25-05:00"
 				type: hourly
 				shiftLength: 12
+				activeUserIndex: 0
 				userIDs: ["%s", "%s"]
 			})
 		}
@@ -138,13 +139,14 @@ func TestGraphQLUpdateRotation(t *testing.T) {
 
 	var updatedRotation struct {
 		Rotation struct {
-			Name        string
-			Description string
-			TimeZone    string
-			Start       string
-			Type        string
-			ShiftLength int
-			Users       []struct {
+			Name            string
+			Description     string
+			TimeZone        string
+			Start           string
+			Type            string
+			ShiftLength     int
+			ActiveUserIndex int
+			Users           []struct {
 				ID string
 			}
 		}
@@ -158,6 +160,7 @@ func TestGraphQLUpdateRotation(t *testing.T) {
 			start
 			type
 			shiftLength
+			activeUserIndex
 			users {
 				id
 			}
@@ -170,6 +173,7 @@ func TestGraphQLUpdateRotation(t *testing.T) {
 	assert.Equal(t, "1997-11-26T12:08:00-05:00", updatedRotation.Rotation.Start) // truncate to minute
 	assert.Equal(t, "hourly", updatedRotation.Rotation.Type)
 	assert.Equal(t, 12, updatedRotation.Rotation.ShiftLength)
+	assert.Equal(t, 0, updatedRotation.Rotation.ActiveUserIndex)
 	assert.Equal(t, u1UUID, updatedRotation.Rotation.Users[0].ID)
 	assert.Equal(t, u2UUID, updatedRotation.Rotation.Users[1].ID)
 }

--- a/smoketest/graphqlupdaterotation_test.go
+++ b/smoketest/graphqlupdaterotation_test.go
@@ -61,10 +61,12 @@ func TestGraphQLUpdateRotation(t *testing.T) {
 					timeZone: "America/Chicago"
 					targets: {
 						newRotation: {
-							name: "foobar"
+							name: "old name"
+							description: "old description"
 							timeZone: "America/Chicago"
 							start: "2020-02-04T12:08:25-06:00"
 							type: daily
+							shiftLength: 6
 						}
 						rules: {
 							start: "00:00"
@@ -92,6 +94,11 @@ func TestGraphQLUpdateRotation(t *testing.T) {
 			updateRotation(input:{
 				id: "%s",
 				name: "new name",
+				description: "new description"
+				timeZone: "America/New_York"
+				start: "1997-11-26T12:08:25-05:00"
+				type: hourly
+				shiftLength: 12
 			})
 		}
 	
@@ -126,15 +133,30 @@ func TestGraphQLUpdateRotation(t *testing.T) {
 
 	var updatedRotation struct {
 		Rotation struct {
-			Name string
+			Name        string
+			Description string
+			TimeZone    string
+			Start       string
+			Type        string
+			ShiftLength int
 		}
 	}
 	doQL(fmt.Sprintf(`
 		query{
 		rotation(id: "%s"){
 			name
+			description
+			timeZone
+			start
+			type
+			shiftLength
 		}
 	}`, rotationID), &updatedRotation)
 
 	assert.Equal(t, "new name", updatedRotation.Rotation.Name)
+	assert.Equal(t, "new description", updatedRotation.Rotation.Description)
+	assert.Equal(t, "America/New_York", updatedRotation.Rotation.TimeZone)
+	assert.Equal(t, "1997-11-26T12:08:00-05:00", updatedRotation.Rotation.Start) // truncate to minute
+	assert.Equal(t, "hourly", updatedRotation.Rotation.Type)
+	assert.Equal(t, 12, updatedRotation.Rotation.ShiftLength)
 }

--- a/smoketest/graphqlupdaterotation_test.go
+++ b/smoketest/graphqlupdaterotation_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/target/goalert/smoketest/harness"
 )
 
@@ -135,7 +136,5 @@ func TestGraphQLUpdateRotation(t *testing.T) {
 		}
 	}`, rotationID), &updatedRotation)
 
-	if updatedRotation.Rotation.Name != "new name" {
-		t.Errorf("got name of %s; want 'new name'", updatedRotation.Rotation.Name)
-	}
+	assert.Equal(t, "new name", updatedRotation.Rotation.Name)
 }

--- a/smoketest/graphqluserfavorites_test.go
+++ b/smoketest/graphqluserfavorites_test.go
@@ -61,7 +61,7 @@ func TestGraphQLUserFavorites(t *testing.T) {
 
 	var s struct {
 		Service struct {
-			IsFavoite bool `json:"isFavorite"`
+			IsFavorite bool
 		}
 	}
 
@@ -73,8 +73,8 @@ func TestGraphQLUserFavorites(t *testing.T) {
 		}
 	`, h.UUID("sid1")), &s)
 
-	if s.Service.IsFavoite != true {
-		t.Fatalf("ERROR: ServiceID %s IsUserFavorite=%t; want true", h.UUID("sid1"), s.Service.IsFavoite)
+	if s.Service.IsFavorite != true {
+		t.Fatalf("ERROR: ServiceID %s IsUserFavorite=%t; want true", h.UUID("sid1"), s.Service.IsFavorite)
 	}
 
 	doQL(fmt.Sprintf(`
@@ -85,8 +85,8 @@ func TestGraphQLUserFavorites(t *testing.T) {
 		}
 	`, h.UUID("sid2")), &s)
 
-	if s.Service.IsFavoite != false {
-		t.Fatalf("ERROR: ServiceID %s IsFavoite=%t; want false", h.UUID("sid2"), s.Service.IsFavoite)
+	if s.Service.IsFavorite != false {
+		t.Fatalf("ERROR: ServiceID %s IsFavorite=%t; want false", h.UUID("sid2"), s.Service.IsFavorite)
 	}
 
 	// Again Setting as user-favorite should result in no change
@@ -122,8 +122,8 @@ func TestGraphQLUserFavorites(t *testing.T) {
 		}
 	`, h.UUID("sid2")), &s)
 
-	if s.Service.IsFavoite != false {
-		t.Fatalf("ERROR: ServiceID %s IsUserFavorite=%t; want false", h.UUID("sid2"), s.Service.IsFavoite)
+	if s.Service.IsFavorite != false {
+		t.Fatalf("ERROR: ServiceID %s IsUserFavorite=%t; want false", h.UUID("sid2"), s.Service.IsFavorite)
 	}
 
 }

--- a/smoketest/graphqluserfavorites_test.go
+++ b/smoketest/graphqluserfavorites_test.go
@@ -3,8 +3,9 @@ package smoketest
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/target/goalert/smoketest/harness"
 	"testing"
+
+	"github.com/target/goalert/smoketest/harness"
 )
 
 // TestGraphQLUserFavorites tests that services can be set and unset as user favorites
@@ -27,8 +28,8 @@ func TestGraphQLUserFavorites(t *testing.T) {
 	h := harness.NewHarness(t, sql, "UserFavorites")
 	defer h.Close()
 
-	doQL := func(t *testing.T, query string, res interface{}) {
-		g := h.GraphQLQueryT(t, query, "/v1/graphql")
+	doQL := func(query string, res interface{}) {
+		g := h.GraphQLQuery2(query)
 		for _, err := range g.Errors {
 			t.Error("GraphQL Error:", err.Message)
 		}
@@ -46,77 +47,83 @@ func TestGraphQLUserFavorites(t *testing.T) {
 		}
 	}
 
-	doQL(t, fmt.Sprintf(`
-		mutation {
-			setUserFavorite (input: {
-				target_type: service ,target_id: "%s"
-			}) {
-				target_id
-			}
+	doQL(fmt.Sprintf(`
+		mutation{
+			setFavorite(input:{
+				target:{
+					id: "%s"
+					type: service
+				}
+				favorite: true
+			})
 		}
 	`, h.UUID("sid1")), nil)
 
 	var s struct {
 		Service struct {
-			IsUserFav bool `json:"is_user_favorite"`
+			IsFavoite bool `json:"isFavorite"`
 		}
 	}
 
-	doQL(t, fmt.Sprintf(`
+	doQL(fmt.Sprintf(`
 		query {
 			service(id: "%s") { 
-				is_user_favorite 
+				isFavorite 
 			}	
 		}
 	`, h.UUID("sid1")), &s)
 
-	if s.Service.IsUserFav != true {
-		t.Fatalf("ERROR: ServiceID %s IsUserFavorite=%t; want true", h.UUID("sid1"), s.Service.IsUserFav)
+	if s.Service.IsFavoite != true {
+		t.Fatalf("ERROR: ServiceID %s IsUserFavorite=%t; want true", h.UUID("sid1"), s.Service.IsFavoite)
 	}
 
-	doQL(t, fmt.Sprintf(`
+	doQL(fmt.Sprintf(`
 		query {
 			service(id: "%s") { 
-				is_user_favorite 
+				isFavorite 
 			}	
 		}
 	`, h.UUID("sid2")), &s)
 
-	if s.Service.IsUserFav != false {
-		t.Fatalf("ERROR: ServiceID %s IsUserFavorite=%t; want false", h.UUID("sid2"), s.Service.IsUserFav)
+	if s.Service.IsFavoite != false {
+		t.Fatalf("ERROR: ServiceID %s IsFavoite=%t; want false", h.UUID("sid2"), s.Service.IsFavoite)
 	}
 
 	// Again Setting as user-favorite should result in no change
-	doQL(t, fmt.Sprintf(`
-		mutation {
-			setUserFavorite (input: {
-				target_type: service ,target_id: "%s"
-			}) {
-				target_id
-			}
+	doQL(fmt.Sprintf(`
+		mutation{
+			setFavorite(input:{
+				target:{
+					id: "%s"
+					type: service
+				}
+				favorite: true
+			})
 		}
 	`, h.UUID("sid2")), nil)
 
-	doQL(t, fmt.Sprintf(`
-		mutation {
-			unsetUserFavorite (input: {
-				target_type: service ,target_id: "%s"
-			}) {
-				target_id
-			}
+	doQL(fmt.Sprintf(`
+		mutation{
+			setFavorite(input:{
+				target:{
+					id: "%s"
+					type: service
+				}
+				favorite: false
+			})
 		}
 	`, h.UUID("sid2")), nil)
 
-	doQL(t, fmt.Sprintf(`
+	doQL(fmt.Sprintf(`
 		query {
 			service(id: "%s") { 
-				is_user_favorite 
+				isFavorite 
 			}	
 		}
 	`, h.UUID("sid2")), &s)
 
-	if s.Service.IsUserFav != false {
-		t.Fatalf("ERROR: ServiceID %s IsUserFavorite=%t; want false", h.UUID("sid2"), s.Service.IsUserFav)
+	if s.Service.IsFavoite != false {
+		t.Fatalf("ERROR: ServiceID %s IsUserFavorite=%t; want false", h.UUID("sid2"), s.Service.IsFavoite)
 	}
 
 }

--- a/smoketest/graphqlusers_test.go
+++ b/smoketest/graphqlusers_test.go
@@ -42,9 +42,9 @@ func TestGraphQLUsers(t *testing.T) {
 	var res struct {
 		Users struct {
 			Nodes []struct {
-				ID string `json:"id"`
-			} `json:"nodes"`
-		} `json:"users"`
+				ID string
+			}
+		}
 	}
 
 	doQL(`

--- a/smoketest/graphqlusers_test.go
+++ b/smoketest/graphqlusers_test.go
@@ -2,9 +2,9 @@ package smoketest
 
 import (
 	"encoding/json"
-	"github.com/target/goalert/smoketest/harness"
-	"github.com/target/goalert/user"
 	"testing"
+
+	"github.com/target/goalert/smoketest/harness"
 )
 
 // TestGraphQLUsers tests that listing users works properly.
@@ -22,7 +22,7 @@ func TestGraphQLUsers(t *testing.T) {
 	defer h.Close()
 
 	doQL := func(query string, res interface{}) {
-		g := h.GraphQLQuery(query)
+		g := h.GraphQLQuery2(query)
 		for _, err := range g.Errors {
 			t.Error("GraphQL Error:", err.Message)
 		}
@@ -40,19 +40,24 @@ func TestGraphQLUsers(t *testing.T) {
 	}
 
 	var res struct {
-		Users []user.User
+		Users struct {
+			Nodes []struct {
+				ID string `json:"id"`
+			} `json:"nodes"`
+		} `json:"users"`
 	}
+
 	doQL(`
 		query {
-			users {
-				id
-				name
-				role
+			users(first: 100) {
+				nodes {
+					id
+				}
 			}
 		}
 	`, &res)
-	if len(res.Users) != 3 {
+	if len(res.Users.Nodes) != 3 {
 		// 3 because the 'GraphQL User' will be implicitly added.
-		t.Errorf("got %d users; want 3", len(res.Users))
+		t.Errorf("got %d users; want 3", len(res.Users.Nodes))
 	}
 }

--- a/smoketest/harness/graphql.go
+++ b/smoketest/harness/graphql.go
@@ -38,13 +38,6 @@ func (h *Harness) insertGraphQLUser() {
 	}
 }
 
-// GraphQLQuery will perform a GraphQL query against the backend, internally
-// handling authentication. Queries are performed with Admin role.
-func (h *Harness) GraphQLQuery(query string) *QLResponse {
-	h.t.Helper()
-	return h.GraphQLQueryT(h.t, query, "/v1/graphql")
-}
-
 // GraphQLQuery2 will perform a GraphQL2 query against the backend, internally
 // handling authentication. Queries are performed with Admin role.
 func (h *Harness) GraphQLQuery2(query string) *QLResponse {

--- a/smoketest/harness/harness.go
+++ b/smoketest/harness/harness.go
@@ -660,9 +660,9 @@ func (h *Harness) WaitAndAssertOnCallUsers(serviceID string, userIDs ...string) 
 		var result struct {
 			Service struct {
 				OnCallUsers []struct {
-					UserID   string `json:"userID"`
-					UserName string `json:"userName"`
-				} `json:"onCallUsers"`
+					UserID   string
+					UserName string
+				}
 			}
 		}
 

--- a/smoketest/harness/harness.go
+++ b/smoketest/harness/harness.go
@@ -640,7 +640,7 @@ func (h *Harness) CreateUser() (u *user.User) {
 func (h *Harness) WaitAndAssertOnCallUsers(serviceID string, userIDs ...string) {
 	h.t.Helper()
 	doQL := func(query string, res interface{}) {
-		g := h.GraphQLQuery(query)
+		g := h.GraphQLQuery2(query)
 		for _, err := range g.Errors {
 			h.t.Error("GraphQL Error:", err.Message)
 		}
@@ -659,26 +659,26 @@ func (h *Harness) WaitAndAssertOnCallUsers(serviceID string, userIDs ...string) 
 	getUsers := func() []string {
 		var result struct {
 			Service struct {
-				OnCall []struct {
-					UserID   string `json:"user_id"`
-					UserName string `json:"user_name"`
-				} `json:"on_call_users"`
+				OnCallUsers []struct {
+					UserID   string `json:"userID"`
+					UserName string `json:"userName"`
+				} `json:"onCallUsers"`
 			}
 		}
 
 		doQL(fmt.Sprintf(`
-			query {
-				service(id: "%s") {
-					on_call_users{
-						user_id
-						user_name
+			query{
+				service(id: "%s"){
+					onCallUsers{
+						userID
+						userName
 					}
 				}
 			}
 		`, serviceID), &result)
 
 		var ids []string
-		for _, oc := range result.Service.OnCall {
+		for _, oc := range result.Service.OnCallUsers {
 			ids = append(ids, oc.UserID)
 		}
 		if len(ids) == 0 {

--- a/smoketest/listalerts_test.go
+++ b/smoketest/listalerts_test.go
@@ -31,7 +31,7 @@ func TestListAlerts(t *testing.T) {
 		query {
 			alerts {
 				nodes {
-					id
+					alertID
 					service {
 						id
 						name
@@ -47,7 +47,7 @@ func TestListAlerts(t *testing.T) {
 	var res struct {
 		Alerts struct {
 			Nodes []struct {
-				ID      int `json:"id,string"`
+				ID      int `json:"alertID"`
 				Service struct {
 					ID   string
 					Name string

--- a/smoketest/listalerts_test.go
+++ b/smoketest/listalerts_test.go
@@ -2,9 +2,10 @@ package smoketest
 
 import (
 	"encoding/json"
-	"github.com/target/goalert/smoketest/harness"
 	"strconv"
 	"testing"
+
+	"github.com/target/goalert/smoketest/harness"
 )
 
 func TestListAlerts(t *testing.T) {

--- a/smoketest/policyreassignment_test.go
+++ b/smoketest/policyreassignment_test.go
@@ -2,9 +2,10 @@ package smoketest
 
 import (
 	"fmt"
-	"github.com/target/goalert/smoketest/harness"
 	"testing"
 	"time"
+
+	"github.com/target/goalert/smoketest/harness"
 )
 
 // TestPolicyReassignment tests that only the active escalation policy is used for alerts.
@@ -63,13 +64,13 @@ values
 	d1.ExpectSMS("testing")
 	tw.WaitAndAssert()
 
-	h.GraphQLQuery(fmt.Sprintf(`
+	h.GraphQLQuery2(fmt.Sprintf(`
 		mutation{
 			updateService(input:{
 				id: "%s"
 				name: "ok"
-				escalation_policy_id: "%s"
-			}) {id}
+				escalationPolicyID: "%s"
+			})
 		}
 	`, h.UUID("sid"), h.UUID("ep2")))
 
@@ -80,13 +81,13 @@ values
 	// no new alerts
 	tw.WaitAndAssert()
 
-	h.GraphQLQuery(fmt.Sprintf(`
+	h.GraphQLQuery2(fmt.Sprintf(`
 		mutation{
 		updateService(input:{
 			id: "%s"
 			name: "ok"
-			escalation_policy_id: "%s"
-		}) {id}
+			escalationPolicyID: "%s"
+		}) 
 		}
 	`, h.UUID("sid"), h.UUID("ep1")))
 

--- a/smoketest/twiliotestsms_test.go
+++ b/smoketest/twiliotestsms_test.go
@@ -2,8 +2,9 @@ package smoketest
 
 import (
 	"fmt"
-	"github.com/target/goalert/smoketest/harness"
 	"testing"
+
+	"github.com/target/goalert/smoketest/harness"
 )
 
 // TestTwilioSMS checks that a test SMS is processed.
@@ -22,7 +23,7 @@ func TestTwilioSMS(t *testing.T) {
 	defer h.Close()
 
 	doQL := func(query string) {
-		g := h.GraphQLQuery(query)
+		g := h.GraphQLQuery2(query)
 		for _, err := range g.Errors {
 			t.Error("GraphQL Error:", err.Message)
 		}
@@ -34,11 +35,7 @@ func TestTwilioSMS(t *testing.T) {
 
 	doQL(fmt.Sprintf(`
 		mutation {
-			sendContactMethodTest(input:{
-				contact_method_id:  "%s",
-			}){
-				id
-			}
+			testContactMethod(id: "%s")
 		}
 		`, cm1))
 

--- a/smoketest/twiliotestvoice_test.go
+++ b/smoketest/twiliotestvoice_test.go
@@ -2,8 +2,9 @@ package smoketest
 
 import (
 	"fmt"
-	"github.com/target/goalert/smoketest/harness"
 	"testing"
+
+	"github.com/target/goalert/smoketest/harness"
 )
 
 // TestTwilioVoice checks that a test voice call is processed.
@@ -22,7 +23,7 @@ func TestTwilioVoice(t *testing.T) {
 	defer h.Close()
 
 	doQL := func(query string) {
-		g := h.GraphQLQuery(query)
+		g := h.GraphQLQuery2(query)
 		for _, err := range g.Errors {
 			t.Error("GraphQL Error:", err.Message)
 		}
@@ -31,17 +32,11 @@ func TestTwilioVoice(t *testing.T) {
 		}
 	}
 
-	cm1 := h.UUID("cm1")
-
 	doQL(fmt.Sprintf(`
 		mutation {
-			sendContactMethodTest(input:{
-				contact_method_id:  "%s",
-			}){
-				id
-			}
+			testContactMethod(id: "%s")
 		}
-		`, cm1))
+		`, h.UUID("cm1")))
 
 	h.Twilio().Device(h.Phone("1")).ExpectVoice("test")
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This removes the `GraphlQLQuery` method in favor of `GraphlQLQuery2` without introducing any new functionality or features.
