### PR TITLE
ui/accessibility: make escalation policy form fields focusable

### DIFF
--- a/web/src/app/escalation-policies/PolicyStepForm.js
+++ b/web/src/app/escalation-policies/PolicyStepForm.js
@@ -136,6 +136,7 @@ export default class PolicyStepForm extends React.Component {
                   <Step>
                     <StepButton
                       aria-label='Show Rotations Select'
+                      aria-expanded={(step === 0).toString()}
                       data-cy='rotations-step'
                       icon={<RotationsIcon />}
                       optional={optionalText}
@@ -164,6 +165,7 @@ export default class PolicyStepForm extends React.Component {
                   <Step>
                     <StepButton
                       aria-label='Show Schedules Select'
+                      aria-expanded={(step === 1).toString()}
                       data-cy='schedules-step'
                       icon={<SchedulesIcon />}
                       optional={optionalText}
@@ -193,6 +195,7 @@ export default class PolicyStepForm extends React.Component {
                     <Step>
                       <StepButton
                         aria-label='Show Slack Channels Select'
+                        aria-expanded={(step === 2).toString()}
                         data-cy='slack-channels-step'
                         icon={<SlackIcon />}
                         optional={optionalText}
@@ -223,6 +226,7 @@ export default class PolicyStepForm extends React.Component {
                   <Step>
                     <StepButton
                       aria-label='Show Users Select'
+                      aria-expanded={(step === 3).toString()}
                       data-cy='users-step'
                       icon={<UsersIcon />}
                       optional={optionalText}

--- a/web/src/app/escalation-policies/PolicyStepForm.js
+++ b/web/src/app/escalation-policies/PolicyStepForm.js
@@ -104,6 +104,7 @@ export default class PolicyStepForm extends React.Component {
           badge: classes.badge,
         }}
         tabIndex='0'
+        aria-label={`toggle ${txt}`}
       >
         <Typography className={classes.label}>{txt}</Typography>
       </Badge>
@@ -135,7 +136,6 @@ export default class PolicyStepForm extends React.Component {
                 >
                   <Step>
                     <StepButton
-                      aria-label='Show Rotations Select'
                       aria-expanded={(step === 0).toString()}
                       data-cy='rotations-step'
                       icon={<RotationsIcon />}
@@ -164,7 +164,6 @@ export default class PolicyStepForm extends React.Component {
                   </Step>
                   <Step>
                     <StepButton
-                      aria-label='Show Schedules Select'
                       aria-expanded={(step === 1).toString()}
                       data-cy='schedules-step'
                       icon={<SchedulesIcon />}
@@ -194,7 +193,6 @@ export default class PolicyStepForm extends React.Component {
                   {cfg['Slack.Enable'] && (
                     <Step>
                       <StepButton
-                        aria-label='Show Slack Channels Select'
                         aria-expanded={(step === 2).toString()}
                         data-cy='slack-channels-step'
                         icon={<SlackIcon />}
@@ -225,7 +223,6 @@ export default class PolicyStepForm extends React.Component {
                   )}
                   <Step>
                     <StepButton
-                      aria-label='Show Users Select'
                       aria-expanded={(step === 3).toString()}
                       data-cy='users-step'
                       icon={<UsersIcon />}

--- a/web/src/app/escalation-policies/PolicyStepForm.js
+++ b/web/src/app/escalation-policies/PolicyStepForm.js
@@ -103,6 +103,7 @@ export default class PolicyStepForm extends React.Component {
         classes={{
           badge: classes.badge,
         }}
+        tabIndex='0'
       >
         <Typography className={classes.label}>{txt}</Typography>
       </Badge>
@@ -132,7 +133,7 @@ export default class PolicyStepForm extends React.Component {
                     root: classes.stepperRoot,
                   }}
                 >
-                  <Step>
+                  <Step tabindex='0'>
                     <StepButton
                       aria-label='Show Rotations Select'
                       data-cy='rotations-step'
@@ -159,7 +160,7 @@ export default class PolicyStepForm extends React.Component {
                       />
                     </StepContent>
                   </Step>
-                  <Step>
+                  <Step tabindex='0'>
                     <StepButton
                       aria-label='Show Schedules Select'
                       data-cy='schedules-step'
@@ -187,7 +188,7 @@ export default class PolicyStepForm extends React.Component {
                     </StepContent>
                   </Step>
                   {cfg['Slack.Enable'] && (
-                    <Step>
+                    <Step tabindex='0'>
                       <StepButton
                         aria-label='Show Slack Channels Select'
                         data-cy='slack-channels-step'
@@ -216,7 +217,7 @@ export default class PolicyStepForm extends React.Component {
                       </StepContent>
                     </Step>
                   )}
-                  <Step>
+                  <Step tabindex='0'>
                     <StepButton
                       aria-label='Show Users Select'
                       data-cy='users-step'

--- a/web/src/app/escalation-policies/PolicyStepForm.js
+++ b/web/src/app/escalation-policies/PolicyStepForm.js
@@ -133,13 +133,14 @@ export default class PolicyStepForm extends React.Component {
                     root: classes.stepperRoot,
                   }}
                 >
-                  <Step tabindex='0'>
+                  <Step>
                     <StepButton
                       aria-label='Show Rotations Select'
                       data-cy='rotations-step'
                       icon={<RotationsIcon />}
                       optional={optionalText}
                       onClick={this.handleStepChange(0)}
+                      tabindex='-1'
                     >
                       {badgeMeUpScotty(
                         getTargetsByType('rotation')(value.targets).length,
@@ -160,13 +161,14 @@ export default class PolicyStepForm extends React.Component {
                       />
                     </StepContent>
                   </Step>
-                  <Step tabindex='0'>
+                  <Step>
                     <StepButton
                       aria-label='Show Schedules Select'
                       data-cy='schedules-step'
                       icon={<SchedulesIcon />}
                       optional={optionalText}
                       onClick={this.handleStepChange(1)}
+                      tabindex='-1'
                     >
                       {badgeMeUpScotty(
                         getTargetsByType('schedule')(value.targets).length,
@@ -188,13 +190,14 @@ export default class PolicyStepForm extends React.Component {
                     </StepContent>
                   </Step>
                   {cfg['Slack.Enable'] && (
-                    <Step tabindex='0'>
+                    <Step>
                       <StepButton
                         aria-label='Show Slack Channels Select'
                         data-cy='slack-channels-step'
                         icon={<SlackIcon />}
                         optional={optionalText}
                         onClick={this.handleStepChange(2)}
+                        tabindex='-1'
                       >
                         {badgeMeUpScotty(
                           getTargetsByType('slackChannel')(value.targets)
@@ -217,7 +220,7 @@ export default class PolicyStepForm extends React.Component {
                       </StepContent>
                     </Step>
                   )}
-                  <Step tabindex='0'>
+                  <Step>
                     <StepButton
                       aria-label='Show Users Select'
                       data-cy='users-step'
@@ -226,6 +229,7 @@ export default class PolicyStepForm extends React.Component {
                       onClick={this.handleStepChange(
                         cfg['Slack.Enable'] ? 3 : 2,
                       )}
+                      tabindex='-1'
                     >
                       {badgeMeUpScotty(
                         getTargetsByType('user')(value.targets).length,

--- a/web/src/app/escalation-policies/PolicyStepForm.js
+++ b/web/src/app/escalation-policies/PolicyStepForm.js
@@ -104,7 +104,7 @@ export default class PolicyStepForm extends React.Component {
           badge: classes.badge,
         }}
         tabIndex='0'
-        aria-label={`toggle ${txt}`}
+        aria-label={`Toggle ${txt}`}
       >
         <Typography className={classes.label}>{txt}</Typography>
       </Badge>

--- a/web/src/app/escalation-policies/PolicyStepForm.js
+++ b/web/src/app/escalation-policies/PolicyStepForm.js
@@ -140,7 +140,7 @@ export default class PolicyStepForm extends React.Component {
                       icon={<RotationsIcon />}
                       optional={optionalText}
                       onClick={this.handleStepChange(0)}
-                      tabindex='-1'
+                      tabIndex='-1'
                     >
                       {badgeMeUpScotty(
                         getTargetsByType('rotation')(value.targets).length,
@@ -168,7 +168,7 @@ export default class PolicyStepForm extends React.Component {
                       icon={<SchedulesIcon />}
                       optional={optionalText}
                       onClick={this.handleStepChange(1)}
-                      tabindex='-1'
+                      tabIndex='-1'
                     >
                       {badgeMeUpScotty(
                         getTargetsByType('schedule')(value.targets).length,
@@ -197,7 +197,7 @@ export default class PolicyStepForm extends React.Component {
                         icon={<SlackIcon />}
                         optional={optionalText}
                         onClick={this.handleStepChange(2)}
-                        tabindex='-1'
+                        tabIndex='-1'
                       >
                         {badgeMeUpScotty(
                           getTargetsByType('slackChannel')(value.targets)
@@ -229,7 +229,7 @@ export default class PolicyStepForm extends React.Component {
                       onClick={this.handleStepChange(
                         cfg['Slack.Enable'] ? 3 : 2,
                       )}
-                      tabindex='-1'
+                      tabIndex='-1'
                     >
                       {badgeMeUpScotty(
                         getTargetsByType('user')(value.targets).length,


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Previously, keyboard users did not receive visual feedback when tabbing through the escalation policy form. This resolves that issue by adding the `tabindex` attribute where needed.

**Screenshots:**

<img width="624" alt="Screen Shot 2020-02-05 at 12 08 46 PM" src="https://user-images.githubusercontent.com/17692467/73869662-5a4e9f00-4810-11ea-8663-b65b4bc42111.png">

**Describe any introduced user-facing changes:**
Keyboard users are now able to receive visual feedback via the browser's default outline when tabbing through focusable form fields

**Other:**
Adds `aria-expanded` attribute to buttons of active accordion fields