### PR TITLE
ui/material-select: set isClearable to always true

### DIFF
--- a/web/src/app/selection/MaterialSelect.js
+++ b/web/src/app/selection/MaterialSelect.js
@@ -111,7 +111,6 @@ export default class MaterialSelect extends Component {
             ) {
               this.setState({ isCleared: false })
             }
-            onChange(value)
           }}
           onChange={val => {
             if (required && val === null) {

--- a/web/src/app/selection/MaterialSelect.js
+++ b/web/src/app/selection/MaterialSelect.js
@@ -27,6 +27,7 @@ export default class MaterialSelect extends Component {
     this.state = {
       isCleared: false,
     }
+    this.buttonClicked = false
   }
 
   static propTypes = {
@@ -83,11 +84,26 @@ export default class MaterialSelect extends Component {
     }
     const { isCleared } = this.state
 
+    const isDescendent = (parent, child) => {
+      if (!child) return false
+      if (child.isSameNode(parent)) return true
+      return isDescendent(parent, child.parentNode)
+    }
+
     return (
+      // going to look into replacing component with material-ui autocomplete component
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
       <div
         data-cy='material-select'
         data-cy-ready={!props.isLoading}
         className={classes.root}
+        onMouseDownCapture={e => {
+          if (isDescendent(this.clearButtonRef.current, e.target))
+            this.buttonClicked = true
+        }}
+        onClick={() => {
+          this.buttonClicked = false
+        }}
       >
         <Select
           menuPortalTarget={document.body}
@@ -104,14 +120,8 @@ export default class MaterialSelect extends Component {
           value={isCleared && required ? { label: '', value: '' } : value}
           clearButtonRef={this.clearButtonRef}
           components={components}
-          onBlur={e => {
-            if (
-              isCleared &&
-              e.relatedTarget !== this.clearButtonRef.current &&
-              required
-            ) {
-              this.setState({ isCleared: false })
-            }
+          onBlur={() => {
+            if (!this.buttonClicked) this.setState({ isCleared: false })
           }}
           onChange={val => {
             if (required && _.isEmpty(val) && !multiple) {

--- a/web/src/app/selection/MaterialSelect.js
+++ b/web/src/app/selection/MaterialSelect.js
@@ -4,6 +4,7 @@ import { withStyles } from '@material-ui/core/styles'
 import Select from 'react-select'
 import { components, styles } from './MaterialSelectComponents'
 import shrinkWorkaround from '../util/shrinkWorkaround'
+import _ from 'lodash-es'
 
 const valueShape = p.shape({
   label: p.string.isRequired,
@@ -81,6 +82,10 @@ export default class MaterialSelect extends Component {
       value: value ? (multiple ? value.join(',') : value.value) : '',
     }
     const { isCleared } = this.state
+    const getValue = () => {
+      if (multiple) return
+      return isCleared && required ? { label: '', value: '' } : value
+    }
 
     return (
       <div
@@ -100,7 +105,7 @@ export default class MaterialSelect extends Component {
           isClearable
           isDisabled={disabled}
           isMulti={multiple}
-          value={isCleared && required ? { label: '', value: '' } : value}
+          value={getValue()}
           clearButtonRef={this.clearButtonRef}
           components={components}
           onBlur={e => {
@@ -113,7 +118,7 @@ export default class MaterialSelect extends Component {
             }
           }}
           onChange={val => {
-            if (required && val === null) {
+            if (required && _.isEmpty(val)) {
               this.setState({ isCleared: true })
               return
             }

--- a/web/src/app/selection/MaterialSelect.js
+++ b/web/src/app/selection/MaterialSelect.js
@@ -82,10 +82,6 @@ export default class MaterialSelect extends Component {
       value: value ? (multiple ? value.join(',') : value.value) : '',
     }
     const { isCleared } = this.state
-    const getValue = () => {
-      if (multiple) return
-      return isCleared && required ? { label: '', value: '' } : value
-    }
 
     return (
       <div
@@ -105,7 +101,7 @@ export default class MaterialSelect extends Component {
           isClearable
           isDisabled={disabled}
           isMulti={multiple}
-          value={getValue()}
+          value={isCleared && required ? { label: '', value: '' } : value}
           clearButtonRef={this.clearButtonRef}
           components={components}
           onBlur={e => {
@@ -118,11 +114,12 @@ export default class MaterialSelect extends Component {
             }
           }}
           onChange={val => {
-            if (required && _.isEmpty(val)) {
+            if (required && _.isEmpty(val) && !multiple) {
               this.setState({ isCleared: true })
               return
             }
-            if (required && val !== null) this.setState({ isCleared: false })
+            if (required && val !== null && !multiple)
+              this.setState({ isCleared: false })
             onChange(val)
           }}
           textFieldProps={textFieldProps}

--- a/web/src/app/selection/MaterialSelect.js
+++ b/web/src/app/selection/MaterialSelect.js
@@ -51,6 +51,7 @@ export default class MaterialSelect extends Component {
       theme,
       value,
       onChange,
+      onInputChange,
       classes,
       disabled,
       required,
@@ -101,7 +102,7 @@ export default class MaterialSelect extends Component {
           if (isDescendent(this.clearButtonRef.current, e.target))
             this.buttonClicked = true
         }}
-        onClick={() => {
+        onClickCapture={() => {
           this.buttonClicked = false
         }}
       >
@@ -131,6 +132,10 @@ export default class MaterialSelect extends Component {
             if (required && val !== null && !multiple)
               this.setState({ isCleared: false })
             onChange(val)
+          }}
+          onInputChange={val => {
+            this.buttonClicked = false
+            if (onInputChange) onInputChange(val)
           }}
           textFieldProps={textFieldProps}
           placeholder=''

--- a/web/src/app/selection/MaterialSelect.js
+++ b/web/src/app/selection/MaterialSelect.js
@@ -52,7 +52,6 @@ export default class MaterialSelect extends Component {
       classes,
       disabled,
       required,
-      onBlur,
 
       label,
       name,
@@ -111,13 +110,16 @@ export default class MaterialSelect extends Component {
               required
             ) {
               this.setState({ isCleared: false })
-              onChange(value)
             }
+            onChange(value)
           }}
           onChange={val => {
-            if (!required) onChange(val)
-            if (val !== null) onChange(val)
-            else this.setState({ isCleared: true })
+            if (required && val === null) {
+              this.setState({ isCleared: true })
+              return
+            }
+            if (required && val !== null) this.setState({ isCleared: false })
+            onChange(val)
           }}
           textFieldProps={textFieldProps}
           placeholder=''

--- a/web/src/app/selection/MaterialSelect.js
+++ b/web/src/app/selection/MaterialSelect.js
@@ -20,6 +20,14 @@ function valueCheck(props, ...args) {
 
 @withStyles(styles, { withTheme: true })
 export default class MaterialSelect extends Component {
+  constructor(props) {
+    super(props)
+    this.clearButtonRef = React.createRef()
+    this.state = {
+      isCleared: false,
+    }
+  }
+
   static propTypes = {
     multiple: p.bool, // allow selecting multiple values
     required: p.bool,
@@ -44,6 +52,7 @@ export default class MaterialSelect extends Component {
       classes,
       disabled,
       required,
+      onBlur,
 
       label,
       name,
@@ -72,6 +81,7 @@ export default class MaterialSelect extends Component {
       InputLabelProps,
       value: value ? (multiple ? value.join(',') : value.value) : '',
     }
+    const { isCleared } = this.state
 
     return (
       <div
@@ -88,12 +98,27 @@ export default class MaterialSelect extends Component {
           }}
           name={name}
           classes={classes}
-          isClearable={!required}
+          isClearable
           isDisabled={disabled}
           isMulti={multiple}
-          value={value}
+          value={isCleared && required ? { label: '', value: '' } : value}
+          clearButtonRef={this.clearButtonRef}
           components={components}
-          onChange={onChange}
+          onBlur={e => {
+            if (
+              isCleared &&
+              e.relatedTarget !== this.clearButtonRef.current &&
+              required
+            ) {
+              this.setState({ isCleared: false })
+              onChange(value)
+            }
+          }}
+          onChange={val => {
+            if (!required) onChange(val)
+            if (val !== null) onChange(val)
+            else this.setState({ isCleared: true })
+          }}
           textFieldProps={textFieldProps}
           placeholder=''
           {...props}

--- a/web/src/app/selection/MaterialSelectComponents.js
+++ b/web/src/app/selection/MaterialSelectComponents.js
@@ -187,6 +187,7 @@ const ClearIndicator = props => {
       {...props.innerProps}
       ref={props.selectProps.clearButtonRef}
       size='small'
+      tabIndex={-1}
       data-cy='select-clear'
     >
       <Clear />

--- a/web/src/app/selection/MaterialSelectComponents.js
+++ b/web/src/app/selection/MaterialSelectComponents.js
@@ -7,6 +7,8 @@ import Chip from '@material-ui/core/Chip'
 import MenuItem from '@material-ui/core/MenuItem'
 import { emphasize } from '@material-ui/core/styles/colorManipulator'
 import ListItemIcon from '@material-ui/core/ListItemIcon'
+import IconButton from '@material-ui/core/IconButton'
+import { Clear } from '@material-ui/icons'
 
 export const styles = theme => ({
   root: {
@@ -179,9 +181,22 @@ export const Menu = props => (
   </Paper>
 )
 
+const ClearIndicator = props => {
+  return (
+    <IconButton
+      {...props.innerProps}
+      ref={props.selectProps.clearButtonRef}
+      size='small'
+    >
+      <Clear />
+    </IconButton>
+  )
+}
+
 export const components = {
   Option,
   Control,
+  ClearIndicator,
   LoadingMessage,
   NoOptionsMessage,
   Placeholder,

--- a/web/src/app/selection/MaterialSelectComponents.js
+++ b/web/src/app/selection/MaterialSelectComponents.js
@@ -187,6 +187,7 @@ const ClearIndicator = props => {
       {...props.innerProps}
       ref={props.selectProps.clearButtonRef}
       size='small'
+      data-cy='select-clear'
     >
       <Clear />
     </IconButton>

--- a/web/src/app/selection/QuerySelect.js
+++ b/web/src/app/selection/QuerySelect.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import p from 'prop-types'
-import { memoize, omit } from 'lodash-es'
+import _, { memoize, omit } from 'lodash-es'
 import MaterialSelect from './MaterialSelect'
 import { mergeFields, fieldAlias, mapInputVars } from '../util/graphql'
 import FavoriteIcon from '@material-ui/icons/Star'
@@ -96,7 +96,8 @@ function makeUseValues(query, mapNode) {
 
     const result = value.map((v, i) => {
       const name = 'data' + i
-      if (!data || !data[name]) return { value: v, label: 'Loading...' }
+      if (!data || !data[name] || _.isEmpty(data[name]))
+        return { value: v, label: 'Loading...' }
 
       return mapNode(data[name])
     })

--- a/web/src/cypress/integration/materialSelect.ts
+++ b/web/src/cypress/integration/materialSelect.ts
@@ -26,7 +26,7 @@ function testMaterialSelect(screen: ScreenFormat) {
           cy.dialogForm({ users: [u1.name, u2.name] })
 
           // Should clear field
-          cy.dialogClearField('users')
+          cy.dialogForm({ users: '' })
           cy.get(`[role=dialog] #dialog-form input[name="rotations"]`)
             .should('not.contain', u1.name)
             .should('not.contain', u2.name)
@@ -54,7 +54,7 @@ function testMaterialSelect(screen: ScreenFormat) {
         cy.dialogTitle('Create Escalation Policy')
 
         // Clears field
-        cy.dialogClearField('repeat')
+        cy.dialogForm({ repeat: '' })
         cy.get('[role=dialog] #dialog-form input[name="repeat"]').should(
           'not.contain',
           defaultVal,
@@ -76,7 +76,7 @@ function testMaterialSelect(screen: ScreenFormat) {
         cy.dialogForm({ name, description, repeat })
 
         // Clears field
-        cy.dialogClearField('repeat')
+        cy.dialogForm({ repeat: '' })
         cy.get('[role=dialog] #dialog-form input[name="repeat"]').should(
           'not.contain',
           repeat,

--- a/web/src/cypress/integration/materialSelect.ts
+++ b/web/src/cypress/integration/materialSelect.ts
@@ -1,0 +1,97 @@
+import { Chance } from 'chance'
+import { testScreen } from '../support'
+const c = new Chance()
+
+testScreen('Material Select', testMaterialSelect)
+
+function testMaterialSelect(screen: ScreenFormat) {
+  describe('Clear Fields', () => {
+    describe('Escalation Policy Steps', () => {
+      let ep: EP
+      beforeEach(() => {
+        cy.createEP().then(e => {
+          ep = e
+          return cy.visit(`escalation-policies/${ep.id}`)
+        })
+      })
+      it('should clear fields and not reset with last values', () => {
+        cy.fixture('users').then(users => {
+          const u1 = users[0]
+          const u2 = users[1]
+
+          cy.pageFab()
+          cy.dialogTitle('Create Step')
+
+          cy.get('button[data-cy="users-step"]').click()
+          cy.dialogForm({ users: [u1.name, u2.name] })
+
+          // Should clear field
+          cy.dialogClearField('users')
+          cy.get(`[role=dialog] #dialog-form input[name="rotations"]`)
+            .should('not.contain', u1.name)
+            .should('not.contain', u2.name)
+
+          cy.get(
+            `[role=dialog] #dialog-form input[name="delayMinutes"]`,
+          ).click()
+
+          // Field should remian clear
+          cy.get(`[role=dialog] #dialog-form input[name="rotations"]`)
+            .should('not.contain', u1.name)
+            .should('not.contain', u2.name)
+
+          cy.dialogFinish('Submit')
+        })
+      })
+    })
+  })
+  describe('Clear Required Fields', () => {
+    describe('Escalation Policy', () => {
+      it('should clear EP repeat count, reset with default value', () => {
+        const defaultVal = '3'
+        cy.visit('escalation-policies')
+        cy.pageFab()
+        cy.dialogTitle('Create Escalation Policy')
+
+        // Clears field
+        cy.dialogClearField('repeat')
+        cy.get('[role=dialog] #dialog-form input[name="repeat"]').should(
+          'not.contain',
+          defaultVal,
+        )
+        // Default value returns
+        cy.get('[role=dialog] #dialog-form').click()
+        cy.dialogContains(defaultVal)
+
+        cy.dialogFinish('Cancel')
+      })
+      it('should clear EP repeat count, reset with last value', () => {
+        const name = 'SM EP ' + c.word({ length: 7 })
+        const description = c.word({ length: 9 })
+        const repeat = c.integer({ min: 0, max: 5 }).toString()
+
+        cy.visit('escalation-policies')
+        cy.pageFab()
+        cy.dialogTitle('Create Escalation Policy')
+        cy.dialogForm({ name, description, repeat })
+
+        // Clears field
+        cy.dialogClearField('repeat')
+        cy.get('[role=dialog] #dialog-form input[name="repeat"]').should(
+          'not.contain',
+          repeat,
+        )
+
+        // Last value returns
+        cy.get('[role=dialog] #dialog-form').click()
+        cy.dialogContains(repeat)
+
+        // Should be on details page
+        cy.dialogFinish('Submit')
+        cy.get('body')
+          .should('contain', name)
+          .should('contain', description)
+      })
+    })
+  })
+}

--- a/web/src/cypress/support/dialog.ts
+++ b/web/src/cypress/support/dialog.ts
@@ -16,9 +16,6 @@ declare global {
 
       /** Update a dialog's form fields with the given values. */
       dialogForm: typeof dialogForm
-
-      /** Clear a dialog field with the given name. */
-      dialogClearField: typeof dialogClearField
     }
   }
 }
@@ -65,23 +62,8 @@ function dialogFinish(s: string): Cypress.Chainable {
     })
 }
 
-function dialogClearField(s: string): Cypress.Chainable {
-  const selector = `[role=dialog] #dialog-form input[name="${s}"]`
-  return dialog()
-    .get(selector)
-    .then(el => {
-      if (
-        el.parents('[data-cy=material-select]').data('cy') === 'material-select'
-      ) {
-        return cy.get(`[data-cy="select-clear"]`).click()
-      }
-      return cy.get(selector).clear()
-    })
-}
-
 Cypress.Commands.add('dialogFinish', dialogFinish)
 Cypress.Commands.add('dialogTitle', dialogTitle)
 Cypress.Commands.add('dialogForm', dialogForm)
 Cypress.Commands.add('dialogContains', dialogContains)
 Cypress.Commands.add('dialogClick', dialogClick)
-Cypress.Commands.add('dialogClearField', dialogClearField)

--- a/web/src/cypress/support/dialog.ts
+++ b/web/src/cypress/support/dialog.ts
@@ -16,6 +16,9 @@ declare global {
 
       /** Update a dialog's form fields with the given values. */
       dialogForm: typeof dialogForm
+
+      /** Clear a dialog field with the given name. */
+      dialogClearField: typeof dialogClearField
     }
   }
 }
@@ -62,8 +65,23 @@ function dialogFinish(s: string): Cypress.Chainable {
     })
 }
 
+function dialogClearField(s: string): Cypress.Chainable {
+  const selector = `[role=dialog] #dialog-form input[name="${s}"]`
+  return dialog()
+    .get(selector)
+    .then(el => {
+      if (
+        el.parents('[data-cy=material-select]').data('cy') === 'material-select'
+      ) {
+        return cy.get(`[data-cy="select-clear"]`).click()
+      }
+      return cy.get(selector).clear()
+    })
+}
+
 Cypress.Commands.add('dialogFinish', dialogFinish)
 Cypress.Commands.add('dialogTitle', dialogTitle)
 Cypress.Commands.add('dialogForm', dialogForm)
 Cypress.Commands.add('dialogContains', dialogContains)
 Cypress.Commands.add('dialogClick', dialogClick)
+Cypress.Commands.add('dialogClearField', dialogClearField)

--- a/web/src/cypress/support/form.ts
+++ b/web/src/cypress/support/form.ts
@@ -126,6 +126,8 @@ function fillFormField(
       .data('cyFallbackType')
 
     if (isSelect) {
+      if (value === '') return cy.get(`[data-cy="select-clear"]`).click()
+
       if (DateTime.isDateTime(value)) {
         throw new TypeError(
           'DateTime only supported for time, date, or datetime-local types',


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Sets isClearable in material-select component to always be true for all fields. If required, field will be reset to last set value (or default) after losing focus.