### PR TITLE
dev: add missing deps for user_favorites

### DIFF
--- a/devtools/resetdb/main.go
+++ b/devtools/resetdb/main.go
@@ -256,7 +256,7 @@ func fillDB(ctx context.Context, url string) error {
 			rot = &id
 		}
 		return []interface{}{asUUID(fav.UserID), svc, sched, rot}
-	})
+	}, "users", "services", "schedules", "rotations")
 
 	_, err = pool.Exec(ctx, "alter table alerts disable trigger trg_enforce_alert_limit")
 	must(err)


### PR DESCRIPTION
**Description:**
Fixes an issue that caused `make regendb` to fail due to DB constraints by adding necessary dependencies to the `user_favorites` insert.