### PR TITLE
smoketests: migrate on call tests to graphql2 

### DIFF
--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -2751,7 +2751,7 @@ input UpdateUserOverrideInput {
 }
 
 input CreateUserOverrideInput {
-  scheduleID: ID!
+  scheduleID: ID
 
   start: ISOTimestamp!
   end: ISOTimestamp!
@@ -2767,6 +2767,7 @@ input CreateScheduleInput {
   favorite: Boolean
 
   targets: [ScheduleTargetInput!]
+  newUserOverrides: [CreateUserOverrideInput!]
 }
 
 input ScheduleTargetInput {
@@ -14333,6 +14334,12 @@ func (ec *executionContext) unmarshalInputCreateScheduleInput(ctx context.Contex
 			if err != nil {
 				return it, err
 			}
+		case "newUserOverrides":
+			var err error
+			it.NewUserOverrides, err = ec.unmarshalOCreateUserOverrideInput2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐCreateUserOverrideInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		}
 	}
 
@@ -14479,7 +14486,7 @@ func (ec *executionContext) unmarshalInputCreateUserOverrideInput(ctx context.Co
 		switch k {
 		case "scheduleID":
 			var err error
-			it.ScheduleID, err = ec.unmarshalNID2string(ctx, v)
+			it.ScheduleID, err = ec.unmarshalOID2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -20643,6 +20650,26 @@ func (ec *executionContext) unmarshalOCreateUserNotificationRuleInput2ᚖgithub�
 	}
 	res, err := ec.unmarshalOCreateUserNotificationRuleInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐCreateUserNotificationRuleInput(ctx, v)
 	return &res, err
+}
+
+func (ec *executionContext) unmarshalOCreateUserOverrideInput2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐCreateUserOverrideInputᚄ(ctx context.Context, v interface{}) ([]CreateUserOverrideInput, error) {
+	var vSlice []interface{}
+	if v != nil {
+		if tmp1, ok := v.([]interface{}); ok {
+			vSlice = tmp1
+		} else {
+			vSlice = []interface{}{v}
+		}
+	}
+	var err error
+	res := make([]CreateUserOverrideInput, len(vSlice))
+	for i := range vSlice {
+		res[i], err = ec.unmarshalNCreateUserOverrideInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐCreateUserOverrideInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
 }
 
 func (ec *executionContext) marshalOEscalationPolicy2githubᚗcomᚋtargetᚋgoalertᚋescalationᚐPolicy(ctx context.Context, sel ast.SelectionSet, v escalation.Policy) graphql.Marshaler {

--- a/graphql2/graphqlapp/schedule.go
+++ b/graphql2/graphqlapp/schedule.go
@@ -200,6 +200,14 @@ func (m *Mutation) CreateSchedule(ctx context.Context, input graphql2.CreateSche
 			}
 		}
 
+		for i, override := range input.NewUserOverrides {
+			override.ScheduleID = &sched.ID
+			_, err = m.CreateUserOverride(ctx, override)
+			if err != nil {
+				return validation.AddPrefix("newUserOverride["+strconv.Itoa(i)+"].", err)
+			}
+		}
+
 		return nil
 	})
 

--- a/graphql2/graphqlapp/useroverride.go
+++ b/graphql2/graphqlapp/useroverride.go
@@ -9,6 +9,7 @@ import (
 	"github.com/target/goalert/override"
 	"github.com/target/goalert/search"
 	"github.com/target/goalert/user"
+	"github.com/target/goalert/validation"
 )
 
 type UserOverride App
@@ -47,8 +48,11 @@ func (m *Mutation) UpdateUserOverride(ctx context.Context, input graphql2.Update
 }
 
 func (m *Mutation) CreateUserOverride(ctx context.Context, input graphql2.CreateUserOverrideInput) (*override.UserOverride, error) {
+	if input.ScheduleID == nil {
+		return nil, validation.NewFieldError("ScheduleID", "is required")
+	}
 	u := &override.UserOverride{
-		Target: assignment.ScheduleTarget(input.ScheduleID),
+		Target: assignment.ScheduleTarget(*input.ScheduleID),
 		Start:  input.Start,
 		End:    input.End,
 	}

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -116,11 +116,12 @@ type CreateRotationInput struct {
 }
 
 type CreateScheduleInput struct {
-	Name        string                `json:"name"`
-	Description *string               `json:"description"`
-	TimeZone    string                `json:"timeZone"`
-	Favorite    *bool                 `json:"favorite"`
-	Targets     []ScheduleTargetInput `json:"targets"`
+	Name             string                    `json:"name"`
+	Description      *string                   `json:"description"`
+	TimeZone         string                    `json:"timeZone"`
+	Favorite         *bool                     `json:"favorite"`
+	Targets          []ScheduleTargetInput     `json:"targets"`
+	NewUserOverrides []CreateUserOverrideInput `json:"newUserOverrides"`
 }
 
 type CreateServiceInput struct {
@@ -149,7 +150,7 @@ type CreateUserNotificationRuleInput struct {
 }
 
 type CreateUserOverrideInput struct {
-	ScheduleID   string    `json:"scheduleID"`
+	ScheduleID   *string   `json:"scheduleID"`
 	Start        time.Time `json:"start"`
 	End          time.Time `json:"end"`
 	AddUserID    *string   `json:"addUserID"`

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -275,7 +275,7 @@ input UpdateUserOverrideInput {
 }
 
 input CreateUserOverrideInput {
-  scheduleID: ID!
+  scheduleID: ID
 
   start: ISOTimestamp!
   end: ISOTimestamp!
@@ -291,6 +291,7 @@ input CreateScheduleInput {
   favorite: Boolean
 
   targets: [ScheduleTargetInput!]
+  newUserOverrides: [CreateUserOverrideInput!]
 }
 
 input ScheduleTargetInput {

--- a/smoketest/graphqloncall_test.go
+++ b/smoketest/graphqloncall_test.go
@@ -148,68 +148,268 @@ func TestGraphQLOnCall(t *testing.T) {
 		}
 	`, true, false)
 
-	// // Active schedule rule, user is replaced
-	// check("User EP Schedule Replace Override", `
-	// 	escalation_policies: [{ id_placeholder: "ep", name: "generated", description: "1"}]
-	// 	escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 	services: [{id_placeholder: "svc", description: "ok", name: "generated", escalation_policy_id: "ep"}]
-	// 	schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generated", description: "1"}]
-	// 	schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	// 	user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-	// `, true, false)
+	// Active schedule rule, user is replaced
+	check("User EP Schedule Add Override", `
+		mutation {
+			createService(
+				input: {
+					name: "{{.UniqName}}"
+					newEscalationPolicy: {
+						name: "{{.UniqName}}"
+						steps: [
+							{
+								delayMinutes: 1
+								newSchedule: {
+									name: "{{.UniqName}}"
+									timeZone: "UTC"
+									targets: [
+										{
+											target: { id: "{{.User2.ID}}", type: user }
+											rules: [
+												{
+													start: "00:00"
+													end: "23:59"
+													weekdayFilter: [true, true, true, true, true, true, true]
+												}
+											]
+										}
+									]
+									newUserOverrides: [
+										{
+											addUserID: "{{.User1.ID}}"
+											removeUserID: "{{.User2.ID}}",
+											start: "1006-01-02T15:04:05Z"
+											end: "4006-01-02T15:04:05Z"
+										}
+									]
+								}
+							}
+						]
+					}
+				}
+			) {
+				id
+			}
+			}
+	`, true, false)
 
-	// // Same scenario, user is NOT replaced (no override)
-	// check("User EP Schedule Replace Override Absent", `
-	// 		escalation_policies: [{ id_placeholder: "ep", name: "generated", description: "1"}]
-	// 		escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 		services: [{id_placeholder: "svc", description: "ok", name: "generated", escalation_policy_id: "ep"}]
-	// 		schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generated", description: "1"}]
-	// 		schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	// 	`, false, true)
+	// Same scenario, user is NOT replaced (no override)
+	check("User EP Schedule Add Override", `
+		mutation {
+			createService(
+				input: {
+					name: "{{.UniqName}}"
+					newEscalationPolicy: {
+						name: "{{.UniqName}}"
+						steps: [
+							{
+								delayMinutes: 1
+								newSchedule: {
+									name: "{{.UniqName}}"
+									timeZone: "UTC"
+									targets: [
+										{
+											target: { id: "{{.User2.ID}}", type: user }
+											rules: [
+												{
+													start: "00:00"
+													end: "23:59"
+													weekdayFilter: [true, true, true, true, true, true, true]
+												}
+											]
+										}
+									]
+								}
+							}
+						]
+					}
+				}
+			) {
+				id
+			}
+			}
+	`, false, true)
 
-	// // Active schedule rule, active rotation participant is replaced
-	// check("User EP Schedule Replace Rotation Override", `
-	// 	escalation_policies: [{ id_placeholder: "ep", name: "generated", description: "1"}]
-	// 	escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 	services: [{id_placeholder: "svc", description: "ok", name: "generated", escalation_policy_id: "ep"}]
-	// 	schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generated", description: "1"}]
-	// 	schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	// 	rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generated", description: "1"}]
-	// 	rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
-	// 	user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-	// `, true, false)
+	// Active schedule rule, active rotation participant is replaced
+	check("User EP Schedule Add Override", `
+		mutation {
+			createService(
+				input: {
+					name: "{{.UniqName}}"
+					newEscalationPolicy: {
+						name: "{{.UniqName}}"
+						steps: [
+							{
+								delayMinutes: 1
+								newSchedule: {
+									name: "{{.UniqName}}"
+									timeZone: "UTC"
+									targets: [
+										{
+											newRotation: {
+												name: "{{.UniqName}}",
+												type: weekly,
+												start: "2006-01-02T15:04:05Z",
+												timeZone: "UTC",
+												userIDs: ["{{.User2.ID}}"]
+											}
+											rules: [{}]
+										}
+									]
+									newUserOverrides: [
+										{
+											addUserID: "{{.User1.ID}}"
+											removeUserID: "{{.User2.ID}}",
+											start: "1006-01-02T15:04:05Z"
+											end: "4006-01-02T15:04:05Z"
+										}
+									]
+								}
+							}
+						]
+					}
+				}
+			) {
+				id
+			}
+			}
+	`, true, false)
 
-	// // Active schedule rule, active rotation participant is NOT replaced (no override)
-	// check("User EP Schedule Replace Rotation Override Absent", `
-	// 	escalation_policies: [{ id_placeholder: "ep", name: "generated", description: "1"}]
-	// 	escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 	services: [{id_placeholder: "svc", description: "ok", name: "generated", escalation_policy_id: "ep"}]
-	// 	schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generated", description: "1"}]
-	// 	schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	// 	rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generated", description: "1"}]
-	// 	rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
-	// `, false, true)
+	// Active schedule rule, active rotation participant is NOT replaced (no override)
+	check("User EP Schedule Add Override", `
+		mutation {
+			createService(
+				input: {
+					name: "{{.UniqName}}"
+					newEscalationPolicy: {
+						name: "{{.UniqName}}"
+						steps: [
+							{
+								delayMinutes: 1
+								newSchedule: {
+									name: "{{.UniqName}}"
+									timeZone: "UTC"
+									targets: [
+										{
+											newRotation: {
+												name: "{{.UniqName}}",
+												type: weekly,
+												start: "2006-01-02T15:04:05Z",
+												timeZone: "UTC",
+												userIDs: ["{{.User2.ID}}"]
+											}
+											rules: [
+												{
+													start: "00:00"
+													end: "23:59"
+													weekdayFilter: [true, true, true, true, true, true, true]
+												}
+											]
+										}
+									]
+								}
+							}
+						]
+					}
+				}
+			) {
+				id
+			}
+			}
+	`, false, true)
 
-	// // Active schedule rule, active rotation participant is removed
-	// check("User EP Schedule Remove Rotation Override", `
-	// 	escalation_policies: [{ id_placeholder: "ep", name: "generated", description: "1"}]
-	// 	escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 	services: [{id_placeholder: "svc", description: "ok", name: "generated", escalation_policy_id: "ep"}]
-	// 	schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generated", description: "1"}]
-	// 	schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	// 	rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generated", description: "1"}]
-	// 	rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
-	// 	user_overrides: [{ remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-	// `, false, false)
+	// Active schedule rule, active rotation participant is removed
+	check("User EP Schedule Add Override", `
+		mutation {
+			createService(
+				input: {
+					name: "{{.UniqName}}"
+					newEscalationPolicy: {
+						name: "{{.UniqName}}"
+						steps: [
+							{
+								delayMinutes: 1
+								newSchedule: {
+									name: "{{.UniqName}}"
+									timeZone: "UTC"
+									targets: [
+										{
+											newRotation: {
+												name: "{{.UniqName}}",
+												type: weekly,
+												start: "2006-01-02T15:04:05Z",
+												timeZone: "UTC",
+												userIDs: ["{{.User2.ID}}"]
+											}
+											rules: [
+												{
+													start: "00:00"
+													end: "23:59"
+													weekdayFilter: [true, true, true, true, true, true, true]
+												}
+											]
+										}
+									]
+									newUserOverrides: [
+										{
+											removeUserID: "{{.User2.ID}}",
+											start: "1006-01-02T15:04:05Z"
+											end: "4006-01-02T15:04:05Z"
+										}
+									]
+								}
+							}
+						]
+					}
+				}
+			) {
+				id
+			}
+			}
+	`, false, false)
 
-	// // Active schedule rule, user is removed
-	// check("User EP Schedule Remove Override", `
-	// 	escalation_policies: [{ id_placeholder: "ep", name: "generated", description: "1"}]
-	// 	escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 	services: [{id_placeholder: "svc", description: "ok", name: "generated", escalation_policy_id: "ep"}]
-	// 	schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generated", description: "1"}]
-	// 	schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	// 	user_overrides: [{remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-	// `, false, false)
+	// Active schedule rule, user is removed
+	check("User EP Schedule Add Override", `
+		mutation {
+			createService(
+				input: {
+					name: "{{.UniqName}}"
+					newEscalationPolicy: {
+						name: "{{.UniqName}}"
+						steps: [
+							{
+								delayMinutes: 1
+								newSchedule: {
+									name: "{{.UniqName}}"
+									timeZone: "UTC"
+									targets: [
+										{
+											target: { id: "{{.User2.ID}}", type: user }
+											rules: [
+												{
+													start: "00:00"
+													end: "23:59"
+													weekdayFilter: [true, true, true, true, true, true, true]
+												}
+											]
+										}
+									]
+									newUserOverrides: [
+										{
+											removeUserID: "{{.User2.ID}}",
+											start: "1006-01-02T15:04:05Z"
+											end: "4006-01-02T15:04:05Z"
+										}
+									]
+								}
+							}
+						]
+					}
+				}
+			) {
+				id
+			}
+			}
+	`, false, false)
 
 }

--- a/smoketest/graphqloncall_test.go
+++ b/smoketest/graphqloncall_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"text/template"
 	"testing"
+	"text/template"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/smoketest/graphqloncall_test.go
+++ b/smoketest/graphqloncall_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"html/template"
+	"text/template"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -453,7 +453,7 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 		[]onCallAssertion{{Service: "svc", EP: "ep", StepNumber: 0, User: "joe"}},
 	)
 
-	// 	// Same scenario, user is NOT replaced (no override), inactive schedule rule
+	// Same scenario, user is NOT replaced (no override), inactive schedule rule
 	check("User EP Schedule No Days Replace Override Absent", `
 		mutation {
 			createService(input:{

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -802,20 +802,50 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 		[]onCallAssertion{},
 	)
 
-	// 	// Active schedule rule, user is removed
-	// 	check("User EP Schedule Remove Override", `
-	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-	// 			schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	// 			user_overrides: [{remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-	// 		`,
-	// 		[]resolver.OnCallAssignment{},
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-	// 		},
-	// 	)
+	// Active schedule rule, user is removed
+	check("User EP Schedule Remove Override", `
+		mutation {
+		createService(
+			input: {
+				name: "{{name  "svc"}}"
+				newEscalationPolicy: {
+					name: "{{name  "ep"}}"
+					steps: [
+						{
+							delayMinutes: 1
+							newSchedule: {
+								name: "{{name  "sched"}}"
+								timeZone: "UTC"
+								targets: [
+									{
+										target: {id:"{{userID "joe"}}", type:user}
+										rules: [
+											{
+												start: "00:00"
+												end: "23:59"
+												weekdayFilter: [true, true, true, true, true, true, true]
+											}
+										]
+									}
+								]
+								newUserOverrides: [
+									{
+										removeUserID: "{{userID "joe"}}"
+										start: "1006-01-02T15:04:05Z"
+										end: "4006-01-02T15:04:05Z"
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		) {
+			id
+		}
+	}`,
+		[]onCallAssertion{},
+	)
 
 	// 	// Multiple add overrides, active schedule rules
 	// 	check("User EP Schedule Multiple Overrides", `

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -698,7 +698,7 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 	)
 
 	// 	Active schedule rule, active rotation participant is removed
-	check("User EP Schedule Replace Rotation Override Absent", `
+	check("User EP Schedule Remove Rotation Override", `
 		mutation {
 		createService(
 			input: {
@@ -748,21 +748,6 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 	}`,
 		[]onCallAssertion{},
 	)
-	// 	check("User EP Schedule Remove Rotation Override", `
-	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-	// 			schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	// 			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
-	// 			rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
-	// 			user_overrides: [{ remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-	// 		`,
-	// 		[]resolver.OnCallAssignment{},
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-	// 		},
-	// 	)
 
 	// 	// Active schedule rule, user is removed
 	// 	check("User EP Schedule Remove Override", `

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -697,7 +697,57 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 		[]onCallAssertion{{Service: "svc", EP: "ep", StepNumber: 0, User: "joe"}},
 	)
 
-	// 	// Active schedule rule, active rotation participant is removed
+	// 	Active schedule rule, active rotation participant is removed
+	check("User EP Schedule Replace Rotation Override Absent", `
+		mutation {
+		createService(
+			input: {
+				name: "{{name  "svc"}}"
+				newEscalationPolicy: {
+					name: "{{name  "ep"}}"
+					steps: [
+						{
+							delayMinutes: 1
+							newSchedule: {
+								name: "{{name  "sched"}}"
+								timeZone: "UTC"
+								targets: [
+									{
+										newRotation: {
+											name: "{{name  "rot"}}"
+											type: weekly
+											shiftLength: 1
+											timeZone: "UTC"
+											start: "2006-01-02T15:04:05Z"
+											userIDs: ["{{userID "joe"}}"]
+										}
+										rules: [
+											{
+												start: "00:00"
+												end: "23:59"
+												weekdayFilter: [true, true, true, true, true, true, true]
+											}
+										]
+									}
+								]
+								newUserOverrides: [
+									{
+										removeUserID: "{{userID "joe"}}"
+										start: "1006-01-02T15:04:05Z"
+										end: "4006-01-02T15:04:05Z"
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		) {
+			id
+		}
+	}`,
+		[]onCallAssertion{},
+	)
 	// 	check("User EP Schedule Remove Rotation Override", `
 	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
 	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -234,7 +234,7 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 		},
 	)
 
-	// 	// Different users on different rotations, users are on call but with different assignment rotations
+	// Different users on different rotations, users are on call but with different assignment rotations
 	check("Multiple Users EP Rotation Direct", `
 		mutation {
 			createService(input:{
@@ -271,19 +271,34 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 		},
 	)
 
-	// 	// EP -> Schedule, where there is an active ADD for a user
-	// 	check("User EP Schedule Add Override", `
-	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-	// 			user_overrides: [{add_user_id: "u1", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-	// 		`,
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-	// 		},
-	// 		nil,
-	// 	)
+	// EP -> Schedule, where there is an ADD for a user
+	check("User EP Schedule Add Override", `
+		mutation {
+			createService(input:{
+				name: "{{name  "svc"}}",
+				newEscalationPolicy: {
+					name: "{{name "ep"}}",
+					steps: [{
+								delayMinutes: 1
+								newSchedule: {
+									name: "sched1"
+									timeZone: "UTC"
+									newUserOverrides: [
+										{
+											addUserID: "{{userID "bob"}}"
+											start: "1006-01-02T15:04:05Z"
+											end: "4006-01-02T15:04:05Z"
+										}
+									]
+								}
+							}]
+				}
+			}){id}
+		}`,
+		[]onCallAssertion{
+			{Service: "svc", EP: "ep", StepNumber: 0, User: "bob"},
+		},
+	)
 
 	// 	// EP -> Schedule, where there is an inactive ADD for a user
 	// 	check("User EP Schedule Inactive Add Override", `

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -1,13 +1,26 @@
 package smoketest
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/target/goalert/engine/resolver"
-	"github.com/target/goalert/smoketest/harness"
-	"strings"
+	"html/template"
+	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/smoketest/harness"
+	"github.com/target/goalert/user"
 )
+
+var onCallAsnQueryTmpl = template.Must(template.New("query").Parse(`
+	query {
+		{{- range $id, $usr := .}}
+			{{$id}}: user(id: "{{$usr.ID}}") { onCallSteps{stepNumber, escalationPolicy {name, assignedTo { name }}} }
+		{{- end}}
+	}
+`))
 
 // TestGraphQLOnCallAssignments tests the logic behind `User.is_on_call`.
 func TestGraphQLOnCallAssignments(t *testing.T) {
@@ -16,17 +29,20 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 	h := harness.NewHarness(t, "", "escalation-policy-step-reorder")
 	defer h.Close()
 
-	doQL := func(t *testing.T, silent bool, query string, res interface{}) {
-		g := h.GraphQLQueryT(t, query, "/v1/graphql")
+	type onCallAssertion struct {
+		Service, EP, User string
+		StepNumber        int
+	}
+
+	doQL := func(t *testing.T, query string, res interface{}) {
+		g := h.GraphQLQueryT(t, query, "/api/graphql")
 		for _, err := range g.Errors {
 			t.Error("GraphQL Error:", err.Message)
 		}
 		if len(g.Errors) > 0 {
 			t.Fatal("errors returned from GraphQL")
 		}
-		if !silent {
-			t.Log("Response:", string(g.Data))
-		}
+		t.Log("Response:", string(g.Data))
 
 		if res == nil {
 			return
@@ -37,454 +53,462 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 		}
 	}
 
-	type asnID struct {
-		Svc, EP, Rot, Sched string
-		Step                int
-	}
-
-	getID := func(a resolver.OnCallAssignment) asnID {
-		return asnID{
-			Svc:   a.ServiceName,
-			EP:    a.EPName,
-			Rot:   a.RotationName,
-			Sched: a.ScheduleName,
-			Step:  a.Level,
-		}
-	}
-
 	var idCounter int
-	check := func(name, input string, user1OnCall, user2OnCall []resolver.OnCallAssignment) {
-		u1 := h.CreateUser()
-		u2 := h.CreateUser()
-		rep := strings.NewReplacer(
-			"generatedA", fmt.Sprintf("generatedA%d", idCounter),
-			"generatedB", fmt.Sprintf("generatedB%d", idCounter),
-		)
-		idCounter++
 
-		for i, oc := range user1OnCall {
-			oc.EPName = rep.Replace(oc.EPName)
-			oc.RotationName = rep.Replace(oc.RotationName)
-			oc.ScheduleName = rep.Replace(oc.ScheduleName)
-			oc.ServiceName = rep.Replace(oc.ServiceName)
-			user1OnCall[i] = oc
-		}
+	check := func(name, tmplStr string, expected []onCallAssertion) {
+		t.Helper()
 
-		for i, oc := range user2OnCall {
-			oc.EPName = rep.Replace(oc.EPName)
-			oc.RotationName = rep.Replace(oc.RotationName)
-			oc.ScheduleName = rep.Replace(oc.ScheduleName)
-			oc.ServiceName = rep.Replace(oc.ServiceName)
-			user2OnCall[i] = oc
-		}
+		users := make(map[string]*user.User)
+		names := make(map[string]string)
+		namesRev := make(map[string]string)
 
-		input = strings.Replace(input, "u1", u1.ID, -1)
-		input = strings.Replace(input, "u2", u2.ID, -1)
-		input = rep.Replace(input)
-		query := fmt.Sprintf(`
-			mutation {
-				createAll(input:{
-					%s
-				}) {
-					services {id}
-					escalation_policies {id}
-					rotations {id}
-					user_overrides {id}
-					schedules {id}
+		tmpl := template.New("mutation")
+		tmpl.Funcs(template.FuncMap{
+			"name": func(id string) string {
+				if name, ok := names[id]; ok {
+					return name
 				}
-			}
-			`, input)
-		t.Run(name, func(t *testing.T) {
+				name := fmt.Sprintf("generated%d", idCounter)
+				idCounter++
+				names[id] = name
+				namesRev[name] = id
+				return name
+			},
+			"userID": func(id string) string {
+				if usr, ok := users[id]; ok {
+					return usr.ID
+				}
+				usr := h.CreateUser()
+				users[id] = usr
+				return usr.ID
+			},
+		})
+		tmpl, err := tmpl.Parse(tmplStr)
+		require.NoError(t, err)
 
-			var resp struct {
-				CreateAll map[string][]struct{ ID string }
-			}
-			doQL(t, false, query, &resp)
+		var buf bytes.Buffer
+		err = tmpl.Execute(&buf, nil)
+		require.NoError(t, err)
+
+		query := buf.String()
+
+		t.Run(name, func(t *testing.T) {
+			doQL(t, query, nil)
 			h.Trigger()
 
-			var onCall struct {
-				User struct {
-					OnCallAssignments []resolver.OnCallAssignment `json:"on_call_assignments"`
+			var onCallState map[string]struct {
+				OnCallSteps []struct {
+					StepNumber       int
+					EscalationPolicy struct {
+						Name       string
+						AssignedTo []struct{ Name string }
+					}
+				}
+			}
+			var buf bytes.Buffer
+			err := onCallAsnQueryTmpl.Execute(&buf, users)
+			require.NoError(t, err, "render query")
+
+			doQL(t, buf.String(), &onCallState)
+
+			// map response to same type as expected value
+			var actualOnCall []onCallAssertion
+			for id, state := range onCallState {
+				for _, step := range state.OnCallSteps {
+					for _, svc := range step.EscalationPolicy.AssignedTo {
+						actualOnCall = append(actualOnCall, onCallAssertion{
+							User: id, StepNumber: step.StepNumber,
+							Service: namesRev[svc.Name], EP: namesRev[step.EscalationPolicy.Name],
+						})
+					}
 				}
 			}
 
-			var hasFailure bool
+			cpy := make([]onCallAssertion, len(expected))
+			copy(cpy, expected) // copy so that we don't modify the original slice
+			expected = cpy
 
-			checkUser := func(name, uid string) {
-
-				t.Run("User_"+name, func(t *testing.T) {
-					doQL(t, false, fmt.Sprintf(`
-						query {
-							user(id: "%s") { on_call_assignments{
-								escalation_policy_name
-								escalation_policy_step_number
-								is_active
-								rotation_name
-								schedule_name
-								service_name
-								user_id
-							} }
-						
-						}
-					`, uid), &onCall)
-
-					m := make(map[asnID]resolver.OnCallAssignment, len(onCall.User.OnCallAssignments))
-					checked := make(map[asnID]bool)
-					for _, a := range onCall.User.OnCallAssignments {
-						m[getID(a)] = a
+			sortAssertions := func(slice []onCallAssertion) {
+				sort.Slice(slice, func(a, b int) bool {
+					if slice[a].User != slice[b].User {
+						return slice[a].User < slice[b].User
 					}
-					var asn []resolver.OnCallAssignment
-					switch name {
-					case "u1":
-						asn = user1OnCall
-					case "u2":
-						asn = user2OnCall
+					if slice[a].Service != slice[b].Service {
+						return slice[a].Service < slice[b].Service
 					}
-
-					for _, a := range asn {
-						id := getID(a)
-						checked[id] = true
-						resp, ok := m[id]
-						if !ok {
-							hasFailure = true
-							t.Errorf("got nil, want assignment %+v", id)
-							continue
-						}
-
-						if resp.UserID != uid {
-							hasFailure = true
-							t.Errorf("Bad UserID for %+v: got %s; want %s", id, resp.UserID, uid)
-						}
-
-						if resp.IsActive != a.IsActive {
-							hasFailure = true
-							t.Errorf("Wrong active state for %+v: got %t; want %t", id, resp.IsActive, a.IsActive)
-						}
+					if slice[a].EP != slice[b].EP {
+						return slice[a].EP < slice[b].EP
 					}
-					for aID := range m {
-						if checked[aID] {
-							continue
-						}
-						hasFailure = true
-						t.Errorf("got unexpected assignment: %+v", aID)
+					if slice[a].StepNumber != slice[b].StepNumber {
+						return slice[a].StepNumber < slice[b].StepNumber
 					}
+					return false
 				})
 			}
+			sortAssertions(expected)
+			sortAssertions(actualOnCall)
 
-			checkUser("u1", u1.ID)
-			checkUser("u2", u2.ID)
-
-			if hasFailure {
-				t.Fatal()
-			}
-
+			assert.EqualValues(t, expected, actualOnCall, "On-call assignments.")
 		})
 	}
 
 	// User directly on EP is always on call
 	check("User EP Direct", `
-			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: user, target_id: "u1" }] }]
-			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
+		mutation {
+			createService(input:{
+				name: "{{name  "svc"}}",
+				newEscalationPolicy: {
+					name: "{{name "ep"}}",
+					steps: [{
+						delayMinutes: 4,
+						targets: [{type: user, id: "{{userID "bob"}}"}]
+					}]
+				}
+			}){id}
+		}
 		`,
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", Level: 0, IsActive: true},
+		[]onCallAssertion{
+			{User: "bob", Service: "svc", EP: "ep"},
 		},
-		nil,
 	)
 
 	// Active participant directly on EP is always on call
+
 	check("User EP Rotation Direct", `
-			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: rotation, target_id: "rot" }] }]
-			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
-			rotation_participants: [{rotation_id: "rot", user_id: "u1"}]
-		`,
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", RotationName: "generatedA", Level: 0, IsActive: true},
-		},
-		nil,
-	)
-
-	// Active participant directly on EP is always on call, rotation directly on EP but no participant, user has no assignments
-	check("Only One User EP Rotation Direct", `
-			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: rotation, target_id: "rot" }, {target_type: rotation, target_id: "rot2" }] }]
-			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "3006-01-02T15:04:05Z", name: "generatedA", description: "1"},
-						{id_placeholder: "rot2", time_zone: "UTC", shift_length: 1, type: weekly, start: "2016-01-02T15:04:05Z", name: "generatedB", description: "2"} ]
-			rotation_participants: [{rotation_id: "rot2", user_id: "u2"}]
-		`,
-		nil,
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", RotationName: "generatedB", Level: 0, IsActive: true},
+		mutation {
+			createService(input:{
+				name: "{{name  "svc"}}",
+				newEscalationPolicy: {
+					name: "{{name "ep"}}",
+					steps: [{
+						delayMinutes: 4,
+						newRotation: {
+							name: "{{name  "rot"}}",
+							type: weekly,
+							shiftLength: 1,
+							timeZone: "UTC",
+							start: "2006-01-02T15:04:05Z"
+							userIDs: ["{{userID "bob"}}"]
+						}
+					}]
+				}
+			}){id}
+		}`,
+		[]onCallAssertion{
+			{User: "bob", EP: "ep", Service: "svc"},
 		},
 	)
+	// 	check("User EP Rotation Direct", `
+	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: rotation, target_id: "rot" }] }]
+	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
+	// 			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
+	// 			rotation_participants: [{rotation_id: "rot", user_id: "u1"}]
+	// 		`,
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", RotationName: "generatedA", Level: 0, IsActive: true},
+	// 		},
+	// 		nil,
+	// 	)
 
-	// Different users on different rotations, users are on call but with different assignment rotations
+	// 	// Active participant directly on EP is always on call, rotation directly on EP but no participant, user has no assignments
+	// 	check("Only One User EP Rotation Direct", `
+	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: rotation, target_id: "rot" }, {target_type: rotation, target_id: "rot2" }] }]
+	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
+	// 			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "3006-01-02T15:04:05Z", name: "generatedA", description: "1"},
+	// 						{id_placeholder: "rot2", time_zone: "UTC", shift_length: 1, type: weekly, start: "2016-01-02T15:04:05Z", name: "generatedB", description: "2"} ]
+	// 			rotation_participants: [{rotation_id: "rot2", user_id: "u2"}]
+	// 		`,
+	// 		nil,
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", RotationName: "generatedB", Level: 0, IsActive: true},
+	// 		},
+	// 	)
+
+	// 	// Different users on different rotations, users are on call but with different assignment rotations
 	check("Multiple Users EP Rotation Direct", `
-			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: rotation, target_id: "rot" }, {target_type: rotation, target_id: "rot2" }] }]
-			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"},
-						{id_placeholder: "rot2", time_zone: "UTC", shift_length: 1, type: weekly, start: "2016-01-02T15:04:05Z", name: "generatedB", description: "2"} ]
-			rotation_participants: [{rotation_id: "rot", user_id: "u1"}, {rotation_id: "rot2", user_id: "u2"}]
-		`,
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", RotationName: "generatedA", Level: 0, IsActive: true},
-		},
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", RotationName: "generatedB", Level: 0, IsActive: true},
-		},
-	)
-
-	// EP -> Schedule, where there is an active ADD for a user
-	check("User EP Schedule Add Override", `
-			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-			user_overrides: [{add_user_id: "u1", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-		`,
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-		},
-		nil,
-	)
-
-	// EP -> Schedule, where there is an inactive ADD for a user
-	check("User EP Schedule Inactive Add Override", `
-			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-			user_overrides: [{add_user_id: "u1", start_time: "3006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-		`,
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-		},
-		nil,
-	)
-
-	// Active schedule rule, user is replaced
-	check("User EP Schedule Replace Override", `
-			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-			schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-			user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-		`,
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-		},
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
+		mutation {
+			createService(input:{
+				name: "{{name  "svc"}}",
+				newEscalationPolicy: {
+					name: "{{name "ep"}}",
+					steps: [{
+						delayMinutes: 4,
+						newRotation: {
+							name: "{{name  "rot1"}}",
+							type: weekly,
+							shiftLength: 1,
+							timeZone: "UTC",
+							start: "2006-01-02T15:04:05Z"
+							userIDs: ["{{userID "bob"}}"]
+						}
+					},{
+						delayMinutes: 4,
+						newRotation: {
+							name: "{{name  "rot2"}}",
+							type: weekly,
+							shiftLength: 1,
+							timeZone: "UTC",
+							start: "2006-01-02T15:04:05Z"
+							userIDs: ["{{userID "joe"}}"]
+						}
+					}]
+				}
+			}){id}
+		}`,
+		[]onCallAssertion{
+			{Service: "svc", EP: "ep", StepNumber: 0, User: "bob"},
+			{Service: "svc", EP: "ep", StepNumber: 1, User: "joe"},
 		},
 	)
 
-	// Active schedule rule, user is replaced but in the future (inactive replacement)
-	check("User EP Schedule Inactive Replace Override", `
-			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-			schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-			user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "3006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-		`,
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-		},
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-		},
-	)
+	// 	// EP -> Schedule, where there is an active ADD for a user
+	// 	check("User EP Schedule Add Override", `
+	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
+	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
+	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
+	// 			user_overrides: [{add_user_id: "u1", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
+	// 		`,
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
+	// 		},
+	// 		nil,
+	// 	)
 
-	// Same scenario, user is NOT replaced (no override)
-	check("User EP Schedule Replace Override Absent", `
-			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-			schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-		`,
-		[]resolver.OnCallAssignment{},
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-		},
-	)
+	// 	// EP -> Schedule, where there is an inactive ADD for a user
+	// 	check("User EP Schedule Inactive Add Override", `
+	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
+	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
+	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
+	// 			user_overrides: [{add_user_id: "u1", start_time: "3006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
+	// 		`,
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
+	// 		},
+	// 		nil,
+	// 	)
 
-	// Same scenario, user is NOT replaced (no override), inactive schedule rule
-	check("User EP Schedule No Days Replace Override Absent", `
-		escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-		escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-		services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-		schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-		schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: false, monday:false, tuesday:false, wednesday: false, thursday: false, friday: false, saturday: false}]
-	`,
-		[]resolver.OnCallAssignment{},
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-		},
-	)
+	// 	// Active schedule rule, user is replaced
+	// 	check("User EP Schedule Replace Override", `
+	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
+	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
+	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
+	// 			schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
+	// 			user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
+	// 		`,
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
+	// 		},
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
+	// 		},
+	// 	)
 
-	// Active schedule rule, active rotation participant is replaced
-	check("User EP Schedule Replace Rotation Override", `
-			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-			schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
-			rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
-			user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-		`,
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-		},
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-		},
-	)
+	// 	// Active schedule rule, user is replaced but in the future (inactive replacement)
+	// 	check("User EP Schedule Inactive Replace Override", `
+	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
+	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
+	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
+	// 			schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
+	// 			user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "3006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
+	// 		`,
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
+	// 		},
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
+	// 		},
+	// 	)
 
-	// Active schedule rule, active rotation participant is replaced
-	check("User EP Schedule Replace Rotation Override", `
-	escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-	escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-	schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-	schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
-	rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
-	user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-`,
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-		},
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-		},
-	)
+	// 	// Same scenario, user is NOT replaced (no override)
+	// 	check("User EP Schedule Replace Override Absent", `
+	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
+	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
+	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
+	// 			schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
+	// 		`,
+	// 		[]resolver.OnCallAssignment{},
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
+	// 		},
+	// 	)
 
-	// Active schedule rule, active rotation participant is replaced with an inactive replace override
-	check("User EP Schedule Replace Rotation Override (Inactive)", `
-		escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-		escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-		services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-		schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-		schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-		rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
-		rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
-		user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "3006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-	`,
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-		},
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-		},
-	)
+	// 	// Same scenario, user is NOT replaced (no override), inactive schedule rule
+	// 	check("User EP Schedule No Days Replace Override Absent", `
+	// 		escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 		escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
+	// 		services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
+	// 		schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
+	// 		schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: false, monday:false, tuesday:false, wednesday: false, thursday: false, friday: false, saturday: false}]
+	// 	`,
+	// 		[]resolver.OnCallAssignment{},
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
+	// 		},
+	// 	)
 
-	// Same as above, but no service assignment
-	check("User EP Schedule Replace Rotation Override No Service", `
-			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-			schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
-			rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
-			user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-		`,
-		[]resolver.OnCallAssignment{},
-		[]resolver.OnCallAssignment{},
-	)
+	// 	// Active schedule rule, active rotation participant is replaced
+	// 	check("User EP Schedule Replace Rotation Override", `
+	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
+	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
+	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
+	// 			schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
+	// 			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
+	// 			rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
+	// 			user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
+	// 		`,
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
+	// 		},
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
+	// 		},
+	// 	)
 
-	// Same as above, but 2 service assignments
-	check("User EP Schedule Replace Rotation Override Double Service", `
-			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"},{description: "ok", name: "generatedB", escalation_policy_id: "ep"}]
-			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-			schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
-			rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
-			user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-		`,
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-			{ServiceName: "generatedB", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-		},
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-			{ServiceName: "generatedB", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-		},
-	)
+	// 	// Active schedule rule, active rotation participant is replaced
+	// 	check("User EP Schedule Replace Rotation Override", `
+	// 	escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 	escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
+	// 	services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
+	// 	schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
+	// 	schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
+	// 	rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
+	// 	rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
+	// 	user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
+	// `,
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
+	// 		},
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
+	// 		},
+	// 	)
 
-	// Active schedule rule, active rotation participant is NOT replaced (no override)
-	check("User EP Schedule Replace Rotation Override Absent", `
-			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-			schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
-			rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
-		`,
-		[]resolver.OnCallAssignment{},
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-		},
-	)
+	// 	// Active schedule rule, active rotation participant is replaced with an inactive replace override
+	// 	check("User EP Schedule Replace Rotation Override (Inactive)", `
+	// 		escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 		escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
+	// 		services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
+	// 		schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
+	// 		schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
+	// 		rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
+	// 		rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
+	// 		user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "3006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
+	// 	`,
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
+	// 		},
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
+	// 		},
+	// 	)
 
-	// Active schedule rule, active rotation participant is removed
-	check("User EP Schedule Remove Rotation Override", `
-			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-			schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
-			rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
-			user_overrides: [{ remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-		`,
-		[]resolver.OnCallAssignment{},
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-		},
-	)
+	// 	// Same as above, but no service assignment
+	// 	check("User EP Schedule Replace Rotation Override No Service", `
+	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
+	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
+	// 			schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
+	// 			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
+	// 			rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
+	// 			user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
+	// 		`,
+	// 		[]resolver.OnCallAssignment{},
+	// 		[]resolver.OnCallAssignment{},
+	// 	)
 
-	// Active schedule rule, user is removed
-	check("User EP Schedule Remove Override", `
-			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-			schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-			user_overrides: [{remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-		`,
-		[]resolver.OnCallAssignment{},
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-		},
-	)
+	// 	// Same as above, but 2 service assignments
+	// 	check("User EP Schedule Replace Rotation Override Double Service", `
+	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
+	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"},{description: "ok", name: "generatedB", escalation_policy_id: "ep"}]
+	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
+	// 			schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
+	// 			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
+	// 			rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
+	// 			user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
+	// 		`,
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
+	// 			{ServiceName: "generatedB", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
+	// 		},
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
+	// 			{ServiceName: "generatedB", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
+	// 		},
+	// 	)
 
-	// Multiple add overrides, active schedule rules
-	check("User EP Schedule Multiple Overrides", `
-			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-			schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-			user_overrides: [{add_user_id: "u1", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"},
-							 {add_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-		`,
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-		},
-		[]resolver.OnCallAssignment{
-			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-		},
-	)
+	// 	// Active schedule rule, active rotation participant is NOT replaced (no override)
+	// 	check("User EP Schedule Replace Rotation Override Absent", `
+	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
+	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
+	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
+	// 			schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
+	// 			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
+	// 			rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
+	// 		`,
+	// 		[]resolver.OnCallAssignment{},
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
+	// 		},
+	// 	)
+
+	// 	// Active schedule rule, active rotation participant is removed
+	// 	check("User EP Schedule Remove Rotation Override", `
+	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
+	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
+	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
+	// 			schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
+	// 			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
+	// 			rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
+	// 			user_overrides: [{ remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
+	// 		`,
+	// 		[]resolver.OnCallAssignment{},
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
+	// 		},
+	// 	)
+
+	// 	// Active schedule rule, user is removed
+	// 	check("User EP Schedule Remove Override", `
+	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
+	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
+	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
+	// 			schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
+	// 			user_overrides: [{remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
+	// 		`,
+	// 		[]resolver.OnCallAssignment{},
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
+	// 		},
+	// 	)
+
+	// 	// Multiple add overrides, active schedule rules
+	// 	check("User EP Schedule Multiple Overrides", `
+	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
+	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
+	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
+	// 			schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
+	// 			user_overrides: [{add_user_id: "u1", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"},
+	// 							 {add_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
+	// 		`,
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
+	// 		},
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
+	// 		},
+	// 	)
 
 }

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"text/template"
 	"sort"
 	"testing"
+	"text/template"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -411,19 +411,37 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 		[]onCallAssertion{{Service: "svc", EP: "ep", StepNumber: 0, User: "joe"}},
 	)
 
-	// 	// Same scenario, user is NOT replaced (no override)
-	// 	check("User EP Schedule Replace Override Absent", `
-	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-	// 			schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	// 		`,
-	// 		[]resolver.OnCallAssignment{},
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-	// 		},
-	// 	)
+	// Same scenario, user is NOT replaced (no override)
+	check("User EP Schedule Replace Override Absent", `
+		mutation {
+			createService(input:{
+				name: "{{name  "svc"}}",
+				newEscalationPolicy: {
+					name: "{{name "ep"}}",
+					steps: [{
+								delayMinutes: 1
+								newSchedule: {
+									name: "{{name "sched"}}"
+									timeZone: "UTC"
+									targets: [
+									{
+										target: {id:"{{userID "joe"}}", type:user}
+										rules: [
+											{
+												start: "00:00"
+												end: "23:59"
+												weekdayFilter: [true, true, true, true, true, true, true]
+											}
+										]
+									}
+								]
+								}
+							}]
+				}
+			}){id}
+		}`,
+		[]onCallAssertion{{Service: "svc", EP: "ep", StepNumber: 0, User: "joe"}},
+	)
 
 	// 	// Same scenario, user is NOT replaced (no override), inactive schedule rule
 	// 	check("User EP Schedule No Days Replace Override Absent", `

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -847,22 +847,54 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 		[]onCallAssertion{},
 	)
 
-	// 	// Multiple add overrides, active schedule rules
-	// 	check("User EP Schedule Multiple Overrides", `
-	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-	// 			schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	// 			user_overrides: [{add_user_id: "u1", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"},
-	// 							 {add_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-	// 		`,
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-	// 		},
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-	// 		},
-	// 	)
+	// Multiple add overrides, active schedule rules
+	check("User EP Schedule Multiple Overrides", `
+		mutation {
+		createService(
+			input: {
+				name: "{{name  "svc"}}"
+				newEscalationPolicy: {
+					name: "{{name  "ep"}}"
+					steps: [
+						{
+							delayMinutes: 1
+							newSchedule: {
+								name: "{{name  "sched"}}"
+								timeZone: "UTC"
+								targets: [
+									{
+										target: {id:"{{userID "joe"}}", type:user}
+										rules: [
+											{
+												start: "00:00"
+												end: "23:59"
+												weekdayFilter: [true, true, true, true, true, true, true]
+											}
+										]
+									}
+								]
+								newUserOverrides: [
+									{
+										addUserID: "{{userID "bob"}}"
+										start: "1006-01-02T15:04:05Z"
+										end: "4006-01-02T15:04:05Z"
+									},
+									{
+										addUserID: "{{userID "joe"}}"
+										start: "1006-01-02T15:04:05Z"
+										end: "4006-01-02T15:04:05Z"
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		) {
+			id
+		}
+	}`,
+		[]onCallAssertion{{Service: "svc", EP: "ep", StepNumber: 0, User: "bob"}, {Service: "svc", EP: "ep", StepNumber: 0, User: "joe"}},
+	)
 
 }

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -234,7 +234,7 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 		},
 	)
 
-	// Different users on different rotations, users are on call but with different assignment rotations
+	// 	// Different users on different rotations, users are on call but with different assignment rotations
 	check("Multiple Users EP Rotation Direct", `
 		mutation {
 			createService(input:{
@@ -271,34 +271,19 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 		},
 	)
 
-	// Different users on different rotations, users are on call but with different assignment rotations
-	check("User EP Schedule Add Override", `
-		mutation {
-			createService(input:{
-				name: "{{name  "svc"}}",
-				newEscalationPolicy: {
-					name: "{{name "ep"}}",
-					steps: [{
-								delayMinutes: 1
-								newSchedule: {
-									name: "sched1"
-									timeZone: "UTC"
-									newUserOverrides: [
-										{
-											addUserID: "{{userID "bob"}}"
-											start: "1006-01-02T15:04:05Z"
-											end: "4006-01-02T15:04:05Z"
-										}
-									]
-								}
-							}]
-				}
-			}){id}
-		}`,
-		[]onCallAssertion{
-			{Service: "svc", EP: "ep", StepNumber: 0, User: "bob"},
-		},
-	)
+	// 	// EP -> Schedule, where there is an active ADD for a user
+	// 	check("User EP Schedule Add Override", `
+	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
+	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
+	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
+	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
+	// 			user_overrides: [{add_user_id: "u1", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
+	// 		`,
+	// 		[]resolver.OnCallAssignment{
+	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
+	// 		},
+	// 		nil,
+	// 	)
 
 	// 	// EP -> Schedule, where there is an inactive ADD for a user
 	// 	check("User EP Schedule Inactive Add Override", `

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -635,75 +635,56 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 	)
 
 	// User EP Schedule Replace Rotation Override Double Service
-	// check("User EP Schedule Replace Rotation Override Double Service", fmt.Sprintf(`
-	// 	mutation {
-	// 	alias0: createService(input: { name: "{{name "svc1"}}", escalationPolicyID: "%s" }) {
-	// 		id
-	// 	}
-	// 	alias1: createService(input: { name: "{{name "svc2"}}", escalationPolicyID: "%s" }) {
-	// 		id
-	// 	}
-	// 	createEscalationPolicyStep(
-	// 		input: {
-	// 			escalationPolicyID: "%s"
-	// 			delayMinutes: 1
-	// 			newSchedule: {
-	// 				name: "{{name "sched"}}"
-	// 				timeZone: "UTC"
-	// 				targets: [
-	// 					{
-	// 						newRotation: {
-	// 							name: "{{name "rot"}}"
-	// 							type: weekly
-	// 							shiftLength: 1
-	// 							timeZone: "UTC"
-	// 							start: "2006-01-02T15:04:05Z"
-	// 							userIDs: ["{{name "joe"}}"]
-	// 						}
-	// 						rules: [
-	// 							{
-	// 								start: "00:00"
-	// 								end: "23:59"
-	// 								weekdayFilter: [true, true, true, true, true, true, true]
-	// 							}
-	// 						]
-	// 					}
-	// 				]
-	// 				newUserOverrides: [
-	// 					{
-	// 						addUserID: "{{userID "bob"}}"
-	// 						removeUserID: "{{userID "joe"}}"
-	// 						start: "1006-01-02T15:04:05Z"
-	// 						end: "4006-01-02T15:04:05Z"
-	// 					}
-	// 				]
-	// 			}
-	// 		}
-	// 	) {
-	// 		id
-	// 	}
-	// }`, h.UUID("eip"), h.UUID("eip"), h.UUID("eip")),
-	// 	[]onCallAssertion{{Service: "svc", EP: "ep", StepNumber: 0, User: "bob"}, {Service: "svc", EP: "ep", StepNumber: 0, User: "joe"}},
-	// )
-	// 	check("User EP Schedule Replace Rotation Override Double Service", `
-	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"},{description: "ok", name: "generatedB", escalation_policy_id: "ep"}]
-	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-	// 			schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	// 			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
-	// 			rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
-	// 			user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-	// 		`,
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-	// 			{ServiceName: "generatedB", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-	// 		},
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-	// 			{ServiceName: "generatedB", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-	// 		},
-	// 	)
+	check("User EP Schedule Replace Rotation Override Double Service", fmt.Sprintf(`
+		mutation {
+		alias0: createService(input: { name: "{{name "svc1"}}", escalationPolicyID: "%s" }) {
+			id
+		}
+		alias1: createService(input: { name: "{{name "svc2"}}", escalationPolicyID: "%s" }) {
+			id
+		}
+		createEscalationPolicyStep(
+			input: {
+				escalationPolicyID: "%s"
+				delayMinutes: 1
+				newSchedule: {
+					name: "{{name "sched"}}"
+					timeZone: "UTC"
+					targets: [
+						{
+							newRotation: {
+								name: "{{name "rot"}}"
+								type: weekly
+								shiftLength: 1
+								timeZone: "UTC"
+								start: "2006-01-02T15:04:05Z"
+								userIDs: ["{{userID "joe"}}"]
+							}
+							rules: [
+								{
+									start: "00:00"
+									end: "23:59"
+									weekdayFilter: [true, true, true, true, true, true, true]
+								}
+							]
+						}
+					]
+					newUserOverrides: [
+						{
+							addUserID: "{{userID "bob"}}"
+							removeUserID: "{{userID "joe"}}"
+							start: "1006-01-02T15:04:05Z"
+							end: "4006-01-02T15:04:05Z"
+						}
+					]
+				}
+			}
+		) {
+			id
+		}
+	}`, h.UUID("eid"), h.UUID("eid"), h.UUID("eid")),
+		[]onCallAssertion{{Service: "svc1", EP: "", StepNumber: 0, User: "bob"}, {Service: "svc2", EP: "", StepNumber: 0, User: "bob"}},
+	)
 
 	// Active schedule rule, active rotation participant is NOT replaced (no override)
 	check("User EP Schedule Replace Rotation Override Absent", `

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"html/template"
+	"text/template"
 	"sort"
 	"testing"
 

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -652,21 +652,50 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 	// 		},
 	// 	)
 
-	// 	// Active schedule rule, active rotation participant is NOT replaced (no override)
-	// 	check("User EP Schedule Replace Rotation Override Absent", `
-	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-	// 			schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	// 			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
-	// 			rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
-	// 		`,
-	// 		[]resolver.OnCallAssignment{},
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-	// 		},
-	// 	)
+	// Active schedule rule, active rotation participant is NOT replaced (no override)
+	check("User EP Schedule Replace Rotation Override Absent", `
+		mutation {
+		createService(
+			input: {
+				name: "{{name  "svc"}}"
+				newEscalationPolicy: {
+					name: "{{name  "ep"}}"
+					steps: [
+						{
+							delayMinutes: 1
+							newSchedule: {
+								name: "{{name  "sched"}}"
+								timeZone: "UTC"
+								targets: [
+									{
+										newRotation: {
+											name: "{{name  "rot"}}"
+											type: weekly
+											shiftLength: 1
+											timeZone: "UTC"
+											start: "2006-01-02T15:04:05Z"
+											userIDs: ["{{userID "joe"}}"]
+										}
+										rules: [
+											{
+												start: "00:00"
+												end: "23:59"
+												weekdayFilter: [true, true, true, true, true, true, true]
+											}
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		) {
+			id
+		}
+	}`,
+		[]onCallAssertion{{Service: "svc", EP: "ep", StepNumber: 0, User: "joe"}},
+	)
 
 	// 	// Active schedule rule, active rotation participant is removed
 	// 	check("User EP Schedule Remove Rotation Override", `

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -234,7 +234,7 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 		},
 	)
 
-	// 	// Different users on different rotations, users are on call but with different assignment rotations
+	// Different users on different rotations, users are on call but with different assignment rotations
 	check("Multiple Users EP Rotation Direct", `
 		mutation {
 			createService(input:{
@@ -271,19 +271,34 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 		},
 	)
 
-	// 	// EP -> Schedule, where there is an active ADD for a user
-	// 	check("User EP Schedule Add Override", `
-	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-	// 			user_overrides: [{add_user_id: "u1", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-	// 		`,
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-	// 		},
-	// 		nil,
-	// 	)
+	// Different users on different rotations, users are on call but with different assignment rotations
+	check("User EP Schedule Add Override", `
+		mutation {
+			createService(input:{
+				name: "{{name  "svc"}}",
+				newEscalationPolicy: {
+					name: "{{name "ep"}}",
+					steps: [{
+								delayMinutes: 1
+								newSchedule: {
+									name: "sched1"
+									timeZone: "UTC"
+									newUserOverrides: [
+										{
+											addUserID: "{{userID "bob"}}"
+											start: "1006-01-02T15:04:05Z"
+											end: "4006-01-02T15:04:05Z"
+										}
+									]
+								}
+							}]
+				}
+			}){id}
+		}`,
+		[]onCallAssertion{
+			{Service: "svc", EP: "ep", StepNumber: 0, User: "bob"},
+		},
+	)
 
 	// 	// EP -> Schedule, where there is an inactive ADD for a user
 	// 	check("User EP Schedule Inactive Add Override", `

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -371,22 +371,45 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 		[]onCallAssertion{{Service: "svc", EP: "ep", StepNumber: 0, User: "bob"}},
 	)
 
-	// 	// Active schedule rule, user is replaced but in the future (inactive replacement)
-	// 	check("User EP Schedule Inactive Replace Override", `
-	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-	// 			schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	// 			user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "3006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-	// 		`,
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-	// 		},
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-	// 		},
-	// 	)
+	//  Active schedule rule, user is replaced but in the future (inactive replacement)
+	check("User EP Schedule Inactive Replace Override", `
+		mutation {
+			createService(input:{
+				name: "{{name  "svc"}}",
+				newEscalationPolicy: {
+					name: "{{name "ep"}}",
+					steps: [{
+								delayMinutes: 1
+								newSchedule: {
+									name: "{{name "sched"}}"
+									timeZone: "UTC"
+									targets: [
+									{
+										target: {id:"{{userID "joe"}}", type:user}
+										rules: [
+											{
+												start: "00:00"
+												end: "23:59"
+												weekdayFilter: [true, true, true, true, true, true, true]
+											}
+										]
+									}
+								]
+									newUserOverrides: [
+										{
+											addUserID: "{{userID "bob"}}"
+											removeUserID: "{{userID "joe"}}"
+											start: "3006-01-02T15:04:05Z"
+											end: "4006-01-02T15:04:05Z"
+										}
+									]
+								}
+							}]
+				}
+			}){id}
+		}`,
+		[]onCallAssertion{{Service: "svc", EP: "ep", StepNumber: 0, User: "joe"}},
+	)
 
 	// 	// Same scenario, user is NOT replaced (no override)
 	// 	check("User EP Schedule Replace Override Absent", `

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -885,7 +885,10 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 			id
 		}
 	}`,
-		[]onCallAssertion{{Service: "svc", EP: "ep", StepNumber: 0, User: "bob"}, {Service: "svc", EP: "ep", StepNumber: 0, User: "joe"}},
+		[]onCallAssertion{
+			{Service: "svc", EP: "ep", StepNumber: 0, User: "bob"},
+			{Service: "svc", EP: "ep", StepNumber: 0, User: "joe"},
+		},
 	)
 
 }

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -581,19 +581,55 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 		[]onCallAssertion{{Service: "svc", EP: "ep", StepNumber: 0, User: "joe"}},
 	)
 
-	// 	// Same as above, but no service assignment
-	// 	check("User EP Schedule Replace Rotation Override No Service", `
-	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-	// 			schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	// 			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
-	// 			rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
-	// 			user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-	// 		`,
-	// 		[]resolver.OnCallAssignment{},
-	// 		[]resolver.OnCallAssignment{},
-	// 	)
+	// Same as above, but no service assignment
+	check("User EP Schedule Replace Rotation Override No Service", `
+		mutation {
+		createEscalationPolicy(
+			input: {
+				name: "{{name  "ep"}}"
+				steps: [
+					{
+						delayMinutes: 1
+						newSchedule: {
+							name: "{{name  "sched"}}"
+							timeZone: "UTC"
+							targets: [
+								{
+									newRotation: {
+										name: "{{name  "rot"}}"
+										type: weekly
+										shiftLength: 1
+										timeZone: "UTC"
+										start: "2006-01-02T15:04:05Z"
+										userIDs: ["{{userID "joe"}}"]
+									}
+									rules: [
+										{
+											start: "00:00"
+											end: "23:59"
+											weekdayFilter: [true, true, true, true, true, true, true]
+										}
+									]
+								}
+							]
+							newUserOverrides: [
+								{
+									addUserID: "{{userID "bob"}}"
+									removeUserID: "{{userID "joe"}}"
+									start: "1006-01-02T15:04:05Z"
+									end: "4006-01-02T15:04:05Z"
+								}
+							]
+						}
+					}
+				]
+			}
+		) {
+			id
+		}
+	}`,
+		[]onCallAssertion{},
+	)
 
 	// 	// Same as above, but 2 service assignments
 	// 	check("User EP Schedule Replace Rotation Override Double Service", `

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -475,43 +475,58 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 		[]onCallAssertion{},
 	)
 
-	// 	// Active schedule rule, active rotation participant is replaced
-	// 	check("User EP Schedule Replace Rotation Override", `
-	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-	// 			schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	// 			rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
-	// 			rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
-	// 			user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-	// 		`,
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-	// 		},
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-	// 		},
-	// 	)
-
-	// 	// Active schedule rule, active rotation participant is replaced
-	// 	check("User EP Schedule Replace Rotation Override", `
-	// 	escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-	// 	escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 	services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-	// 	schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-	// 	schedule_rules: [{target:{target_type:rotation, target_id:"rot"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	// 	rotations: [{id_placeholder: "rot", time_zone: "UTC", shift_length: 1, type: weekly, start: "2006-01-02T15:04:05Z", name: "generatedA", description: "1"}]
-	// 	rotation_participants: [{rotation_id: "rot", user_id: "u2"}]
-	// 	user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-	// `,
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-	// 		},
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-	// 		},
-	// 	)
+	// Active schedule rule, active rotation participant is replaced
+	check("User EP Schedule Replace Rotation Override", `
+		mutation {
+		createService(
+			input: {
+				name: "{{name  "svc"}}"
+				newEscalationPolicy: {
+					name: "{{name  "ep"}}"
+					steps: [
+						{
+							delayMinutes: 1
+							newSchedule: {
+								name: "{{name  "sched"}}"
+								timeZone: "UTC"
+								targets: [
+									{
+										newRotation: {
+											name: "{{name  "rot"}}"
+											type: weekly
+											shiftLength: 1
+											timeZone: "UTC"
+											start: "2006-01-02T15:04:05Z"
+											userIDs: ["{{userID "joe"}}"]
+										}
+										rules: [
+											{
+												start: "00:00"
+												end: "23:59"
+												weekdayFilter: [true, true, true, true, true, true, true]
+											}
+										]
+									}
+								]
+								newUserOverrides: [
+									{
+										addUserID: "{{userID "bob"}}"
+										removeUserID: "{{userID "joe"}}"
+										start: "1006-01-02T15:04:05Z"
+										end: "4006-01-02T15:04:05Z"
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		) {
+			id
+		}
+	}`,
+		[]onCallAssertion{{Service: "svc", EP: "ep", StepNumber: 0, User: "bob"}},
+	)
 
 	// 	// Active schedule rule, active rotation participant is replaced with an inactive replace override
 	// 	check("User EP Schedule Replace Rotation Override (Inactive)", `

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -444,18 +444,36 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 	)
 
 	// 	// Same scenario, user is NOT replaced (no override), inactive schedule rule
-	// 	check("User EP Schedule No Days Replace Override Absent", `
-	// 		escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-	// 		escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 		services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-	// 		schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-	// 		schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: false, monday:false, tuesday:false, wednesday: false, thursday: false, friday: false, saturday: false}]
-	// 	`,
-	// 		[]resolver.OnCallAssignment{},
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-	// 		},
-	// 	)
+	check("User EP Schedule No Days Replace Override Absent", `
+		mutation {
+			createService(input:{
+				name: "{{name  "svc"}}",
+				newEscalationPolicy: {
+					name: "{{name "ep"}}",
+					steps: [{
+								delayMinutes: 1
+								newSchedule: {
+									name: "{{name "sched"}}"
+									timeZone: "UTC"
+									targets: [
+									{
+										target: {id:"{{userID "joe"}}", type:user}
+										rules: [
+											{
+												start: "00:00"
+												end: "23:59"
+												weekdayFilter: [false, false, false, false, false, false, false]
+											}
+										]
+									}
+								]
+								}
+							}]
+				}
+			}){id}
+		}`,
+		[]onCallAssertion{},
+	)
 
 	// 	// Active schedule rule, active rotation participant is replaced
 	// 	check("User EP Schedule Replace Rotation Override", `

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -332,22 +332,44 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 		[]onCallAssertion{},
 	)
 
-	// 	// Active schedule rule, user is replaced
-	// 	check("User EP Schedule Replace Override", `
-	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
-	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]
-	// 			services: [{id_placeholder: "svc", description: "ok", name: "generatedA", escalation_policy_id: "ep"}]
-	// 			schedules: [{id_placeholder: "s", time_zone: "UTC", name: "generatedA", description: "1"}]
-	// 			schedule_rules: [{target:{target_type:user, target_id:"u2"}, start:"00:00", end:"23:59", schedule_id: "s", sunday: true, monday:true, tuesday:true, wednesday: true, thursday: true, friday: true, saturday: true}]
-	// 			user_overrides: [{add_user_id: "u1", remove_user_id: "u2", start_time: "1006-01-02T15:04:05Z", end_time: "4006-01-02T15:04:05Z", target_type: schedule, target_id: "s"}]
-	// 		`,
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: true},
-	// 		},
-	// 		[]resolver.OnCallAssignment{
-	// 			{ServiceName: "generatedA", EPName: "generatedA", ScheduleName: "generatedA", Level: 0, IsActive: false},
-	// 		},
-	// 	)
+	check("User EP Schedule Replace Override", `
+		mutation {
+			createService(input:{
+				name: "{{name  "svc"}}",
+				newEscalationPolicy: {
+					name: "{{name "ep"}}",
+					steps: [{
+								delayMinutes: 1
+								newSchedule: {
+									name: "{{name "sched"}}"
+									timeZone: "UTC"
+									targets: [
+									{
+										target: {id:"{{userID "joe"}}", type:user}
+										rules: [
+											{
+												start: "00:00"
+												end: "23:59"
+												weekdayFilter: [true, true, true, true, true, true, true]
+											}
+										]
+									}
+								]
+									newUserOverrides: [
+										{
+											addUserID: "{{userID "bob"}}"
+											removeUserID: "{{userID "joe"}}"
+											start: "1006-01-02T15:04:05Z"
+											end: "4006-01-02T15:04:05Z"
+										}
+									]
+								}
+							}]
+				}
+			}){id}
+		}`,
+		[]onCallAssertion{{Service: "svc", EP: "ep", StepNumber: 0, User: "bob"}},
+	)
 
 	// 	// Active schedule rule, user is replaced but in the future (inactive replacement)
 	// 	check("User EP Schedule Inactive Replace Override", `

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -690,7 +690,10 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 			id
 		}
 	}`, h.UUID("eid"), h.UUID("eid"), h.UUID("eid")),
-		[]onCallAssertion{{Service: "svc1", EPName: "esc policy", StepNumber: 0, User: "bob"}, {Service: "svc2", EPName: "esc policy", StepNumber: 0, User: "bob"}},
+		[]onCallAssertion{
+			{Service: "svc1", EPName: "esc policy", StepNumber: 0, User: "bob"},
+			{Service: "svc2", EPName: "esc policy", StepNumber: 0, User: "bob"},
+		},
 	)
 
 	// Active schedule rule, active rotation participant is NOT replaced (no override)

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -26,7 +26,10 @@ var onCallAsnQueryTmpl = template.Must(template.New("query").Parse(`
 func TestGraphQLOnCallAssignments(t *testing.T) {
 	t.Parallel()
 
-	h := harness.NewHarness(t, "", "escalation-policy-step-reorder")
+	sql := `insert into escalation_policies (id, name) 
+					values ({{uuid "eid"}}, 'esc policy');`
+
+	h := harness.NewHarness(t, sql, "escalation-policy-step-reorder")
 	defer h.Close()
 
 	type onCallAssertion struct {
@@ -631,7 +634,57 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 		[]onCallAssertion{},
 	)
 
-	// 	// Same as above, but 2 service assignments
+	// User EP Schedule Replace Rotation Override Double Service
+	// check("User EP Schedule Replace Rotation Override Double Service", fmt.Sprintf(`
+	// 	mutation {
+	// 	alias0: createService(input: { name: "{{name "svc1"}}", escalationPolicyID: "%s" }) {
+	// 		id
+	// 	}
+	// 	alias1: createService(input: { name: "{{name "svc2"}}", escalationPolicyID: "%s" }) {
+	// 		id
+	// 	}
+	// 	createEscalationPolicyStep(
+	// 		input: {
+	// 			escalationPolicyID: "%s"
+	// 			delayMinutes: 1
+	// 			newSchedule: {
+	// 				name: "{{name "sched"}}"
+	// 				timeZone: "UTC"
+	// 				targets: [
+	// 					{
+	// 						newRotation: {
+	// 							name: "{{name "rot"}}"
+	// 							type: weekly
+	// 							shiftLength: 1
+	// 							timeZone: "UTC"
+	// 							start: "2006-01-02T15:04:05Z"
+	// 							userIDs: ["{{name "joe"}}"]
+	// 						}
+	// 						rules: [
+	// 							{
+	// 								start: "00:00"
+	// 								end: "23:59"
+	// 								weekdayFilter: [true, true, true, true, true, true, true]
+	// 							}
+	// 						]
+	// 					}
+	// 				]
+	// 				newUserOverrides: [
+	// 					{
+	// 						addUserID: "{{userID "bob"}}"
+	// 						removeUserID: "{{userID "joe"}}"
+	// 						start: "1006-01-02T15:04:05Z"
+	// 						end: "4006-01-02T15:04:05Z"
+	// 					}
+	// 				]
+	// 			}
+	// 		}
+	// 	) {
+	// 		id
+	// 	}
+	// }`, h.UUID("eip"), h.UUID("eip"), h.UUID("eip")),
+	// 	[]onCallAssertion{{Service: "svc", EP: "ep", StepNumber: 0, User: "bob"}, {Service: "svc", EP: "ep", StepNumber: 0, User: "joe"}},
+	// )
 	// 	check("User EP Schedule Replace Rotation Override Double Service", `
 	// 			escalation_policies: [{ id_placeholder: "ep", name: "generatedA", description: "1"}]
 	// 			escalation_policy_steps: [{escalation_policy_id: "ep", delay_minutes: 1, targets: [{target_type: schedule, target_id: "s" }] }]


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This migrates the tests in `smoketest/graphqloncall_test.go` and `smoketest/graphqloncallassignments_test.go` to use the graphql2 endpoint

**Describe any introduced API changes:**

To help accomplish this, we added the ability to create `newUserOverrides` as a nested field for `newSchedule`, and `scheduleID` is therefore optional

e.g. 

```go
...
steps: [{
	delayMinutes: 1,
	newSchedule: {
		name: "David",
		timeZone: "UTC",
		newUserOverrides: [{
			addUserID: "{{.User1.ID}}",
			start: "1006-01-02T15:04:05Z",
			end: "4006-01-02T15:04:05Z"
		}]
	}	
}]
...
```
