### PR TITLE
auth: refactor token handling and shorten cal-sub token strings

### DIFF
--- a/app/initauth.go
+++ b/app/initauth.go
@@ -18,6 +18,7 @@ func (app *App) initAuth(ctx context.Context) error {
 		SessionKeyring: app.SessionKeyring,
 		IntKeyStore:    app.IntegrationKeyStore,
 		CalSubStore:    app.CalSubStore,
+		APIKeyring:     app.APIKeyring,
 	})
 	if err != nil {
 		return errors.Wrap(err, "init auth handler")

--- a/auth/authtoken/encode.go
+++ b/auth/authtoken/encode.go
@@ -1,0 +1,49 @@
+package authtoken
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+
+	"github.com/target/goalert/validation"
+)
+
+// A SignFunc will return a signature for the given payload.
+type SignFunc func(payload []byte) (signature []byte, err error)
+
+// Encode will return a signed, URL-safe string representation of the token.
+// If signFn is nil, the signature will be omitted.
+func (t Token) Encode(signFn SignFunc) (string, error) {
+	var b []byte
+
+	enc := b64Encoding
+	switch t.Version {
+	case 0:
+		return t.ID.String(), nil
+	case 1:
+		if t.Type != TypeSession {
+			return "", validation.NewFieldError("Type", "version 1 only supports session tokens")
+		}
+		b = make([]byte, 17)
+		b[0] = 'S'
+		copy(b[1:], t.ID.Bytes())
+		enc = base64.URLEncoding
+	case 2:
+		b = make([]byte, 27)
+		b[0] = 'V' // versioned header format
+		b[1] = 2
+		b[2] = byte(t.Type)
+		copy(b[3:], t.ID.Bytes())
+		binary.BigEndian.PutUint64(b[19:], uint64(t.CreatedAt.Unix()))
+	default:
+		return "", validation.NewFieldError("Type", "unsupported version")
+	}
+
+	if signFn != nil {
+		sig, err := signFn(b)
+		if err != nil {
+			return "", err
+		}
+		b = append(b, sig...)
+	}
+	return enc.EncodeToString(b), nil
+}

--- a/auth/authtoken/parse.go
+++ b/auth/authtoken/parse.go
@@ -1,0 +1,90 @@
+package authtoken
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/target/goalert/validation"
+)
+
+// A VerifyFunc will verify that the signature is valid for the given payload. Additionally,
+// if supported, it indicates if an old-but-still-valid key (since been rotated) was used
+// to generate the signature.
+type VerifyFunc func(payload, signature []byte) (isValid, isOldKey bool)
+
+func alwaysValid([]byte, []byte) (bool, bool) { return true, false }
+
+// Parse will parse a token string, optionally verifying it's signature.
+// If verifyFn is nil, the signature is ignored.
+func Parse(s string, verifyFn VerifyFunc) (*Token, bool, error) {
+	if len(s) == 36 {
+		// integration key type is the only one with possible length 36. Session keys, even if
+		// we switched to a 128-bit signature would be a minimum of 38 base64-encoded chars.
+		id, err := uuid.FromString(s)
+		if err != nil {
+			return nil, false, validation.NewGenericError(err.Error())
+		}
+		return &Token{ID: id}, false, nil
+	}
+	if verifyFn == nil {
+		verifyFn = alwaysValid
+	}
+
+	enc := b64Encoding
+	if s[0] == 'U' { // always 'U' if it's an encoded session token (first encoded byte is 'S')
+		// session tokens were/are encoded with padding enabled
+		enc = base64.URLEncoding
+	}
+
+	data, err := enc.DecodeString(s)
+	if err != nil {
+		return nil, false, validation.NewGenericError(err.Error())
+	}
+	if len(data) < 2 {
+		return nil, false, validation.NewGenericError("invalid length")
+	}
+	headerFormat := data[0]
+	if headerFormat == 'S' {
+		// session token (version: 1)
+		if len(data) < 17 {
+			return nil, false, validation.NewGenericError("invalid length")
+		}
+		valid, isOldKey := verifyFn(data[:17], data[17:])
+		if !valid {
+			return nil, false, validation.NewGenericError("invalid signature")
+		}
+		t := &Token{
+			Version: 1,
+			Type:    TypeSession,
+		}
+		copy(t.ID[:], data[1:])
+		return t, isOldKey, nil
+	}
+
+	// Ensure we're using the new "versioned" token format
+	if headerFormat != 'V' {
+		return nil, false, validation.NewGenericError("invalid token header format")
+	}
+
+	switch data[1] {
+	case 2:
+		if len(data) < 26 {
+			return nil, false, validation.NewGenericError("invalid length")
+		}
+		valid, isOldKey := verifyFn(data[:27], data[27:])
+		if !valid {
+			return nil, false, validation.NewGenericError("invalid signature")
+		}
+		t := &Token{
+			Version: 2,
+			Type:    Type(data[2]),
+		}
+		copy(t.ID[:], data[3:])
+		t.CreatedAt = time.Unix(int64(binary.BigEndian.Uint64(data[19:])), 0)
+		return t, isOldKey, nil
+	}
+
+	return nil, false, validation.NewGenericError("unsupported token version")
+}

--- a/auth/authtoken/token.go
+++ b/auth/authtoken/token.go
@@ -1,0 +1,18 @@
+package authtoken
+
+import (
+	"encoding/base64"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+)
+
+var b64Encoding = base64.URLEncoding.WithPadding(base64.NoPadding)
+
+// Token represents an authentication token.
+type Token struct {
+	Version   int
+	Type      Type
+	ID        uuid.UUID
+	CreatedAt time.Time
+}

--- a/auth/authtoken/token_test.go
+++ b/auth/authtoken/token_test.go
@@ -1,0 +1,101 @@
+package authtoken
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToken_Version0(t *testing.T) {
+	tok := &Token{
+		ID: uuid.UUID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+	}
+	s, err := tok.Encode(nil)
+	assert.NoError(t, err)
+	// v0 integration keys are just a hex-encoded UUID
+	assert.Equal(t, "01020304-0506-0708-090a-0b0c0d0e0f10", s)
+
+	parsed, isOld, err := Parse(s, nil)
+	assert.NoError(t, err)
+	assert.False(t, isOld)
+	assert.EqualValues(t, tok, parsed)
+}
+
+func TestToken_Version1(t *testing.T) {
+	t.Run("encoding/decoding", func(t *testing.T) {
+		tok := &Token{
+			Version: 1,
+			ID:      uuid.FromStringOrNil("a592fe16-edb5-45bb-a7d2-d109fae252bc"),
+			Type:    TypeSession,
+		}
+		s, err := tok.Encode(func(b []byte) ([]byte, error) { return []byte("sig"), nil })
+		assert.NoError(t, err)
+		// v1 integration keys are just a hex-encoded UUID
+		dec, err := base64.URLEncoding.DecodeString(s)
+		assert.NoError(t, err) // should be valid base64
+
+		var exp bytes.Buffer
+		exp.WriteByte('S')        // Session key
+		exp.Write(tok.ID.Bytes()) // ID
+		exp.WriteString("sig")    // Signature
+		assert.Equal(t, exp.Bytes(), dec)
+
+		parsed, isOld, err := Parse(s, func(p, sig []byte) (bool, bool) {
+			assert.Equal(t, exp.Bytes()[:exp.Len()-3], p)
+			assert.Equal(t, []byte("sig"), sig)
+			return true, true
+		})
+		assert.NoError(t, err)
+		assert.True(t, isOld)
+		assert.EqualValues(t, tok, parsed)
+	})
+
+	t.Run("existing key", func(t *testing.T) {
+		const exampleKey = "U9obklyVC0wduWIy75nbivABDxwc-rANyqNA4CZQzhkJHuNlUCfJDPpcG6W9bEIPddqPbh-sxMS1Km87jC9yLASp3i1UWtdDu2udCzM="
+		parsed, isOld, err := Parse(exampleKey, func([]byte, []byte) (bool, bool) { return true, true })
+		assert.NoError(t, err)
+		assert.True(t, isOld)
+		assert.EqualValues(t, &Token{
+			Type:    TypeSession,
+			Version: 1,
+			ID:      uuid.FromStringOrNil("da1b925c-950b-4c1d-b962-32ef99db8af0"),
+		}, parsed)
+	})
+}
+
+func TestToken_Version2(t *testing.T) {
+	tok := &Token{
+		Version:   2,
+		Type:      TypeCalSub,
+		ID:        uuid.UUID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+		CreatedAt: time.Unix(1337, 0),
+	}
+	s, err := tok.Encode(func(b []byte) ([]byte, error) { return []byte("sig"), nil })
+	assert.NoError(t, err)
+	// v2 integration keys are just a hex-encoded UUID
+	dec, err := b64Encoding.DecodeString(s)
+	assert.NoError(t, err) // should be valid base64
+
+	var exp bytes.Buffer
+	exp.WriteByte('V')                                                 // Versioned header flag
+	exp.WriteByte(2)                                                   // version
+	exp.WriteByte(byte(TypeCalSub))                                    // type
+	exp.Write(tok.ID.Bytes())                                          // ID
+	binary.Write(&exp, binary.BigEndian, uint64(tok.CreatedAt.Unix())) // CreatedAt
+	exp.WriteString("sig")                                             // Signature
+	assert.Equal(t, exp.Bytes(), dec)
+
+	parsed, isOld, err := Parse(s, func(p, sig []byte) (bool, bool) {
+		assert.Equal(t, exp.Bytes()[:exp.Len()-3], p)
+		assert.Equal(t, sig, []byte("sig"))
+		return true, true
+	})
+	assert.NoError(t, err)
+	assert.True(t, isOld)
+	assert.EqualValues(t, tok, parsed)
+}

--- a/auth/authtoken/token_test.go
+++ b/auth/authtoken/token_test.go
@@ -45,7 +45,8 @@ func TestToken_Version1(t *testing.T) {
 		exp.WriteString("sig")    // Signature
 		assert.Equal(t, exp.Bytes(), dec)
 
-		parsed, isOld, err := Parse(s, func(p, sig []byte) (bool, bool) {
+		parsed, isOld, err := Parse(s, func(typ Type, p, sig []byte) (bool, bool) {
+			assert.Equal(t, TypeSession, typ)
 			assert.Equal(t, exp.Bytes()[:exp.Len()-3], p)
 			assert.Equal(t, []byte("sig"), sig)
 			return true, true
@@ -57,7 +58,7 @@ func TestToken_Version1(t *testing.T) {
 
 	t.Run("existing key", func(t *testing.T) {
 		const exampleKey = "U9obklyVC0wduWIy75nbivABDxwc-rANyqNA4CZQzhkJHuNlUCfJDPpcG6W9bEIPddqPbh-sxMS1Km87jC9yLASp3i1UWtdDu2udCzM="
-		parsed, isOld, err := Parse(exampleKey, func([]byte, []byte) (bool, bool) { return true, true })
+		parsed, isOld, err := Parse(exampleKey, func(Type, []byte, []byte) (bool, bool) { return true, true })
 		assert.NoError(t, err)
 		assert.True(t, isOld)
 		assert.EqualValues(t, &Token{
@@ -90,7 +91,8 @@ func TestToken_Version2(t *testing.T) {
 	exp.WriteString("sig")                                             // Signature
 	assert.Equal(t, exp.Bytes(), dec)
 
-	parsed, isOld, err := Parse(s, func(p, sig []byte) (bool, bool) {
+	parsed, isOld, err := Parse(s, func(typ Type, p, sig []byte) (bool, bool) {
+		assert.Equal(t, TypeCalSub, typ)
 		assert.Equal(t, exp.Bytes()[:exp.Len()-3], p)
 		assert.Equal(t, sig, []byte("sig"))
 		return true, true

--- a/auth/authtoken/type.go
+++ b/auth/authtoken/type.go
@@ -1,0 +1,11 @@
+package authtoken
+
+// Type represents the type of an authentication token.
+type Type byte
+
+// Available valid token types.
+const (
+	TypeUnknown Type = iota // always make the zero-value Unknown
+	TypeSession
+	TypeCalSub
+)

--- a/auth/handlerconfig.go
+++ b/auth/handlerconfig.go
@@ -1,0 +1,17 @@
+package auth
+
+import (
+	"github.com/target/goalert/calendarsubscription"
+	"github.com/target/goalert/integrationkey"
+	"github.com/target/goalert/keyring"
+	"github.com/target/goalert/user"
+)
+
+// HandlerConfig provides configuration for the auth handler.
+type HandlerConfig struct {
+	UserStore      user.Store
+	SessionKeyring keyring.Keyring
+	APIKeyring     keyring.Keyring
+	IntKeyStore    integrationkey.Store
+	CalSubStore    *calendarsubscription.Store
+}

--- a/calendarsubscription/store.go
+++ b/calendarsubscription/store.go
@@ -34,8 +34,6 @@ type Store struct {
 	oc   oncall.Store
 }
 
-const tokenAudience = "ga-cal-sub"
-
 // NewStore will create a new Store with the given parameters.
 func NewStore(ctx context.Context, db *sql.DB, apiKeyring keyring.Keyring, oc oncall.Store) (*Store, error) {
 	p := &util.Prepare{DB: db, Ctx: ctx}

--- a/calendarsubscription/store.go
+++ b/calendarsubscription/store.go
@@ -6,13 +6,13 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	uuid "github.com/satori/go.uuid"
+	"github.com/target/goalert/auth/authtoken"
 	"github.com/target/goalert/config"
 	"github.com/target/goalert/keyring"
 	"github.com/target/goalert/oncall"
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/util"
-	"github.com/target/goalert/util/log"
 	"github.com/target/goalert/util/sqlutil"
 	"github.com/target/goalert/validation"
 	"github.com/target/goalert/validation/validate"
@@ -111,25 +111,13 @@ func (cs *CalendarSubscription) scanFrom(scanFn func(...interface{}) error) erro
 
 // Authorize will return an authorized context associated with the given token. If the token is invalid
 // or otherwise can not be authenticated, an error is returned.
-func (s *Store) Authorize(ctx context.Context, token string) (context.Context, error) {
-	var c jwt.StandardClaims
-	_, err := s.keys.VerifyJWT(token, &c)
-	if err != nil {
-		log.Debug(ctx, err)
-		return ctx, validation.NewFieldError("token", "verification failed")
-	}
-
-	if !c.VerifyAudience(tokenAudience, true) {
-		return ctx, validation.NewFieldError("aud", "invalid audience")
-	}
-
-	err = validate.UUID("sub", c.Subject)
-	if err != nil {
-		return ctx, err
+func (s *Store) Authorize(ctx context.Context, tok authtoken.Token) (context.Context, error) {
+	if tok.Type != authtoken.TypeCalSub {
+		return ctx, validation.NewFieldError("token", "invalid type")
 	}
 
 	var userID string
-	err = s.authUser.QueryRowContext(ctx, c.Subject, time.Unix(c.IssuedAt, 0)).Scan(&userID)
+	err := s.authUser.QueryRowContext(ctx, tok.ID, tok.CreatedAt).Scan(&userID)
 	if err == sql.ErrNoRows {
 		return ctx, validation.NewFieldError("sub", "invalid")
 	}
@@ -139,7 +127,7 @@ func (s *Store) Authorize(ctx context.Context, token string) (context.Context, e
 
 	return permission.UserSourceContext(ctx, userID, permission.RoleUser, &permission.SourceInfo{
 		Type: permission.SourceTypeCalendarSubscription,
-		ID:   c.Subject,
+		ID:   tok.ID.String(),
 	}), nil
 }
 
@@ -196,11 +184,12 @@ func (s *Store) CreateTx(ctx context.Context, tx *sql.Tx, cs *CalendarSubscripti
 		return nil, err
 	}
 
-	n.token, err = s.keys.SignJWT(jwt.StandardClaims{
-		Subject:  n.ID,
-		Audience: tokenAudience,
-		IssuedAt: now.Unix(),
-	})
+	n.token, err = authtoken.Token{
+		Type:      authtoken.TypeCalSub,
+		Version:   2,
+		CreatedAt: now,
+		ID:        uuid.FromStringOrNil(n.ID),
+	}.Encode(s.keys.Sign)
 	return n, err
 }
 

--- a/smoketest/harness/graphql.go
+++ b/smoketest/harness/graphql.go
@@ -33,9 +33,14 @@ func (h *Harness) insertGraphQLUser() {
 		h.t.Fatal(errors.Wrap(err, "create GraphQL user"))
 	}
 
-	h.sessToken, _, err = h.authH.CreateSession(context.Background(), "goalert-smoketest", "bcefacc0-4764-012d-7bfb-002500d5decb")
+	tok, err := h.authH.CreateSession(context.Background(), "goalert-smoketest", "bcefacc0-4764-012d-7bfb-002500d5decb")
 	if err != nil {
 		h.t.Fatal(errors.Wrap(err, "create auth session"))
+	}
+
+	h.sessToken, err = tok.Encode(h.sessKey.Sign)
+	if err != nil {
+		h.t.Fatal(errors.Wrap(err, "sign auth session"))
 	}
 }
 

--- a/util/errutil/httperror.go
+++ b/util/errutil/httperror.go
@@ -50,7 +50,7 @@ func HTTPError(ctx context.Context, w http.ResponseWriter, err error) bool {
 		http.Error(w, errors.Cause(err).Error(), http.StatusForbidden)
 		return true
 	}
-	if validation.IsValidationError(err) {
+	if validation.IsClientError(err) {
 		log.Debug(ctx, err)
 		http.Error(w, errors.Cause(err).Error(), http.StatusBadRequest)
 		return true

--- a/validation/fieldvalidationerror.go
+++ b/validation/fieldvalidationerror.go
@@ -23,6 +23,9 @@ type MultiFieldError interface {
 type validation interface {
 	Validation() bool
 }
+type client interface {
+	ClientError() bool
+}
 
 type fieldError struct {
 	stack     errors.StackTrace
@@ -99,6 +102,14 @@ func NewFieldError(fieldName string, reason string) FieldError {
 // IsValidationError will determine if an error's cause is a field validation error.
 func IsValidationError(err error) bool {
 	if e, ok := errors.Cause(err).(validation); ok && e.Validation() {
+		return true
+	}
+	return false
+}
+
+// IsClientError will determine if an error's cause is due to request/client error.
+func IsClientError(err error) bool {
+	if e, ok := errors.Cause(err).(client); ok && e.ClientError() {
 		return true
 	}
 	return false


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR introduces a new package `authtokens` that handles parsing and encoding all used token formats in GoAlert.

Additionally, it changes the calendar subscription token from a JWT token to a binary base64 encoded string. This is due to size constraints on subscription URLs for some calendar providers.
