### PR TITLE
dev: add POSTGRES_HOST_AUTH_METHOD env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,7 @@ postgres:
 	docker run -d \
 		--restart=always \
 		-e POSTGRES_USER=goalert \
+		-e POSTGRES_HOST_AUTH_METHOD=trust \
 		--name goalert-postgres \
 		-p 5432:5432 \
 		postgres:11-alpine || docker start goalert-postgres

--- a/devtools/runjson/localdev-cypress-prod.json
+++ b/devtools/runjson/localdev-cypress-prod.json
@@ -67,6 +67,7 @@
       "run",
       "--rm",
       "--name=smoketest-postgres",
+      "-e=POSTGRES_HOST_AUTH_METHOD=trust",
       "-p=5433:5432",
       "postgres:11-alpine"
     ]

--- a/devtools/runjson/localdev-cypress.json
+++ b/devtools/runjson/localdev-cypress.json
@@ -82,6 +82,7 @@
       "--rm",
       "--name=smoketest-postgres",
       "-p=5433:5432",
+      "-e=POSTGRES_HOST_AUTH_METHOD=trust",
       "postgres:11-alpine"
     ]
   },


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Recent versions of the Postgres container now require `POSTGRES_HOST_AUTH_METHOD=trust` to be set in order for the containers to start in the previous relied-on mode. Without being set, commands like `make postgres` or `make cy-wide` will fail as the db container will fail to start.

This PR adds the required settings where necessary to allow development tools to behave the same way as they have in the past with recent versions of the container.
