### PR TITLE
ui: remove reminderMinutes

### DIFF
--- a/web/src/app/schedules/calendar-subscribe/CalendarSubscribeCreateDialog.js
+++ b/web/src/app/schedules/calendar-subscribe/CalendarSubscribeCreateDialog.js
@@ -62,7 +62,7 @@ export default function CalendarSubscribeCreateDialog(props) {
       input: {
         scheduleID: value.scheduleID,
         name: value.name,
-        reminderMinutes: [0],
+        reminderMinutes: [0], // default reminder at shift start time
         disabled: false,
       },
     },

--- a/web/src/app/schedules/calendar-subscribe/CalendarSubscribeCreateDialog.js
+++ b/web/src/app/schedules/calendar-subscribe/CalendarSubscribeCreateDialog.js
@@ -62,7 +62,7 @@ export default function CalendarSubscribeCreateDialog(props) {
       input: {
         scheduleID: value.scheduleID,
         name: value.name,
-        reminderMinutes: value.reminderMinutes.map(r => r && r.value),
+        reminderMinutes: [0],
         disabled: false,
       },
     },

--- a/web/src/app/schedules/calendar-subscribe/CalendarSubscribeEditDialog.js
+++ b/web/src/app/schedules/calendar-subscribe/CalendarSubscribeEditDialog.js
@@ -3,9 +3,7 @@ import { PropTypes as p } from 'prop-types'
 import gql from 'graphql-tag'
 import { useQuery, useMutation } from '@apollo/react-hooks'
 import FormDialog from '../../dialogs/FormDialog'
-import CalendarSubscribeForm, {
-  reminderMinutesOptions,
-} from './CalendarSubscribeForm'
+import CalendarSubscribeForm from './CalendarSubscribeForm'
 import { GenericError, ObjectNotFound } from '../../error-pages'
 import _ from 'lodash-es'
 import Spinner from '../../loading/components/Spinner'
@@ -16,7 +14,6 @@ const query = gql`
     userCalendarSubscription(id: $id) {
       id
       name
-      reminderMinutes
       scheduleID
     }
   }
@@ -62,9 +59,6 @@ export function CalendarSubscribeEditDialogContent(props) {
   const [value, setValue] = useState({
     name: _.get(data, 'name', ''),
     scheduleID: _.get(data, 'scheduleID', null),
-    reminderMinutes: _.get(data, 'reminderMinutes', []).map(r =>
-      reminderMinutesOptions.find(opt => opt.value === r),
-    ),
   })
 
   // setup the mutation
@@ -73,7 +67,6 @@ export function CalendarSubscribeEditDialogContent(props) {
       input: {
         id: props.data.id,
         name: value.name,
-        reminderMinutes: value.reminderMinutes.map(r => r && r.value),
       },
     },
     onCompleted: () => props.onClose(),

--- a/web/src/app/schedules/calendar-subscribe/CalendarSubscribeForm.js
+++ b/web/src/app/schedules/calendar-subscribe/CalendarSubscribeForm.js
@@ -3,35 +3,6 @@ import { PropTypes as p } from 'prop-types'
 import { FormContainer, FormField } from '../../forms'
 import { Grid, TextField } from '@material-ui/core'
 import { ScheduleSelect } from '../../selection'
-import MaterialSelect from '../../selection/MaterialSelect'
-import _ from 'lodash-es'
-
-export const reminderMinutesOptions = [
-  {
-    label: 'At time of shift',
-    value: 0,
-  },
-  {
-    label: '5 minutes before',
-    value: 5,
-  },
-  {
-    label: '10 minutes before',
-    value: 10,
-  },
-  {
-    label: '30 minutes before',
-    value: 30,
-  },
-  {
-    label: '1 hour before',
-    value: 60,
-  },
-  {
-    label: '1 day before',
-    value: 1440,
-  },
-]
 
 export default function CalendarSubscribeForm(props) {
   return (
@@ -49,7 +20,7 @@ export default function CalendarSubscribeForm(props) {
             fullWidth
             component={TextField}
             name='name'
-            label='Subscription Name'
+            label='Subscription Source Name'
             placeholder='My iCloud Calendar'
             required
           />
@@ -64,49 +35,9 @@ export default function CalendarSubscribeForm(props) {
             name='scheduleID'
           />
         </Grid>
-        {renderReminderMinutesFields()}
       </Grid>
     </FormContainer>
   )
-
-  function renderReminderMinutesFields() {
-    const arr = _.get(props, 'value.reminderMinutes', []).slice()
-
-    const fields = []
-    // push 1 more field than there are values, max of 5 fields
-    // every field after the first is optional
-    for (let i = 0; i < arr.length + 1 && i < 5; i++) {
-      fields.push(
-        <Grid key={i} item xs={12}>
-          <FormField
-            fullWidth
-            component={MaterialSelect}
-            name={`reminderMinutes[${i}]`}
-            label={getReminderLabel(i)}
-            options={reminderMinutesOptions}
-            mapValue={() => (arr[i] ? arr[i] : null)}
-          />
-        </Grid>,
-      )
-    }
-
-    return fields
-  }
-
-  function getReminderLabel(idx) {
-    switch (idx) {
-      case 0:
-        return 'Reminder'
-      case 1:
-        return 'Second Reminder'
-      case 2:
-        return 'Third Reminder'
-      case 3:
-        return 'Fourth Reminder'
-      case 4:
-        return 'Fifth Reminder'
-    }
-  }
 }
 
 CalendarSubscribeForm.propTypes = {

--- a/web/src/cypress/integration/calendarSubscriptions.ts
+++ b/web/src/cypress/integration/calendarSubscriptions.ts
@@ -31,10 +31,7 @@ function testSubs(screen: ScreenFormat) {
       // fill form out and submit
       cy.get('[data-cy="subscribe-btn"]').click()
       cy.dialogTitle('Create New Calendar Subscription')
-      cy.dialogForm({
-        name,
-        'reminderMinutes[0]': 'At time of shift',
-      })
+      cy.dialogForm({ name })
       cy.dialogClick('Submit')
       cy.dialogTitle('Success!')
       cy.dialogContains(Cypress.config().baseUrl + '/api/v2/calendar?token=')
@@ -61,7 +58,6 @@ function testSubs(screen: ScreenFormat) {
       cy.dialogForm({
         name,
         scheduleID: sched.name,
-        'reminderMinutes[0]': 'At time of shift',
       })
       cy.dialogClick('Submit')
       cy.dialogTitle('Success!')
@@ -70,57 +66,6 @@ function testSubs(screen: ScreenFormat) {
 
       cy.get('[data-cy="list-empty-message"]').should('not', 'exist')
       cy.get('[data-cy=calendar-subscriptions]').should('contain', name)
-    })
-
-    it('should add and remove additional valarms', () => {
-      cy.visit('/profile/schedule-calendar-subscriptions')
-      cy.pageFab()
-
-      const check = (shouldExist: Array<boolean>) => {
-        cy.get('input[name="reminderMinutes[0]"]').should(
-          shouldExist[0] ? 'exist' : 'not.exist',
-        )
-        cy.get('input[name="reminderMinutes[1]"]').should(
-          shouldExist[1] ? 'exist' : 'not.exist',
-        )
-        cy.get('input[name="reminderMinutes[2]"]').should(
-          shouldExist[2] ? 'exist' : 'not.exist',
-        )
-        cy.get('input[name="reminderMinutes[3]"]').should(
-          shouldExist[3] ? 'exist' : 'not.exist',
-        )
-        cy.get('input[name="reminderMinutes[4]"]').should(
-          shouldExist[4] ? 'exist' : 'not.exist',
-        )
-      }
-
-      // only 1st valarm field should exist to start
-      check([true, false, false, false, false])
-
-      cy.dialogForm({ 'reminderMinutes[0]': 'At time of shift' })
-      check([true, true, false, false, false])
-
-      cy.dialogForm({ 'reminderMinutes[1]': 'At time of shift' })
-      check([true, true, true, false, false])
-
-      cy.dialogForm({ 'reminderMinutes[2]': 'At time of shift' })
-      check([true, true, true, true, false])
-
-      cy.dialogForm({ 'reminderMinutes[3]': 'At time of shift' })
-      check([true, true, true, true, true])
-
-      // clearing the optional valarm fields should remove the redundant fields
-      cy.dialogForm({ 'reminderMinutes[3]': '' })
-      check([true, true, true, true, false])
-
-      cy.dialogForm({ 'reminderMinutes[2]': '' })
-      check([true, true, true, false, false])
-
-      cy.dialogForm({ 'reminderMinutes[1]': '' })
-      check([true, true, false, false, false])
-
-      cy.dialogForm({ 'reminderMinutes[0]': '' })
-      check([true, false, false, false, false])
     })
   })
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR removes `reminderMinutes` fields from the UI when creating or editing calendar subscriptions and updates cypress tests.  It also sets a default reminder on new calendar subscriptions created in the UI to be the on-call shift start.  No GraphQL or backend adjustments were made (still support specifying alternate reminderMinutes).



