### PR TITLE
ui: fix polling when calling `useQuery`

### DIFF
--- a/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertServiceListItem.js
+++ b/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertServiceListItem.js
@@ -45,7 +45,7 @@ export default function CreateAlertServiceListItem(props) {
 
   const { service } = data || {}
 
-  if (loading) return 'Loading...'
+  if (!data && loading) return 'Loading...'
   if (queryError) return 'Error fetching data.'
 
   const serviceURL = absURL('/services/' + id + '/alerts')

--- a/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertServiceSelect.js
+++ b/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertServiceSelect.js
@@ -87,7 +87,9 @@ export function CreateAlertServiceSelect(props) {
 
   const fieldRef = useRef()
   const classes = useStyles()
-  const searchResults = _.get(data, 'services.nodes', [])
+  const searchResults = _.get(data, 'services.nodes', []).filter(
+    id => !value.includes(id),
+  )
 
   const queryErrorMsg = allErrors(queryError)
     .map(e => e.message)
@@ -224,7 +226,12 @@ export function CreateAlertServiceSelect(props) {
                 data-cy='service-select-item'
                 key={service.id}
                 disabled={value.length >= CREATE_ALERT_LIMIT}
-                onClick={() => onChange([...value, service.id])}
+                onClick={() =>
+                  onChange([
+                    ...value.filter(id => id !== service.id),
+                    service.id,
+                  ])
+                }
               >
                 <ListItemText primary={service.name} />
                 {service.isFavorite && (

--- a/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertServiceSelect.js
+++ b/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertServiceSelect.js
@@ -96,7 +96,7 @@ export function CreateAlertServiceSelect(props) {
   let placeholderMsg = null
   if (queryErrorMsg) {
     placeholderMsg = null
-  } else if (loading || searchQueryInput !== searchUserInput) {
+  } else if ((!data && loading) || searchQueryInput !== searchUserInput) {
     placeholderMsg = 'Loading...'
   } else if (searchResults.length === 0) {
     placeholderMsg = 'No services found'

--- a/web/src/app/alerts/pages/AlertDetailPage.js
+++ b/web/src/app/alerts/pages/AlertDetailPage.js
@@ -63,7 +63,7 @@ export default class AlertDetailPage extends Component {
         pollInterval={POLL_INTERVAL}
       >
         {({ loading, error, data, startPolling }) => {
-          if (loading) return <Spinner />
+          if (!data && loading) return <Spinner />
           if (error) {
             startPolling(POLL_ERROR_INTERVAL)
             return <GenericError error={error.message} />

--- a/web/src/app/apollo.js
+++ b/web/src/app/apollo.js
@@ -128,6 +128,7 @@ export const GraphQLClient = new ApolloClient({
   cache,
   defaultOptions: {
     query: queryOpts,
+    watchQuery: queryOpts,
   },
 })
 
@@ -167,6 +168,7 @@ export const GraphQLClientWithErrors = new ApolloClient({
   cache,
   defaultOptions: {
     query: queryOpts,
+    watchQuery: queryOpts,
     mutate: { awaitRefetchQueries: true, errorPolicy: 'all' },
   },
 })

--- a/web/src/app/escalation-policies/PolicyDetails.js
+++ b/web/src/app/escalation-policies/PolicyDetails.js
@@ -43,7 +43,7 @@ export default function PolicyDetails(props) {
 
   const data = _.get(_data, 'escalationPolicy', null)
 
-  if (loading) return <Spinner />
+  if (!data && loading) return <Spinner />
   if (error) return <GenericError error={error.message} />
 
   if (!data) {

--- a/web/src/app/schedules/ScheduleDeleteDialog.js
+++ b/web/src/app/schedules/ScheduleDeleteDialog.js
@@ -36,7 +36,7 @@ export default function ScheduleDeleteDialog(props) {
     },
   })
 
-  if (dataLoading) return <Spinner />
+  if (!data && dataLoading) return <Spinner />
 
   return (
     <FormDialog

--- a/web/src/app/schedules/ScheduleTZFilter.js
+++ b/web/src/app/schedules/ScheduleTZFilter.js
@@ -24,7 +24,7 @@ export function ScheduleTZFilter(props) {
   let label, tz
   if (error) {
     label = 'Error: ' + (error.message || error)
-  } else if (loading) {
+  } else if (!data && loading) {
     label = 'Fetching timezone information...'
   } else {
     tz = data.schedule.timeZone

--- a/web/src/app/services/ServiceOnCallList.js
+++ b/web/src/app/services/ServiceOnCallList.js
@@ -63,7 +63,7 @@ export default function ServiceOnCallList({ serviceID }) {
       },
     ]
     style.color = 'gray'
-  } else if (loading) {
+  } else if (!data && loading) {
     items = [
       {
         title: 'Fetching users...',

--- a/web/src/app/util/Chips.js
+++ b/web/src/app/util/Chips.js
@@ -40,7 +40,7 @@ export function ServiceChip(props) {
   const getLabel = () => {
     if (name) return name
 
-    if (loading) return 'Loading...'
+    if (!data && loading) return 'Loading...'
 
     if (error) return `Error: ${error.message}`
 

--- a/web/src/app/util/Chips.js
+++ b/web/src/app/util/Chips.js
@@ -35,6 +35,7 @@ export function ServiceChip(props) {
     },
     skip: Boolean(name),
     fetchPolicy: 'cache-first',
+    pollInterval: 0,
   })
 
   const getLabel = () => {

--- a/web/src/app/util/Query.js
+++ b/web/src/app/util/Query.js
@@ -94,7 +94,7 @@ export default class Query extends React.PureComponent {
       return this.props.render(args)
     }
 
-    if (loading) {
+    if (!data && loading) {
       if (this.props.partialQuery) {
         try {
           const data = this.props.client.readQuery({

--- a/web/src/app/util/QuerySetFavoriteButton.js
+++ b/web/src/app/util/QuerySetFavoriteButton.js
@@ -66,7 +66,7 @@ export function QuerySetFavoriteButton(props) {
     <SetFavoriteButton
       typeName={typeName}
       isFavorite={isFavorite}
-      loading={loading}
+      loading={!data && loading}
       onClick={() => toggleFav()}
     />
   )


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes a regression where default polling stopped working within the application in many instances.

The `watchQuery` field needed to be added in addition to `query` for default options. Consequently, a number of places needed to check for existing data before rendering spinners to not flicker on data fetch.

Fixes #450 