### PR TITLE
ui: use graphql2 api in alert details

### DIFF
--- a/web/src/app/alerts/components/AlertDetails.js
+++ b/web/src/app/alerts/components/AlertDetails.js
@@ -147,7 +147,7 @@ export default class AlertDetails extends Component {
       repeat: state?.repeatCount,
       numSteps: ep.steps.length,
       steps: ep.steps,
-      status: alert.status.toLowerCase(),
+      status: alert.status,
       currentLevel: state?.stepNumber,
       lastEscalation: state?.lastEscalation,
     }
@@ -155,7 +155,7 @@ export default class AlertDetails extends Component {
 
   canAutoEscalate() {
     const { repeat, numSteps, status, currentLevel } = this.epsHelper()
-    if (status !== 'statusunacknowledged') return false
+    if (status !== 'StatusUnacknowledged') return false
     if (repeat === -1) return true
     return currentLevel + 1 < numSteps * (repeat + 1)
   }
@@ -358,7 +358,7 @@ export default class AlertDetails extends Component {
   getMenuOptions = () => {
     const { id, status } = this.props.data
 
-    if (status.toLowerCase() === 'statusclosed') return [] // no options to show if alert is already closed
+    if (status === 'StatusClosed') return [] // no options to show if alert is already closed
     const updateStatusMutation = gql`
       mutation UpdateAlertsMutation($input: UpdateAlertsInput!) {
         updateAlerts(input: $input) {
@@ -409,7 +409,7 @@ export default class AlertDetails extends Component {
       },
     }
 
-    if (status.toLowerCase() === 'statusunacknowledged') options.push(ack)
+    if (status === 'StatusUnacknowledged') options.push(ack)
     options.push(close)
     options.push(esc)
     return options

--- a/web/src/app/alerts/components/AlertDetails.js
+++ b/web/src/app/alerts/components/AlertDetails.js
@@ -15,7 +15,7 @@ import Typography from '@material-ui/core/Typography'
 import withStyles from '@material-ui/core/styles/withStyles'
 import isFullScreen from '@material-ui/core/withMobileDialog'
 import Countdown from 'react-countdown-now'
-import {RotationLink, ScheduleLink, ServiceLink, UserLink} from '../../links'
+import { RotationLink, ScheduleLink, ServiceLink, UserLink } from '../../links'
 import { styles } from '../../styles/materialStyles'
 import Options from '../../util/Options'
 import gql from 'graphql-tag'
@@ -214,7 +214,9 @@ export default class AlertDetails extends Component {
 
       let rotationsRender
       if (rotations.length > 0) {
-        rotationsRender = <div>Rotations: {this.renderRotations(rotations, id)}</div>
+        rotationsRender = (
+          <div>Rotations: {this.renderRotations(rotations, id)}</div>
+        )
       }
 
       let schedulesRender
@@ -238,13 +240,10 @@ export default class AlertDetails extends Component {
         <TableRow key={index} className={className}>
           <TableCell>Step #{index + 1}</TableCell>
           <TableCell>
-            {!targets.length && (
-              <Typography>&mdash;</Typography>
-            )}
+            {!targets.length && <Typography>&mdash;</Typography>}
             {rotationsRender}
             {schedulesRender}
             {usersRender}
-
           </TableCell>
           <TableCell>{this.renderTimer(index, delayMinutes)}</TableCell>
         </TableRow>
@@ -362,7 +361,9 @@ export default class AlertDetails extends Component {
     if (status.toLowerCase() === 'statusclosed') return [] // no options to show if alert is already closed
     const updateStatusMutation = gql`
       mutation UpdateAlertsMutation($input: UpdateAlertsInput!) {
-        updateAlerts(input: $input) { id }
+        updateAlerts(input: $input) {
+          id
+        }
       }
     `
     const options = []
@@ -384,7 +385,9 @@ export default class AlertDetails extends Component {
       mutation: {
         query: gql`
           mutation EscalateAlertMutation($input: [Int!]) {
-            escalateAlerts(input: $input) { id }
+            escalateAlerts(input: $input) {
+              id
+            }
           }
         `,
         variables: {

--- a/web/src/app/alerts/components/AlertDetails.js
+++ b/web/src/app/alerts/components/AlertDetails.js
@@ -15,7 +15,7 @@ import Typography from '@material-ui/core/Typography'
 import withStyles from '@material-ui/core/styles/withStyles'
 import isFullScreen from '@material-ui/core/withMobileDialog'
 import Countdown from 'react-countdown-now'
-import { ScheduleLink, ServiceLink, UserLink } from '../../links'
+import {RotationLink, ScheduleLink, ServiceLink, UserLink} from '../../links'
 import { styles } from '../../styles/materialStyles'
 import Options from '../../util/Options'
 import gql from 'graphql-tag'
@@ -98,13 +98,13 @@ export default class AlertDetails extends Component {
     )
   }
 
-  renderUsers(users, stepID) {
-    return users.map((user, i) => {
+  renderRotations(rotations, stepID) {
+    return rotations.map((rotation, i) => {
       const sep = i === 0 ? '' : ', '
       return (
-        <span key={stepID + user.id}>
+        <span key={stepID + rotation.id}>
           {sep}
-          {UserLink(user)}
+          {RotationLink(rotation)}
         </span>
       )
     })
@@ -117,6 +117,18 @@ export default class AlertDetails extends Component {
         <span key={stepID + schedule.id}>
           {sep}
           {ScheduleLink(schedule)}
+        </span>
+      )
+    })
+  }
+
+  renderUsers(users, stepID) {
+    return users.map((user, i) => {
+      const sep = i === 0 ? '' : ', '
+      return (
+        <span key={stepID + user.id}>
+          {sep}
+          {UserLink(user)}
         </span>
       )
     })
@@ -196,12 +208,13 @@ export default class AlertDetails extends Component {
     return steps.map((step, index) => {
       const { delayMinutes, id, targets } = step
 
-      const users = targets.filter(t => t.type === 'user')
+      const rotations = targets.filter(t => t.type === 'rotation')
       const schedules = targets.filter(t => t.type === 'schedule')
+      const users = targets.filter(t => t.type === 'user')
 
-      let usersRender
-      if (users.length > 0) {
-        usersRender = <div>Users: {this.renderUsers(users, id)}</div>
+      let rotationsRender
+      if (rotations.length > 0) {
+        rotationsRender = <div>Rotations: {this.renderRotations(rotations, id)}</div>
       }
 
       let schedulesRender
@@ -209,6 +222,11 @@ export default class AlertDetails extends Component {
         schedulesRender = (
           <div>Schedules: {this.renderSchedules(schedules, id)}</div>
         )
+      }
+
+      let usersRender
+      if (users.length > 0) {
+        usersRender = <div>Users: {this.renderUsers(users, id)}</div>
       }
 
       let className
@@ -223,8 +241,10 @@ export default class AlertDetails extends Component {
             {!targets.length && (
               <Typography>&mdash;</Typography>
             )}
-            {usersRender}
+            {rotationsRender}
             {schedulesRender}
+            {usersRender}
+
           </TableCell>
           <TableCell>{this.renderTimer(index, delayMinutes)}</TableCell>
         </TableRow>

--- a/web/src/app/alerts/pages/AlertDetailPage.js
+++ b/web/src/app/alerts/pages/AlertDetailPage.js
@@ -5,49 +5,35 @@ import gql from 'graphql-tag'
 import { Query } from 'react-apollo'
 import AlertDetails from '../components/AlertDetails'
 import { POLL_ERROR_INTERVAL, POLL_INTERVAL } from '../../util/poll_intervals'
-import { LegacyGraphQLClient } from '../../apollo'
 
 const query = gql`
   query AlertDetailsPageQuery($id: Int!) {
     alert(id: $id) {
-      number: _id
       id
-      status: status_2
-      escalation_level
-      description
-      details
+      alertID
+      status
       summary
-      service_id
-      source
-      assignments {
-        id
-        name
-      }
+      details
+      createdAt
       service {
         id
         name
-        escalation_policy_id
-      }
-      logs_2 {
-        event
-        message
-        timestamp
-      }
-      escalation_policy_snapshot {
-        repeat
-        current_level
-        last_escalation
-        steps {
-          delay_minutes
-          users {
-            id
-            name
-          }
-          schedules {
-            id
-            name
+        escalationPolicy {
+          id
+          steps {
+            delayMinutes
+            targets {
+              id
+              type
+              name
+            }
           }
         }
+      }
+      state {
+        lastEscalation
+        stepNumber
+        repeatCount
       }
     }
   }
@@ -58,7 +44,6 @@ export default class AlertDetailPage extends Component {
     return (
       <Query
         query={query}
-        client={LegacyGraphQLClient}
         variables={{ id: this.props.match.params.alertID }}
         pollInterval={POLL_INTERVAL}
       >

--- a/web/src/app/services/components/ServiceAlerts.js
+++ b/web/src/app/services/components/ServiceAlerts.js
@@ -74,7 +74,7 @@ export default function ServiceAlerts(props) {
       <PageActions key='actions'>
         <Search key='search' />
         <AlertsListFilter key='filter' serviceID={serviceID} />
-        <Options key='options' options={getMenuOptions()} />
+        <Options key='options' options={getMenuOptions()} legacyClient />
       </PageActions>
       {showDialog && (
         <FormDialog

--- a/web/src/app/util/Options.js
+++ b/web/src/app/util/Options.js
@@ -38,6 +38,7 @@ export default class Options extends Component {
     transformProps: p.object, // override props to position menu on desktop
     options: p.array.isRequired, // [{ disabled: false, text: '', onClick: () => { . . . } }]
     positionRelative: p.bool, // if true, disables the options menu being fixed to the top right
+    legacyClient: p.bool, // if true, uses the legacy graphql client for mutations
   }
 
   state = {
@@ -110,8 +111,8 @@ export default class Options extends Component {
     // wrap with mutation component
     return (
       <Mutation
-        client={LegacyGraphQLClient}
         key={idx}
+        client={this.props.legacyClient ? LegacyGraphQLClient : null}
         mutation={o.mutation.query}
         update={(cache, { data }) => {
           // invoke on success function if exists


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR converts the api calls from alert details pages to use the Graphql2 client in Apollo.

**Out of Scope:**
Converting alert details files to hooks and TypeScript

**Describe any introduced user-facing changes:**
Rotations will now appear in the escalation policy countdown table
