### PR TITLE
schedules/util: handle DST changes for the week after

### DIFF
--- a/web/src/app/schedules/util.js
+++ b/web/src/app/schedules/util.js
@@ -85,6 +85,17 @@ export function weekdaySummary(filter) {
   return d.join(', ')
 }
 
+// dstWeekOffset will return dt forward or backward a week
+// if `dt.offset` does not match the `expectedOffset`.
+function dstWeekOffset(expectedOffset, dt) {
+  if (dt.offset === expectedOffset) return dt
+
+  dt = dt.minus({ weeks: 1 })
+  if (dt.offset === expectedOffset) return dt
+
+  return dt.plus({ weeks: 2 })
+}
+
 export function parseClock(s, zone) {
   const dt = DateTime.fromObject({
     hours: parseInt(s.split(':')[0], 10),
@@ -93,11 +104,7 @@ export function parseClock(s, zone) {
     zone,
   })
 
-  // backtrack if we jumped over DST
-  if (dt.offset !== DateTime.utc().setZone('zone').offset)
-    return dt.minus({ weeks: 1 })
-
-  return dt
+  return dstWeekOffset(DateTime.utc().setZone('zone').offset, dt)
 }
 
 export function formatClock(dt) {


### PR DESCRIPTION
The existing fix would handle the week before a DST change,
but would not handle parsing clock values the week of/after.

<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes an issue where `parseClock` would return an incorrect time the week of/after a DST change. 