### PR TITLE
dev: fix typescript file checking on commit and make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ check: generate web/src/node_modules
 	go vet ./...
 	go run github.com/gordonklaus/ineffassign .
 	CGO_ENABLED=0 go run honnef.co/go/tools/cmd/staticcheck ./...
-	(cd web/src && yarn fmt)
+	(cd web/src && yarn fmt && yarn tsc-app && yarn tsc-cypress)
 	./devtools/ci/tasks/scripts/codecheck.sh
 
 check-all: check test smoketest cy-wide-prod-run cy-mobile-prod-run

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ start-prod: bin/waitfor web/inline_data_gen.go bin/runjson
 	bin/runjson <devtools/runjson/localdev-prod.json
 
 jest: web/src/node_modules
-	cd web/src && yarn tsc-app && node_modules/.bin/jest $(JEST_ARGS)
+	cd web/src && node_modules/.bin/jest $(JEST_ARGS)
 
 test: web/src/node_modules jest
 	go test -short ./...

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ start-prod: bin/waitfor web/inline_data_gen.go bin/runjson
 	bin/runjson <devtools/runjson/localdev-prod.json
 
 jest: web/src/node_modules
-	cd web/src && node_modules/.bin/jest $(JEST_ARGS)
+	cd web/src && yarn tsc-app && node_modules/.bin/jest $(JEST_ARGS)
 
 test: web/src/node_modules jest
 	go test -short ./...

--- a/web/src/app/tsconfig.json
+++ b/web/src/app/tsconfig.json
@@ -14,6 +14,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["./*"],
+  "include": ["**/*"],
   "exclude": ["./node_modules/", "./build/"]
 }

--- a/web/src/app/tsconfig.json
+++ b/web/src/app/tsconfig.json
@@ -7,7 +7,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "noImplicitAny": true,
-    "isolatedModules": true,
+    "isolatedModules": false,
     "noEmit": true,
     "experimentalDecorators": true,
     "noImplicitThis": true,

--- a/web/src/app/tsconfig.json
+++ b/web/src/app/tsconfig.json
@@ -14,6 +14,5 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["**/*"],
-  "exclude": ["./node_modules/", "./build/"]
+  "include": ["**/*"]
 }

--- a/web/src/app/tsconfig.json
+++ b/web/src/app/tsconfig.json
@@ -7,7 +7,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "noImplicitAny": true,
-    "isolatedModules": false,
+    "isolatedModules": true,
     "noEmit": true,
     "experimentalDecorators": true,
     "noImplicitThis": true,

--- a/web/src/app/tsconfig.json
+++ b/web/src/app/tsconfig.json
@@ -14,6 +14,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["./app/"],
+  "include": ["./*"],
   "exclude": ["./node_modules/", "./build/"]
 }

--- a/web/src/cypress/plugins/index.js
+++ b/web/src/cypress/plugins/index.js
@@ -35,7 +35,7 @@ module.exports = (on, config) => {
             exclude: [/node_modules/],
             use: [
               {
-                loader: 'ts-loader',
+                loader: 'babel-loader',
               },
             ],
           },

--- a/web/src/cypress/tsconfig.json
+++ b/web/src/cypress/tsconfig.json
@@ -9,7 +9,6 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    // TODO: set isolatedModules to true
     "noImplicitAny": true,
     "isolatedModules": false,
     "noEmit": true,

--- a/web/src/cypress/tsconfig.json
+++ b/web/src/cypress/tsconfig.json
@@ -18,5 +18,5 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["**/*.ts"]
+  "include": ["**/*"]
 }

--- a/web/src/cypress/tsconfig.json
+++ b/web/src/cypress/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "baseUrl": "../node_modules",
-    "lib": ["es2015", "dom"],
+    "lib": ["es6", "dom"],
     "types": ["cypress"],
     "jsx": "react",
     "allowJs": true,

--- a/web/src/cypress/tsconfig.json
+++ b/web/src/cypress/tsconfig.json
@@ -4,7 +4,19 @@
     "baseUrl": "../node_modules",
     "target": "es5",
     "lib": ["es2015", "dom"],
-    "types": ["cypress"]
+    "types": ["cypress"],
+    "jsx": "react",
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    // TODO: set to noImplicitAny to true
+    "noImplicitAny": true,
+    "isolatedModules": false,
+    "noEmit": true,
+    "experimentalDecorators": true,
+    "noImplicitThis": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["**/*.ts"]
 }

--- a/web/src/cypress/tsconfig.json
+++ b/web/src/cypress/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "strict": true,
     "baseUrl": "../node_modules",
-    "target": "es5",
     "lib": ["es2015", "dom"],
     "types": ["cypress"],
     "jsx": "react",

--- a/web/src/cypress/tsconfig.json
+++ b/web/src/cypress/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../app/tsconfig",
+  "compilerOptions": {
+    "isolatedModules": false
+  },
   "include": ["**/*"]
 }

--- a/web/src/cypress/tsconfig.json
+++ b/web/src/cypress/tsconfig.json
@@ -1,20 +1,4 @@
 {
-  "compilerOptions": {
-    "strict": true,
-    "baseUrl": "../node_modules",
-    "lib": ["es6", "dom"],
-    "types": ["cypress"],
-    "jsx": "react",
-    "allowJs": true,
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "noImplicitAny": true,
-    "isolatedModules": false,
-    "noEmit": true,
-    "experimentalDecorators": true,
-    "noImplicitThis": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
-  },
+  "extends": "../app/tsconfig",
   "include": ["**/*"]
 }

--- a/web/src/cypress/tsconfig.json
+++ b/web/src/cypress/tsconfig.json
@@ -9,7 +9,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    // TODO: set to noImplicitAny to true
+    // TODO: set isolatedModules to true
     "noImplicitAny": true,
     "isolatedModules": false,
     "noEmit": true,

--- a/web/src/package.json
+++ b/web/src/package.json
@@ -5,9 +5,11 @@
   "main": "index.js",
   "scripts": {
     "slint": "stylelint ./app/**/*.css",
-    "lint": "eslint . && tsc -p ./tsconfig.json",
+    "lint": "eslint . && tsc -p app/tsconfig.json",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
-    "fmt": "prettier -l --write '**/*.{js,yml,yaml,json,css,ts,tsx,html}' && eslint --fix . && tsc -p ./tsconfig.json",
+    "fmt": "prettier -l --write '**/*.{js,yml,yaml,json,css,ts,tsx,html}' && eslint --fix .",
+    "tsc-app": "tsc -p app/tsconfig.json",
+    "tsc-cypress": "tsc -p cypress/tsconfig.json",
     "build-deps": "webpack --config ./webpack.dll.config.js --progress"
   },
   "jest": {
@@ -24,9 +26,6 @@
     }
   },
   "lint-staged": {
-    "*.{ts,tsx}": [
-      "tsc --allowJs --jsx react --noEmit --isolatedModules --noImplicitAny --strict --noImplicitThis --lib es6,dom --esModuleInterop --noFallthroughCasesInSwitch --experimentalDecorators"
-    ],
     "*.{json,yml,yaml,ts,tsx,html}": [
       "prettier --write"
     ],
@@ -172,7 +171,6 @@
     "stylelint": "13.2.0",
     "stylelint-config-standard": "20.0.0",
     "terser-webpack-plugin": "2.3.5",
-    "ts-loader": "6.2.1",
     "typescript": "3.8.3",
     "webpack": "4.41.6",
     "webpack-cli": "3.3.11",

--- a/web/src/package.json
+++ b/web/src/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "slint": "stylelint ./app/**/*.css",
-    "lint": "eslint . && tsc -p app/tsconfig.json",
+    "lint": "eslint . && tsc -p app/tsconfig.json && tsc -p cypress/tsconfig.json",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "fmt": "prettier -l --write '**/*.{js,yml,yaml,json,css,ts,tsx,html}' && eslint --fix .",
     "tsc-app": "tsc -p app/tsconfig.json",

--- a/web/src/webpack.cypress.js
+++ b/web/src/webpack.cypress.js
@@ -36,7 +36,7 @@ module.exports = {
         exclude: [/node_modules/],
         use: [
           {
-            loader: 'ts-loader',
+            loader: 'babel-loader',
           },
         ],
       },

--- a/web/src/yarn.lock
+++ b/web/src/yarn.lock
@@ -2910,7 +2910,7 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.4.tgz#9cf2de494ca84060a2a8d2854edd6dfb0445f386"
   integrity sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -4161,7 +4161,7 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@4.1.0, enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
+enhanced-resolve@4.1.0, enhanced-resolve@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz#41c7e0bfdfe74ac1ffe1e57ad6a5c6c9f3742a7f"
   integrity sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==
@@ -7497,7 +7497,7 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.0, micromatch@^4.0.2:
+micromatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
   integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
@@ -11172,17 +11172,6 @@ ts-invariant@^0.4.0, ts-invariant@^0.4.4:
   integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
   dependencies:
     tslib "^1.9.3"
-
-ts-loader@6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-6.2.1.tgz#67939d5772e8a8c6bdaf6277ca023a4812da02ef"
-  integrity sha512-Dd9FekWuABGgjE1g0TlQJ+4dFUfYGbYcs52/HQObE0ZmUNjQlmLAS7xXsSzy23AMaMwipsx5sNHvoEpT2CZq1g==
-  dependencies:
-    chalk "^2.3.0"
-    enhanced-resolve "^4.0.0"
-    loader-utils "^1.0.2"
-    micromatch "^4.0.0"
-    semver "^6.0.0"
 
 tslib@^1.10.0, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR moves src/tsconfig.json to app/ and keeps the cypress/ and app/tsconfig.json files separate. Also updates the package.json to lint the project with a unified config and creates separate yarn scripts to format and type check app/ and cypress/.

- husky will **not** run typechecking pre-commit
- make check should fail if there are any typescript errors
- uses babel-loader to build cypress bundles

**Out of Scope:**
eslint will not check typescript files (current state)
