### PR TITLE
cypress: fix failing test

### DIFF
--- a/web/src/cypress/integration/scheduleCalendar.ts
+++ b/web/src/cypress/integration/scheduleCalendar.ts
@@ -138,11 +138,16 @@ function testCalendar(screen: ScreenFormat): void {
     // go from week to monthly view
     // e.g. if navigating to an overlap of two months such as
     // Jan 27 - Feb 2, show the latter month (February)
+    let monthsToAdd = 0
+    if (weekSpansTwoMonths(now) && now.day > 7) {
+      monthsToAdd = 1
+    }
+
     cy.get('button[data-cy="show-month"]').click()
     cy.get('button[data-cy="show-month"]').should('be.disabled')
     cy.get('[data-cy="calendar-header"]').should(
       'contain',
-      monthHeaderFormat(now.plus({ months: weekSpansTwoMonths(now) ? 1 : 0 })),
+      monthHeaderFormat(now.plus({ months: monthsToAdd })),
     )
   })
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Fixes a test that would fail on overlap months (e.g. Jan 27 - Feb 2) when adding months to assert text.