### PR TITLE
ui: consistify alert timestamps

### DIFF
--- a/web/src/app/alerts/AlertDetailLogs.js
+++ b/web/src/app/alerts/AlertDetailLogs.js
@@ -1,19 +1,16 @@
 import React, { useState } from 'react'
 import p from 'prop-types'
 import Button from '@material-ui/core/Button'
-import Divider from '@material-ui/core/Divider'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
-import Typography from '@material-ui/core/Typography'
 import gql from 'graphql-tag'
 import { useQuery } from '@apollo/react-hooks'
 import { DateTime } from 'luxon'
 import _ from 'lodash-es'
-import { logTimeFormat } from '../util/timeFormat'
-import { POLL_INTERVAL } from '../config'
 import { formatTimeSince } from '../util/timeFormat'
+import { POLL_INTERVAL } from '../config'
 
 const FETCH_LIMIT = 149
 const QUERY_LIMIT = 35

--- a/web/src/app/alerts/AlertDetailLogs.js
+++ b/web/src/app/alerts/AlertDetailLogs.js
@@ -1,16 +1,19 @@
 import React, { useState } from 'react'
 import p from 'prop-types'
+import Button from '@material-ui/core/Button'
 import Divider from '@material-ui/core/Divider'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
-import Button from '@material-ui/core/Button'
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
+import Typography from '@material-ui/core/Typography'
 import gql from 'graphql-tag'
 import { useQuery } from '@apollo/react-hooks'
 import { DateTime } from 'luxon'
+import _ from 'lodash-es'
 import { logTimeFormat } from '../util/timeFormat'
 import { POLL_INTERVAL } from '../config'
-import _ from 'lodash-es'
+import { formatTimeSince } from '../util/timeFormat'
 
 const FETCH_LIMIT = 149
 const QUERY_LIMIT = 35
@@ -67,6 +70,7 @@ export default function AlertDetailLogs(props) {
       },
     })
   }
+
   const renderList = (items, loadMore) => {
     return (
       <List data-cy='alert-logs'>
@@ -84,23 +88,25 @@ export default function AlertDetailLogs(props) {
       </List>
     )
   }
-  const renderItems = (timestamp, message) => {
-    if (props.showExactTimes)
-      return (
-        <ListItemText
-          primary={DateTime.fromISO(timestamp).toFormat(
-            'MMM dd yyyy, h:mm:ss a',
-          )}
-          secondary={message}
-        />
+
+  const renderItem = (timestamp, message, idx) => {
+    let timestampFmtd = formatTimeSince(timestamp)
+    if (props.showExactTimes) {
+      timestampFmtd = DateTime.fromISO(timestamp).toLocaleString(
+        DateTime.DATETIME_FULL,
       )
+    }
+
     return (
-      <ListItemText
-        primary={logTimeFormat(timestamp, DateTime.local().startOf('day'))}
-        secondary={message}
-      />
+      <ListItem key={idx} divider>
+        <ListItemText primary={message} />
+        <ListItemSecondaryAction>
+          <ListItemText secondary={timestampFmtd} />
+        </ListItemSecondaryAction>
+      </ListItem>
     )
   }
+
   if (events.length === 0) {
     return renderList(
       <ListItem>
@@ -108,6 +114,7 @@ export default function AlertDetailLogs(props) {
       </ListItem>,
     )
   }
+
   if (error) {
     return renderList(
       <ListItem>
@@ -115,6 +122,7 @@ export default function AlertDetailLogs(props) {
       </ListItem>,
     )
   }
+
   if (loading && !data) {
     return renderList(
       <ListItem>
@@ -122,16 +130,13 @@ export default function AlertDetailLogs(props) {
       </ListItem>,
     )
   }
+
   return renderList(
-    events.map((log, index) => (
-      <div key={index}>
-        <Divider />
-        <ListItem>{renderItems(log.timestamp, log.message)}</ListItem>
-      </div>
-    )),
+    events.map((event, idx) => renderItem(event.timestamp, event.message, idx)),
     pageInfo.hasNextPage,
   )
 }
+
 AlertDetailLogs.propTypes = {
   alertID: p.number.isRequired,
   showExactTimes: p.bool,

--- a/web/src/app/alerts/AlertsList.js
+++ b/web/src/app/alerts/AlertsList.js
@@ -3,6 +3,7 @@ import { PropTypes as p } from 'prop-types'
 import gql from 'graphql-tag'
 import {
   Hidden,
+  ListItemText,
   Snackbar,
   SnackbarContent,
   Typography,
@@ -279,11 +280,7 @@ export default function AlertsList(props) {
             .toUpperCase()
             .replace('STATUS', '')}`,
           subText: (props.serviceID ? '' : a.service.name + ': ') + a.summary,
-          action: (
-            <Typography variant='caption'>
-              {formatTimeSince(a.createdAt)}
-            </Typography>
-          ),
+          action: <ListItemText secondary={formatTimeSince(a.createdAt)} />,
           url: `/alerts/${a.id}`,
           selectable: a.status !== 'StatusClosed',
         })}

--- a/web/src/app/alerts/AlertsList.js
+++ b/web/src/app/alerts/AlertsList.js
@@ -6,7 +6,6 @@ import {
   ListItemText,
   Snackbar,
   SnackbarContent,
-  Typography,
   makeStyles,
   isWidthDown,
 } from '@material-ui/core'


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR updates the formatting of the timestamps in the alert details event log to match the format of the calendar events when "Full Timestamps" is toggled on, and the alerts list time since open when toggled off.

**Describe any introduced user-facing changes:**
- Event log message rendered as primary text (previous: secondary)
- Event log timestamps rendered on right of list item
- Event log timestamps `Today at 11:41 AM` -> `2m ago`
- Event log full timestamps `Apr 02 2020, 11:41:18 AM` -> `April 2, 2020, 11:41 AM CDT`
- Updates AlertsList ListItem to use the proper component, being ListItemText (instead of Typography)
  - Visible changes: Text color black -> grey, with a slightly larger font size