### PR TITLE
ui: fix search focus lost after typing on EP list

### DIFF
--- a/web/src/app/escalation-policies/PolicyRouter.js
+++ b/web/src/app/escalation-policies/PolicyRouter.js
@@ -47,16 +47,16 @@ export default function PolicyRouter() {
 
   return (
     <Switch>
-      <Route exact path='/escalation-policies' component={renderList} />
+      <Route exact path='/escalation-policies' render={renderList} />
       <Route
         exact
         path='/escalation-policies/:escalationPolicyID'
-        component={renderDetails}
+        render={renderDetails}
       />
       <Route
         exact
         path='/escalation-policies/:escalationPolicyID/services'
-        component={renderServices}
+        render={renderServices}
       />
       <Route component={PageNotFound} />
     </Switch>

--- a/web/src/cypress/support/page-search.ts
+++ b/web/src/cypress/support/page-search.ts
@@ -12,6 +12,7 @@ export function pageSearch(s: string): Cypress.Chainable {
     cy.get('[data-cy=search-field] input')
       .type(`{selectall}${s}`)
       .should('have.value', s)
+      .should('have.focus')
   })
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes an issue on the escalation policy list where focus was lost after typing in the search field. This was due to the fact that we were using the `component` prop where we should have used `render` prop while utilizing `react-router-dom`.