### PR TITLE
cypress: resolve fallback datetime timepicker test issue

### DIFF
--- a/web/src/cypress/support/form.ts
+++ b/web/src/cypress/support/form.ts
@@ -94,7 +94,7 @@ function materialCalendar(date: string | DateTime): void {
 
     // click on the day
     cy.get('body')
-      .contains('button', new RegExp(`^${dt.day.toString()}$`))
+      .contains("button[tabindex='0']", new RegExp(`^${dt.day.toString()}$`))
       .click({ force: true })
   })
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR resolves a flaky test case where we were querying on all buttons for days in the material calendar component. 
e.g. fails when searching for button containing "30"
<img width="395" alt="Screen Shot 2020-04-06 at 11 16 29 AM" src="https://user-images.githubusercontent.com/17692467/78584359-bd06eb80-77fd-11ea-9dc3-38bf12e74f43.png">

Old Query: "Search for button containing 30"
New query: "Search for clickable button containing 30"