### PR TITLE
wds: re-enable hot module reloading

### DIFF
--- a/web/handler.go
+++ b/web/handler.go
@@ -52,7 +52,12 @@ func NewHandler(urlStr, prefix string) (http.Handler, error) {
 	mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Cache-Control", "private; max-age=31536000, stale-while-revalidate=600, stale-if-error=259200")
 		w.Header().Set("ETag", indexETag)
-		http.ServeContent(w, req, "/", time.Time{}, bytes.NewReader(buf.Bytes()))
+
+		if strings.Contains(req.RequestURI, "hot-update.json") {
+			http.ServeContent(w, req, "/hmr/", time.Time{}, bytes.NewReader(buf.Bytes()))
+		} else {
+			http.ServeContent(w, req, "/", time.Time{}, bytes.NewReader(buf.Bytes()))
+		}
 	})
 
 	return mux, nil

--- a/web/handler.go
+++ b/web/handler.go
@@ -52,7 +52,6 @@ func NewHandler(urlStr, prefix string) (http.Handler, error) {
 	mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Cache-Control", "private; max-age=31536000, stale-while-revalidate=600, stale-if-error=259200")
 		w.Header().Set("ETag", indexETag)
-
 		http.ServeContent(w, req, "/", time.Time{}, bytes.NewReader(buf.Bytes()))
 	})
 

--- a/web/handler.go
+++ b/web/handler.go
@@ -53,7 +53,7 @@ func NewHandler(urlStr, prefix string) (http.Handler, error) {
 		w.Header().Set("Cache-Control", "private; max-age=31536000, stale-while-revalidate=600, stale-if-error=259200")
 		w.Header().Set("ETag", indexETag)
 
-		if strings.Contains(req.RequestURI, "hot-update.json") {
+		if strings.Contains(req.RequestURI, "hot-update.js") { // send .js and .json files
 			http.ServeContent(w, req, "/hmr/", time.Time{}, bytes.NewReader(buf.Bytes()))
 		} else {
 			http.ServeContent(w, req, "/", time.Time{}, bytes.NewReader(buf.Bytes()))

--- a/web/handler.go
+++ b/web/handler.go
@@ -53,11 +53,7 @@ func NewHandler(urlStr, prefix string) (http.Handler, error) {
 		w.Header().Set("Cache-Control", "private; max-age=31536000, stale-while-revalidate=600, stale-if-error=259200")
 		w.Header().Set("ETag", indexETag)
 
-		if strings.Contains(req.RequestURI, "hot-update.js") { // send .js and .json files
-			http.ServeContent(w, req, "/hmr/", time.Time{}, bytes.NewReader(buf.Bytes()))
-		} else {
-			http.ServeContent(w, req, "/", time.Time{}, bytes.NewReader(buf.Bytes()))
-		}
+		http.ServeContent(w, req, "/", time.Time{}, bytes.NewReader(buf.Bytes()))
 	})
 
 	return mux, nil

--- a/web/src/webpack.config.js
+++ b/web/src/webpack.config.js
@@ -87,8 +87,6 @@ module.exports = (env = { GOALERT_VERSION: 'dev' }) => ({
 
     // host: HOST,
     port: PORT,
-
-    writeToDisk: true,
   },
 
   // Webpack plugins

--- a/web/src/webpack.config.js
+++ b/web/src/webpack.config.js
@@ -18,8 +18,8 @@ module.exports = (env = { GOALERT_VERSION: 'dev' }) => ({
   output: {
     path: BUILD,
     filename: 'static/[name].js',
-    hotUpdateChunkFilename: 'build/[hash].hot-update.js',
-    hotUpdateMainFilename: 'build/[hash].hot-update.json',
+    hotUpdateChunkFilename: 'build/hot-update.js',
+    hotUpdateMainFilename: 'build/hot-update.json',
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.css'],

--- a/web/src/webpack.config.js
+++ b/web/src/webpack.config.js
@@ -18,6 +18,8 @@ module.exports = (env = { GOALERT_VERSION: 'dev' }) => ({
   output: {
     path: BUILD,
     filename: 'static/[name].js',
+    hotUpdateChunkFilename: 'build/[hash].hot-update.js',
+    hotUpdateMainFilename: 'build/[hash].hot-update.json',
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.css'],
@@ -85,6 +87,8 @@ module.exports = (env = { GOALERT_VERSION: 'dev' }) => ({
 
     // host: HOST,
     port: PORT,
+
+    writeToDisk: true,
   },
 
   // Webpack plugins


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR re-enables hot module reloading with the Webpack Dev Server by serving the hot reload hash files to the build directory for WDS to pick up and trigger a reload.