### PR TITLE
dev: generate string union types instead of const enums

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ cy-mobile-prod-run: web/inline_data_gen.go cypress
 
 web/src/schema.d.ts: graphql2/schema.graphql
 	go generate ./web/src
+	(cd web/src && yarn prettier -l --write schema.d.ts)
 
 start: bin/waitfor web/src/node_modules web/src/build/vendorPackages.dll.js bin/runjson web/src/schema.d.ts
 	# force rebuild to ensure build-flags are set

--- a/Makefile
+++ b/Makefile
@@ -158,9 +158,8 @@ cy-wide-prod-run: web/inline_data_gen.go cypress
 cy-mobile-prod-run: web/inline_data_gen.go cypress
 	make cy-mobile-prod CY_ACTION=run
 
-web/src/schema.d.ts: graphql2/schema.graphql
+web/src/schema.d.ts: graphql2/schema.graphql web/src/node_modules
 	go generate ./web/src
-	(cd web/src && yarn prettier -l --write schema.d.ts)
 
 start: bin/waitfor web/src/node_modules web/src/build/vendorPackages.dll.js bin/runjson web/src/schema.d.ts
 	# force rebuild to ensure build-flags are set

--- a/devtools/gqltsgen/main.go
+++ b/devtools/gqltsgen/main.go
@@ -73,7 +73,7 @@ func main() {
 			for _, e := range def.EnumValues {
 				fmt.Fprintf(w, " | '%s'", e.Name)
 			}
-			fmt.Fprintf(w, "\n")
+			fmt.Fprintf(w, "\n\n")
 		case ast.InputObject, ast.Object:
 			fmt.Fprintf(w, "export interface %s {\n", def.Name)
 			for _, e := range def.Fields {
@@ -83,9 +83,9 @@ func main() {
 				}
 				fmt.Fprintf(w, "  %s: %s\n", e.Name+mod, typeName(e.Type))
 			}
-			fmt.Fprintf(w, "}\n")
+			fmt.Fprintf(w, "}\n\n")
 		case ast.Scalar:
-			fmt.Fprintf(w, "export type %s = string\n", def.Name)
+			fmt.Fprintf(w, "export type %s = string\n\n", def.Name)
 		default:
 			log.Fatal("Unsupported kind:", def.Name, def.Kind)
 		}

--- a/devtools/gqltsgen/main.go
+++ b/devtools/gqltsgen/main.go
@@ -69,11 +69,11 @@ func main() {
 	for _, def := range doc.Definitions {
 		switch def.Kind {
 		case ast.Enum:
-			fmt.Fprintf(w, "export enum %s {\n", def.Name)
+			fmt.Fprintf(w, "export type %s = ", def.Name)
 			for _, e := range def.EnumValues {
-				fmt.Fprintf(w, "  %s = '%s',\n", e.Name, e.Name)
+				fmt.Fprintf(w, " | '%s'", e.Name)
 			}
-			fmt.Fprintf(w, "}\n")
+			fmt.Fprintf(w, "\n")
 		case ast.InputObject, ast.Object:
 			fmt.Fprintf(w, "export interface %s {\n", def.Name)
 			for _, e := range def.Fields {

--- a/web/src/genschema.go
+++ b/web/src/genschema.go
@@ -1,3 +1,4 @@
 package src
 
 //go:generate go run ../../devtools/gqltsgen/main.go -out ./schema.d.ts ../../graphql2/schema.graphql
+//go:generate ./node_modules/.bin/prettier -l --write schema.d.ts

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -30,29 +30,35 @@ export interface Query {
   slackChannels: SlackChannelConnection
   slackChannel?: SlackChannel
 }
+
 export interface SlackChannelSearchOptions {
   first?: number
   after?: string
   search?: string
   omit?: string[]
 }
+
 export interface SlackChannel {
   id: string
   name: string
 }
+
 export interface SlackChannelConnection {
   nodes: SlackChannel[]
   pageInfo: PageInfo
 }
+
 export interface SystemLimit {
   id: SystemLimitID
   description: string
   value: number
 }
+
 export interface SystemLimitInput {
   id: SystemLimitID
   value: number
 }
+
 export interface ConfigValue {
   id: string
   description: string
@@ -60,11 +66,14 @@ export interface ConfigValue {
   type: ConfigType
   password: boolean
 }
+
 export interface ConfigHint {
   id: string
   value: string
 }
+
 export type ConfigType = 'string' | 'stringList' | 'integer' | 'boolean'
+
 export type SystemLimitID =
   | 'CalendarSubscriptionsPerUser'
   | 'NotificationRulesPerUser'
@@ -78,6 +87,7 @@ export type SystemLimitID =
   | 'TargetsPerSchedule'
   | 'HeartbeatMonitorsPerService'
   | 'UserOverridesPerSchedule'
+
 export interface UserOverrideSearchOptions {
   first?: number
   after?: string
@@ -89,10 +99,12 @@ export interface UserOverrideSearchOptions {
   start?: ISOTimestamp
   end?: ISOTimestamp
 }
+
 export interface UserOverrideConnection {
   nodes: UserOverride[]
   pageInfo: PageInfo
 }
+
 export interface UserOverride {
   id: string
   start: ISOTimestamp
@@ -103,6 +115,7 @@ export interface UserOverride {
   removeUser?: User
   target: Target
 }
+
 export interface LabelSearchOptions {
   first?: number
   after?: string
@@ -110,12 +123,14 @@ export interface LabelSearchOptions {
   uniqueKeys?: boolean
   omit?: string[]
 }
+
 export interface LabelKeySearchOptions {
   first?: number
   after?: string
   search?: string
   omit?: string[]
 }
+
 export interface LabelValueSearchOptions {
   key: string
   first?: number
@@ -123,14 +138,17 @@ export interface LabelValueSearchOptions {
   search?: string
   omit?: string[]
 }
+
 export interface LabelConnection {
   nodes: Label[]
   pageInfo: PageInfo
 }
+
 export interface StringConnection {
   nodes: string[]
   pageInfo: PageInfo
 }
+
 export interface Mutation {
   addAuthSubject: boolean
   deleteAuthSubject: boolean
@@ -169,27 +187,32 @@ export interface Mutation {
   setConfig: boolean
   setSystemLimits: boolean
 }
+
 export interface UpdateAlertsByServiceInput {
   serviceID: string
   newStatus: AlertStatus
 }
+
 export interface CreateAlertInput {
   summary: string
   details?: string
   serviceID: string
 }
+
 export interface CreateUserCalendarSubscriptionInput {
   name: string
   reminderMinutes?: number[]
   scheduleID: string
   disabled?: boolean
 }
+
 export interface UpdateUserCalendarSubscriptionInput {
   id: string
   name?: string
   reminderMinutes?: number[]
   disabled?: boolean
 }
+
 export interface UserCalendarSubscription {
   id: string
   name: string
@@ -200,10 +223,12 @@ export interface UserCalendarSubscription {
   disabled: boolean
   url?: string
 }
+
 export interface ConfigValueInput {
   id: string
   value: string
 }
+
 export interface UpdateUserOverrideInput {
   id: string
   start?: ISOTimestamp
@@ -211,6 +236,7 @@ export interface UpdateUserOverrideInput {
   addUserID?: string
   removeUserID?: string
 }
+
 export interface CreateUserOverrideInput {
   scheduleID?: string
   start: ISOTimestamp
@@ -218,6 +244,7 @@ export interface CreateUserOverrideInput {
   addUserID?: string
   removeUserID?: string
 }
+
 export interface CreateScheduleInput {
   name: string
   description?: string
@@ -226,36 +253,43 @@ export interface CreateScheduleInput {
   targets?: ScheduleTargetInput[]
   newUserOverrides?: CreateUserOverrideInput[]
 }
+
 export interface ScheduleTargetInput {
   scheduleID?: string
   target?: TargetInput
   newRotation?: CreateRotationInput
   rules: ScheduleRuleInput[]
 }
+
 export interface ScheduleRuleInput {
   id?: string
   start?: ClockTime
   end?: ClockTime
   weekdayFilter?: boolean[]
 }
+
 export interface SetLabelInput {
   target?: TargetInput
   key: string
   value: string
 }
+
 export interface TimeZoneSearchOptions {
   first?: number
   after?: string
   search?: string
   omit?: string[]
 }
+
 export interface TimeZoneConnection {
   nodes: TimeZone[]
   pageInfo: PageInfo
 }
+
 export interface TimeZone {
   id: string
 }
+
 export interface CreateServiceInput {
   name: string
   description?: string
@@ -266,12 +300,14 @@ export interface CreateServiceInput {
   labels?: SetLabelInput[]
   newHeartbeatMonitors?: CreateHeartbeatMonitorInput[]
 }
+
 export interface CreateEscalationPolicyInput {
   name: string
   description?: string
   repeat?: number
   steps?: CreateEscalationPolicyStepInput[]
 }
+
 export interface CreateEscalationPolicyStepInput {
   escalationPolicyID?: string
   delayMinutes: number
@@ -279,6 +315,7 @@ export interface CreateEscalationPolicyStepInput {
   newRotation?: CreateRotationInput
   newSchedule?: CreateScheduleInput
 }
+
 export interface EscalationPolicyStep {
   id: string
   stepNumber: number
@@ -286,18 +323,21 @@ export interface EscalationPolicyStep {
   targets: Target[]
   escalationPolicy?: EscalationPolicy
 }
+
 export interface UpdateScheduleInput {
   id: string
   name?: string
   description?: string
   timeZone?: string
 }
+
 export interface UpdateServiceInput {
   id: string
   name?: string
   description?: string
   escalationPolicyID?: string
 }
+
 export interface UpdateEscalationPolicyInput {
   id: string
   name?: string
@@ -305,27 +345,33 @@ export interface UpdateEscalationPolicyInput {
   repeat?: number
   stepIDs?: string[]
 }
+
 export interface UpdateEscalationPolicyStepInput {
   id: string
   delayMinutes?: number
   targets?: TargetInput[]
 }
+
 export interface SetFavoriteInput {
   target: TargetInput
   favorite: boolean
 }
+
 export interface EscalationPolicyConnection {
   nodes: EscalationPolicy[]
   pageInfo: PageInfo
 }
+
 export interface AlertConnection {
   nodes: Alert[]
   pageInfo: PageInfo
 }
+
 export interface ScheduleConnection {
   nodes: Schedule[]
   pageInfo: PageInfo
 }
+
 export interface Schedule {
   id: string
   name: string
@@ -337,6 +383,7 @@ export interface Schedule {
   target?: ScheduleTarget
   isFavorite: boolean
 }
+
 export interface OnCallShift {
   userID: string
   user?: User
@@ -344,11 +391,13 @@ export interface OnCallShift {
   end: ISOTimestamp
   truncated: boolean
 }
+
 export interface ScheduleTarget {
   scheduleID: string
   target: Target
   rules: ScheduleRule[]
 }
+
 export interface ScheduleRule {
   id: string
   scheduleID: string
@@ -357,10 +406,12 @@ export interface ScheduleRule {
   weekdayFilter: boolean[]
   target: Target
 }
+
 export interface RotationConnection {
   nodes: Rotation[]
   pageInfo: PageInfo
 }
+
 export interface CreateRotationInput {
   name: string
   description?: string
@@ -371,6 +422,7 @@ export interface CreateRotationInput {
   shiftLength?: number
   userIDs?: string[]
 }
+
 export interface Rotation {
   id: string
   name: string
@@ -385,11 +437,14 @@ export interface Rotation {
   users: User[]
   nextHandoffTimes: ISOTimestamp[]
 }
+
 export type RotationType = 'weekly' | 'daily' | 'hourly'
+
 export interface UpdateAlertsInput {
   alertIDs: number[]
   newStatus: AlertStatus
 }
+
 export interface UpdateRotationInput {
   id: string
   name?: string
@@ -401,6 +456,7 @@ export interface UpdateRotationInput {
   activeUserIndex?: number
   userIDs?: string[]
 }
+
 export interface RotationSearchOptions {
   first?: number
   after?: string
@@ -409,12 +465,14 @@ export interface RotationSearchOptions {
   favoritesOnly?: boolean
   favoritesFirst?: boolean
 }
+
 export interface EscalationPolicySearchOptions {
   first?: number
   after?: string
   search?: string
   omit?: string[]
 }
+
 export interface ScheduleSearchOptions {
   first?: number
   after?: string
@@ -423,6 +481,7 @@ export interface ScheduleSearchOptions {
   favoritesOnly?: boolean
   favoritesFirst?: boolean
 }
+
 export interface ServiceSearchOptions {
   first?: number
   after?: string
@@ -431,12 +490,14 @@ export interface ServiceSearchOptions {
   favoritesOnly?: boolean
   favoritesFirst?: boolean
 }
+
 export interface UserSearchOptions {
   first?: number
   after?: string
   search?: string
   omit?: string[]
 }
+
 export interface AlertSearchOptions {
   filterByStatus?: AlertStatus[]
   filterByServiceID?: string[]
@@ -446,8 +507,11 @@ export interface AlertSearchOptions {
   favoritesOnly?: boolean
   omit?: number[]
 }
+
 export type ISOTimestamp = string
+
 export type ClockTime = string
+
 export interface Alert {
   id: string
   alertID: number
@@ -460,24 +524,29 @@ export interface Alert {
   state?: AlertState
   recentEvents: AlertLogEntryConnection
 }
+
 export interface AlertRecentEventsOptions {
   limit?: number
   after?: string
 }
+
 export interface AlertLogEntryConnection {
   nodes: AlertLogEntry[]
   pageInfo: PageInfo
 }
+
 export interface AlertLogEntry {
   id: number
   timestamp: ISOTimestamp
   message: string
 }
+
 export interface AlertState {
   lastEscalation: ISOTimestamp
   stepNumber: number
   repeatCount: number
 }
+
 export interface Service {
   id: string
   name: string
@@ -490,22 +559,27 @@ export interface Service {
   labels: Label[]
   heartbeatMonitors: HeartbeatMonitor[]
 }
+
 export interface CreateIntegrationKeyInput {
   serviceID?: string
   type: IntegrationKeyType
   name: string
 }
+
 export interface CreateHeartbeatMonitorInput {
   serviceID: string
   name: string
   timeoutMinutes: number
 }
+
 export interface UpdateHeartbeatMonitorInput {
   id: string
   name?: string
   timeoutMinutes?: number
 }
+
 export type HeartbeatMonitorState = 'inactive' | 'healthy' | 'unhealthy'
+
 export interface HeartbeatMonitor {
   id: string
   serviceID: string
@@ -515,10 +589,12 @@ export interface HeartbeatMonitor {
   lastHeartbeat?: ISOTimestamp
   href: string
 }
+
 export interface Label {
   key: string
   value: string
 }
+
 export interface IntegrationKey {
   id: string
   serviceID: string
@@ -526,12 +602,15 @@ export interface IntegrationKey {
   name: string
   href: string
 }
+
 export type IntegrationKeyType = 'generic' | 'grafana' | 'site24x7' | 'email'
+
 export interface ServiceOnCallUser {
   userID: string
   userName: string
   stepNumber: number
 }
+
 export interface EscalationPolicy {
   id: string
   name: string
@@ -540,19 +619,23 @@ export interface EscalationPolicy {
   assignedTo: Target[]
   steps: EscalationPolicyStep[]
 }
+
 export type AlertStatus =
   | 'StatusAcknowledged'
   | 'StatusClosed'
   | 'StatusUnacknowledged'
+
 export interface Target {
   id: string
   type: TargetType
   name?: string
 }
+
 export interface TargetInput {
   id: string
   type: TargetType
 }
+
 export type TargetType =
   | 'escalationPolicy'
   | 'notificationChannel'
@@ -568,22 +651,27 @@ export type TargetType =
   | 'contactMethod'
   | 'heartbeatMonitor'
   | 'calendarSubscription'
+
 export interface ServiceConnection {
   nodes: Service[]
   pageInfo: PageInfo
 }
+
 export interface UserConnection {
   nodes: User[]
   pageInfo: PageInfo
 }
+
 export interface AuthSubjectConnection {
   nodes: AuthSubject[]
   pageInfo: PageInfo
 }
+
 export interface PageInfo {
   endCursor?: string
   hasNextPage: boolean
 }
+
 export interface UpdateUserInput {
   id: string
   name?: string
@@ -591,12 +679,15 @@ export interface UpdateUserInput {
   role?: UserRole
   statusUpdateContactMethodID?: string
 }
+
 export interface AuthSubjectInput {
   userID: string
   providerID: string
   subjectID: string
 }
+
 export type UserRole = 'unknown' | 'user' | 'admin'
+
 export interface User {
   id: string
   role: UserRole
@@ -609,13 +700,16 @@ export interface User {
   authSubjects: AuthSubject[]
   onCallSteps: EscalationPolicyStep[]
 }
+
 export interface UserNotificationRule {
   id: string
   delayMinutes: number
   contactMethodID: string
   contactMethod?: UserContactMethod
 }
+
 export type ContactMethodType = 'SMS' | 'VOICE'
+
 export interface UserContactMethod {
   id: string
   type?: ContactMethodType
@@ -624,6 +718,7 @@ export interface UserContactMethod {
   formattedValue: string
   disabled: boolean
 }
+
 export interface CreateUserContactMethodInput {
   userID: string
   type: ContactMethodType
@@ -631,23 +726,28 @@ export interface CreateUserContactMethodInput {
   value: string
   newUserNotificationRule?: CreateUserNotificationRuleInput
 }
+
 export interface CreateUserNotificationRuleInput {
   userID?: string
   contactMethodID?: string
   delayMinutes: number
 }
+
 export interface UpdateUserContactMethodInput {
   id: string
   name?: string
   value?: string
 }
+
 export interface SendContactMethodVerificationInput {
   contactMethodID: string
 }
+
 export interface VerifyContactMethodInput {
   contactMethodID: string
   code: number
 }
+
 export interface AuthSubject {
   providerID: string
   subjectID: string

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -64,26 +64,20 @@ export interface ConfigHint {
   id: string
   value: string
 }
-export enum ConfigType {
-  string = 'string',
-  stringList = 'stringList',
-  integer = 'integer',
-  boolean = 'boolean',
-}
-export enum SystemLimitID {
-  CalendarSubscriptionsPerUser = 'CalendarSubscriptionsPerUser',
-  NotificationRulesPerUser = 'NotificationRulesPerUser',
-  ContactMethodsPerUser = 'ContactMethodsPerUser',
-  EPStepsPerPolicy = 'EPStepsPerPolicy',
-  EPActionsPerStep = 'EPActionsPerStep',
-  ParticipantsPerRotation = 'ParticipantsPerRotation',
-  RulesPerSchedule = 'RulesPerSchedule',
-  IntegrationKeysPerService = 'IntegrationKeysPerService',
-  UnackedAlertsPerService = 'UnackedAlertsPerService',
-  TargetsPerSchedule = 'TargetsPerSchedule',
-  HeartbeatMonitorsPerService = 'HeartbeatMonitorsPerService',
-  UserOverridesPerSchedule = 'UserOverridesPerSchedule',
-}
+export type ConfigType = 'string' | 'stringList' | 'integer' | 'boolean'
+export type SystemLimitID =
+  | 'CalendarSubscriptionsPerUser'
+  | 'NotificationRulesPerUser'
+  | 'ContactMethodsPerUser'
+  | 'EPStepsPerPolicy'
+  | 'EPActionsPerStep'
+  | 'ParticipantsPerRotation'
+  | 'RulesPerSchedule'
+  | 'IntegrationKeysPerService'
+  | 'UnackedAlertsPerService'
+  | 'TargetsPerSchedule'
+  | 'HeartbeatMonitorsPerService'
+  | 'UserOverridesPerSchedule'
 export interface UserOverrideSearchOptions {
   first?: number
   after?: string
@@ -391,11 +385,7 @@ export interface Rotation {
   users: User[]
   nextHandoffTimes: ISOTimestamp[]
 }
-export enum RotationType {
-  weekly = 'weekly',
-  daily = 'daily',
-  hourly = 'hourly',
-}
+export type RotationType = 'weekly' | 'daily' | 'hourly'
 export interface UpdateAlertsInput {
   alertIDs: number[]
   newStatus: AlertStatus
@@ -515,11 +505,7 @@ export interface UpdateHeartbeatMonitorInput {
   name?: string
   timeoutMinutes?: number
 }
-export enum HeartbeatMonitorState {
-  inactive = 'inactive',
-  healthy = 'healthy',
-  unhealthy = 'unhealthy',
-}
+export type HeartbeatMonitorState = 'inactive' | 'healthy' | 'unhealthy'
 export interface HeartbeatMonitor {
   id: string
   serviceID: string
@@ -540,12 +526,7 @@ export interface IntegrationKey {
   name: string
   href: string
 }
-export enum IntegrationKeyType {
-  generic = 'generic',
-  grafana = 'grafana',
-  site24x7 = 'site24x7',
-  email = 'email',
-}
+export type IntegrationKeyType = 'generic' | 'grafana' | 'site24x7' | 'email'
 export interface ServiceOnCallUser {
   userID: string
   userName: string
@@ -559,11 +540,10 @@ export interface EscalationPolicy {
   assignedTo: Target[]
   steps: EscalationPolicyStep[]
 }
-export enum AlertStatus {
-  StatusAcknowledged = 'StatusAcknowledged',
-  StatusClosed = 'StatusClosed',
-  StatusUnacknowledged = 'StatusUnacknowledged',
-}
+export type AlertStatus =
+  | 'StatusAcknowledged'
+  | 'StatusClosed'
+  | 'StatusUnacknowledged'
 export interface Target {
   id: string
   type: TargetType
@@ -573,22 +553,21 @@ export interface TargetInput {
   id: string
   type: TargetType
 }
-export enum TargetType {
-  escalationPolicy = 'escalationPolicy',
-  notificationChannel = 'notificationChannel',
-  slackChannel = 'slackChannel',
-  notificationPolicy = 'notificationPolicy',
-  rotation = 'rotation',
-  service = 'service',
-  schedule = 'schedule',
-  user = 'user',
-  integrationKey = 'integrationKey',
-  userOverride = 'userOverride',
-  notificationRule = 'notificationRule',
-  contactMethod = 'contactMethod',
-  heartbeatMonitor = 'heartbeatMonitor',
-  calendarSubscription = 'calendarSubscription',
-}
+export type TargetType =
+  | 'escalationPolicy'
+  | 'notificationChannel'
+  | 'slackChannel'
+  | 'notificationPolicy'
+  | 'rotation'
+  | 'service'
+  | 'schedule'
+  | 'user'
+  | 'integrationKey'
+  | 'userOverride'
+  | 'notificationRule'
+  | 'contactMethod'
+  | 'heartbeatMonitor'
+  | 'calendarSubscription'
 export interface ServiceConnection {
   nodes: Service[]
   pageInfo: PageInfo
@@ -617,11 +596,7 @@ export interface AuthSubjectInput {
   providerID: string
   subjectID: string
 }
-export enum UserRole {
-  unknown = 'unknown',
-  user = 'user',
-  admin = 'admin',
-}
+export type UserRole = 'unknown' | 'user' | 'admin'
 export interface User {
   id: string
   role: UserRole
@@ -640,10 +615,7 @@ export interface UserNotificationRule {
   contactMethodID: string
   contactMethod?: UserContactMethod
 }
-export enum ContactMethodType {
-  SMS = 'SMS',
-  VOICE = 'VOICE',
-}
+export type ContactMethodType = 'SMS' | 'VOICE'
 export interface UserContactMethod {
   id: string
   type?: ContactMethodType


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Ambient const enums are not allowed when the '--isolatedModules' flag is provided with typescript, effectively making the exported enums unusable

- uses string union types instead of enums
- run `prettier -l --write schema.d.ts` after generating
- reintroduce double newlines for readability