### PR TITLE
cypress: remove api endpoint option

### DIFF
--- a/web/src/cypress/support/alert.ts
+++ b/web/src/cypress/support/alert.ts
@@ -25,7 +25,7 @@ function getAlertLogs(id: number): Cypress.Chainable<Array<AlertLog>> {
   // NOTE next recursively builds logs to ultimately yield an AlertLog[]
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const next = (logs: AlertLog[], after: string): Cypress.Chainable<any> =>
-    cy.graphql2(query, { id, after }).then((res: GraphQLResponse) => {
+    cy.graphql(query, { id, after }).then((res: GraphQLResponse) => {
       const hasNextPage: boolean = res.alert.recentEvents.pageInfo.hasNextPage
       const endCursor: string = res.alert.recentEvents.pageInfo.endCursor
       const nodes: AlertLog[] = res.alert.recentEvents.nodes
@@ -64,7 +64,7 @@ function getAlert(id: number): Cypress.Chainable<Alert> {
     }
   `
 
-  return cy.graphql2(query, { id }).then((res: GraphQLResponse) => res.alert)
+  return cy.graphql(query, { id }).then((res: GraphQLResponse) => res.alert)
 }
 
 function createAlertLogs(opts?: AlertLogOptions): Cypress.Chainable<AlertLogs> {
@@ -144,7 +144,7 @@ function createAlert(a?: AlertOptions): Cypress.Chainable<Alert> {
   }
 
   return cy
-    .graphql2(query, {
+    .graphql(query, {
       input: {
         serviceID: a.serviceID,
         summary: a.summary || c.sentence({ words: 3 }),

--- a/web/src/cypress/support/calendar-subscription.ts
+++ b/web/src/cypress/support/calendar-subscription.ts
@@ -50,7 +50,7 @@ function createCalendarSubscription(
 
   // create and return subscription
   return cy
-    .graphql2(mutation, {
+    .graphql(mutation, {
       input: {
         name: cs?.name || 'SM Subscription ' + c.word({ length: 8 }),
         reminderMinutes,

--- a/web/src/cypress/support/ep.ts
+++ b/web/src/cypress/support/ep.ts
@@ -30,7 +30,7 @@ function createEP(ep?: EPOptions): Cypress.Chainable<EP> {
   const stepCount = ep.stepCount || 0
 
   return cy
-    .graphql2(policyMutation, {
+    .graphql(policyMutation, {
       input: {
         name: ep.name || 'SM EP ' + c.word({ length: 8 }),
         description: ep.description || c.sentence(),
@@ -40,7 +40,7 @@ function createEP(ep?: EPOptions): Cypress.Chainable<EP> {
     .then((res: GraphQLResponse) => res.createEscalationPolicy)
     .then((pol: EP) => {
       for (let i = 0; i < stepCount; i++) {
-        cy.graphql2(stepMutation, {
+        cy.graphql(stepMutation, {
           input: {
             escalationPolicyID: pol.id,
             delayMinutes: 10,
@@ -60,7 +60,7 @@ function deleteEP(id: string): Cypress.Chainable<void> {
     }
    `
 
-  return cy.graphql2(mutation, {
+  return cy.graphql(mutation, {
     input: [
       {
         type: 'escalationPolicy',
@@ -80,7 +80,7 @@ function createEPStep(step?: EPStepOptions): Cypress.Chainable<EPStep> {
   }
 
   return cy
-    .graphql2(stepMutation, {
+    .graphql(stepMutation, {
       input: {
         escalationPolicyID: step.epID,
         delayMinutes: step.delay || c.integer({ min: 1, max: 9000 }),

--- a/web/src/cypress/support/graphql.ts
+++ b/web/src/cypress/support/graphql.ts
@@ -5,7 +5,7 @@ interface GraphQLResponse {
 }
 
 // runs a graphql query returning the data response (after asserting no errors)
-function graphql2(query: string, variables?: any): Cypress.Chainable<any> {
+function graphql(query: string, variables?: any): Cypress.Chainable<any> {
   const url = '/api/graphql'
   if (!variables) variables = {}
 
@@ -30,6 +30,6 @@ function graphql2(query: string, variables?: any): Cypress.Chainable<any> {
   })
 }
 
-Cypress.Commands.add('graphql2', graphql2)
+Cypress.Commands.add('graphql', graphql)
 
 export {}

--- a/web/src/cypress/support/graphql.ts
+++ b/web/src/cypress/support/graphql.ts
@@ -5,11 +5,8 @@ interface GraphQLResponse {
 }
 
 // runs a graphql query returning the data response (after asserting no errors)
-function graphql(
-  query: string,
-  variables?: any,
-  url = '/v1/graphql',
-): Cypress.Chainable<any> {
+function graphql2(query: string, variables?: any): Cypress.Chainable<any> {
+  const url = '/api/graphql'
   if (!variables) variables = {}
 
   return cy.request('POST', url, { query, variables }).then((res) => {
@@ -33,10 +30,6 @@ function graphql(
   })
 }
 
-function graphql2(query: string, variables?: any): Cypress.Chainable<any> {
-  return graphql(query, variables, '/api/graphql')
-}
-Cypress.Commands.add('graphql', graphql)
 Cypress.Commands.add('graphql2', graphql2)
 
 export {}

--- a/web/src/cypress/support/limits.ts
+++ b/web/src/cypress/support/limits.ts
@@ -19,7 +19,7 @@ function getLimits(): Cypress.Chainable<Limits> {
       value
     }
   }`
-  return cy.graphql2(query).then((res: GraphQLResponse) => {
+  return cy.graphql(query).then((res: GraphQLResponse) => {
     res.systemLimits.forEach((l: SystemLimits) => {
       limits.set(l.id, { value: l.value, description: l.description })
     })
@@ -33,7 +33,7 @@ function updateLimits(input: SystemLimitInput[]): Cypress.Chainable<boolean> {
     setSystemLimits(input: $input)
   }`
 
-  return cy.graphql2(query, { input: input })
+  return cy.graphql(query, { input: input })
 }
 
 Cypress.Commands.add('getLimits', getLimits)

--- a/web/src/cypress/support/profile.ts
+++ b/web/src/cypress/support/profile.ts
@@ -50,7 +50,7 @@ function addContactMethod(
 
   const newPhone = '+1763' + c.integer({ min: 3000000, max: 3999999 })
   return cy
-    .graphql2(mutation, {
+    .graphql(mutation, {
       input: {
         userID: cm.userID,
         name: cm.name || 'SM CM ' + c.word({ length: 8 }),
@@ -100,7 +100,7 @@ function addNotificationRule(
   `
 
   return cy
-    .graphql2(mutation, {
+    .graphql(mutation, {
       input: {
         userID: nr.userID,
         contactMethodID: nr.contactMethodID,
@@ -135,11 +135,11 @@ function clearContactMethods(id: string): Cypress.Chainable {
     }
   `
 
-  return cy.graphql2(query, { id }).then((res: GraphQLResponse) => {
+  return cy.graphql(query, { id }).then((res: GraphQLResponse) => {
     if (!res.user.contactMethods.length) return
 
     res.user.contactMethods.forEach((cm: ContactMethod) => {
-      cy.graphql2(mutation, {
+      cy.graphql(mutation, {
         input: [
           {
             type: 'contactMethod',
@@ -162,7 +162,7 @@ function resetProfile(prof?: Profile): Cypress.Chainable {
     }
   `
 
-  return clearContactMethods(prof.id).graphql2(mutation, {
+  return clearContactMethods(prof.id).graphql(mutation, {
     input: {
       id: prof.id,
       name: prof.name,

--- a/web/src/cypress/support/rotation.ts
+++ b/web/src/cypress/support/rotation.ts
@@ -28,7 +28,7 @@ function createRotation(rot?: RotationOptions): Cypress.Chainable<Rotation> {
     const ids = c.pickset(users, rot.count).map((usr: Profile) => usr.id)
 
     return cy
-      .graphql2(query, {
+      .graphql(query, {
         input: {
           name: rot.name || 'SM Rot ' + c.word({ length: 8 }),
           description: rot.description || c.sentence(),
@@ -56,7 +56,7 @@ function deleteRotation(id: string): Cypress.Chainable<void> {
     }
   `
 
-  return cy.graphql2(query, { input: { id: id, type: 'rotation' } })
+  return cy.graphql(query, { input: { id: id, type: 'rotation' } })
 }
 
 Cypress.Commands.add('createRotation', createRotation)

--- a/web/src/cypress/support/schedule.ts
+++ b/web/src/cypress/support/schedule.ts
@@ -76,12 +76,12 @@ function setScheduleTarget(
   const { schedule, ...params } = tgt
 
   return cy
-    .graphql2(mutation, {
+    .graphql(mutation, {
       input: params,
     })
     .then(() => {
       return cy
-        .graphql2(query, {
+        .graphql(query, {
           id: params.scheduleID,
           tgt: params.target,
         })
@@ -109,7 +109,7 @@ function createSchedule(sched?: ScheduleOptions): Cypress.Chainable<Schedule> {
   if (!sched) sched = {}
 
   return cy
-    .graphql2(query, {
+    .graphql(query, {
       input: {
         name: sched.name || 'SM Sched ' + c.word({ length: 8 }),
         description: sched.description || c.sentence(),
@@ -127,7 +127,7 @@ function deleteSchedule(id: string): Cypress.Chainable<void> {
     }
   `
 
-  return cy.graphql2(mutation, {
+  return cy.graphql(mutation, {
     input: [
       {
         type: 'schedule',

--- a/web/src/cypress/support/service.ts
+++ b/web/src/cypress/support/service.ts
@@ -20,7 +20,7 @@ function getService(svcID: string): Cypress.Chainable<Service> {
     }
   `
   return cy
-    .graphql2(query, { id: svcID })
+    .graphql(query, { id: svcID })
     .then((res: GraphQLResponse) => res.service)
 }
 
@@ -51,7 +51,7 @@ function createService(svc?: ServiceOptions): Cypress.Chainable<Service> {
   }
 
   return cy
-    .graphql2(query, {
+    .graphql(query, {
       input: {
         name: svc.name || 'SM Svc ' + c.word({ length: 8 }),
         description: svc.description || c.sentence(),
@@ -68,7 +68,7 @@ function deleteService(id: string): Cypress.Chainable<void> {
       deleteService(input: $input) { id }
     }
   `
-  return cy.graphql2(query, { input: { id } })
+  return cy.graphql(query, { input: { id } })
 }
 
 function createLabel(label?: LabelOptions): Cypress.Chainable<Label> {
@@ -90,7 +90,7 @@ function createLabel(label?: LabelOptions): Cypress.Chainable<Label> {
   const svcID = label.svcID
 
   return cy
-    .graphql2(query, {
+    .graphql(query, {
       input: {
         target: {
           type: 'service',
@@ -136,7 +136,7 @@ function createHeartbeatMonitor(
   `
 
   return cy
-    .graphql2(query, {
+    .graphql(query, {
       input: {
         serviceID: svcID,
         name: name,

--- a/web/src/cypress/types/graphql.d.ts
+++ b/web/src/cypress/types/graphql.d.ts
@@ -1,7 +1,6 @@
 declare namespace Cypress {
   interface Chainable {
     graphql: typeof graphql
-    graphql2: typeof graphql
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
In the spirit of #608 this PR removes the option to specify a graphql API endpoint other than `'/api/graphql'`