### PR TITLE
sms: support all twilio stop codes

### DIFF
--- a/notification/twilio/sms.go
+++ b/notification/twilio/sms.go
@@ -214,6 +214,17 @@ func (s *SMS) ServeStatusCallback(w http.ResponseWriter, req *http.Request) {
 
 }
 
+// isStopMessage checks the body of the message against single-word matches
+// i.e. "stop" will unsubscribe, however "please stop" will not.
+func isStopMessage(body string) bool {
+	switch strings.ToLower(body) {
+	case "stop", "stopall", "unsubscribe", "cancel", "end", "quit":
+		return true
+	}
+
+	return false
+}
+
 func (s *SMS) ServeMessage(w http.ResponseWriter, req *http.Request) {
 	if disabled(w, req) {
 		return
@@ -266,10 +277,7 @@ func (s *SMS) ServeMessage(w http.ResponseWriter, req *http.Request) {
 	}
 
 	body := req.FormValue("Body")
-	// twilio unsubscribes on single-word matches
-	// i.e. "please stop" will not result in unsubscribing on their end.
-	checkBody := func(str string) bool { return strings.ToLower(body) == str }
-	if checkBody("stop") || checkBody("stopall") || checkBody("unsubscribe") || checkBody("cancel") || checkBody("end") || checkBody("quit") {
+	if isStopMessage(body) {
 		err := retry.DoTemporaryError(func(int) error {
 			errCh := make(chan error, 1)
 			s.respCh <- &notification.MessageResponse{


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR enables all Twilio stop codes via SMS: STOP, STOPALL, UNSUBSCRIBE, CANCEL, END, and QUIT.

**Additional Info:**
Stop codes are now processed on exact matches, to fall inline with [Twilio's processing logic](https://support.twilio.com/hc/en-us/articles/223134027-Twilio-support-for-opt-out-keywords-SMS-STOP-filtering-): 
> Only single-word messages will trigger the block. So, for example, replying STOP will stop the customer from receiving messages from that particular Twilio number, but replying "STOP PLEASE" or "PLEASE CANCEL" will not.