### PR TITLE
Makefile: add missing dep for `make generate`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ graphql2/mapconfig.go: $(CFGPARAMS) config/config.go
 graphql2/generated.go: graphql2/schema.graphql graphql2/gqlgen.yml
 	go generate ./graphql2
 
-generate:
+generate: web/src/node_modules
 	go generate ./...
 
 smoketest: install bin/goalert


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Adding missing dependency to the `generate` task in the Makefile now that prettier is required for schema generation.

This fixes the issue where `make generate` (or `make check`) would fail if `node_modules` hasn't been initialized yet.