### PR TITLE
waitfor: support postgresql:// URI scheme

### DIFF
--- a/devtools/waitfor/main.go
+++ b/devtools/waitfor/main.go
@@ -60,7 +60,7 @@ func main() {
 	defer cancel()
 
 	for _, u := range flag.Args() {
-		if strings.HasPrefix(u, "postgres://") {
+		if strings.HasPrefix(u, "postgres://") || strings.HasPrefix(u, "postgresql://") {
 			waitForPostgres(ctx, u)
 		} else {
 			waitForHTTP(ctx, u)


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR tweaks the `watifor` devtool to allow both `postgresql://` and `postgres://` URI scheme designators.  Both are valid per PostgreSQL's [documentation](https://www.postgresql.org/docs/11/libpq-connect.html#LIBPQ-CONNSTRINGl):
> The URI scheme designator can be either postgresql:// or postgres://. 


