### PR TITLE
docs: action=close matches on both summary and details

### DIFF
--- a/web/src/app/documentation/IntegrationKeys.md
+++ b/web/src/app/documentation/IntegrationKeys.md
@@ -9,7 +9,7 @@
 | `token`   | **Required** | The integration key to use.                                                                                                                                         |
 | `summary` | **Required** | Short description of the alert sent as SMS and voice.                                                                                                               |
 | `details` | _optional_   | Additional information about the alert, supports markdown.                                                                                                          |
-| `action`  | _optional_   | If set to `close`, it will close any matching alerts.                                                                                                               |
+| `action`  | _optional_   | If set to `close`, it will close any matching alerts (`summary` AND `details` must be identical).                                                                   |
 | `dedup`   | _optional_   | All calls for the same service with the same `dedup` string will update the same alert (if open) or create a new one. Defaults to using summary & details together. |
 
 ### Examples:


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR updates our in-app documentation on Integration Keys.  Includes info when using query param `action=close`, the `summary` and `details` parameters must be identical to target alert for close to function properly.
