### PR TITLE
deps: ignore @material-ui/core until 4.10.x

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -11,4 +11,4 @@ update_configs:
       # see https://github.com/target/goalert/pull/634
       - match:
           dependency_name: "@material-ui/core"
-          version_requirement: "<=4.9.x"
+          version_requirement: "<=4.10.0"


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Follow-up from #634 - ignoring updates to `material-ui/core` until next major version (`4.10.x`).