### PR TITLE
switchover: fix prominent bugs

### DIFF
--- a/switchover/dbsync/changelog.go
+++ b/switchover/dbsync/changelog.go
@@ -94,6 +94,7 @@ func (s *Sync) ChangeLogEnable(ctx context.Context, sh *ishell.Context) error {
 		err = errors.Wrap(err, name)
 	}
 	sh.Println("Resetting change log...")
+	runNew("clear dest change_log", changeLogTableDel)
 	runNew("configure dest change_log", changeLogTableDef)
 	run("clear change_log", changeLogTableDel)
 	run("configure change_log", changeLogTableDef)
@@ -162,6 +163,13 @@ func (s *Sync) ChangeLogDisable(ctx context.Context, sh *ishell.Context) error {
 		_, err = s.oldDB.ExecContext(ctx, stmt)
 		err = errors.Wrap(err, name)
 	}
+	runNew := func(name, stmt string) {
+		if err != nil {
+			return
+		}
+		_, err = s.newDB.ExecContext(ctx, stmt)
+		err = errors.Wrap(err, name)
+	}
 
 	p := mpb.NewWithContext(ctx)
 	bar := p.AddBar(int64(len(s.tables)),
@@ -181,6 +189,7 @@ func (s *Sync) ChangeLogDisable(ctx context.Context, sh *ishell.Context) error {
 	sh.Println("Resetting change log...")
 	run("remove change hook", changeLogFuncDel)
 	run("remove change_log", changeLogTableDel)
+	runNew("remove dest change_log", changeLogTableDel)
 	if err != nil {
 		return err
 	}

--- a/switchover/dbsync/shell.go
+++ b/switchover/dbsync/shell.go
@@ -163,6 +163,9 @@ func RunShell(oldURL, newURL string) error {
 				if contains(ignoreSyncTables, t.Name) {
 					continue
 				}
+				if t.Name == "change_log" {
+					continue
+				}
 				process = append(process, t)
 			}
 			bar := p.AddBar(int64(len(process)),
@@ -192,7 +195,7 @@ func RunShell(oldURL, newURL string) error {
 				return err
 			}
 			sh.Println(status)
-			sh.Println("change_log disabled")
+			sh.Println("destination DB cleared")
 			return nil
 		},
 	})


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes some of the more prominent bugs in the switchover code.

- enable/disable will now drop the `change_log` table in both DBs consistently and is now handled by `reset-dest` appropriately (fixes need to enable/disable before `reset-dest` will work)
- initial sync will truncate destination tables before starting (fixes requirement to run `reset-dest` before starting)
- run `vacuum analyze` after initial sync (fixes perf. issues after switchover)
- cache `use_next_db` lookup (fixes connection delays after switchover is complete)
