### PR TITLE
alert logs: display when contact method is disabled

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -142,7 +142,7 @@ func NewEngine(ctx context.Context, db *sql.DB, c *Config) (*Engine, error) {
 			notification.DestTypeSlackChannel: {PerSecond: 5, Batch: 5 * time.Second},
 		},
 		Pausable: p.mgr,
-	})
+	}, c.AlertLogStore)
 	if err != nil {
 		return nil, errors.Wrap(err, "messaging backend")
 	}

--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -264,7 +264,7 @@ func NewDB(ctx context.Context, db *sql.DB, c *Config, a alertlog.Store) (*DB, e
 				set
 					last_status = 'failed',
 					last_status_at = now(),
-					status_details = 'contact method disabled',
+					status_details = 'failed: contact method disabled',
 					cycle_id = null,
 					next_retry_at = null
 				from user_contact_methods cm

--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	alertlog "github.com/target/goalert/alert/log"
 	"github.com/target/goalert/config"
 	"github.com/target/goalert/engine/processinglock"
 	"github.com/target/goalert/lock"
@@ -42,6 +43,7 @@ type DB struct {
 	sendDeadlineExpired *sql.Stmt
 
 	failDisabledCM *sql.Stmt
+	alertlogstore  alertlog.Store
 
 	sentByCMType *sql.Stmt
 
@@ -60,7 +62,7 @@ type DB struct {
 }
 
 // NewDB creates a new DB. If config is nil, DefaultConfig() is used.
-func NewDB(ctx context.Context, db *sql.DB, c *Config) (*DB, error) {
+func NewDB(ctx context.Context, db *sql.DB, c *Config, a alertlog.Store) (*DB, error) {
 	lock, err := processinglock.NewLock(ctx, db, processinglock.Config{
 		Type:    processinglock.TypeMessage,
 		Version: 7,
@@ -124,8 +126,9 @@ func NewDB(ctx context.Context, db *sql.DB, c *Config) (*DB, error) {
 		return nil, p.Err
 	}
 	return &DB{
-		lock: lock,
-		c:    *c,
+		lock:          lock,
+		c:             *c,
+		alertlogstore: a,
 
 		updateStatus: updateStatus,
 		tempFail:     tempFail,
@@ -256,19 +259,22 @@ func NewDB(ctx context.Context, db *sql.DB, c *Config) (*DB, error) {
 		currentTime: p.P(`select now()`),
 
 		failDisabledCM: p.P(`
-			update outgoing_messages msg
-			set
-				last_status = 'failed',
-				last_status_at = now(),
-				status_details = 'contact method disabled',
-				cycle_id = null,
-				next_retry_at = null
-			from user_contact_methods cm
-			where
-				msg.last_status = 'pending' and
-				msg.message_type != 'verification_message' and
-				cm.id = msg.contact_method_id and
-				cm.disabled
+			with disabled as (
+				update outgoing_messages msg
+				set
+					last_status = 'failed',
+					last_status_at = now(),
+					status_details = 'contact method disabled',
+					cycle_id = null,
+					next_retry_at = null
+				from user_contact_methods cm
+				where
+					msg.last_status = 'pending' and
+					msg.message_type != 'verification_message' and
+					cm.id = msg.contact_method_id and
+					cm.disabled
+				returning msg.id, alert_id
+			) select distinct id, alert_id from disabled
 		`),
 
 		insertAlertBundle: p.P(`
@@ -569,9 +575,35 @@ func (db *DB) _SendMessages(ctx context.Context, send SendFunc, status StatusFun
 		return errors.Wrap(err, "clear disabled status updates")
 	}
 
-	_, err = tx.Stmt(db.failDisabledCM).ExecContext(execCtx)
+	// processes disabled CMs and writes to alert log if disabled
+	cms, err := tx.Stmt(db.failDisabledCM).QueryContext(execCtx)
 	if err != nil {
 		return errors.Wrap(err, "check for disabled CMs")
+	}
+
+	type msgMeta struct {
+		MessageID string
+		AlertID   int
+	}
+
+	var msgs []msgMeta
+	for cms.Next() {
+		var msg msgMeta
+		err = cms.Scan(&msg.MessageID, &msg.AlertID)
+		if err != nil {
+			return errors.Wrap(err, "scan all disabled CM messages")
+		}
+		msgs = append(msgs, msg)
+	}
+	cms.Close()
+
+	for _, m := range msgs {
+		meta := alertlog.NotificationMetaData{
+			MessageID: m.MessageID,
+		}
+
+		// log failures
+		db.alertlogstore.MustLogTx(ctx, tx, m.AlertID, alertlog.TypeNotificationSent, meta)
 	}
 
 	_, err = tx.Stmt(db.sendDeadlineExpired).ExecContext(ctx)

--- a/notification/store.go
+++ b/notification/store.go
@@ -322,10 +322,12 @@ func (db *DB) FindManyMessageStatuses(ctx context.Context, ids ...string) ([]Mes
 	for rows.Next() {
 		var lastStatus string
 		var hasNextRetry bool
-		err = rows.Scan(&s.ID, &lastStatus, &s.Details, &s.ProviderMessageID, &s.Sequence, &hasNextRetry)
+		var providerMsgID sql.NullString
+		err = rows.Scan(&s.ID, &lastStatus, &s.Details, &providerMsgID, &s.Sequence, &hasNextRetry)
 		if err != nil {
 			return nil, err
 		}
+		s.ProviderMessageID = providerMsgID.String
 
 		switch lastStatus {
 		case "pending", "sending", "queued_remotely":


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [ ] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR logs notification_sent (but failed) when the applicable user's contact method is disabled.