### PR TITLE
profile: display an error dialog if test contact method mutation fails

### DIFF
--- a/web/src/app/users/UserContactMethodList.js
+++ b/web/src/app/users/UserContactMethodList.js
@@ -2,7 +2,16 @@ import React, { useState } from 'react'
 import p from 'prop-types'
 import gql from 'graphql-tag'
 import FlatList from '../lists/FlatList'
-import { Button, Card, CardHeader, Grid, IconButton } from '@material-ui/core'
+import {
+  Button,
+  Card,
+  Dialog,
+  DialogActions,
+  DialogTitle,
+  CardHeader,
+  Grid,
+  IconButton,
+} from '@material-ui/core'
 import { useQuery } from 'react-apollo'
 import { isWidthUp } from '@material-ui/core/withWidth'
 import { sortContactMethods } from './util'
@@ -17,6 +26,7 @@ import { styles as globalStyles } from '../styles/materialStyles'
 import useWidth from '../util/useWidth'
 import Spinner from '../loading/components/Spinner'
 import { GenericError } from '../error-pages'
+import DialogContentError from '../dialogs/components/DialogContentError'
 
 const query = gql`
   query cmList($id: ID!) {
@@ -60,7 +70,10 @@ export default function UserContactMethodList(props) {
   const [showEditDialogByID, setShowEditDialogByID] = useState(null)
   const [showDeleteDialogByID, setShowDeleteDialogByID] = useState(null)
 
-  const [sendTest] = useMutation(testCM)
+  const [showSendTestErrorDialog, setShowSendTestErrorDialog] = useState(false)
+  const [sendTest, sendTestStatus] = useMutation(testCM, {
+    onError: () => setShowSendTestErrorDialog(true),
+  })
 
   const { loading, error, data } = useQuery(query, {
     variables: {
@@ -105,7 +118,6 @@ export default function UserContactMethodList(props) {
     if (!cm.disabled) {
       actions.push({
         label: 'Send Test',
-        // todo: show dialog with error if test message fails to send
         onClick: () =>
           sendTest({
             variables: {
@@ -183,6 +195,22 @@ export default function UserContactMethodList(props) {
             onClose={() => setShowDeleteDialogByID(null)}
           />
         )}
+        <Dialog
+          open={showSendTestErrorDialog}
+          onClose={() => setShowSendTestErrorDialog(false)}
+        >
+          <DialogTitle>An error occurred</DialogTitle>
+          <DialogContentError error={sendTestStatus?.error?.message ?? ''} />
+          <DialogActions>
+            <Button
+              color='primary'
+              variant='contained'
+              onClick={() => setShowSendTestErrorDialog(false)}
+            >
+              Okay
+            </Button>
+          </DialogActions>
+        </Dialog>
       </Card>
     </Grid>
   )


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR displays an error dialogue if sending a test message fails from `< UserContactMethodList />`