### PR TITLE
alert log: add smoketests

### DIFF
--- a/devtools/mocktwilio/sms.go
+++ b/devtools/mocktwilio/sms.go
@@ -238,7 +238,7 @@ func (sms *SMS) process() {
 		if accepted {
 			sms.updateStatus(twilio.MessageStatusDelivered)
 		} else {
-			sms.updateStatus(twilio.MessageStatusUndelivered)
+			sms.updateStatus(twilio.MessageStatusFailed)
 		}
 	}
 }
@@ -269,7 +269,7 @@ func (sms *SMS) Accept() {
 	close(sms.acceptCh)
 }
 
-// Reject will cause the SMS to be marked as undelivered (failed).
+// Reject will cause the SMS to be marked as failed.
 func (sms *SMS) Reject() {
 	sms.acceptCh <- false
 	close(sms.acceptCh)

--- a/smoketest/alertlog_test.go
+++ b/smoketest/alertlog_test.go
@@ -43,7 +43,7 @@ func TestVoiceFailure(t *testing.T) {
 func TestNoImmediateNR(t *testing.T) {
 	t.Parallel()
 
-	var sql = makeSQL(true, false, true, true)
+	var sql = makeSQL(false, false, true, true)
 	h := harness.NewHarness(t, sql, "add-no-notification-alert-log")
 	defer h.Close()
 
@@ -57,12 +57,40 @@ func TestNoImmediateNR(t *testing.T) {
 	assert.Contains(t, msg, "no immediate rule")
 }
 
+// DONE !!!
 func TestNoOnCallUsers(t *testing.T) {
 	t.Parallel()
+
+	var sql = makeSQL(false, true, true, false)
+	h := harness.NewHarness(t, sql, "add-no-notification-alert-log")
+	defer h.Close()
+
+	// create alert
+	doQL(h, t, makeCreateAlertMut(h), nil)
+	h.Trigger()
+	logs := getLogs(h, t)
+
+	// most recent entry
+	var details = logs.Alert.RecentEvents.Nodes[0].State.Details
+	assert.Equal(t, "No one was on-call", details)
 }
 
+// DONE !!!
 func TestNoEPSteps(t *testing.T) {
 	t.Parallel()
+
+	var sql = makeSQL(false, true, false, false)
+	h := harness.NewHarness(t, sql, "add-no-notification-alert-log")
+	defer h.Close()
+
+	// create alert
+	doQL(h, t, makeCreateAlertMut(h), nil)
+	h.Trigger()
+	logs := getLogs(h, t)
+
+	// most recent entry
+	var details = logs.Alert.RecentEvents.Nodes[0].State.Details
+	assert.Equal(t, "No escalation policy steps", details)
 }
 
 func makeSQL(disabledCM bool, nr bool, epStep bool, epStepUser bool) string {

--- a/smoketest/alertlog_test.go
+++ b/smoketest/alertlog_test.go
@@ -33,7 +33,8 @@ func TestAlertLog(t *testing.T) {
 		EPStepUser bool
 	}
 
-	doQL := func(h *harness.Harness, query string, res interface{}) {
+	doQL := func(t *testing.T, h *harness.Harness, query string, res interface{}) {
+		t.Helper()
 		g := h.GraphQLQuery2(query)
 		for _, err := range g.Errors {
 			t.Error("GraphQL Error:", err.Message)
@@ -103,7 +104,7 @@ func TestAlertLog(t *testing.T) {
 			defer h.Close()
 
 			// create alert
-			doQL(h, makeCreateAlertMut(h), nil)
+			doQL(t, h, makeCreateAlertMut(h), nil)
 
 			if before != nil {
 				before(t, h)
@@ -112,7 +113,7 @@ func TestAlertLog(t *testing.T) {
 
 			// get logs
 			var l alertLogs
-			doQL(h, fmt.Sprintf(`
+			doQL(t, h, fmt.Sprintf(`
 			query {
 					alert(id: %d) {
 						recentEvents(input: { limit: 15 }) {

--- a/smoketest/alertlog_test.go
+++ b/smoketest/alertlog_test.go
@@ -1,0 +1,171 @@
+package smoketest
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/target/goalert/smoketest/harness"
+)
+
+type logs struct {
+	Alert struct {
+		RecentEvents struct {
+			Nodes []struct {
+				Message string `json:"message"`
+				State   struct {
+					Details string `json:"details"`
+				} `json:"state"`
+			} `json:"nodes"`
+		} `json:"recentEvents"`
+	} `json:"alert"`
+}
+
+func getLogs(h *harness.Harness, t *testing.T) *logs {
+	var result logs
+	doQL(h, t, fmt.Sprintf(`
+		query {
+  			alert(id: %d) {
+    			recentEvents(input: { limit: 15 }) {
+						nodes {
+							message
+							state {
+								details
+							}
+						}
+    			}
+  			}
+		}
+	`, 1), &result)
+
+	return &result
+}
+
+func makeCreateAlertMut(h *harness.Harness) string {
+	return fmt.Sprintf(
+		`mutation {
+			createAlert(input: {
+				summary: "foo",
+				serviceID: "%s"
+			}){ id }
+		}`,
+		h.UUID("sid"),
+	)
+}
+
+func TestNotificationSentSuccess(t *testing.T) {
+	t.Parallel()
+}
+
+// DONE !!!
+func TestDisabledContactMethod(t *testing.T) {
+	t.Parallel()
+
+	var sql = makeSQL(true, true, true, true)
+	h := harness.NewHarness(t, sql, "escalation-policy-step-reorder")
+	defer h.Close()
+
+	// create alert
+	doQL(h, t, makeCreateAlertMut(h), nil)
+
+	h.Trigger()
+
+	logs := getLogs(h, t)
+
+	// most recent entry
+	var details = logs.Alert.RecentEvents.Nodes[0].State.Details
+	assert.Equal(t, "contact method disabled", details)
+
+	for _, node := range logs.Alert.RecentEvents.Nodes {
+		fmt.Println("LOG: ", node.State.Details)
+	}
+}
+
+func TestSMSFailure(t *testing.T) {
+	t.Parallel()
+}
+
+func TestVoiceFailure(t *testing.T) {
+	t.Parallel()
+}
+
+func TestNoImmediateNR(t *testing.T) {
+	t.Parallel()
+}
+
+func TestNoOnCallUsers(t *testing.T) {
+	t.Parallel()
+}
+
+func TestNoEPSteps(t *testing.T) {
+	t.Parallel()
+}
+
+func makeSQL(disabledCM bool, nr bool, epStep bool, epStepUser bool) string {
+	// start initial sql with user and cm
+	var setupSQL = fmt.Sprintf(`
+		insert into users (id, name, email) 
+		values ({{uuid "user"}}, 'bob', 'joe');
+
+		insert into user_contact_methods (id, user_id, name, type, value, disabled) 
+		values ({{uuid "cm1"}}, {{uuid "user"}}, 'personal', 'SMS', {{phone "1"}}, %t);
+	`, disabledCM)
+
+	// add notification rule if specified
+	if nr {
+		fmt.Println("MAKING NR")
+		setupSQL = setupSQL + `
+			insert into user_notification_rules (user_id, contact_method_id, delay_minutes) 
+			values ({{uuid "user"}}, {{uuid "cm1"}}, 0);
+		`
+	}
+
+	// add ep
+	setupSQL = setupSQL + `
+		insert into escalation_policies (id, name) 
+		values ({{uuid "eid"}}, 'esc policy');
+	`
+
+	// add ep step if specified
+	if epStep {
+		setupSQL = setupSQL + `
+			insert into escalation_policy_steps (id, escalation_policy_id) 
+			values ({{uuid "esid"}}, {{uuid "eid"}});
+		`
+	}
+
+	// add user to ep step if step and stepUser specified
+	if epStep && epStepUser {
+		setupSQL = setupSQL + `
+			insert into escalation_policy_actions (escalation_policy_step_id, user_id) 
+			values ({{uuid "esid"}}, {{uuid "user"}});
+		`
+	}
+
+	// add service
+	setupSQL = setupSQL + `
+		insert into services (id, escalation_policy_id, name) 
+		values ({{uuid "sid"}}, {{uuid "eid"}}, 'service');
+	`
+
+	return setupSQL
+}
+
+func doQL(h *harness.Harness, t *testing.T, query string, res interface{}) {
+	g := h.GraphQLQuery2(query)
+	for _, err := range g.Errors {
+		t.Error("GraphQL Error:", err.Message)
+	}
+	if len(g.Errors) > 0 {
+		t.Fatal("errors returned from GraphQL")
+	}
+	t.Log("Response:", string(g.Data))
+	if res == nil {
+		return
+	}
+	err := json.Unmarshal(g.Data, &res)
+	if err != nil {
+		t.Fatal("failed to parse response:", err)
+	}
+}

--- a/smoketest/alertlog_test.go
+++ b/smoketest/alertlog_test.go
@@ -133,20 +133,38 @@ func TestAlertLog(t *testing.T) {
 	}
 
 	// test successful notification sent
-	check("NotificationSentSuccess", config{CMDisabled: false, CMType: "SMS", NR: true, EPStep: true, EPStepUser: true}, nil, func(t *testing.T, h *harness.Harness, l alertLogs) {
+	check("NotificationSentSuccess", config{
+		CMDisabled: false,
+		CMType:     "SMS",
+		NR:         true,
+		EPStep:     true,
+		EPStepUser: true,
+	}, nil, func(t *testing.T, h *harness.Harness, l alertLogs) {
 		var msg = l.Alert.RecentEvents.Nodes[0].Message
 		assert.Contains(t, msg, "Notification sent")
 		h.Twilio(t).Device(h.Phone("1")).ExpectSMS("Alert #1: foo")
 	})
 
 	// test disabled contact method
-	check("DisabledContactMethod", config{CMDisabled: true, CMType: "SMS", NR: true, EPStep: true, EPStepUser: true}, nil, func(t *testing.T, h *harness.Harness, l alertLogs) {
+	check("DisabledContactMethod", config{
+		CMDisabled: true,
+		CMType:     "SMS",
+		NR:         true,
+		EPStep:     true,
+		EPStepUser: true,
+	}, nil, func(t *testing.T, h *harness.Harness, l alertLogs) {
 		var details = l.Alert.RecentEvents.Nodes[0].State.Details
 		assert.Contains(t, details, "contact method disabled")
 	})
 
 	// test SMS failure
-	check("SMSFailure", config{CMDisabled: false, CMType: "SMS", NR: true, EPStep: true, EPStepUser: true}, func(t *testing.T, h *harness.Harness) {
+	check("SMSFailure", config{
+		CMDisabled: false,
+		CMType:     "SMS",
+		NR:         true,
+		EPStep:     true,
+		EPStepUser: true,
+	}, func(t *testing.T, h *harness.Harness) {
 		h.Twilio(t).Device(h.Phone("1")).RejectSMS("Alert #1: foo")
 	}, func(t *testing.T, h *harness.Harness, l alertLogs) {
 		var msg = l.Alert.RecentEvents.Nodes[0].Message
@@ -156,7 +174,13 @@ func TestAlertLog(t *testing.T) {
 	})
 
 	// test VOICE failure
-	check("VOICEFailure", config{CMDisabled: false, CMType: "VOICE", NR: true, EPStep: true, EPStepUser: true}, func(t *testing.T, h *harness.Harness) {
+	check("VOICEFailure", config{
+		CMDisabled: false,
+		CMType:     "VOICE",
+		NR:         true,
+		EPStep:     true,
+		EPStepUser: true,
+	}, func(t *testing.T, h *harness.Harness) {
 		h.Twilio(t).Device(h.Phone("1")).RejectVoice("foo")
 	}, func(t *testing.T, h *harness.Harness, l alertLogs) {
 		var msg = l.Alert.RecentEvents.Nodes[0].Message
@@ -166,19 +190,37 @@ func TestAlertLog(t *testing.T) {
 	})
 
 	// test no immediate notification rule
-	check("NoImmediateNR", config{CMDisabled: false, CMType: "SMS", NR: false, EPStep: true, EPStepUser: true}, nil, func(t *testing.T, h *harness.Harness, l alertLogs) {
+	check("NoImmediateNR", config{
+		CMDisabled: false,
+		CMType:     "SMS",
+		NR:         false,
+		EPStep:     true,
+		EPStepUser: true,
+	}, nil, func(t *testing.T, h *harness.Harness, l alertLogs) {
 		var msg = l.Alert.RecentEvents.Nodes[0].Message
 		assert.Contains(t, msg, "no immediate rule")
 	})
 
 	// test no on-call users
-	check("NoOnCallUsers", config{CMDisabled: false, CMType: "SMS", NR: true, EPStep: true, EPStepUser: false}, nil, func(t *testing.T, h *harness.Harness, l alertLogs) {
+	check("NoOnCallUsers", config{
+		CMDisabled: false,
+		CMType:     "SMS",
+		NR:         true,
+		EPStep:     true,
+		EPStepUser: false,
+	}, nil, func(t *testing.T, h *harness.Harness, l alertLogs) {
 		var details = l.Alert.RecentEvents.Nodes[0].State.Details
 		assert.Contains(t, details, "No one was on-call")
 	})
 
 	// test no steps on an escalation policy
-	check("NoEPSteps", config{CMDisabled: false, CMType: "SMS", NR: true, EPStep: false, EPStepUser: false}, nil, func(t *testing.T, h *harness.Harness, l alertLogs) {
+	check("NoEPSteps", config{
+		CMDisabled: false,
+		CMType:     "SMS",
+		NR:         true,
+		EPStep:     false,
+		EPStepUser: false,
+	}, nil, func(t *testing.T, h *harness.Harness, l alertLogs) {
 		var details = l.Alert.RecentEvents.Nodes[0].State.Details
 		assert.Contains(t, details, "No escalation policy steps")
 	})

--- a/smoketest/alertlog_test.go
+++ b/smoketest/alertlog_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/target/goalert/smoketest/harness"
 )
 
-// DONE !!!
 func TestNotificationSentSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -28,7 +27,6 @@ func TestNotificationSentSuccess(t *testing.T) {
 	h.Twilio(t).Device(h.Phone("1")).ExpectSMS("Alert #1: foo")
 }
 
-// DONE !!!
 func TestDisabledContactMethod(t *testing.T) {
 	t.Parallel()
 
@@ -46,7 +44,6 @@ func TestDisabledContactMethod(t *testing.T) {
 	assert.Equal(t, "contact method disabled", details)
 }
 
-// DONE !!!
 func TestSMSFailure(t *testing.T) {
 	t.Parallel()
 
@@ -67,7 +64,6 @@ func TestSMSFailure(t *testing.T) {
 	assert.Equal(t, "failed", details)
 }
 
-// DONE !!!
 func TestVoiceFailure(t *testing.T) {
 	t.Parallel()
 
@@ -88,7 +84,6 @@ func TestVoiceFailure(t *testing.T) {
 	assert.Equal(t, "failed", details)
 }
 
-// DONE !!!
 func TestNoImmediateNR(t *testing.T) {
 	t.Parallel()
 
@@ -106,7 +101,6 @@ func TestNoImmediateNR(t *testing.T) {
 	assert.Contains(t, msg, "no immediate rule")
 }
 
-// DONE !!!
 func TestNoOnCallUsers(t *testing.T) {
 	t.Parallel()
 
@@ -124,7 +118,6 @@ func TestNoOnCallUsers(t *testing.T) {
 	assert.Equal(t, "No one was on-call", details)
 }
 
-// DONE !!!
 func TestNoEPSteps(t *testing.T) {
 	t.Parallel()
 
@@ -154,7 +147,6 @@ func makeSQL(disabledCM bool, cmType string, nr bool, epStep bool, epStepUser bo
 
 	// add notification rule if specified
 	if nr {
-		fmt.Println("MAKING NR")
 		setupSQL = setupSQL + `
 			insert into user_notification_rules (user_id, contact_method_id, delay_minutes) 
 			values ({{uuid "user"}}, {{uuid "cm1"}}, 0);

--- a/smoketest/harness/graphql.go
+++ b/smoketest/harness/graphql.go
@@ -70,7 +70,7 @@ func (h *Harness) SetSystemLimit(id limit.ID, value int) {
 		UPDATE config_limits
 		SET max = %d
 		WHERE id='%s'; 
-	`, value, id))
+	`, value, id), nil)
 }
 
 // GraphQLQueryT will perform a GraphQL query against the backend, internally

--- a/smoketest/harness/harness.go
+++ b/smoketest/harness/harness.go
@@ -124,7 +124,7 @@ func NewHarness(t *testing.T, initSQL, migrationName string) *Harness {
 	return h
 }
 
-func NewHarnessWithTmpl(t *testing.T, initSQL string, sqlData interface{}, migrationName string) *Harness {
+func NewHarnessWithData(t *testing.T, initSQL string, sqlData interface{}, migrationName string) *Harness {
 	t.Helper()
 	h := NewStoppedHarness(t, initSQL, sqlData, migrationName)
 	h.Start()

--- a/smoketest/harness/harness.go
+++ b/smoketest/harness/harness.go
@@ -119,7 +119,14 @@ func (h *Harness) Config() config.Config {
 // the result. It starts a backend process pre-configured to a mock twilio server for monitoring notifications as well.
 func NewHarness(t *testing.T, initSQL, migrationName string) *Harness {
 	t.Helper()
-	h := NewStoppedHarness(t, initSQL, migrationName)
+	h := NewStoppedHarness(t, initSQL, nil, migrationName)
+	h.Start()
+	return h
+}
+
+func NewHarnessWithTmpl(t *testing.T, initSQL string, sqlData interface{}, migrationName string) *Harness {
+	t.Helper()
+	h := NewStoppedHarness(t, initSQL, sqlData, migrationName)
 	h.Start()
 	return h
 }
@@ -130,7 +137,7 @@ func NewHarness(t *testing.T, initSQL, migrationName string) *Harness {
 // Note that the now() function will be locked to the init timestamp for inspection.
 func NewHarnessDebugDB(t *testing.T, initSQL, migrationName string) *Harness {
 	t.Helper()
-	h := NewStoppedHarness(t, initSQL, migrationName)
+	h := NewStoppedHarness(t, initSQL, nil, migrationName)
 	h.Migrate("")
 
 	t.Fatal("DEBUG DB ::", h.dbURL)
@@ -144,7 +151,7 @@ const (
 )
 
 // NewStoppedHarness will create a NewHarness, but will not call Start.
-func NewStoppedHarness(t *testing.T, initSQL, migrationName string) *Harness {
+func NewStoppedHarness(t *testing.T, initSQL string, sqlData interface{}, migrationName string) *Harness {
 	t.Helper()
 	if testing.Short() {
 		t.Skip("skipping Harness tests for short mode")
@@ -215,21 +222,21 @@ func NewStoppedHarness(t *testing.T, initSQL, migrationName string) *Harness {
 	// freeze DB time until backend starts
 	h.execQuery(`
 		create schema testing_overrides;
-		alter database ` + sqlutil.QuoteID(name) + ` set search_path = "$user", public,testing_overrides, pg_catalog;
+		alter database `+sqlutil.QuoteID(name)+` set search_path = "$user", public,testing_overrides, pg_catalog;
 		
 
 		create or replace function testing_overrides.now()
 		returns timestamp with time zone
 		as $$
 			begin
-			return '` + start.Format(dbTimeFormat) + `';
+			return '`+start.Format(dbTimeFormat)+`';
 			end;
 		$$ language plpgsql;
-	`)
+	`, nil)
 
 	h.Migrate(migrationName)
 	h.initSlack()
-	h.execQuery(initSQL)
+	h.execQuery(initSQL, sqlData)
 
 	return h
 }
@@ -408,7 +415,7 @@ func (h *Harness) setDBOffset(d time.Duration) {
 	`,
 		h.start.Add(d).Format(dbTimeFormat),
 		h.pgResume.Format(dbTimeFormat),
-	))
+	), nil)
 	h.trigger()
 }
 
@@ -428,7 +435,7 @@ func (h *Harness) FastForward(d time.Duration) {
 	h.setDBOffset(h.delayOffset)
 }
 
-func (h *Harness) execQuery(sql string) {
+func (h *Harness) execQuery(sql string, data interface{}) {
 	h.t.Helper()
 	t := template.New("sql")
 	t.Funcs(template.FuncMap{
@@ -444,7 +451,7 @@ func (h *Harness) execQuery(sql string) {
 	}
 
 	b := new(bytes.Buffer)
-	err = t.Execute(b, nil)
+	err = t.Execute(b, data)
 	if err != nil {
 		h.t.Fatalf("failed to render query template: %v", err)
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adds tests for the following scenarios in the alert log:
- successful sent notification gets logged
- disabled contact method gets logged
- sms failure gets logged
- voice failure gets logged
- "no immediate rule" gets logged
- "no on-call users" gets logged
- "no escalation policy steps" gets logged