### PR TITLE
fix for <1 minute getting stuck switching active

### DIFF
--- a/web/src/app/util/CountDown.js
+++ b/web/src/app/util/CountDown.js
@@ -106,13 +106,11 @@ export default class CountDown extends Component {
 
   componentDidMount() {
     this._counter = setInterval(() => {
-      if (this.state.timeRemaining > 0) {
-        this.setState({
-          timeRemaining:
-            DateTime.fromISO(this.props.end).toSeconds() -
-            DateTime.local().toSeconds(),
-        })
-      }
+      this.setState({
+        timeRemaining:
+          DateTime.fromISO(this.props.end).toSeconds() -
+          DateTime.local().toSeconds(),
+      })
     }, 1000)
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
the "<1 minute" active text now changes to "Active for..."  automatically within up to a few seconds after switching, rather than sometimes getting stuck on "<1 minute" until page reload 
