### PR TITLE
all-in-one: use alpine base image

### DIFF
--- a/devtools/ci/dockerfiles/all-in-one/Dockerfile
+++ b/devtools/ci/dockerfiles/all-in-one/Dockerfile
@@ -11,7 +11,8 @@ RUN go mod download
 COPY . /goalert
 RUN make bin/resetdb bin/goalert BUNDLE=1 BUILD_FLAGS=-trimpath
 
-FROM postgres:11-alpine
+FROM alpine:3.12
+RUN apk --no-cache add postgresql postgresql-contrib musl-locales tzdata ca-certificates
 COPY --from=build /goalert/bin/goalert /goalert/bin/resetdb /bin/
 COPY devtools/ci/dockerfiles/all-in-one/start.sh /bin/start.sh
 ENV GOALERT_LISTEN :8081

--- a/devtools/ci/dockerfiles/all-in-one/start.sh
+++ b/devtools/ci/dockerfiles/all-in-one/start.sh
@@ -7,9 +7,8 @@ if ! test -f /init-db
 then
   mkdir -p ${PGDATA} /run/postgresql /var/log/postgresql &&\
   chown postgres ${PGDATA} /run/postgresql /var/log/postgresql &&\
-  su postgres -s /bin/sh -c "initdb $PGDATA" &&\
-  echo "host all  all    0.0.0.0/0  md5" >> $PGDATA/pg_hba.conf &&\
-  echo "listen_addresses='*'" >> $PGDATA/postgresql.conf &&\
+  su postgres -s /bin/sh -c "initdb --auth-local trust -N $PGDATA" &&\
+  echo "listen_addresses=''" >> $PGDATA/postgresql.conf &&\
   echo "fsync = off" >> $PGDATA/postgresql.conf &&\
   echo "full_page_writes = off" >> $PGDATA/postgresql.conf
   touch /init-db


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This image updates the all-in-one Dockerfile to use `alpine:3.12` as the base image instead of `postgres:11-alpine`

The resulting image now (correctly) has a single exposed port for the application (`8081`) now that the DB is used via unix socket.