### PR TITLE
ui: disable rendering quick links container if no links present

### DIFF
--- a/web/src/app/details/DetailsPage.js
+++ b/web/src/app/details/DetailsPage.js
@@ -134,7 +134,7 @@ export default function DetailsPage(props) {
         <Card>
           <CardContent>
             <Grid container spacing={2}>
-              <Grid item xs={isDesktopMode(width) ? 8 : 12}>
+              <Grid item xs={isDesktopMode(width) && links ? 8 : 12}>
                 {icon && <div className={classes.iconContainer}>{icon}</div>}
                 <Typography
                   data-cy='details-heading'
@@ -160,12 +160,14 @@ export default function DetailsPage(props) {
                   </Typography>
                 )}
               </Grid>
-              <Hidden smDown>
-                <Grid className={classes.quickLinksContainer} item xs={4}>
-                  <Divider orientation='vertical' />
-                  {links}
-                </Grid>
-              </Hidden>
+              {links && (
+                <Hidden smDown>
+                  <Grid className={classes.quickLinksContainer} item xs={4}>
+                    <Divider orientation='vertical' />
+                    {links}
+                  </Grid>
+                </Hidden>
+              )}
             </Grid>
           </CardContent>
         </Card>


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR addresses an issue where the container for Quick Links (and it's vertical divider) were still being rendered on the page even if no quick links were given.

**Screenshots:**
Before:
![image](https://user-images.githubusercontent.com/11381794/86833429-2269b300-c05f-11ea-88bc-d99f6acb6c79.png)
![image](https://user-images.githubusercontent.com/11381794/86833589-580e9c00-c05f-11ea-88a7-df305cf74c73.png)

After:
![image](https://user-images.githubusercontent.com/11381794/86833447-2695d080-c05f-11ea-8803-4b2b918b2bca.png)
![image](https://user-images.githubusercontent.com/11381794/86833543-45946280-c05f-11ea-8426-f6fbdef3ad21.png)
