### PR TITLE
ui: fix debounce bug on rotations list search

### DIFF
--- a/web/src/app/rotations/RotationRouter.js
+++ b/web/src/app/rotations/RotationRouter.js
@@ -43,7 +43,7 @@ export default function RotationRouter() {
 
   return (
     <Switch>
-      <Route exact path='/rotations' component={renderList} />
+      <Route exact path='/rotations' render={renderList} />
       <Route
         exact
         path='/rotations/:rotationID'


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes an issue where the rotation's list search field would lose focus after the field would debounce. This was due to the fact that we were using `component` instead of `render` from `react-router-dom` to render the component (we are referencing a function that renders, not referencing a component directly).