### PR TITLE
alertlog: handle empty details correctly

### DIFF
--- a/graphql2/graphqlapp/alert.go
+++ b/graphql2/graphqlapp/alert.go
@@ -88,10 +88,14 @@ func (a *AlertLogEntry) notificationSentState(ctx context.Context, obj *alertlog
 		prefix = "Delivered"
 	case notification.MessageStateFailedTemp, notification.MessageStateFailedPerm:
 		prefix = "Failed"
+	default:
+		prefix = "Unknown"
 	}
 
 	details := s.Details
-	if !strings.EqualFold(prefix, details) {
+	if details == "" {
+		details = prefix
+	} else if !strings.EqualFold(prefix, details) {
 		details = prefix + ": " + details
 	}
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Resolves an edge case in the alert log details text when `status_details` is empty.