### PR TITLE
graphql: default `includeNotified` to false for API compatability

### DIFF
--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -3547,7 +3547,7 @@ input AlertSearchOptions {
   first: Int = 15
   after: String = ""
   favoritesOnly: Boolean = false
-  includeNotified: Boolean = true
+  includeNotified: Boolean = false
   omit: [Int!]
 }
 
@@ -15065,9 +15065,6 @@ func (ec *executionContext) unmarshalInputAlertSearchOptions(ctx context.Context
 
 	if _, present := asMap["first"]; !present {
 		asMap["first"] = 15
-	}
-	if _, present := asMap["includeNotified"]; !present {
-		asMap["includeNotified"] = true
 	}
 
 	for k, v := range asMap {

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -701,7 +701,7 @@ input AlertSearchOptions {
   first: Int = 15
   after: String = ""
   favoritesOnly: Boolean = false
-  includeNotified: Boolean = true
+  includeNotified: Boolean = false
   omit: [Int!]
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR updates the default value of `includeNotified` in the alerts query to preserve compatibility for existing clients.
