### PR TITLE
ui/admin: render sections in accordion

### DIFF
--- a/web/src/app/admin/AdminConfig.tsx
+++ b/web/src/app/admin/AdminConfig.tsx
@@ -177,7 +177,12 @@ export default function AdminConfig(): JSX.Element {
               expanded={section === groupID}
               onChange={handleExpandChange(groupID)}
             >
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <AccordionSummary
+                aria-expanded={section === groupID}
+                aria-controls={`accordion-sect-${groupID}`}
+                id={`accordion-${groupID}`}
+                expandIcon={<ExpandMoreIcon />}
+              >
                 <Typography
                   component='h2'
                   variant='subtitle1'
@@ -199,7 +204,11 @@ export default function AdminConfig(): JSX.Element {
                   null}
               </AccordionSummary>
 
-              <AccordionDetails>
+              <AccordionDetails
+                id={`accordion-sect-${groupID}`}
+                role='region'
+                aria-labelledby={`accordion-${groupID}`}
+              >
                 <Form style={{ width: '100%' }}>
                   <AdminSection
                     value={values}

--- a/web/src/app/admin/AdminSection.tsx
+++ b/web/src/app/admin/AdminSection.tsx
@@ -4,7 +4,7 @@ import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 import Typography from '@material-ui/core/Typography'
 import { FormContainer } from '../forms'
-import { defaultTo } from 'lodash-es'
+import _, { defaultTo } from 'lodash-es'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import {
   StringInput,
@@ -14,7 +14,6 @@ import {
 } from './AdminFieldComponents'
 import { ConfigValue } from '../../schema'
 import { yellow } from '@material-ui/core/colors'
-import _ from 'lodash-es'
 
 const components = {
   string: StringInput,

--- a/web/src/app/admin/AdminSection.tsx
+++ b/web/src/app/admin/AdminSection.tsx
@@ -5,7 +5,7 @@ import ListItemText from '@material-ui/core/ListItemText'
 import Typography from '@material-ui/core/Typography'
 import { FormContainer } from '../forms'
 import { defaultTo } from 'lodash-es'
-import { makeStyles } from '@material-ui/core/styles'
+import { makeStyles, Theme } from '@material-ui/core/styles'
 import {
   StringInput,
   StringListInput,
@@ -13,6 +13,7 @@ import {
   BoolInput,
 } from './AdminFieldComponents'
 import { ConfigValue } from '../../schema'
+import { yellow } from '@material-ui/core/colors'
 
 const components = {
   string: StringInput,
@@ -32,7 +33,10 @@ interface AdminSectionProps {
   onChange: (id: string, value: null | string) => void
 }
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme: Theme) => ({
+  activeItem: {
+    backgroundColor: yellow[300],
+  },
   listItem: {
     // leaves some room around fields without descriptions
     // 71px is the height of the checkbox field without w/o a desc
@@ -41,9 +45,15 @@ const useStyles = makeStyles(() => ({
   },
   listItemText: {
     maxWidth: '50%',
+    [theme.breakpoints.up('md')]: {
+      maxWidth: '65%',
+    },
   },
   listItemAction: {
     width: '50%',
+    [theme.breakpoints.up('md')]: {
+      width: '35%',
+    },
     display: 'flex',
     justifyContent: 'flex-end',
   },
@@ -73,7 +83,11 @@ export default function AdminSection(props: AdminSectionProps): JSX.Element {
           return (
             <ListItem
               key={f.id}
-              className={classes.listItem}
+              className={
+                classes.listItem +
+                ' ' +
+                (_.has(value, f.id) ? classes.activeItem : '')
+              }
               divider={idx !== fields.length - 1}
             >
               <ListItemText

--- a/web/src/app/admin/AdminSection.tsx
+++ b/web/src/app/admin/AdminSection.tsx
@@ -14,6 +14,7 @@ import {
 } from './AdminFieldComponents'
 import { ConfigValue } from '../../schema'
 import { yellow } from '@material-ui/core/colors'
+import _ from 'lodash-es'
 
 const components = {
   string: StringInput,

--- a/web/src/app/admin/AdminSection.tsx
+++ b/web/src/app/admin/AdminSection.tsx
@@ -35,7 +35,7 @@ interface AdminSectionProps {
 
 const useStyles = makeStyles((theme: Theme) => ({
   activeItem: {
-    backgroundColor: yellow[300],
+    backgroundColor: yellow[100],
   },
   listItem: {
     // leaves some room around fields without descriptions

--- a/web/src/cypress/support/form.ts
+++ b/web/src/cypress/support/form.ts
@@ -106,15 +106,26 @@ function fillFormField(
 ): Cypress.Chainable<JQuery<HTMLElement>> {
   const selector = `${selPrefix} input[name="${name}"],textarea[name="${name}"]`
 
-  if (typeof value === 'boolean') {
-    if (!value) return cy.get(selector).uncheck()
-
-    return cy.get(selector).check()
-  }
-
   return cy
     .get(selector)
     .then((el) => {
+      // Auto detect/expand accordion sections if need be
+      const accordionSectionID = el
+        .parents('[aria-labelledby][role=region]')
+        .attr('id')
+      if (accordionSectionID) {
+        const ctrl = `[aria-controls=${accordionSectionID}][aria-expanded=false]`
+        if (Cypress.$(ctrl).length > 0) {
+          cy.get(ctrl).click()
+        }
+      }
+
+      if (typeof value === 'boolean') {
+        if (!value) return cy.get(selector).uncheck()
+
+        return cy.get(selector).check()
+      }
+
       const isSelect =
         el.parents('[data-cy=material-select]').data('cy') ===
           'material-select' ||


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR updates the admin config page to use accordions for the individual sections.

- `fillFormField` in cypress tests will now automatically handle accordions that are labelled appropriately for accessibility
- changes highlighted in yellow
- summary of enabled/disabled, and number of changes per-section

Closes #796 


![image](https://user-images.githubusercontent.com/595010/89417779-c42eff00-d6f4-11ea-8881-184982d641e6.png)
