### PR TITLE
engine/message: append alert log failure when Twilio is disabled

### DIFF
--- a/alert/log/store.go
+++ b/alert/log/store.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/target/goalert/config"
 	"github.com/target/goalert/integrationkey"
 	"github.com/target/goalert/notificationchannel"
 	"github.com/target/goalert/permission"
@@ -266,6 +267,8 @@ func (db *DB) logAny(ctx context.Context, tx *sql.Tx, insertStmt *sql.Stmt, id i
 		return err
 	}
 
+	fmt.Println(_type)
+
 	var classExtras []string
 	switch _type {
 	case _TypeAcknowledgeAll:
@@ -287,6 +290,7 @@ func (db *DB) logAny(ctx context.Context, tx *sql.Tx, insertStmt *sql.Stmt, id i
 	}
 
 	src := permission.Source(ctx)
+	fmt.Println(src)
 	if src != nil {
 		switch src.Type {
 		case permission.SourceTypeNotificationChannel:
@@ -320,7 +324,12 @@ func (db *DB) logAny(ctx context.Context, tx *sql.Tx, insertStmt *sql.Stmt, id i
 			}
 			if _type == TypeNoNotificationSent {
 				// no CMID for no notification sent
-				r.subject.classifier = "no immediate rule"
+				cfg := config.FromContext(ctx)
+				if !cfg.Twilio.Enable {
+					r.subject.classifier = "Twilio Disabled"
+				} else {
+					r.subject.classifier = "no immediate rule"
+				}
 				break
 			}
 			var cmType contactmethod.Type

--- a/alert/log/store.go
+++ b/alert/log/store.go
@@ -267,8 +267,6 @@ func (db *DB) logAny(ctx context.Context, tx *sql.Tx, insertStmt *sql.Stmt, id i
 		return err
 	}
 
-	fmt.Println(_type)
-
 	var classExtras []string
 	switch _type {
 	case _TypeAcknowledgeAll:
@@ -290,7 +288,6 @@ func (db *DB) logAny(ctx context.Context, tx *sql.Tx, insertStmt *sql.Stmt, id i
 	}
 
 	src := permission.Source(ctx)
-	fmt.Println(src)
 	if src != nil {
 		switch src.Type {
 		case permission.SourceTypeNotificationChannel:

--- a/alert/log/store.go
+++ b/alert/log/store.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/target/goalert/config"
 	"github.com/target/goalert/integrationkey"
 	"github.com/target/goalert/notificationchannel"
 	"github.com/target/goalert/permission"
@@ -321,12 +320,7 @@ func (db *DB) logAny(ctx context.Context, tx *sql.Tx, insertStmt *sql.Stmt, id i
 			}
 			if _type == TypeNoNotificationSent {
 				// no CMID for no notification sent
-				cfg := config.FromContext(ctx)
-				if !cfg.Twilio.Enable {
-					r.subject.classifier = "Twilio Disabled"
-				} else {
-					r.subject.classifier = "no immediate rule"
-				}
+				r.subject.classifier = "no immediate rule"
 				break
 			}
 			var cmType contactmethod.Type

--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -298,7 +298,7 @@ func NewDB(ctx context.Context, db *sql.DB, c *Config, a alertlog.Store) (*DB, e
 
 		insertAlertBundle: p.P(`
 			with new_msg as (
-				insert into outgoing_messages ( 
+				insert into outgoing_messages (
 					id,
 					created_at,
 					message_type,
@@ -860,7 +860,6 @@ func (db *DB) sendMessage(ctx context.Context, cLock *processinglock.Conn, send 
 	if m.AlertID != 0 {
 		ctx = log.WithField(ctx, "AlertID", m.AlertID)
 	}
-
 	_, err := cLock.Exec(ctx, db.setSending, m.ID)
 	if err != nil {
 		return false, err

--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -284,7 +284,7 @@ func NewDB(ctx context.Context, db *sql.DB, c *Config, a alertlog.Store) (*DB, e
 			set
 				last_status = 'failed',
 				last_status_at = now(),
-				status_details = 'twilio disabled',
+				status_details = 'SMS/Voice support not enabled by administrator',
 				cycle_id = null,
 				next_retry_at = null
 			from user_contact_methods cm


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
When twilio is disabled and trying to send message to the user, it will notify the user in the alert log that twilio is disabled.
**Screenshots:**
<img width="1680" alt="Screen Shot 2020-08-03 at 2 32 22 PM" src="https://user-images.githubusercontent.com/36461401/89220246-d5fa9000-d596-11ea-9bc5-edd1c2d46463.png">
