### PR TITLE
dev/harness: add GraphQLQueryUserT method

### DIFF
--- a/smoketest/graphqloncall_test.go
+++ b/smoketest/graphqloncall_test.go
@@ -18,7 +18,7 @@ func TestGraphQLOnCall(t *testing.T) {
 	t.Parallel()
 
 	doQL := func(t *testing.T, h *harness.Harness, query string, res interface{}) {
-		g := h.GraphQLQueryT(t, query, "/api/graphql")
+		g := h.GraphQLQueryT(t, query)
 		for _, err := range g.Errors {
 			t.Error("GraphQL Error:", err.Message)
 		}

--- a/smoketest/graphqloncallassignments_test.go
+++ b/smoketest/graphqloncallassignments_test.go
@@ -47,7 +47,7 @@ func TestGraphQLOnCallAssignments(t *testing.T) {
 			defer h.Close()
 
 			doQL := func(t *testing.T, query string, res interface{}) {
-				g := h.GraphQLQueryT(t, query, "/api/graphql")
+				g := h.GraphQLQueryT(t, query)
 				for _, err := range g.Errors {
 					t.Error("GraphQL Error:", err.Message)
 				}

--- a/smoketest/harness/graphql.go
+++ b/smoketest/harness/graphql.go
@@ -29,7 +29,7 @@ func (h *Harness) insertGraphQLUser(userID string) string {
 		permission.SudoContext(context.Background(), func(ctx context.Context) {
 			_, err = h.backend.UserStore.Insert(ctx, &user.User{
 				Name: "GraphQL User",
-				ID:   DefaultGraphQLAdminUserID,
+				ID:   userID,
 				Role: permission.RoleAdmin,
 			})
 		})
@@ -38,7 +38,7 @@ func (h *Harness) insertGraphQLUser(userID string) string {
 		}
 	}
 
-	tok, err := h.backend.AuthHandler.CreateSession(context.Background(), "goalert-smoketest", DefaultGraphQLAdminUserID)
+	tok, err := h.backend.AuthHandler.CreateSession(context.Background(), "goalert-smoketest", userID)
 	if err != nil {
 		h.t.Fatal(errors.Wrap(err, "create auth session"))
 	}

--- a/smoketest/harness/graphql.go
+++ b/smoketest/harness/graphql.go
@@ -19,36 +19,43 @@ import (
 	"github.com/target/goalert/user"
 )
 
-func (h *Harness) insertGraphQLUser() {
+// DefaultGraphQLAdminUserID is the UserID created & used for GraphQL calls by default.
+const DefaultGraphQLAdminUserID = "00000000-0000-0000-0000-000000000000"
+
+func (h *Harness) insertGraphQLUser(userID string) string {
 	h.t.Helper()
 	var err error
-	permission.SudoContext(context.Background(), func(ctx context.Context) {
-		_, err = h.backend.UserStore.Insert(ctx, &user.User{
-			Name: "GraphQL User",
-			ID:   "bcefacc0-4764-012d-7bfb-002500d5decb",
-			Role: permission.RoleAdmin,
+	if userID == DefaultGraphQLAdminUserID {
+		permission.SudoContext(context.Background(), func(ctx context.Context) {
+			_, err = h.backend.UserStore.Insert(ctx, &user.User{
+				Name: "GraphQL User",
+				ID:   DefaultGraphQLAdminUserID,
+				Role: permission.RoleAdmin,
+			})
 		})
-	})
-	if err != nil {
-		h.t.Fatal(errors.Wrap(err, "create GraphQL user"))
+		if err != nil {
+			h.t.Fatal(errors.Wrap(err, "create GraphQL user"))
+		}
 	}
 
-	tok, err := h.backend.AuthHandler.CreateSession(context.Background(), "goalert-smoketest", "bcefacc0-4764-012d-7bfb-002500d5decb")
+	tok, err := h.backend.AuthHandler.CreateSession(context.Background(), "goalert-smoketest", DefaultGraphQLAdminUserID)
 	if err != nil {
 		h.t.Fatal(errors.Wrap(err, "create auth session"))
 	}
 
-	h.sessToken, err = tok.Encode(h.backend.SessionKeyring.Sign)
+	h.gqlSessions[userID], err = tok.Encode(h.backend.SessionKeyring.Sign)
 	if err != nil {
 		h.t.Fatal(errors.Wrap(err, "sign auth session"))
 	}
+
+	return h.gqlSessions[userID]
 }
 
 // GraphQLQuery2 will perform a GraphQL2 query against the backend, internally
 // handling authentication. Queries are performed with Admin role.
 func (h *Harness) GraphQLQuery2(query string) *QLResponse {
 	h.t.Helper()
-	return h.GraphQLQueryT(h.t, query, "/api/graphql")
+	return h.GraphQLQueryT(h.t, query)
 }
 
 // SetConfigValue will update the config value id (e.g. `General.PublicURL`) to the provided value.
@@ -75,9 +82,23 @@ func (h *Harness) SetSystemLimit(id limit.ID, value int) {
 
 // GraphQLQueryT will perform a GraphQL query against the backend, internally
 // handling authentication. Queries are performed with Admin role.
-func (h *Harness) GraphQLQueryT(t *testing.T, query string, u string) *QLResponse {
+func (h *Harness) GraphQLQueryT(t *testing.T, query string) *QLResponse {
 	t.Helper()
-	h.addGraphUser.Do(h.insertGraphQLUser)
+	return h.GraphQLQueryUserT(t, DefaultGraphQLAdminUserID, query)
+}
+
+// GraphQLQueryUserT will perform a GraphQL query against the backend, internally
+// handling authentication. Queries are performed with the provided UserID.
+func (h *Harness) GraphQLQueryUserT(t *testing.T, userID, query string) *QLResponse {
+	t.Helper()
+
+	h.mx.Lock()
+	tok := h.gqlSessions[userID]
+	if tok == "" {
+		tok = h.insertGraphQLUser(userID)
+	}
+	h.mx.Unlock()
+
 	query = strings.Replace(query, "\t", "", -1)
 	q := struct{ Query string }{Query: query}
 
@@ -87,7 +108,7 @@ func (h *Harness) GraphQLQueryT(t *testing.T, query string, u string) *QLRespons
 	}
 	t.Log("Query:", query)
 
-	url := h.URL() + u
+	url := h.URL() + "/api/graphql"
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
 	if err != nil {
 		t.Fatal("failed to make request:", err)
@@ -95,7 +116,7 @@ func (h *Harness) GraphQLQueryT(t *testing.T, query string, u string) *QLRespons
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{
 		Name:  auth.CookieName,
-		Value: h.sessToken,
+		Value: tok,
 	})
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/smoketest/harness/harness.go
+++ b/smoketest/harness/harness.go
@@ -102,7 +102,7 @@ type Harness struct {
 	userGeneratedIndex int
 	addGraphUser       sync.Once
 
-	sessToken string
+	gqlSessions map[string]string
 }
 
 func (h *Harness) Config() config.Config {
@@ -184,6 +184,8 @@ func NewStoppedHarness(t *testing.T, initSQL string, sqlData interface{}, migrat
 		dbURL:          DBURL(name),
 		lastTimeChange: start,
 		start:          start,
+
+		gqlSessions: make(map[string]string),
 
 		t: t,
 	}

--- a/smoketest/harness/harness.go
+++ b/smoketest/harness/harness.go
@@ -100,7 +100,6 @@ type Harness struct {
 	db *pgxpool.Pool
 
 	userGeneratedIndex int
-	addGraphUser       sync.Once
 
 	gqlSessions map[string]string
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adds a `GraphQLQueryUserT` method to the test harness that allows running graphQL queries via arbitrary UserIDs. This should make it possible to create users within initSQL and run a query from the same user.
