### PR TITLE
engine: fix message stall on disabled test message

### DIFF
--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -276,7 +276,7 @@ func NewDB(ctx context.Context, db *sql.DB, c *Config, a alertlog.Store) (*DB, e
 					cm.id = msg.contact_method_id and
 					cm.disabled
 				returning msg.id as msg_id, alert_id, msg.user_id, cm.id as cm_id
-			) select distinct msg_id, alert_id, user_id, cm_id from disabled
+			) select distinct msg_id, alert_id, user_id, cm_id from disabled where alert_id notnull
 		`),
 
 		failSMSVoice: p.P(`

--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -612,11 +612,16 @@ func (db *DB) _SendMessages(ctx context.Context, send SendFunc, status StatusFun
 		defer rows.Close()
 
 		for rows.Next() {
+			var alertID sql.NullInt64
 			var msg msgMeta
-			err = rows.Scan(&msg.MessageID, &msg.AlertID, &msg.UserID, &msg.CMID)
+			err = rows.Scan(&msg.MessageID, &alertID, &msg.UserID, &msg.CMID)
 			if err != nil {
 				return errors.Wrap(err, "scan all failed messages")
 			}
+			if !alertID.Valid {
+				continue
+			}
+			msg.AlertID = int(alertID.Int64)
 			msgs = append(msgs, msg)
 		}
 	}

--- a/smoketest/cmtestdisable_test.go
+++ b/smoketest/cmtestdisable_test.go
@@ -1,0 +1,30 @@
+package smoketest
+
+import (
+	"testing"
+
+	"github.com/target/goalert/smoketest/harness"
+)
+
+// TestCMTestDisable checks for a condition where a test message is scheduled but the contact method is immediately disabled.
+func TestCMTestDisable(t *testing.T) {
+	t.Parallel()
+
+	sqlQuery := `
+		insert into users (id, name, email) 
+		values 
+			({{uuid "user"}}, 'bob', 'joe');
+		insert into user_contact_methods (id, user_id, name, type, value, disabled) 
+		values
+			({{uuid "cm1"}}, {{uuid "user"}}, 'personal', 'SMS', {{phone "1"}}, true),
+			({{uuid "cm2"}}, {{uuid "user"}}, 'personal2', 'SMS', {{phone "2"}}, false);
+		insert into outgoing_messages (message_type, contact_method_id, last_status, user_id)
+		values
+			('test_notification', {{uuid "cm1"}}, 'pending', {{uuid "user"}}),
+			('test_notification', {{uuid "cm2"}}, 'pending', {{uuid "user"}});
+	`
+	h := harness.NewHarness(t, sqlQuery, "add-verification-code")
+	defer h.Close()
+
+	h.Twilio(t).Device(h.Phone("2")).ExpectSMS("test")
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes an issue where unsubscribing while a test message is pending (or otherwise having a pending test message on a disabled contact method) can lead to a state where a scan error prevents outgoing messages from being processed.
