### PR TITLE
feature/temp-schedules: fix bugs with invalid user IDs

### DIFF
--- a/app/initstores.go
+++ b/app/initstores.go
@@ -134,8 +134,16 @@ func (app *App) initStores(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "init service store")
 	}
+
+	if app.UserStore == nil {
+		app.UserStore, err = user.NewDB(ctx, app.db)
+	}
+	if err != nil {
+		return errors.Wrap(err, "init user store")
+	}
+
 	if app.ScheduleStore == nil {
-		app.ScheduleStore, err = schedule.NewStore(ctx, app.db)
+		app.ScheduleStore, err = schedule.NewStore(ctx, app.db, app.UserStore)
 	}
 	if err != nil {
 		return errors.Wrap(err, "init schedule store")
@@ -146,13 +154,6 @@ func (app *App) initStores(ctx context.Context) error {
 	}
 	if err != nil {
 		return errors.Wrap(err, "init rotation store")
-	}
-
-	if app.UserStore == nil {
-		app.UserStore, err = user.NewDB(ctx, app.db)
-	}
-	if err != nil {
-		return errors.Wrap(err, "init user store")
 	}
 
 	if app.NCStore == nil {

--- a/engine/cleanupmanager/update.go
+++ b/engine/cleanupmanager/update.go
@@ -98,7 +98,7 @@ func (db *DB) update(ctx context.Context) error {
 	lookup := lookupMap(currentUsers)
 	for _, dat := range m {
 		cleanupScheduleData(&dat.Data, lookup, now)
-		rawData, err := json.Marshal(dat)
+		rawData, err := json.Marshal(dat.Data)
 		if err != nil {
 			return err
 		}

--- a/engine/schedulemanager/db.go
+++ b/engine/schedulemanager/db.go
@@ -78,7 +78,7 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 		`),
 		startOnCall: p.P(`
 			insert into schedule_on_call_users (schedule_id, start_time, user_id)
-			values ($1, now(), $2)
+			select $1, now(), $2 from users where id = $2
 		`),
 		endOnCall: p.P(`
 			update schedule_on_call_users

--- a/schedule/fixedshift.go
+++ b/schedule/fixedshift.go
@@ -2,6 +2,7 @@ package schedule
 
 import (
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -55,6 +56,10 @@ func mergeShiftsByTime(shifts []FixedShift) []FixedShift {
 			result = append(result, s)
 			continue
 		}
+
+		// TODO: remove once we switch to uuid.UUID
+		s.UserID = strings.ToLower(s.UserID)
+
 		result[l].End = maxTime(result[l].End, s.End)
 	}
 

--- a/schedule/store.go
+++ b/schedule/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/target/goalert/user"
 	"github.com/target/goalert/util/sqlutil"
 
 	"github.com/pkg/errors"
@@ -29,13 +30,16 @@ type Store struct {
 	findOneUp *sql.Stmt
 
 	findMany *sql.Stmt
+
+	usr user.Store
 }
 
-func NewStore(ctx context.Context, db *sql.DB) (*Store, error) {
+func NewStore(ctx context.Context, db *sql.DB, usr user.Store) (*Store, error) {
 	p := &util.Prepare{DB: db, Ctx: ctx}
 
 	return &Store{
-		db: db,
+		db:  db,
+		usr: usr,
 
 		findData:    p.P(`SELECT data FROM schedule_data WHERE schedule_id = $1`),
 		findUpdData: p.P(`SELECT data FROM schedule_data WHERE schedule_id = $1 FOR UPDATE`),

--- a/schedule/storefixedshifts.go
+++ b/schedule/storefixedshifts.go
@@ -73,6 +73,24 @@ func (store *Store) FixedShiftGroups(ctx context.Context, tx *sql.Tx, scheduleID
 		}
 	}
 
+	check, err := store.usr.UserExists(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer check.Done()
+
+	for i, tmp := range data.V1.TemporarySchedules {
+		shifts := tmp.Shifts[:0]
+		for _, shift := range tmp.Shifts {
+			if !check.UserExistsString(shift.UserID) {
+				continue
+			}
+			shifts = append(shifts, shift)
+		}
+		tmp.Shifts = shifts
+		data.V1.TemporarySchedules[i] = tmp
+	}
+
 	return data.V1.TemporarySchedules, nil
 }
 

--- a/schedule/storefixedshifts.go
+++ b/schedule/storefixedshifts.go
@@ -79,6 +79,7 @@ func (store *Store) FixedShiftGroups(ctx context.Context, tx *sql.Tx, scheduleID
 	}
 	defer check.Done()
 
+	// omit shifts for non-existant users
 	for i, tmp := range data.V1.TemporarySchedules {
 		shifts := tmp.Shifts[:0]
 		for _, shift := range tmp.Shifts {

--- a/schedule/storefixedshifts.go
+++ b/schedule/storefixedshifts.go
@@ -25,7 +25,6 @@ func (store *Store) validateShifts(ctx context.Context, fname string, max int, s
 	if err != nil {
 		return err
 	}
-	defer check.Done()
 
 	for i, s := range shifts {
 		err := validate.UUID(fmt.Sprintf("%s[%d].UserID", fname, i), s.UserID)
@@ -77,7 +76,6 @@ func (store *Store) FixedShiftGroups(ctx context.Context, tx *sql.Tx, scheduleID
 	if err != nil {
 		return nil, err
 	}
-	defer check.Done()
 
 	// omit shifts for non-existant users
 	for i, tmp := range data.V1.TemporarySchedules {

--- a/smoketest/fixedshifts_test.go
+++ b/smoketest/fixedshifts_test.go
@@ -72,6 +72,7 @@ func TestFixedShifts(t *testing.T) {
 		end: "9999-08-24T21:03:54Z",
 		shifts: [{start: "0001-08-24T21:03:54Z", end: "9998-08-24T21:03:54Z", userID: "%s"}]
 	})}`, h.UUID("sched"), h.UUID("alt-user")))
+	h.Trigger()
 
 	h.Escalate(1, 0)
 
@@ -82,6 +83,7 @@ func TestFixedShifts(t *testing.T) {
 		start: "0000-08-24T21:03:54Z",
 		end: "9999-08-24T21:03:54Z"
 	})}`, h.UUID("sched")))
+	h.Trigger()
 
 	h.Escalate(1, 0)
 

--- a/user/cache.go
+++ b/user/cache.go
@@ -73,7 +73,7 @@ func (db *DB) userExistMap(ctx context.Context) (map[uuid.UUID]struct{}, error) 
 		return m, nil
 	}
 
-	var ids []uuid.UUID
+	ids := make([]uuid.UUID, (len(data)-sha256.Size)/16)
 	err = binary.Read(bytes.NewReader(data[sha256.Size:]), binary.BigEndian, &ids)
 	if err != nil {
 		db.userExist <- m
@@ -83,7 +83,6 @@ func (db *DB) userExistMap(ctx context.Context) (map[uuid.UUID]struct{}, error) 
 	for k := range m {
 		delete(m, k)
 	}
-
 	for _, id := range ids {
 		m[id] = struct{}{}
 	}

--- a/user/cache.go
+++ b/user/cache.go
@@ -92,11 +92,6 @@ func (db *DB) userExistMap(ctx context.Context) (map[uuid.UUID]struct{}, error) 
 	return m, nil
 }
 
-type userIDData struct {
-	Hash [sha256.Size]byte
-	IDs  []uuid.UUID
-}
-
 func (db *DB) currentUserIDs(ctx context.Context) (result []byte, err error) {
 	rows, err := db.ids.QueryContext(ctx)
 	if err != nil {

--- a/user/cache.go
+++ b/user/cache.go
@@ -1,0 +1,139 @@
+package user
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"strings"
+	"time"
+
+	"github.com/golang/groupcache"
+	uuid "github.com/satori/go.uuid"
+	"github.com/target/goalert/permission"
+)
+
+func timeKey(key string, dur time.Duration) string {
+	return key + "\n" + time.Now().Round(dur).Format(time.RFC3339)
+}
+func keyName(keyWithTime string) string {
+	return strings.SplitN(keyWithTime, "\n", 2)[0]
+}
+
+// ExistanceChecker allows checking if various users exist. Done must be called when finished.
+type ExistanceChecker interface {
+	UserExistsString(id string) bool
+	UserExistsUUID(id uuid.UUID) bool
+	Done()
+}
+
+type checker struct {
+	m  map[uuid.UUID]struct{}
+	ch chan map[uuid.UUID]struct{}
+}
+
+func (c *checker) UserExistsString(id string) bool { return c.UserExistsUUID(uuid.FromStringOrNil(id)) }
+func (c *checker) UserExistsUUID(id uuid.UUID) bool {
+	_, ok := c.m[id]
+	return ok
+}
+func (c *checker) Done() {
+	if c.m == nil {
+		return
+	}
+	c.ch <- c.m
+	c.m = nil
+}
+
+// UserExists returns an ExistanceChecker.
+func (db *DB) UserExists(ctx context.Context) (ExistanceChecker, error) {
+	err := permission.LimitCheckAny(ctx)
+	if err != nil {
+		return nil, err
+	}
+	m, err := db.userExistMap(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &checker{
+		m:  m,
+		ch: db.userExist,
+	}, nil
+}
+
+func (db *DB) userExistMap(ctx context.Context) (map[uuid.UUID]struct{}, error) {
+	var data []byte
+	err := db.grp.Get(ctx, timeKey("userIDs", time.Minute), groupcache.AllocatingByteSliceSink(&data))
+	if err != nil {
+		return nil, err
+	}
+
+	var idData userIDData
+	err = binary.Read(bytes.NewReader(data), binary.BigEndian, &idData)
+	if err != nil {
+		return nil, err
+	}
+
+	m := <-db.userExist
+
+	if bytes.Equal(idData.Hash[:], db.userExistHash) {
+		return m, nil
+	}
+
+	for k := range m {
+		delete(m, k)
+	}
+
+	for _, id := range idData.IDs {
+		m[id] = struct{}{}
+	}
+	db.userExistHash = idData.Hash[:]
+
+	return m, nil
+}
+
+type userIDData struct {
+	Hash [sha256.Size]byte
+	IDs  []uuid.UUID
+}
+
+func (db *DB) currentUserIDs(ctx context.Context) (result []byte, err error) {
+	rows, err := db.ids.QueryContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var data userIDData
+	sum := sha256.New()
+	for rows.Next() {
+		var id uuid.UUID
+		err = rows.Scan(&id)
+		if err != nil {
+			return nil, err
+		}
+		sum.Write(id[:])
+		data.IDs = append(data.IDs, id)
+	}
+	sum.Sum(data.Hash[:0])
+
+	buf := bytes.NewBuffer(nil)
+	err = binary.Write(buf, binary.BigEndian, data)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (db *DB) cacheGet(ctx context.Context, key string, dest groupcache.Sink) error {
+	switch keyName(key) {
+	case "userIDs":
+		data, err := db.currentUserIDs(ctx)
+		if err != nil {
+			return err
+		}
+		return dest.SetBytes(data)
+	}
+	return nil
+}

--- a/user/store.go
+++ b/user/store.go
@@ -153,7 +153,7 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 		return nil, p.Err
 	}
 
-	store.userExist <- make(map[uuid.UUID]struct{}, 5000)
+	store.userExist <- make(map[uuid.UUID]struct{})
 
 	store.grp = groupcache.NewGroup(fmt.Sprintf("user.store[%d]", atomic.AddInt64(&grpN, 1)), 1024*1024, groupcache.GetterFunc(store.cacheGet))
 

--- a/user/store.go
+++ b/user/store.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sync/atomic"
+
+	"github.com/golang/groupcache"
+	uuid "github.com/satori/go.uuid"
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/util"
 	"github.com/target/goalert/util/sqlutil"
@@ -24,6 +28,8 @@ type Store interface {
 	FindMany(context.Context, []string) ([]User, error)
 	Search(context.Context, *SearchOptions) ([]User, error)
 
+	UserExists(context.Context) (ExistanceChecker, error)
+
 	AddAuthSubjectTx(ctx context.Context, tx *sql.Tx, a *AuthSubject) error
 	DeleteAuthSubjectTx(ctx context.Context, tx *sql.Tx, a *AuthSubject) error
 	FindAllAuthSubjectsForUser(ctx context.Context, userID string) ([]AuthSubject, error)
@@ -35,6 +41,8 @@ var _ Store = &DB{}
 // DB implements the Store against a *sql.DB backend.
 type DB struct {
 	db *sql.DB
+
+	ids *sql.Stmt
 
 	insert  *sql.Stmt
 	update  *sql.Stmt
@@ -51,13 +59,24 @@ type DB struct {
 	deleteUserAuthSubject *sql.Stmt
 
 	findAuthSubjectsByUser *sql.Stmt
+
+	grp *groupcache.Group
+
+	userExistHash []byte
+	userExist     chan map[uuid.UUID]struct{}
 }
+
+var grpN int64
 
 // NewDB will create a DB backend from a sql.DB. An error will be returned if statements fail to prepare.
 func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 	p := &util.Prepare{DB: db, Ctx: ctx}
-	return &DB{
+	store := &DB{
 		db: db,
+
+		userExist: make(chan map[uuid.UUID]struct{}, 1),
+
+		ids: p.P(`SELECT id FROM users`),
 
 		insert: p.P(`
 			INSERT INTO users (
@@ -129,7 +148,16 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 				provider_id = $2 AND 
 				subject_id = $3
 		`),
-	}, p.Err
+	}
+	if p.Err != nil {
+		return nil, p.Err
+	}
+
+	store.userExist <- make(map[uuid.UUID]struct{}, 5000)
+
+	store.grp = groupcache.NewGroup(fmt.Sprintf("user.store[%d]", atomic.AddInt64(&grpN, 1)), 1024*1024, groupcache.GetterFunc(store.cacheGet))
+
+	return store, nil
 }
 
 func (db *DB) DeleteManyTx(ctx context.Context, tx *sql.Tx, ids []string) error {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adds a cached list of valid user IDs for validating fixed shift data. The IDs are currently refreshed once per minute.

It uses the groupcache package, meaning future work can allow a single call for user IDs within an entire cluster (rather than per instance).

It also fixes an issue where invalid user IDs within fixed shift data would cause the engine to abort due to the on-call insert failing.

