### PR TITLE
setFixedShifts: validate time ranges strictly

### DIFF
--- a/schedule/validate.go
+++ b/schedule/validate.go
@@ -1,0 +1,63 @@
+package schedule
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/target/goalert/validation"
+	"github.com/target/goalert/validation/validate"
+)
+
+func validateTimeRange(prefix string, start, end time.Time) error {
+	if !end.After(start) {
+		return validation.NewFieldError(prefix+"End", fmt.Sprintf("must be after %sStart", prefix))
+	}
+
+	return nil
+}
+func validateWithinTimeRange(tPrefix, prefix string, tStart, tEnd, start, end time.Time) error {
+	if tStart.Before(start) {
+		return validation.NewFieldError(tPrefix+"Start", fmt.Sprintf("must not be before %sStart", prefix))
+	}
+	if !tStart.Before(end) {
+		return validation.NewFieldError(tPrefix+"Start", fmt.Sprintf("must be before %sEnd", prefix))
+	}
+	if !tEnd.After(start) {
+		return validation.NewFieldError(tPrefix+"End", fmt.Sprintf("must be after %sStart", prefix))
+	}
+	if tEnd.After(end) {
+		return validation.NewFieldError(tPrefix+"End", fmt.Sprintf("must not be after %sEnd", prefix))
+	}
+
+	return nil
+}
+
+func (store *Store) validateShifts(ctx context.Context, fname string, max int, shifts []FixedShift, start, end time.Time) error {
+	if len(shifts) > max {
+		return validation.NewFieldError(fname, "too many shifts defined")
+	}
+
+	check, err := store.usr.UserExists(ctx)
+	if err != nil {
+		return err
+	}
+
+	for i, s := range shifts {
+		prefix := fmt.Sprintf("%s[%d].", fname, i)
+
+		err := validate.Many(
+			validate.UUID(prefix+"UserID", s.UserID),
+			validateTimeRange(prefix, s.Start, s.End),
+			validateWithinTimeRange(prefix, "", s.Start, s.End, start, end),
+		)
+		if err != nil {
+			return err
+		}
+		if !check.UserExistsString(s.UserID) {
+			return validation.NewFieldError(prefix+"UserID", "user does not exist")
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR updates the validation on the setFixedShifts mutation to require time ranges and values to be correct. Previously all values would be merged together and the resulting output would be cleaned/normalized and then used.

This change ensures that UI bugs or invalid API calls return with an error rather than accepted as best-effort for this mutation.