### PR TITLE
engine/messages: track first-alert by destination type

### DIFF
--- a/engine/message/queue_test.go
+++ b/engine/message/queue_test.go
@@ -18,10 +18,11 @@ func TestQueue_Sort(t *testing.T) {
 		Sent:
 		- Test to User C
 		- Verify to User H (< 60 seconds ago)
+		- Alert to Slack for Service B
 
 		Pending:
 		- Alert to User A, Service A (first alert)
-		- Alert to User E, Service B (created 2nd)
+		- Alert to User E, Service B (created 2nd -- SMS so Slack doesn't affect first alert status)
 		- Alert to User H, Service C (created 3nd) -- Not sent, user H already notified
 		- Verify to User F
 		- Verify to User A -- Not sent, (will get an alert for Service A)
@@ -50,6 +51,12 @@ func TestQueue_Sort(t *testing.T) {
 			UserID: "User H",
 			Dest:   notification.Dest{Type: notification.DestTypeSMS, ID: "SMS H"},
 			SentAt: n.Add(-30 * time.Second),
+		},
+		{
+			Type:      TypeAlertNotification,
+			ServiceID: "Service B",
+			Dest:      notification.Dest{Type: notification.DestTypeSlackChannel, ID: "Slack B"},
+			SentAt:    n.Add(-30 * time.Second),
 		},
 
 		// Pending


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR updates the priority message sorting to track first-alert status per-destination-type. This is intended to prevent issues where contact methods with high throughput, but potentially low visibility (e.g. email) from de-prioritizing someone getting say a phone call or text before other services are notified using those methods.

**Additional Context**
GoAlert will prioritize the first alert notification to a service above all others, if the service has had no outgoing notifications within the last 2 minutes. This is intended to "guarantee" that at least one on-call user of a service will receive at least one notification for at least one alert when/if the system is at total capacity for sending messages.

As an example, SMS and VOICE calls are allowed by Twilio at a rate of 1 per second. When there are more notifications pending than this limit, prioritization is used to decide which notifications are the most critical to keep things flowing.

With this change the first-alert priority will be segmented per type, meaning an on-call user for a service should receive at least 1 SMS message, before another service gets a second SMS -- even if the first service had a user notified by phone call, email, Slack, etc..
