### PR TITLE
session migration: set last access time

### DIFF
--- a/migrate/inline_data_gen.go
+++ b/migrate/inline_data_gen.go
@@ -589,8 +589,8 @@ K3t-dTtBCQEEFY95UcyLeYLe3V5N36DJzc3F7HIyTvIPRf4x_bSolvwMKlb7sQ82inYyQn8kqVfZ4zj5
 29-a-jju3zCCxvUbu31rGcjAxq_0YyXztUYNZQQSzPo6zhPmED-fQoGwUNTGNdndQIDXNrox8kZJXeni
 Zmrc8U6E0VFafOtiXlapyZcP_uD4bg41B5LuuF4V20yEXXg3v1aTsq-U2_T9ynm9J-u6wmUUu805Bm6V
 ldlDUe_vS7HYbetZsZqL9LNUqzRfpdvFqki3xWZLPddf0sX80eJqMf3W0v5reAJs98nmlxiXhxfe5itu
-cu6-8Ppt7FU2tsOKxoZBEqSPS2ljqu0l_WorsHF5hKrWW1VVdu9rlZVZ3mUFd0-WUML3FjXy8b5DyRsG
--P8PAAD__6bRMP4ePQQA
+cu6-8Ppt7FU2tsOKxoZBEqSPS2ljqu0l_WorsHF5hKrWrV4mgMsIn7e0uo2ZZDiFW_vIz3VBzZevDDQ7
+MnO8rArvyRJKIt-iRj4ueSh5wyr__wEAAP__oEPyB3I9BAA=
 `
 	dataRange := func(start, end int) func() []byte {
 		return func() []byte {
@@ -606,7 +606,7 @@ cu6-8Ppt7FU2tsOKxoZBEqSPS2ljqu0l_WorsHF5hKrWW1VVdu9rlZVZ3mUFd0-WUML3FjXy8b5DyRsG
 				defer r.Close()
 
 				buf := new(bytes.Buffer)
-				buf.Grow(46515)
+				buf.Grow(46543)
 
 				_, err = io.Copy(buf, r)
 				if err != nil {
@@ -820,6 +820,6 @@ cu6-8Ppt7FU2tsOKxoZBEqSPS2ljqu0l_WorsHF5hKrWW1VVdu9rlZVZ3mUFd0-WUML3FjXy8b5DyRsG
 		{Data: dataRange(276825, 277098), Name: "migrations/20200716212352-prometheus-alertmanager-integration.sql"},
 		{Data: dataRange(277098, 277334), Name: "migrations/20200805132936-test-verify-index.sql"},
 		{Data: dataRange(277334, 277505), Name: "migrations/20200908095243-session-access-time.sql"},
-		{Data: dataRange(277505, 277790), Name: "migrations/20200922140909-session-last-access-time.sql"},
+		{Data: dataRange(277505, 277874), Name: "migrations/20200922140909-session-last-access-time.sql"},
 	}
 }

--- a/migrate/migrations/20200922140909-session-last-access-time.sql
+++ b/migrate/migrations/20200922140909-session-last-access-time.sql
@@ -1,4 +1,7 @@
 -- +migrate Up
+
+UPDATE auth_user_sessions SET last_access_at = now() WHERE last_access_at ISNULL;
+
 ALTER TABLE auth_user_sessions
     ALTER COLUMN last_access_at SET DEFAULT now(),
     ALTER COLUMN last_access_at SET NOT NULL;


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes an issue with a recent migration that fails to apply when there are old user sessions missing access times.