### PR TITLE
ui: address warnings when using material select dropdowns

### DIFF
--- a/web/src/app/selection/MaterialSelect.tsx
+++ b/web/src/app/selection/MaterialSelect.tsx
@@ -74,7 +74,7 @@ interface MultiSelectProps {
 
 export default function MaterialSelect(
   props: CommonSelectProps & (MultiSelectProps | SingleSelectProps),
-) {
+): JSX.Element {
   const classes = useStyles()
   const {
     disabled,
@@ -92,7 +92,7 @@ export default function MaterialSelect(
     value,
   } = props
 
-  const getLabel = () =>
+  const getLabel = (): string =>
     Array.isArray(value) ? value[0]?.label ?? '' : value?.label ?? ''
 
   const [inputValue, setInputValue] = useState(getLabel())


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR address various warnings seen while using `MaterialSelect` around interface types of incoming props, and the current selected value matching what's in the options array now that strict validation has been added within the library.