### PR TITLE
user: non-admin viewing other user's profile pages fix

### DIFF
--- a/web/src/app/users/UserDetails.js
+++ b/web/src/app/users/UserDetails.js
@@ -21,32 +21,6 @@ import { GenericError, ObjectNotFound } from '../error-pages'
 import { useConfigValue, useSessionInfo } from '../util/RequireConfig'
 import { AppLink } from '../util/AppLink'
 
-const query = gql`
-  query userInfo($id: ID!) {
-    user(id: $id) {
-      id
-      name
-      email
-      contactMethods {
-        id
-      }
-      onCallSteps {
-        id
-        escalationPolicy {
-          id
-          assignedTo {
-            id
-            name
-          }
-        }
-      }
-      sessions {
-        id
-      }
-    }
-  }
-`
-
 const useStyles = makeStyles({
   gravatarText: {
     textAlign: 'center',
@@ -72,6 +46,55 @@ function serviceCount(onCallSteps = []) {
 }
 
 export default function UserDetails(props) {
+  const userQuery = gql`
+    query userInfo($id: ID!) {
+      user(id: $id) {
+        id
+        name
+        email
+        contactMethods {
+          id
+        }
+        onCallSteps {
+          id
+          escalationPolicy {
+            id
+            assignedTo {
+              id
+              name
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const sessionsQuery = gql`
+    query userInfo($id: ID!) {
+      user(id: $id) {
+        id
+        name
+        email
+        contactMethods {
+          id
+        }
+        onCallSteps {
+          id
+          escalationPolicy {
+            id
+            assignedTo {
+              id
+              name
+            }
+          }
+        }
+        sessions {
+          id
+        }
+      }
+    }
+  `
+
   const classes = useStyles()
 
   const { userID: currentUserID, isAdmin } = useSessionInfo()
@@ -80,16 +103,19 @@ export default function UserDetails(props) {
   const [createNR, setCreateNR] = useState(false)
   const [showVerifyDialogByID, setShowVerifyDialogByID] = useState(null)
 
-  const { data, loading, error } = useQuery(query, {
-    variables: { id: props.userID },
-  })
+  const { data, loading, error } = useQuery(
+    props.readOnly ? userQuery : sessionsQuery,
+    {
+      variables: { id: props.userID },
+    },
+  )
 
   if (error) return <GenericError error={error.message} />
   if (!_.get(data, 'user.id')) return loading ? <Spinner /> : <ObjectNotFound />
 
   const user = _.get(data, 'user')
   const svcCount = serviceCount(user.onCallSteps)
-  const sessCount = user.sessions.length
+  const sessCount = props.readOnly ? 0 : user.sessions.length
 
   const disableNR = user.contactMethods.length === 0
 

--- a/web/src/app/users/UserDetails.js
+++ b/web/src/app/users/UserDetails.js
@@ -44,8 +44,8 @@ const userQuery = gql`
   }
 `
 
-const sessionsQuery = gql`
-  query userInfo($id: ID!) {
+const profileQuery = gql`
+  query profileInfo($id: ID!) {
     user(id: $id) {
       id
       name
@@ -104,7 +104,7 @@ export default function UserDetails(props) {
   const [showVerifyDialogByID, setShowVerifyDialogByID] = useState(null)
 
   const { data, loading, error } = useQuery(
-    props.readOnly ? userQuery : sessionsQuery,
+    props.readOnly ? userQuery : profileQuery,
     {
       variables: { id: props.userID },
     },

--- a/web/src/app/users/UserDetails.js
+++ b/web/src/app/users/UserDetails.js
@@ -104,7 +104,7 @@ export default function UserDetails(props) {
   const [showVerifyDialogByID, setShowVerifyDialogByID] = useState(null)
 
   const { data, loading, error } = useQuery(
-    props.readOnly ? userQuery : profileQuery,
+    isAdmin || props.userID === currentUserID ? profileQuery : userQuery,
     {
       variables: { id: props.userID },
     },
@@ -115,7 +115,8 @@ export default function UserDetails(props) {
 
   const user = _.get(data, 'user')
   const svcCount = serviceCount(user.onCallSteps)
-  const sessCount = props.readOnly ? 0 : user.sessions.length
+  const sessCount =
+    isAdmin || props.userID === currentUserID ? user.sessions.length : 0
 
   const disableNR = user.contactMethods.length === 0
 

--- a/web/src/app/users/UserDetails.js
+++ b/web/src/app/users/UserDetails.js
@@ -21,6 +21,55 @@ import { GenericError, ObjectNotFound } from '../error-pages'
 import { useConfigValue, useSessionInfo } from '../util/RequireConfig'
 import { AppLink } from '../util/AppLink'
 
+const userQuery = gql`
+  query userInfo($id: ID!) {
+    user(id: $id) {
+      id
+      name
+      email
+      contactMethods {
+        id
+      }
+      onCallSteps {
+        id
+        escalationPolicy {
+          id
+          assignedTo {
+            id
+            name
+          }
+        }
+      }
+    }
+  }
+`
+
+const sessionsQuery = gql`
+  query userInfo($id: ID!) {
+    user(id: $id) {
+      id
+      name
+      email
+      contactMethods {
+        id
+      }
+      onCallSteps {
+        id
+        escalationPolicy {
+          id
+          assignedTo {
+            id
+            name
+          }
+        }
+      }
+      sessions {
+        id
+      }
+    }
+  }
+`
+
 const useStyles = makeStyles({
   gravatarText: {
     textAlign: 'center',
@@ -46,55 +95,6 @@ function serviceCount(onCallSteps = []) {
 }
 
 export default function UserDetails(props) {
-  const userQuery = gql`
-    query userInfo($id: ID!) {
-      user(id: $id) {
-        id
-        name
-        email
-        contactMethods {
-          id
-        }
-        onCallSteps {
-          id
-          escalationPolicy {
-            id
-            assignedTo {
-              id
-              name
-            }
-          }
-        }
-      }
-    }
-  `
-
-  const sessionsQuery = gql`
-    query userInfo($id: ID!) {
-      user(id: $id) {
-        id
-        name
-        email
-        contactMethods {
-          id
-        }
-        onCallSteps {
-          id
-          escalationPolicy {
-            id
-            assignedTo {
-              id
-              name
-            }
-          }
-        }
-        sessions {
-          id
-        }
-      }
-    }
-  `
-
   const classes = useStyles()
 
   const { userID: currentUserID, isAdmin } = useSessionInfo()


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR includes a fix so that `non-admin` users (that have the role of `user`) can view other user's profile pages.

**Which issue(s) this PR fixes:**
Fixes #905 
This PR fixes a bug where users who were not admins were not able to view other user's profile pages. The backend returns an `access denied` error when non-admins tried to view other user's profile pages (from the graphql query for user -> sessions). The front-end query has now been modified to only query for sessions if it's the logged in user or an admin. Else it will not query for sessions info.
