### PR TITLE
active sessions: change ordering to descending

### DIFF
--- a/web/src/app/users/UserSessionList.tsx
+++ b/web/src/app/users/UserSessionList.tsx
@@ -111,7 +111,7 @@ export default function UserSessionList(
   const sessions: UserSession[] = _.sortBy(
     data?.user?.sessions || [],
     (s: UserSession) => (s.current ? '_' + s.lastAccessAt : s.lastAccessAt),
-  )
+  ).reverse()
 
   const [logoutOne, logoutOneStatus] = useMutation(mutationLogoutOne, {
     variables: { id: (endSession as Session)?.id },


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR changes the ordering of active sessions to use descending order (last access time).  This places your active session on top and your most recently used sessions near the top (instead of the bottom).

**Which issue(s) this PR fixes:**
Fixes #906 

**Screenshots:**
![image](https://user-images.githubusercontent.com/23565500/94733179-fd6aa080-032c-11eb-8de3-b40d0f9632dc.png)

