### PR TITLE
engine/escalationmanager: fix regression in escalation logs

### DIFF
--- a/app/tracing.go
+++ b/app/tracing.go
@@ -17,7 +17,8 @@ func configTracing(ctx context.Context, c Config) ([]trace.Exporter, error) {
 	var exporters []trace.Exporter
 	if c.JaegerEndpoint != "" || c.JaegerAgentEndpoint != "" {
 		exporter, err := jaeger.NewExporter(jaeger.Options{
-			Endpoint:      c.JaegerEndpoint,
+			CollectorEndpoint: c.JaegerEndpoint + "/api/traces",
+
 			AgentEndpoint: c.JaegerAgentEndpoint,
 			ServiceName:   "goalert",
 		})

--- a/devtools/runjson/localdev.json
+++ b/devtools/runjson/localdev.json
@@ -17,7 +17,8 @@
       "-l=localhost:3030",
       "--ui-url=http://localhost:3035",
       "--jaeger-endpoint=http://localhost:14268",
-      "--db-url=postgres://goalert@localhost:5432/goalert?sslmode=disable"
+      "--db-url=postgres://goalert@localhost:5432/goalert?sslmode=disable",
+      "--tracing-probability=1"
     ],
     "Restart": true,
     "IgnoreErrors": true,

--- a/engine/escalationmanager/db.go
+++ b/engine/escalationmanager/db.go
@@ -146,8 +146,8 @@ func NewDB(ctx context.Context, db *sql.DB, log alertlog.Store) (*DB, error) {
 			)
 			select distinct esc.alert_id, step isnull and chan isnull
 			from to_escalate esc
-			left join _step_cycles step on step.ep_step_id = esc.ep_step_id
-			left join _step_channels chan on chan.ep_step_id = esc.ep_step_id
+			left join _step_cycles step on step.alert_id = esc.alert_id
+			left join _step_channels chan on chan.alert_id = esc.alert_id
 		`),
 
 		deletedSteps: p.P(`
@@ -220,8 +220,8 @@ func NewDB(ctx context.Context, db *sql.DB, log alertlog.Store) (*DB, error) {
 			)
 			select distinct esc.alert_id, esc.repeated, esc.step_number, step isnull and chan isnull
 			from to_escalate esc
-			left join _step_cycles step on step.ep_step_id = esc.ep_step_id
-			left join _step_channels chan on chan.ep_step_id = esc.ep_step_id
+			left join _step_cycles step on step.alert_id = esc.alert_id
+			left join _step_channels chan on chan.alert_id = esc.alert_id
 		`),
 		normalEscalation: p.P(`
 			with to_escalate as (
@@ -302,8 +302,8 @@ func NewDB(ctx context.Context, db *sql.DB, log alertlog.Store) (*DB, error) {
 			)
 			select distinct esc.alert_id, esc.repeated, esc.step_number, esc.old_delay, esc.forced, step isnull and chan isnull
 			from to_escalate esc
-			left join _step_cycles step on step.ep_step_id = esc.ep_step_id
-			left join _step_channels chan on chan.ep_step_id = esc.ep_step_id
+			left join _step_cycles step on step.alert_id = esc.alert_id
+			left join _step_channels chan on chan.alert_id = esc.alert_id
 		`),
 	}, p.Err
 }

--- a/engine/escalationmanager/db.go
+++ b/engine/escalationmanager/db.go
@@ -144,7 +144,7 @@ func NewDB(ctx context.Context, db *sql.DB, log alertlog.Store) (*DB, error) {
 				where
 					state.alert_id = esc.alert_id
 			)
-			select esc.alert_id, step isnull and chan isnull
+			select distinct esc.alert_id, step isnull and chan isnull
 			from to_escalate esc
 			left join _step_cycles step on step.ep_step_id = esc.ep_step_id
 			left join _step_channels chan on chan.ep_step_id = esc.ep_step_id
@@ -218,7 +218,7 @@ func NewDB(ctx context.Context, db *sql.DB, log alertlog.Store) (*DB, error) {
 				where
 					state.alert_id = esc.alert_id
 			)
-			select esc.alert_id, esc.repeated, esc.step_number, step isnull and chan isnull
+			select distinct esc.alert_id, esc.repeated, esc.step_number, step isnull and chan isnull
 			from to_escalate esc
 			left join _step_cycles step on step.ep_step_id = esc.ep_step_id
 			left join _step_channels chan on chan.ep_step_id = esc.ep_step_id
@@ -300,7 +300,7 @@ func NewDB(ctx context.Context, db *sql.DB, log alertlog.Store) (*DB, error) {
 				where
 					state.alert_id = esc.alert_id
 			)
-			select esc.alert_id, esc.repeated, esc.step_number, esc.old_delay, esc.forced, step isnull and chan isnull
+			select distinct esc.alert_id, esc.repeated, esc.step_number, esc.old_delay, esc.forced, step isnull and chan isnull
 			from to_escalate esc
 			left join _step_cycles step on step.ep_step_id = esc.ep_step_id
 			left join _step_channels chan on chan.ep_step_id = esc.ep_step_id


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR addresses some problems/regressions with the escalation manager:
- When multiple users are on call, or multiple alerts are escalated on the same policy, multiple logs were added
- It was multiplicative (e.g. 27 alerts = 27x27=729 entries) causing cycle timeouts
- Log entries were sent one-at-a-time, they are now batched with like-metadata in a single call of alert ids
- Part of debugging led to fixing local tracing with jaeger in `make start`

**Which issue(s) this PR fixes:**
Fixes #912 

