### PR TITLE
material select: set empty input when multiple is true

### DIFF
--- a/web/src/app/selection/MaterialSelect.tsx
+++ b/web/src/app/selection/MaterialSelect.tsx
@@ -95,11 +95,12 @@ export default function MaterialSelect(
   const getLabel = (): string =>
     Array.isArray(value) ? value[0]?.label ?? '' : value?.label ?? ''
 
-  const [inputValue, setInputValue] = useState(getLabel())
+  const [inputValue, setInputValue] = useState(multiple ? '' : getLabel())
   useEffect(() => {
+    if (multiple) return
     if (!value) setInputValue('')
     if (!inputValue && value) setInputValue(getLabel())
-  }, [value])
+  }, [value, multiple])
 
   const multi = multiple ? { multiple: true } : {}
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes a regression that caused the search text to be set in MaterialSelect fields when in multi-selection mode.

**Which issue(s) this PR fixes:**
Fixes #911 
