### PR TITLE
material select: fix onBlur handler

### DIFF
--- a/web/src/app/selection/MaterialSelect.tsx
+++ b/web/src/app/selection/MaterialSelect.tsx
@@ -151,7 +151,7 @@ export default function MaterialSelect(
           setInputValue('')
         }
       }}
-      onBlur={getLabel}
+      onBlur={() => setInputValue(multiple || !value ? '' : getLabel())}
       loading={isLoading}
       getOptionLabel={(option) => option?.label ?? ''}
       options={options}

--- a/web/src/app/selection/MaterialSelect.tsx
+++ b/web/src/app/selection/MaterialSelect.tsx
@@ -85,21 +85,30 @@ export default function MaterialSelect(
     name,
     noOptionsText,
     onChange,
-    onInputChange,
+    onInputChange = () => {},
     options: _options,
     placeholder,
     required,
     value,
   } = props
 
-  const getLabel = (): string =>
-    Array.isArray(value) ? value[0]?.label ?? '' : value?.label ?? ''
+  // getInputLabel will return the label of the current value.
+  //
+  // If in multi-select mode an empty string is always returned as selected values
+  // are never preserved in the input field (they are chips instead).
+  const getInputLabel = (): string =>
+    multiple || Array.isArray(value) ? '' : value?.label || ''
 
-  const [inputValue, setInputValue] = useState(multiple ? '' : getLabel())
+  const [inputValue, _setInputValue] = useState(getInputLabel())
+
+  const setInputValue = (input: string) => {
+    _setInputValue(input)
+    onInputChange(input)
+  }
   useEffect(() => {
     if (multiple) return
     if (!value) setInputValue('')
-    if (!inputValue && value) setInputValue(getLabel())
+    if (!inputValue && value) setInputValue(getInputLabel())
   }, [value, multiple])
 
   const multi = multiple ? { multiple: true } : {}
@@ -151,7 +160,7 @@ export default function MaterialSelect(
           setInputValue('')
         }
       }}
-      onBlur={() => setInputValue(multiple || !value ? '' : getLabel())}
+      onBlur={() => setInputValue(getInputLabel())}
       loading={isLoading}
       getOptionLabel={(option) => option?.label ?? ''}
       options={options}

--- a/web/src/app/selection/MaterialSelect.tsx
+++ b/web/src/app/selection/MaterialSelect.tsx
@@ -185,7 +185,6 @@ export default function MaterialSelect(
             onChange={({ target }) => {
               const newInputVal: string = target.value
               setInputValue(newInputVal)
-              if (onInputChange) onInputChange(newInputVal)
             }}
             error={error}
           />

--- a/web/src/app/selection/MaterialSelect.tsx
+++ b/web/src/app/selection/MaterialSelect.tsx
@@ -101,7 +101,7 @@ export default function MaterialSelect(
 
   const [inputValue, _setInputValue] = useState(getInputLabel())
 
-  const setInputValue = (input: string) => {
+  const setInputValue = (input: string): void => {
     _setInputValue(input)
     onInputChange(input)
   }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR addresses a recent regression where the onBlur handler for material selects no longer worked properly.

**Which issue(s) this PR fixes:**
Fixes #920 
