### PR TITLE
dev: fix `goimports` command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,10 +198,10 @@ migrate/inline_data_gen.go: migrate/migrations migrate/migrations/*.sql $(INLINE
 	go generate ./migrate
 
 graphql2/mapconfig.go: $(CFGPARAMS) config/config.go graphql2/generated.go devtools/configparams/main.go
-	(cd ./graphql2 && go run ../devtools/configparams/main.go -out mapconfig.go && goimports -w ./mapconfig.go) || go generate ./graphql2
+	(cd ./graphql2 && go run ../devtools/configparams/main.go -out mapconfig.go && go run golang.org/x/tools/cmd/goimports -w ./mapconfig.go) || go generate ./graphql2
 
 graphql2/maplimit.go: $(CFGPARAMS) limit/id.go graphql2/generated.go devtools/limitapigen/main.go
-	(cd ./graphql2 && go run ../devtools/limitapigen/main.go -out maplimit.go && goimports -w ./maplimit.go) || go generate ./graphql2
+	(cd ./graphql2 && go run ../devtools/limitapigen/main.go -out maplimit.go && go run golang.org/x/tools/cmd/goimports -w ./maplimit.go) || go generate ./graphql2
 
 graphql2/generated.go: graphql2/schema.graphql graphql2/gqlgen.yml go.mod
 	go generate ./graphql2


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Updates the make file to use `go run golang.org/x/tools/cmd/goimports` instead of executing `goimports` directly.

Using `go run ...` will automatically pull the tool, as well as using the correct version, rather than requiring the user to install it manually.