### PR TITLE
mailgun: address validation fix

### DIFF
--- a/mailgun/mailgun.go
+++ b/mailgun/mailgun.go
@@ -39,11 +39,11 @@ func httpError(ctx context.Context, w http.ResponseWriter, err error) bool {
 		return false
 	}
 
-	type clientErr interface {
+	var clientErr interface {
 		ClientError() bool
 	}
 
-	if e, ok := err.(clientErr); ok && e.ClientError() {
+	if errors.As(err, &clientErr) && clientErr.ClientError() {
 		log.Debug(ctx, err)
 		http.Error(w, err.Error(), http.StatusNotAcceptable)
 		return true

--- a/smoketest/mailgunalerts_test.go
+++ b/smoketest/mailgunalerts_test.go
@@ -90,6 +90,15 @@ func TestMailgunAlerts(t *testing.T) {
 
 	h.Twilio(t).Device(h.Phone("1")).ExpectSMS("second alert")
 
+	v.Set("recipient", "w"+h.UUID("intkey")+"@"+cfg.Mailgun.EmailDomain)
+	resp, err = http.PostForm(h.URL()+"/api/v2/mailgun/incoming", v)
+	assert.Nil(t, err)
+	if !assert.Equal(t, 406, resp.StatusCode, "reject invalid address with 406 (v2 URL)") {
+		return
+	}
+	// restore
+	v.Set("recipient", h.UUID("intkey")+"@"+cfg.Mailgun.EmailDomain)
+
 	v.Set("body-plain", strings.Repeat("too big", 1<<20)) // ~7MiB
 
 	resp, err = http.PostForm(h.URL()+"/api/v2/mailgun/incoming", v)


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes an issue where an invalid recipient address would cause a `500` response instead of the expected `406` when a message is to be rejected for failing validation.

**Screenshots:**
![image](https://user-images.githubusercontent.com/595010/95886676-824db500-0d44-11eb-81d5-f65e1f2ef6ea.png)

