### PR TITLE
fix: handle empty default values in fallback datetime picker

### DIFF
--- a/web/src/app/util/ISOPickers.js
+++ b/web/src/app/util/ISOPickers.js
@@ -24,9 +24,7 @@ function useISOPicker(
   const params = useSelector(urlParamSelector)
   const zone = timeZone || params('tz', 'local')
   const dtValue = value ? DateTime.fromISO(value, { zone }) : null
-  const [inputValue, setInputValue] = useState(
-    value ? dtValue.toFormat(format) : '',
-  )
+  const [inputValue, setInputValue] = useState(dtValue?.toFormat(format) ?? '')
 
   // parseInput takes input from the form control and returns a DateTime
   // object representing the value, or null (if invalid or empty).

--- a/web/src/app/util/ISOPickers.js
+++ b/web/src/app/util/ISOPickers.js
@@ -91,7 +91,7 @@ function useISOPicker(
   const FallbackIcon = type === 'time' ? AccessTime : DateRange
   return (
     <Fallback
-      value={dtValue}
+      value={value ? dtValue : null}
       onChange={(v) => handleChange({ target: { value: v } })}
       showTodayButton
       DialogProps={{

--- a/web/src/app/util/ISOPickers.js
+++ b/web/src/app/util/ISOPickers.js
@@ -32,8 +32,9 @@ function useISOPicker(
     if (input instanceof DateTime) return input
     if (!input) return null
 
-    if (type === 'time' && !dtValue)
+    if (type === 'time' && !dtValue) {
       throw new Error('initial value is required for type=time')
+    }
 
     const dt = DateTime.fromFormat(input, format, { zone })
     if (dt.isValid) {

--- a/web/src/app/util/ISOPickers.js
+++ b/web/src/app/util/ISOPickers.js
@@ -32,10 +32,13 @@ function useISOPicker(
     if (input instanceof DateTime) return input
     if (!input) return null
 
+    if (type === 'time' && !dtValue)
+      throw new Error('initial value is required for type=time')
+
     const dt = DateTime.fromFormat(input, format, { zone })
     if (dt.isValid) {
       if (type === 'time') {
-        return DateTime.fromISO(value, { zone }).set({
+        return dtValue.set({
           hour: dt.hour,
           minute: dt.minute,
         })

--- a/web/src/app/util/ISOPickers.js
+++ b/web/src/app/util/ISOPickers.js
@@ -23,8 +23,10 @@ function useISOPicker(
   const native = hasInputSupport(type)
   const params = useSelector(urlParamSelector)
   const zone = timeZone || params('tz', 'local')
-  const dtValue = DateTime.fromISO(value, { zone })
-  const [inputValue, setInputValue] = useState(dtValue.toFormat(format))
+  const dtValue = value ? DateTime.fromISO(value, { zone }) : null
+  const [inputValue, setInputValue] = useState(
+    value ? dtValue.toFormat(format) : '',
+  )
 
   // parseInput takes input from the form control and returns a DateTime
   // object representing the value, or null (if invalid or empty).
@@ -35,7 +37,7 @@ function useISOPicker(
     const dt = DateTime.fromFormat(input, format, { zone })
     if (dt.isValid) {
       if (type === 'time') {
-        return dtValue.set({
+        return DateTime.fromISO(value, { zone }).set({
           hour: dt.hour,
           minute: dt.minute,
         })
@@ -66,7 +68,7 @@ function useISOPicker(
     const newVal = inputToISO(e.target.value)
     // Only fire the parent's `onChange` handler when we have a new valid value,
     // taking care to ensure we ignore any zonal differences.
-    if (newVal && newVal !== dtValue.toUTC().toISO()) {
+    if (newVal && newVal !== dtValue?.toUTC().toISO()) {
       onChange(newVal)
     }
   }

--- a/web/src/app/util/ISOPickers.js
+++ b/web/src/app/util/ISOPickers.js
@@ -23,18 +23,14 @@ function useISOPicker(
   const native = hasInputSupport(type)
   const params = useSelector(urlParamSelector)
   const zone = timeZone || params('tz', 'local')
-  const dtValue = value ? DateTime.fromISO(value, { zone }) : null
-  const [inputValue, setInputValue] = useState(dtValue?.toFormat(format) ?? '')
+  const dtValue = DateTime.fromISO(value, { zone })
+  const [inputValue, setInputValue] = useState(dtValue.toFormat(format))
 
   // parseInput takes input from the form control and returns a DateTime
   // object representing the value, or null (if invalid or empty).
   const parseInput = (input) => {
     if (input instanceof DateTime) return input
     if (!input) return null
-
-    if (type === 'time' && !dtValue) {
-      throw new Error('initial value is required for type=time')
-    }
 
     const dt = DateTime.fromFormat(input, format, { zone })
     if (dt.isValid) {
@@ -70,7 +66,7 @@ function useISOPicker(
     const newVal = inputToISO(e.target.value)
     // Only fire the parent's `onChange` handler when we have a new valid value,
     // taking care to ensure we ignore any zonal differences.
-    if (newVal && newVal !== dtValue?.toUTC().toISO()) {
+    if (newVal && newVal !== dtValue.toUTC().toISO()) {
       onChange(newVal)
     }
   }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [ ] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Currently, the fallback non-native datetime picker component defaults to `now` when given an empty value such as an empty string.

**Screenshots:**
<img width="614" alt="Screen Shot 2020-10-13 at 2 29 16 PM" src="https://user-images.githubusercontent.com/17692467/95912733-cce12880-0d68-11eb-94fa-a9d773195236.png">

