### PR TITLE
temp schedules: temp schedules swipe-able form bounds

### DIFF
--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -110,7 +110,14 @@ export default function TempSchedDialog({
         >
           <VirtualizeAnimatedViews
             index={step}
-            onChangeIndex={(i: number) => setStep(i)}
+            onChangeIndex={(i: number) => {
+              if (i < 0 || i > 1) return
+              if (edit) {
+                setStep(1)
+                return
+              }
+              setStep(i)
+            }}
             slideRenderer={renderSlide}
             disabled // disables slides from changing outside of action buttons
             containerStyle={{ height: '100%' }}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [ ] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Temp schedules form now has bounds to prevent swiping into empty pages, or to step 1 from an already created temp schedule.
