### PR TITLE
temp schedules: timestamp bounds validation

### DIFF
--- a/web/src/app/icons/components/Icons.js
+++ b/web/src/app/icons/components/Icons.js
@@ -28,10 +28,11 @@ export class Trash extends Component {
 export class Warning extends Component {
   static propTypes = {
     message: p.string,
+    placement: p.string,
   }
 
   render() {
-    const { classes, message } = this.props
+    const { classes, message, placement } = this.props
 
     const warningIcon = (
       <WarningIcon
@@ -46,7 +47,7 @@ export class Warning extends Component {
     }
 
     return (
-      <Tooltip title={message} placement='right'>
+      <Tooltip title={message} placement={placement || 'right'}>
         {warningIcon}
       </Tooltip>
     )

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
@@ -15,7 +15,7 @@ import TempSchedAddShiftForm from './TempSchedAddShiftForm'
 import { ScheduleTZFilter } from '../ScheduleTZFilter'
 import { DateTime, Interval } from 'luxon'
 import { FieldError } from '../../util/errutil'
-import { isAfter, isBefore } from '../../util/luxon-helpers'
+import { isISOAfter, isISOBefore } from '../../util/shifts'
 
 const useStyles = makeStyles((theme) => ({
   contentText,
@@ -152,19 +152,19 @@ export default function TempSchedAddShiftsStep({
       return result
     }
 
-    if (!isAfter(shift.end, shift?.start)) {
+    if (!isISOAfter(shift.end, shift?.start)) {
       result.push({
         field: 'end',
         message: 'must be after shift start time',
       } as FieldError)
     }
-    if (isBefore(shift.start, start)) {
+    if (isISOBefore(shift.start, start)) {
       result.push({
         field: 'start',
         message: 'must not be before temporary schedule start time',
       } as FieldError)
     }
-    if (isAfter(shift.end, end)) {
+    if (isISOAfter(shift.end, end)) {
       result.push({
         field: 'end',
         message: 'must not extend beyond temporary schedule end time',

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
@@ -15,6 +15,7 @@ import TempSchedAddShiftForm from './TempSchedAddShiftForm'
 import { ScheduleTZFilter } from '../ScheduleTZFilter'
 import { DateTime, Interval } from 'luxon'
 import { FieldError } from '../../util/errutil'
+import { isAfter, isBefore } from '../../util/luxon-helpers'
 
 const useStyles = makeStyles((theme) => ({
   contentText,
@@ -73,14 +74,6 @@ function DTToShifts(shifts: DTShift[]): Shift[] {
 
 function shiftEquals(a: Shift, b: Shift): boolean {
   return a.start === b.start && a.end === b.end && a.userID === b.userID
-}
-
-function isAfter(a: string, b: string): boolean {
-  return DateTime.fromISO(a) > DateTime.fromISO(b)
-}
-
-function isBefore(a: string, b: string): boolean {
-  return DateTime.fromISO(a) < DateTime.fromISO(b)
 }
 
 // mergeShifts will take the incoming shifts and merge them with

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -65,6 +65,7 @@ export default function TempSchedDialog({
             key={key}
             stepText='STEP 1 OF 2'
             scheduleID={scheduleID}
+            value={value}
           />
         )
       case 1:

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -10,7 +10,7 @@ import { bindKeyboard, virtualize } from 'react-swipeable-views-utils'
 import SwipeableViews from 'react-swipeable-views'
 import TempSchedAddShiftsStep from './TempSchedAddShiftsStep'
 import TempSchedTimesStep from './TempSchedTimesStep'
-import { isAfter, isBefore } from '../../util/luxon-helpers'
+import { parseInterval } from '../../util/shifts'
 // allows changing the index programatically
 const VirtualizeAnimatedViews = bindKeyboard(virtualize(SwipeableViews))
 
@@ -42,8 +42,9 @@ export default function TempSchedDialog({
     ),
   })
 
+  const schedInterval = parseInterval(value)
   const hasInvalidShift = value.shifts.some(
-    (s) => isAfter(value.start, s.start) || isBefore(value.end, s.end),
+    (s) => !schedInterval.engulfs(parseInterval(s)),
   )
 
   const shiftErrors = hasInvalidShift

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -52,6 +52,7 @@ export default function TempSchedDialog({
         {
           message:
             'One or more shifts extend beyond the start and/or end of this temporary schedule',
+          nonSubmit: step !== 1,
         },
       ]
     : []

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -10,6 +10,7 @@ import { bindKeyboard, virtualize } from 'react-swipeable-views-utils'
 import SwipeableViews from 'react-swipeable-views'
 import TempSchedAddShiftsStep from './TempSchedAddShiftsStep'
 import TempSchedTimesStep from './TempSchedTimesStep'
+import { isAfter, isBefore } from '../../util/luxon-helpers'
 // allows changing the index programatically
 const VirtualizeAnimatedViews = bindKeyboard(virtualize(SwipeableViews))
 
@@ -40,6 +41,19 @@ export default function TempSchedDialog({
       _.pick(s, 'start', 'end', 'userID'),
     ),
   })
+
+  const hasInvalidShift = value.shifts.some(
+    (s) => isAfter(value.start, s.start) || isBefore(value.end, s.end),
+  )
+
+  const shiftErrors = hasInvalidShift
+    ? [
+        {
+          message:
+            'One or more shifts extend beyond the start and/or end of this temporary schedule',
+        },
+      ]
+    : []
 
   const [submit, { loading, error, data }] = useMutation(mutation, {
     onCompleted: () => onClose(),
@@ -91,7 +105,7 @@ export default function TempSchedDialog({
   const fieldErrs = fieldErrors(error).map((e) => ({
     message: `${e.field}: ${e.message}`,
   }))
-  const errs = nonFieldErrs.concat(fieldErrs)
+  const errs = nonFieldErrs.concat(fieldErrs).concat(shiftErrors)
 
   return (
     <FormDialog

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -53,9 +53,15 @@ export default function TempSchedShiftsList({
 
     if (!shifts.length) return []
 
+    const scheduleDawn = DateTime.fromISO(start, { zone }).startOf('day')
+    const scheduleDusk = DateTime.fromISO(end, { zone }).endOf('day')
+
+    const firstShiftDawn = shifts[0].start.startOf('day')
+    const lastShiftDusk = shifts[shifts.length - 1].end.endOf('day')
+
     const displaySpan = Interval.fromDateTimes(
-      DateTime.fromISO(start, { zone }).startOf('day'),
-      DateTime.fromISO(end, { zone }).startOf('day'),
+      DateTime.min(scheduleDawn, firstShiftDawn),
+      DateTime.max(scheduleDusk, lastShiftDusk),
     )
 
     const result: FlatListListItem[] = []

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -66,9 +66,7 @@ export default function TempSchedShiftsList({
         DateTime.fromISO(s.start, { zone }),
         DateTime.fromISO(s.end, { zone }),
       ),
-      isValid: schedInterval.engulfs(
-        parseInterval({ start: s.start, end: s.end }),
-      ),
+      isValid: schedInterval.engulfs(parseInterval(s)),
     }))
 
     if (!shifts.length) return []

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -78,15 +78,12 @@ export default function TempSchedShiftsList({
       shifts[0],
     )
 
-    const scheduleStart = DateTime.fromISO(start, { zone })
-    const scheduleEnd = DateTime.fromISO(end, { zone })
-
     const firstShiftStart = shifts[0].start
     const lastShiftEnd = lastShift.end
 
     const displaySpan = Interval.fromDateTimes(
-      DateTime.min(scheduleStart, firstShiftStart).startOf('day'),
-      DateTime.max(scheduleEnd, lastShiftEnd).endOf('day'),
+      DateTime.min(schedInterval.start, firstShiftStart).startOf('day'),
+      DateTime.max(schedInterval.end, lastShiftEnd).endOf('day'),
     )
 
     const result: FlatListListItem[] = []

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -3,20 +3,26 @@ import { IconButton, makeStyles, Typography } from '@material-ui/core'
 import FlatList from '../../lists/FlatList'
 import { Shift } from './sharedUtils'
 import { UserAvatar } from '../../util/avatars'
-import { Delete } from '@material-ui/icons'
-import { Warning } from '../../icons/components/Icons'
+import { Delete, Error } from '@material-ui/icons'
 import { useUserInfo } from '../../util/useUserInfo'
 import { DateTime, Interval } from 'luxon'
 import { useURLParam } from '../../actions'
 import { relativeDate } from '../../util/timeFormat'
 import _ from 'lodash-es'
 import { isBefore, isAfter } from '../../util/luxon-helpers'
+import Tooltip from '@material-ui/core/Tooltip/Tooltip'
+import { styles } from '../../styles/materialStyles'
 
-const useStyles = makeStyles({
-  secondaryActionWrapper: {
-    display: 'flex',
-    alignItems: 'center',
-  },
+const useStyles = makeStyles((theme) => {
+  return {
+    secondaryActionWrapper: {
+      display: 'flex',
+      alignItems: 'center',
+    },
+    secondaryActionError: {
+      color: styles(theme).error.color,
+    },
+  }
 })
 
 type TempSchedShiftsListProps = {
@@ -117,10 +123,12 @@ export default function TempSchedShiftsList({
           secondaryAction: s.added ? null : (
             <div className={classes.secondaryActionWrapper}>
               {!s.isValid && (
-                <Warning
-                  message='This shift extends beyond the start and/or end of this temporary schedule'
+                <Tooltip
+                  title='This shift extends beyond the start and/or end of this temporary schedule'
                   placement='left'
-                />
+                >
+                  <Error className={classes.secondaryActionError} />
+                </Tooltip>
               )}
               <IconButton onClick={() => onRemove(s.shift)}>
                 <Delete />

--- a/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
@@ -9,8 +9,7 @@ import { FormField } from '../../forms'
 import { ISODateTimePicker } from '../../util/ISOPickers'
 import { contentText, StepContainer, Value } from './sharedUtils'
 import { ScheduleTZFilter } from '../ScheduleTZFilter'
-
-import { DateTime } from 'luxon'
+import { isISOBefore } from '../../util/shifts'
 
 const useStyles = makeStyles({
   contentText,
@@ -29,8 +28,8 @@ export default function TempSchedTimesStep({
 }: TempSchedTimesStepProps): JSX.Element {
   const classes = useStyles()
 
-  function isValid(): Error | null {
-    if (DateTime.fromISO(value.start) < DateTime.fromISO(value.end)) return null
+  function validate(): Error | null {
+    if (isISOBefore(value.start, value.end)) return null
     return new Error('Start date/time cannot be after end date/time.')
   }
 
@@ -62,7 +61,7 @@ export default function TempSchedTimesStep({
             component={ISODateTimePicker}
             required
             name='start'
-            validate={() => isValid()}
+            validate={() => validate()}
           />
         </Grid>
         <Grid item xs={6}>
@@ -71,7 +70,7 @@ export default function TempSchedTimesStep({
             component={ISODateTimePicker}
             required
             name='end'
-            validate={() => isValid()}
+            validate={() => validate()}
           />
         </Grid>
       </Grid>

--- a/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
@@ -7,8 +7,10 @@ import {
 } from '@material-ui/core'
 import { FormField } from '../../forms'
 import { ISODateTimePicker } from '../../util/ISOPickers'
-import { contentText, StepContainer } from './sharedUtils'
+import { contentText, StepContainer, Value } from './sharedUtils'
 import { ScheduleTZFilter } from '../ScheduleTZFilter'
+
+import { DateTime } from 'luxon'
 
 const useStyles = makeStyles({
   contentText,
@@ -17,13 +19,20 @@ const useStyles = makeStyles({
 type TempSchedTimesStepProps = {
   scheduleID: string
   stepText: string
+  value: Value
 }
 
 export default function TempSchedTimesStep({
   scheduleID,
   stepText,
+  value,
 }: TempSchedTimesStepProps): JSX.Element {
   const classes = useStyles()
+
+  function isValid(): Error | null {
+    if (DateTime.fromISO(value.start) < DateTime.fromISO(value.end)) return null
+    return new Error('Start date/time cannot be after end date/time.')
+  }
 
   return (
     <StepContainer width='35%'>
@@ -53,6 +62,7 @@ export default function TempSchedTimesStep({
             component={ISODateTimePicker}
             required
             name='start'
+            validate={() => isValid()}
           />
         </Grid>
         <Grid item xs={6}>
@@ -61,6 +71,7 @@ export default function TempSchedTimesStep({
             component={ISODateTimePicker}
             required
             name='end'
+            validate={() => isValid()}
           />
         </Grid>
       </Grid>

--- a/web/src/app/util/luxon-helpers.js
+++ b/web/src/app/util/luxon-helpers.js
@@ -31,3 +31,13 @@ export function getEndOfWeek(luxonDateTime = DateTime.local()) {
     })
     .endOf('day')
 }
+
+// compare two iso datetime strings
+export function isAfter(a, b) {
+  return DateTime.fromISO(a) > DateTime.fromISO(b)
+}
+
+// compare two iso datetime strings
+export function isBefore(a, b) {
+  return DateTime.fromISO(a) < DateTime.fromISO(b)
+}

--- a/web/src/app/util/luxon-helpers.js
+++ b/web/src/app/util/luxon-helpers.js
@@ -31,13 +31,3 @@ export function getEndOfWeek(luxonDateTime = DateTime.local()) {
     })
     .endOf('day')
 }
-
-// compare two iso datetime strings
-export function isAfter(a, b) {
-  return DateTime.fromISO(a) > DateTime.fromISO(b)
-}
-
-// compare two iso datetime strings
-export function isBefore(a, b) {
-  return DateTime.fromISO(a) < DateTime.fromISO(b)
-}

--- a/web/src/app/util/shifts.ts
+++ b/web/src/app/util/shifts.ts
@@ -31,3 +31,15 @@ export function trimSpans<T extends SpanISO>(
     }),
   )
 }
+
+// isISOAfter
+// Compares two ISO timestamps, returning true if `a` occurs after `b`.
+export function isISOAfter(a: string, b: string): boolean {
+  return DateTime.fromISO(a) > DateTime.fromISO(b)
+}
+
+// isISOBefore
+// Compares two ISO timestamps, returning true if `a` occurs before `b`.
+export function isISOBefore(a: string, b: string): boolean {
+  return DateTime.fromISO(a) < DateTime.fromISO(b)
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [ ] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**

- added validation for start/end date/time so end must be after start
- display all shifts in shift list, doesn't filter by start/end
- added warning icon next to out of bounds shifts
- added floating warning in bottom left for out of bounds shifts

**Which issue(s) this PR fixes:**
Fixes #930 
