### PR TITLE
temporary schedules: warning when creating or editing an override that overlaps a temp. schedule

### DIFF
--- a/web/src/app/details/Notices.tsx
+++ b/web/src/app/details/Notices.tsx
@@ -31,20 +31,25 @@ const useStyles = makeStyles({
 })
 
 interface NoticesProps {
-  notices: Notice[] // checks against .length are safe as notices is required
+  notices?: Notice[]
 }
 
-export default function Notices(props: NoticesProps): JSX.Element {
+export default function Notices({
+  notices = [],
+}: NoticesProps): JSX.Element | null {
   const classes = useStyles()
   const [noticesExpanded, setNoticesExpanded] = useState(false)
 
-  function renderShowAllToggle(): ReactNode {
-    if (props.notices.length <= 1) return null
+  if (!notices.length) {
+    return null
+  }
 
+  function renderShowAllToggle(): ReactNode {
+    if (notices.length <= 1) return null
     return (
       <Badge
         color='primary'
-        badgeContent={props.notices.length - 1}
+        badgeContent={notices.length - 1}
         invisible={noticesExpanded}
       >
         <IconButton onClick={() => setNoticesExpanded(!noticesExpanded)}>
@@ -64,7 +69,7 @@ export default function Notices(props: NoticesProps): JSX.Element {
         return ''
       case 1:
         return classes.secondGridItem
-      case props.notices.length - 1:
+      case notices.length - 1:
         return classes.lastGridItem
       default:
         return classes.gridItem
@@ -94,11 +99,11 @@ export default function Notices(props: NoticesProps): JSX.Element {
 
   return (
     <Grid container>
-      {renderNotice(props.notices[0], 0)}
+      {renderNotice(notices[0], 0)}
       <Grid item xs={12}>
         <Collapse in={noticesExpanded}>
           <Grid container>
-            {props.notices.slice(1).map((n, i) => renderNotice(n, i + 1))}
+            {notices.slice(1).map((n, i) => renderNotice(n, i + 1))}
           </Grid>
         </Collapse>
       </Grid>

--- a/web/src/app/dialogs/FormDialog.js
+++ b/web/src/app/dialogs/FormDialog.js
@@ -15,6 +15,7 @@ import { styles as globalStyles } from '../styles/materialStyles'
 import gracefulUnmount from '../util/gracefulUnmount'
 import { Form } from '../forms'
 import ErrorBoundary from '../main/ErrorBoundary'
+import Notices from '../details/Notices'
 
 const styles = (theme) => {
   const { cancelButton, dialogWidth } = globalStyles(theme)
@@ -48,7 +49,13 @@ export default class FormDialog extends React.PureComponent {
     title: p.node.isRequired,
     subTitle: p.node,
     caption: p.node,
-
+    notices: p.arrayOf(
+      p.shape({
+        type: p.oneOf(['WARNING', 'ERROR', 'INFO']).isRequired,
+        message: p.string.isRequired,
+        details: p.string.isRequired,
+      }),
+    ),
     errors: p.arrayOf(
       p.shape({
         message: p.string.isRequired,
@@ -86,6 +93,7 @@ export default class FormDialog extends React.PureComponent {
   }
 
   static defaultProps = {
+    notices: [],
     errors: [],
     onClose: () => {},
     onSubmit: () => {},
@@ -101,6 +109,7 @@ export default class FormDialog extends React.PureComponent {
       classes,
       confirm,
       disableGutters,
+      notices,
       errors,
       fullScreen,
       isUnmounting,
@@ -132,6 +141,7 @@ export default class FormDialog extends React.PureComponent {
         }
         {...dialogProps}
       >
+        <Notices notices={notices} />
         <DialogTitleWrapper
           fullScreen={isFullScreen}
           onClose={onClose}

--- a/web/src/app/schedules/ScheduleOverrideCreateDialog.js
+++ b/web/src/app/schedules/ScheduleOverrideCreateDialog.js
@@ -6,6 +6,7 @@ import { DateTime } from 'luxon'
 import ScheduleOverrideForm from './ScheduleOverrideForm'
 import { fieldErrors, nonFieldErrors } from '../util/errutil'
 import gql from 'graphql-tag'
+import useOverrideNotices from './useOverrideNotices'
 
 const copyText = {
   add: {
@@ -42,6 +43,8 @@ export default function ScheduleOverrideCreateDialog(props) {
     ...props.defaultValue,
   })
 
+  const notices = useOverrideNotices(props.scheduleID, value)
+
   const [mutate, { loading, error }] = useMutation(mutation, {
     variables: {
       input: {
@@ -58,6 +61,7 @@ export default function ScheduleOverrideCreateDialog(props) {
       title={copyText[props.variant].title}
       subTitle={copyText[props.variant].desc}
       errors={nonFieldErrors(error)}
+      notices={notices} // create and edit dialogue
       onSubmit={() => mutate()}
       form={
         <ScheduleOverrideForm

--- a/web/src/app/schedules/ScheduleOverrideForm.js
+++ b/web/src/app/schedules/ScheduleOverrideForm.js
@@ -30,19 +30,6 @@ const query = gql`
     }
   }
 `
-const scheduleQuery = gql`
-  query($id: ID!) {
-    schedule(id: $id) {
-      id
-      name
-      temporarySchedules {
-        start
-        end
-      }
-    }
-  }
-`
-
 const useStyles = makeStyles({
   tzNote: {
     display: 'flex',
@@ -70,7 +57,7 @@ export default function ScheduleOverrideForm(props) {
   )
 
   // used to grab conflicting errors from pre-existing overrides
-  const { data: overrides } = useQuery(query, {
+  const { data } = useQuery(query, {
     variables: {
       id: _.get(conflictingUserFieldError, 'details.CONFLICTING_ID', ''),
     },
@@ -78,22 +65,11 @@ export default function ScheduleOverrideForm(props) {
     skip: !conflictingUserFieldError,
   })
 
-  const { data: tempSchedules } = useQuery(scheduleQuery, {
-    variables: {
-      id: scheduleID,
-    },
-    pollInterval: 0,
-  })
-
-  const scheduleDetails = _.get(tempSchedules, 'schedule.temporarySchedules')
-
-  console.log('scheduleDetails: ', scheduleDetails)
-
   const userConflictErrors = errors
     .filter((e) => e.field !== 'userID')
     .concat(
       conflictingUserFieldError
-        ? mapOverrideUserError(_.get(overrides, 'userOverride'), value, zone)
+        ? mapOverrideUserError(_.get(data, 'userOverride'), value, zone)
         : [],
     )
 

--- a/web/src/app/schedules/ScheduleOverrideForm.js
+++ b/web/src/app/schedules/ScheduleOverrideForm.js
@@ -30,6 +30,18 @@ const query = gql`
     }
   }
 `
+const scheduleQuery = gql`
+  query($id: ID!) {
+    schedule(id: $id) {
+      id
+      name
+      temporarySchedules {
+        start
+        end
+      }
+    }
+  }
+`
 
 const useStyles = makeStyles({
   tzNote: {
@@ -58,7 +70,7 @@ export default function ScheduleOverrideForm(props) {
   )
 
   // used to grab conflicting errors from pre-existing overrides
-  const { data } = useQuery(query, {
+  const { data: overrides } = useQuery(query, {
     variables: {
       id: _.get(conflictingUserFieldError, 'details.CONFLICTING_ID', ''),
     },
@@ -66,11 +78,22 @@ export default function ScheduleOverrideForm(props) {
     skip: !conflictingUserFieldError,
   })
 
+  const { data: tempSchedules } = useQuery(scheduleQuery, {
+    variables: {
+      id: scheduleID,
+    },
+    pollInterval: 0,
+  })
+
+  const scheduleDetails = _.get(tempSchedules, 'schedule.temporarySchedules')
+
+  console.log('scheduleDetails: ', scheduleDetails)
+
   const userConflictErrors = errors
     .filter((e) => e.field !== 'userID')
     .concat(
       conflictingUserFieldError
-        ? mapOverrideUserError(_.get(data, 'userOverride'), value, zone)
+        ? mapOverrideUserError(_.get(overrides, 'userOverride'), value, zone)
         : [],
     )
 

--- a/web/src/app/schedules/useOverrideNotices.ts
+++ b/web/src/app/schedules/useOverrideNotices.ts
@@ -31,9 +31,6 @@ export default function useOverrideNotices(
     return []
   }
   const tempSchedules = _.get(data, 'schedule.temporarySchedules')
-
-  console.log('loading data: ', loading)
-  console.log('scheduleDetails: ', tempSchedules)
   const valueInterval = parseInterval(value)
   const doesOverlap = tempSchedules
     .map(parseInterval)

--- a/web/src/app/schedules/useOverrideNotices.ts
+++ b/web/src/app/schedules/useOverrideNotices.ts
@@ -1,0 +1,52 @@
+import { Notice } from '../../schema'
+import { parseInterval, SpanISO } from '../util/shifts'
+import gql from 'graphql-tag'
+import { useQuery } from 'react-apollo'
+import _ from 'lodash-es'
+import { Interval } from 'luxon'
+
+const scheduleQuery = gql`
+  query($id: ID!) {
+    schedule(id: $id) {
+      id
+      name
+      temporarySchedules {
+        start
+        end
+      }
+    }
+  }
+`
+export default function useOverrideNotices(
+  scheduleID: string,
+  value: SpanISO,
+): Notice[] {
+  const { data, loading } = useQuery(scheduleQuery, {
+    variables: {
+      id: scheduleID,
+    },
+    pollInterval: 0,
+  })
+  if (loading) {
+    return []
+  }
+  const tempSchedules = _.get(data, 'schedule.temporarySchedules')
+
+  console.log('loading data: ', loading)
+  console.log('scheduleDetails: ', tempSchedules)
+  const valueInterval = parseInterval(value)
+  const doesOverlap = tempSchedules
+    .map(parseInterval)
+    .some((invl: Interval) => invl.overlaps(valueInterval))
+
+  if (!doesOverlap) {
+    return []
+  }
+  return [
+    {
+      type: 'WARNING',
+      message: 'This override overlaps with one or more temporary schedules',
+      details: 'Overrides do not take affect during temporary schedules',
+    },
+  ]
+}

--- a/web/src/app/util/shifts.ts
+++ b/web/src/app/util/shifts.ts
@@ -1,7 +1,7 @@
 import { DateTime, Interval } from 'luxon'
 import _ from 'lodash-es'
 
-interface SpanISO {
+export interface SpanISO {
   start: string
   end: string
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
When a user edits or adds a temporary schedule, a warning appears above the form when the start or end time overlaps with a temporary schedule. A new hook was added, 'userOverrideNotices' to handle the query of start and end times and returns a warning to the FormDialog component if there is an existing overlap with a temporary schedule. Other supporting files were also modified to support this new functionality. 

**Which issue(s) this PR fixes:**
Fixes https://github.com/target/goalert/issues/929

**Out of Scope:**
ScheduleOverrideEditDialog.js is out of scope because it is a class component, the useOverrideNotices hook can only be implemented in a React component. 

**Screenshots:**
![image](https://user-images.githubusercontent.com/33384962/96191361-85de6900-0f09-11eb-89aa-e3f127196a0e.png)

**Describe any introduced user-facing changes:**
A warning banner appears in the dialog box when the start or end time of an override overlaps with a temporary schedule. 
