### PR TITLE
docker: use embedded TZ data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ GIT_TREE=$(shell git diff-index --quiet HEAD -- && echo clean || echo dirty)
 GIT_VERSION=$(shell git describe --tags --dirty --match 'v*' || echo dev-$(shell date -u +"%Y%m%d%H%M%S"))
 BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BUILD_FLAGS=
+BUILD_TAGS+=timetzdata
+
+export ZONEINFO=$(shell go env GOROOT)/lib/time/zoneinfo.zip
 
 LD_FLAGS+=-X github.com/target/goalert/version.gitCommit=$(GIT_COMMIT)
 LD_FLAGS+=-X github.com/target/goalert/version.gitVersion=$(GIT_VERSION)

--- a/devtools/ci/dockerfiles/all-in-one/Dockerfile
+++ b/devtools/ci/dockerfiles/all-in-one/Dockerfile
@@ -12,7 +12,7 @@ COPY . /goalert
 RUN make bin/resetdb bin/goalert BUNDLE=1 BUILD_FLAGS=-trimpath
 
 FROM alpine:3.12
-RUN apk --no-cache add postgresql postgresql-contrib musl-locales tzdata ca-certificates
+RUN apk --no-cache add postgresql postgresql-contrib musl-locales ca-certificates
 COPY --from=build /goalert/bin/goalert /goalert/bin/resetdb /bin/
 COPY devtools/ci/dockerfiles/all-in-one/start.sh /bin/start.sh
 ENV GOALERT_LISTEN :8081

--- a/devtools/ci/dockerfiles/goalert/Dockerfile
+++ b/devtools/ci/dockerfiles/goalert/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-RUN apk --no-cache add tzdata ca-certificates
+RUN apk --no-cache add ca-certificates
 ENV GOALERT_LISTEN :8081
 EXPOSE 8081
 CMD ["/usr/bin/goalert"]


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR updates the Makefile and Dockerfile to use embedded TZ data instead of relying on the system package.

This is to resolve an issue where DST values were no longer calculated properly in TZ versions `2020b` onwards (e.g. latest in the alpine build).

ZONEINFO is now set to use the tz data that ships under GOROOT for testing. This should help to ensure that binaries and container images are more consistent with regard to calculated times.