### PR TITLE
feature/temp schedules: set min start date to now()

### DIFF
--- a/web/src/app/forms/FormField.js
+++ b/web/src/app/forms/FormField.js
@@ -36,8 +36,9 @@ export class FormField extends React.PureComponent {
     fieldName: p.string,
 
     // min and max values specify the range to clamp a int value
-    min: p.number,
-    max: p.number,
+    // will be passed to base component for input controls
+    min: p.oneOfType([p.number, p.string]),
+    max: p.oneOfType([p.number, p.string]),
 
     // used if name is set,
     // but the error name is different from graphql responses

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftForm.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftForm.tsx
@@ -1,6 +1,7 @@
 import { Grid, TextField, Typography, makeStyles } from '@material-ui/core'
 import { DateTime } from 'luxon'
 import React, { useState } from 'react'
+import { useURLParam } from '../../actions'
 import { FormField } from '../../forms'
 import { UserSelect } from '../../selection'
 import { ISODateTimePicker } from '../../util/ISOPickers'
@@ -18,6 +19,8 @@ const useStyles = makeStyles({
 export default function TempSchedAddShiftForm(): JSX.Element {
   const classes = useStyles()
   const [manualEntry, setManualEntry] = useState(false)
+  const [zone] = useURLParam('tz', 'local')
+  const now = DateTime.local().setZone(zone).startOf('day').toFormat("yyyy-MM-dd'T'HH:mm:ss")
 
   return (
     <React.Fragment>
@@ -35,6 +38,7 @@ export default function TempSchedAddShiftForm(): JSX.Element {
           component={ISODateTimePicker}
           label='Shift Start'
           name='start'
+          min={now}
           mapOnChangeValue={(value: string, formValue: Value) => {
             if (!manualEntry) {
               const diff = DateTime.fromISO(value).diff(
@@ -53,6 +57,7 @@ export default function TempSchedAddShiftForm(): JSX.Element {
             component={ISODateTimePicker}
             label='Shift End'
             name='end'
+            min={now}
             hint={
               <Typography
                 className={classes.typography}

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftForm.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftForm.tsx
@@ -20,7 +20,10 @@ export default function TempSchedAddShiftForm(): JSX.Element {
   const classes = useStyles()
   const [manualEntry, setManualEntry] = useState(false)
   const [zone] = useURLParam('tz', 'local')
-  const now = DateTime.local().setZone(zone).startOf('day').toFormat("yyyy-MM-dd'T'HH:mm:ss")
+  const now = DateTime.local()
+    .setZone(zone)
+    .startOf('day')
+    .toFormat("yyyy-MM-dd'T'HH:mm:ss")
 
   return (
     <React.Fragment>

--- a/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
@@ -1,9 +1,5 @@
 import React from 'react'
-import {
-  Grid,
-  DialogContentText,
-  Typography,
-} from '@material-ui/core'
+import { Grid, DialogContentText, Typography } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core/styles'
 import { FormField } from '../../forms'
 import { ISODateTimePicker } from '../../util/ISOPickers'
@@ -30,7 +26,10 @@ export default function TempSchedTimesStep({
 }: TempSchedTimesStepProps): JSX.Element {
   const classes = useStyles()
   const [zone] = useURLParam('tz', 'local')
-  const now = DateTime.local().setZone(zone).startOf('day').toFormat("yyyy-MM-dd'T'HH:mm:ss")
+  const now = DateTime.local()
+    .setZone(zone)
+    .startOf('day')
+    .toFormat("yyyy-MM-dd'T'HH:mm:ss")
 
   function validate(): Error | null {
     if (isISOBefore(value.start, value.end)) return null

--- a/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
@@ -3,13 +3,15 @@ import {
   Grid,
   DialogContentText,
   Typography,
-  makeStyles,
 } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
 import { FormField } from '../../forms'
 import { ISODateTimePicker } from '../../util/ISOPickers'
 import { contentText, StepContainer, Value } from './sharedUtils'
 import { ScheduleTZFilter } from '../ScheduleTZFilter'
 import { isISOBefore } from '../../util/shifts'
+import { DateTime } from 'luxon'
+import { useURLParam } from '../../actions'
 
 const useStyles = makeStyles({
   contentText,
@@ -27,6 +29,8 @@ export default function TempSchedTimesStep({
   value,
 }: TempSchedTimesStepProps): JSX.Element {
   const classes = useStyles()
+  const [zone] = useURLParam('tz', 'local')
+  const now = DateTime.local().setZone(zone).startOf('day').toFormat("yyyy-MM-dd'T'HH:mm:ss")
 
   function validate(): Error | null {
     if (isISOBefore(value.start, value.end)) return null
@@ -63,6 +67,7 @@ export default function TempSchedTimesStep({
             required
             name='start'
             validate={() => validate()}
+            min={now}
           />
         </Grid>
         <Grid item xs={6}>
@@ -72,6 +77,7 @@ export default function TempSchedTimesStep({
             required
             name='end'
             validate={() => validate()}
+            min={now}
           />
         </Grid>
       </Grid>

--- a/web/src/app/util/ISOPickers.tsx
+++ b/web/src/app/util/ISOPickers.tsx
@@ -1,5 +1,12 @@
-import React, { useState, useEffect, ChangeEvent, FC } from 'react'
-import { DatePicker, TimePicker, DateTimePicker, TimePickerProps, DatePickerProps, DateTimePickerProps } from '@material-ui/pickers'
+import React, { useState, useEffect, ChangeEvent, FC, ReactNode } from 'react'
+import {
+  DatePicker,
+  TimePicker,
+  DateTimePicker,
+  TimePickerProps,
+  DatePickerProps,
+  DateTimePickerProps,
+} from '@material-ui/pickers'
 import { useSelector } from 'react-redux'
 import { urlParamSelector } from '../selectors'
 import { DateTime, DurationUnit } from 'luxon'
@@ -17,7 +24,10 @@ type ISOPickersProps = {
 }
 
 // Supported fallback types
-type FallbackType =  FC<TimePickerProps> | FC<DatePickerProps> | FC<DateTimePickerProps>
+type FallbackType =
+  | FC<TimePickerProps>
+  | FC<DatePickerProps>
+  | FC<DateTimePickerProps>
 
 // Static settings defined in the ISOPickers variations (date, time, etc)
 type ISOPickersSettings = {
@@ -41,10 +51,10 @@ function hasInputSupport(name: string): boolean {
 function useISOPicker(
   { value = '', onChange, timeZone, min, max, ...otherProps }: ISOPickersProps,
   { format, truncateTo, type, Fallback }: ISOPickersSettings,
-) {
+): ReactNode {
   const native = hasInputSupport(type)
   const params = useSelector(urlParamSelector)
-  const zone = timeZone || params('tz', 'local') as string
+  const zone = timeZone || (params('tz', 'local') as string)
   const dtValue = DateTime.fromISO(value, { zone })
   const [inputValue, setInputValue] = useState(
     value ? dtValue.toFormat(format) : '',
@@ -52,7 +62,7 @@ function useISOPicker(
 
   // parseInput takes input from the form control and returns a DateTime
   // object representing the value, or null (if invalid or empty).
-  const parseInput = (input: Input) => {
+  const parseInput = (input: Input): DateTime | null => {
     if (input instanceof DateTime) return input
     if (!input) return null
 
@@ -84,13 +94,7 @@ function useISOPicker(
     setInputValue(value ? dtValue.toFormat(format) : '')
   }, [value, zone])
 
-  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const val = e.target.value
-    setInputValue(val)
-    handleChange(val)
-  }
-
-  const handleChange = (val: Input) => {
+  const handleChange = (val: Input): void => {
     const newVal = inputToISO(val)
     // Only fire the parent's `onChange` handler when we have a new valid value,
     // taking care to ensure we ignore any zonal differences.
@@ -99,11 +103,11 @@ function useISOPicker(
     }
   }
 
-  // starts with label above textfield so format placeholder can be seen
-  const shrinkInputLabel = (p: { [key: string]: any }) => ({
-    ...(p?.InputLabelProps ?? {}),
-    shrink: true,
-  })
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    const val = e.target.value
+    setInputValue(val)
+    handleChange(val)
+  }
 
   if (native) {
     return (
@@ -113,7 +117,10 @@ function useISOPicker(
         onChange={handleInputChange}
         inputProps={{ min, max }}
         {...otherProps}
-        InputLabelProps={shrinkInputLabel(otherProps)}
+        InputLabelProps={{
+          ...otherProps,
+          shrink: true,
+        }}
       />
     )
   }
@@ -146,12 +153,15 @@ function useISOPicker(
       }}
       {...cypressProps}
       {...otherProps}
-      InputLabelProps={shrinkInputLabel(otherProps)}
+      InputLabelProps={{
+        ...otherProps,
+        shrink: true,
+      }}
     />
   )
 }
 
-export function ISOTimePicker(props: ISOPickersProps) {
+export function ISOTimePicker(props: ISOPickersProps): ReactNode {
   return useISOPicker(props, {
     Fallback: TimePicker,
     format: 'HH:mm',
@@ -160,7 +170,7 @@ export function ISOTimePicker(props: ISOPickersProps) {
   })
 }
 
-export function ISODateTimePicker(props: ISOPickersProps) {
+export function ISODateTimePicker(props: ISOPickersProps): ReactNode {
   return useISOPicker(props, {
     Fallback: DateTimePicker,
     format: `yyyy-MM-dd'T'HH:mm`,
@@ -169,7 +179,7 @@ export function ISODateTimePicker(props: ISOPickersProps) {
   })
 }
 
-export function ISODatePicker(props: ISOPickersProps) {
+export function ISODatePicker(props: ISOPickersProps): ReactNode {
   return useISOPicker(props, {
     Fallback: DatePicker,
     format: 'yyyy-MM-dd',


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [ ] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [ ] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR ensures that the start date of a temporary schedule can not begin in the past.

**Additional Info:**
- Converts `ISOPickers` to Typescript
- Adds support for `min` and `max` dates in `ISOPickers`

**Screenshots:**
<img width="550" src="https://user-images.githubusercontent.com/11381794/96932038-1b7e7900-1473-11eb-883d-717f776745ca.png" />