### PR TITLE
feature/temp schedules: set min start date to now()

### DIFF
--- a/web/src/app/forms/FormField.js
+++ b/web/src/app/forms/FormField.js
@@ -36,7 +36,7 @@ export class FormField extends React.PureComponent {
     fieldName: p.string,
 
     // min and max values specify the range to clamp a int value
-    // expects a parsable date, if string
+    // expects an ISO timestamp, if string
     min: p.oneOfType([p.number, p.string]),
     max: p.oneOfType([p.number, p.string]),
 

--- a/web/src/app/forms/FormField.js
+++ b/web/src/app/forms/FormField.js
@@ -36,8 +36,9 @@ export class FormField extends React.PureComponent {
     fieldName: p.string,
 
     // min and max values specify the range to clamp a int value
-    min: p.number,
-    max: p.number,
+    // expects a parsable date, if string
+    min: p.oneOfType([p.number, p.string]),
+    max: p.oneOfType([p.number, p.string]),
 
     // used if name is set,
     // but the error name is different from graphql responses

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftForm.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftForm.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 import { Grid, TextField } from '@material-ui/core'
 import { DateTime } from 'luxon'
-import { useURLParam } from '../../actions'
 import { FormField } from '../../forms'
 import { UserSelect } from '../../selection'
 import ClickableText from '../../util/ClickableText'
@@ -10,10 +9,7 @@ import { Value } from './sharedUtils'
 
 export default function TempSchedAddShiftForm(): JSX.Element {
   const [manualEntry, setManualEntry] = useState(false)
-  const [zone] = useURLParam('tz', 'local')
-  const [now] = useState(
-    DateTime.local().setZone(zone).startOf('minute').toISO(),
-  )
+  const [now] = useState(DateTime.utc().startOf('minute').toISO())
 
   return (
     <React.Fragment>

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftForm.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { Grid, TextField } from '@material-ui/core'
 import { DateTime } from 'luxon'
 import { useURLParam } from '../../actions'
@@ -11,15 +11,10 @@ import { Value } from './sharedUtils'
 export default function TempSchedAddShiftForm(): JSX.Element {
   const [manualEntry, setManualEntry] = useState(false)
   const [zone] = useURLParam('tz', 'local')
-  const [now, setNow] = useState<string>()
-  useEffect(() => {
-    setNow(
-      DateTime.local()
-        .setZone(zone)
-        .startOf('minute')
-        .toISO(),
-    )
-  }, [])
+  const [now] = useState(DateTime.local()
+  .setZone(zone)
+  .startOf('minute')
+  .toISO())
 
   return (
     <React.Fragment>

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftForm.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftForm.tsx
@@ -13,8 +13,12 @@ export default function TempSchedAddShiftForm(): JSX.Element {
   const [zone] = useURLParam('tz', 'local')
   const [now, setNow] = useState<string>()
   useEffect(() => {
-    setNow( DateTime.local().setZone(zone)
-    .startOf('minute').toFormat("yyyy-MM-dd'T'HH:mm:ss"))
+    setNow(
+      DateTime.local()
+        .setZone(zone)
+        .startOf('minute')
+        .toFormat("yyyy-MM-dd'T'HH:mm:ss"),
+    )
   }, [])
 
   return (

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftForm.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftForm.tsx
@@ -1,6 +1,7 @@
+import React, { useEffect, useState } from 'react'
 import { Grid, TextField } from '@material-ui/core'
 import { DateTime } from 'luxon'
-import React, { useState } from 'react'
+import { useURLParam } from '../../actions'
 import { FormField } from '../../forms'
 import { UserSelect } from '../../selection'
 import ClickableText from '../../util/ClickableText'
@@ -9,6 +10,12 @@ import { Value } from './sharedUtils'
 
 export default function TempSchedAddShiftForm(): JSX.Element {
   const [manualEntry, setManualEntry] = useState(false)
+  const [zone] = useURLParam('tz', 'local')
+  const [now, setNow] = useState<string>()
+  useEffect(() => {
+    setNow( DateTime.local().setZone(zone)
+    .startOf('minute').toFormat("yyyy-MM-dd'T'HH:mm:ss"))
+  }, [])
 
   return (
     <React.Fragment>
@@ -26,6 +33,7 @@ export default function TempSchedAddShiftForm(): JSX.Element {
           component={ISODateTimePicker}
           label='Shift Start'
           name='start'
+          min={now}
           mapOnChangeValue={(value: string, formValue: Value) => {
             if (!manualEntry) {
               const diff = DateTime.fromISO(value).diff(
@@ -44,6 +52,7 @@ export default function TempSchedAddShiftForm(): JSX.Element {
             component={ISODateTimePicker}
             label='Shift End'
             name='end'
+            min={now}
             hint={
               <ClickableText
                 text='Configure as duration'

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftForm.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftForm.tsx
@@ -17,7 +17,7 @@ export default function TempSchedAddShiftForm(): JSX.Element {
       DateTime.local()
         .setZone(zone)
         .startOf('minute')
-        .toFormat("yyyy-MM-dd'T'HH:mm:ss"),
+        .toISO(),
     )
   }, [])
 

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftForm.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftForm.tsx
@@ -11,10 +11,9 @@ import { Value } from './sharedUtils'
 export default function TempSchedAddShiftForm(): JSX.Element {
   const [manualEntry, setManualEntry] = useState(false)
   const [zone] = useURLParam('tz', 'local')
-  const [now] = useState(DateTime.local()
-  .setZone(zone)
-  .startOf('minute')
-  .toISO())
+  const [now] = useState(
+    DateTime.local().setZone(zone).startOf('minute').toISO(),
+  )
 
   return (
     <React.Fragment>

--- a/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
@@ -37,7 +37,7 @@ export default function TempSchedTimesStep({
       DateTime.local()
         .setZone(zone)
         .startOf('minute')
-        .toFormat("yyyy-MM-dd'T'HH:mm:ss"),
+        .toISO(),
     )
   }, [])
 

--- a/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
@@ -10,7 +10,6 @@ import { ISODateTimePicker } from '../../util/ISOPickers'
 import { contentText, StepContainer, Value } from './sharedUtils'
 import { ScheduleTZFilter } from '../ScheduleTZFilter'
 import { isISOBefore } from '../../util/shifts'
-import { useURLParam } from '../../actions'
 import { DateTime } from 'luxon'
 
 const useStyles = makeStyles({
@@ -30,10 +29,7 @@ export default function TempSchedTimesStep({
 }: TempSchedTimesStepProps): JSX.Element {
   const classes = useStyles()
 
-  const [zone] = useURLParam('tz', 'local')
-  const [now] = useState(
-    DateTime.local().setZone(zone).startOf('minute').toISO(),
-  )
+  const [now] = useState(DateTime.utc().startOf('minute').toISO())
 
   function validate(): Error | null {
     if (isISOBefore(value.start, value.end)) return null

--- a/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import {
   Grid,
   DialogContentText,
@@ -31,15 +31,10 @@ export default function TempSchedTimesStep({
   const classes = useStyles()
 
   const [zone] = useURLParam('tz', 'local')
-  const [now, setNow] = useState<string>()
-  useEffect(() => {
-    setNow(
-      DateTime.local()
-        .setZone(zone)
-        .startOf('minute')
-        .toISO(),
-    )
-  }, [])
+  const [now] = useState(DateTime.local()
+  .setZone(zone)
+  .startOf('minute')
+  .toISO())
 
   function validate(): Error | null {
     if (isISOBefore(value.start, value.end)) return null

--- a/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
@@ -33,8 +33,12 @@ export default function TempSchedTimesStep({
   const [zone] = useURLParam('tz', 'local')
   const [now, setNow] = useState<string>()
   useEffect(() => {
-    setNow( DateTime.local().setZone(zone)
-    .startOf('minute').toFormat("yyyy-MM-dd'T'HH:mm:ss"))
+    setNow(
+      DateTime.local()
+        .setZone(zone)
+        .startOf('minute')
+        .toFormat("yyyy-MM-dd'T'HH:mm:ss"),
+    )
   }, [])
 
   function validate(): Error | null {

--- a/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
@@ -31,10 +31,9 @@ export default function TempSchedTimesStep({
   const classes = useStyles()
 
   const [zone] = useURLParam('tz', 'local')
-  const [now] = useState(DateTime.local()
-  .setZone(zone)
-  .startOf('minute')
-  .toISO())
+  const [now] = useState(
+    DateTime.local().setZone(zone).startOf('minute').toISO(),
+  )
 
   function validate(): Error | null {
     if (isISOBefore(value.start, value.end)) return null

--- a/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
@@ -28,7 +28,6 @@ export default function TempSchedTimesStep({
   value,
 }: TempSchedTimesStepProps): JSX.Element {
   const classes = useStyles()
-
   const [now] = useState(DateTime.utc().startOf('minute').toISO())
 
   function validate(): Error | null {

--- a/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedTimesStep.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   Grid,
   DialogContentText,
@@ -10,6 +10,8 @@ import { ISODateTimePicker } from '../../util/ISOPickers'
 import { contentText, StepContainer, Value } from './sharedUtils'
 import { ScheduleTZFilter } from '../ScheduleTZFilter'
 import { isISOBefore } from '../../util/shifts'
+import { useURLParam } from '../../actions'
+import { DateTime } from 'luxon'
 
 const useStyles = makeStyles({
   contentText,
@@ -27,6 +29,13 @@ export default function TempSchedTimesStep({
   value,
 }: TempSchedTimesStepProps): JSX.Element {
   const classes = useStyles()
+
+  const [zone] = useURLParam('tz', 'local')
+  const [now, setNow] = useState<string>()
+  useEffect(() => {
+    setNow( DateTime.local().setZone(zone)
+    .startOf('minute').toFormat("yyyy-MM-dd'T'HH:mm:ss"))
+  }, [])
 
   function validate(): Error | null {
     if (isISOBefore(value.start, value.end)) return null
@@ -62,6 +71,7 @@ export default function TempSchedTimesStep({
             component={ISODateTimePicker}
             required
             name='start'
+            min={now}
             validate={() => validate()}
           />
         </Grid>
@@ -71,6 +81,7 @@ export default function TempSchedTimesStep({
             component={ISODateTimePicker}
             required
             name='end'
+            min={now}
             validate={() => validate()}
           />
         </Grid>

--- a/web/src/app/util/ISOPickers.js
+++ b/web/src/app/util/ISOPickers.js
@@ -73,11 +73,14 @@ function useISOPicker(
     }
   }
 
-  // starts with label above textfield so format placeholder can be seen
-  const shrinkInputLabel = (p) => ({
-    ...(p?.InputLabelProps ?? {}),
-    shrink: true,
-  })
+  // shrink: true sets the label above the textfield so the placeholder can be properly seen
+  const inputLabelProps = otherProps?.InputLabelProps ?? {}
+  inputLabelProps.shrink = true
+
+  // sets min and max if set
+  const inputProps = otherProps?.inputProps ?? {}
+  if (min) inputProps.min = DateTime.fromISO(min).toFormat(format)
+  if (max) inputProps.max = DateTime.fromISO(max).toFormat(format)
 
   if (native) {
     return (
@@ -86,8 +89,8 @@ function useISOPicker(
         value={inputValue}
         onChange={handleChange}
         {...otherProps}
-        inputProps={{ ...(otherProps?.inputProps ?? {}), min, max }}
-        InputLabelProps={shrinkInputLabel(otherProps)}
+        InputLabelProps={inputLabelProps}
+        inputProps={inputProps}
       />
     )
   }
@@ -121,7 +124,7 @@ function useISOPicker(
       }}
       {...extraProps}
       {...otherProps}
-      InputLabelProps={shrinkInputLabel(otherProps)}
+      InputLabelProps={inputLabelProps}
     />
   )
 }
@@ -137,7 +140,7 @@ export function ISOTimePicker(props) {
 
 export function ISODateTimePicker(props) {
   return useISOPicker(props, {
-    format: `yyyy-MM-dd'T'HH:mm`,
+    format: `yyyy-MM-dd'T'HH:mm`, // yyyy-MM-dd'T'HH:mm:ss
     Fallback: DateTimePicker,
     truncateTo: 'minute',
     type: 'datetime-local',

--- a/web/src/app/util/ISOPickers.js
+++ b/web/src/app/util/ISOPickers.js
@@ -17,7 +17,7 @@ function hasInputSupport(name) {
 }
 
 function useISOPicker(
-  { value, onChange, timeZone, ...otherProps },
+  { value, onChange, timeZone, min, max, ...otherProps },
   { format, truncateTo, type, Fallback },
 ) {
   const native = hasInputSupport(type)
@@ -86,6 +86,7 @@ function useISOPicker(
         value={inputValue}
         onChange={handleChange}
         {...otherProps}
+        inputProps={{ ...(otherProps?.inputProps ?? {}), min, max }}
         InputLabelProps={shrinkInputLabel(otherProps)}
       />
     )
@@ -103,6 +104,8 @@ function useISOPicker(
       value={dtValue}
       onChange={(v) => handleChange({ target: { value: v } })}
       showTodayButton
+      minDate={min}
+      maxDate={max}
       DialogProps={{
         'data-cy': 'picker-fallback',
       }}

--- a/web/src/app/util/ISOPickers.js
+++ b/web/src/app/util/ISOPickers.js
@@ -140,7 +140,7 @@ export function ISOTimePicker(props) {
 
 export function ISODateTimePicker(props) {
   return useISOPicker(props, {
-    format: `yyyy-MM-dd'T'HH:mm`, // yyyy-MM-dd'T'HH:mm:ss
+    format: `yyyy-MM-dd'T'HH:mm`,
     Fallback: DateTimePicker,
     truncateTo: 'minute',
     type: 'datetime-local',


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [ ] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR ensures that the start date of a temporary schedule can not begin in the past.

**Describe any introduced API changes:**
Adds support for `min` and `max` dates in `ISOPickers`

**Screenshots:**
<img width="550" src="https://user-images.githubusercontent.com/11381794/96932038-1b7e7900-1473-11eb-883d-717f776745ca.png" />