### PR TITLE
fix: memoize calendar event handlers to prevent tooltip flicker

### DIFF
--- a/web/src/app/schedules/ScheduleDetails.js
+++ b/web/src/app/schedules/ScheduleDetails.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
 import p from 'prop-types'
 import gql from 'graphql-tag'
 import { useQuery } from 'react-apollo'
@@ -45,6 +45,18 @@ export default function ScheduleDetails({ scheduleID }) {
   const [showDelete, setShowDelete] = useState(false)
   const [configTempSchedule, setConfigTempSchedule] = useState(null)
   const [deleteTempSchedule, setDeleteTempSchedule] = useState(null)
+
+  const onNewTempSched = useMemo(() => () => setConfigTempSchedule(true), [
+    scheduleID,
+  ])
+  const onEditTempSched = useMemo(
+    () => (sched) => setConfigTempSchedule(sched),
+    [scheduleID],
+  )
+  const onDeleteTempSched = useMemo(
+    () => (sched) => setDeleteTempSchedule(sched),
+    [scheduleID],
+  )
 
   const resetFilter = useResetURLParams(
     'userFilter',
@@ -153,9 +165,9 @@ export default function ScheduleDetails({ scheduleID }) {
         pageFooter={
           <ScheduleCalendarQuery
             scheduleID={scheduleID}
-            onNewTempSched={() => setConfigTempSchedule(true)}
-            onEditTempSched={(sched) => setConfigTempSchedule(sched)}
-            onDeleteTempSched={(sched) => setDeleteTempSchedule(sched)}
+            onNewTempSched={onNewTempSched}
+            onEditTempSched={onEditTempSched}
+            onDeleteTempSched={onDeleteTempSched}
           />
         }
       />

--- a/web/src/app/schedules/ScheduleDetails.js
+++ b/web/src/app/schedules/ScheduleDetails.js
@@ -46,16 +46,14 @@ export default function ScheduleDetails({ scheduleID }) {
   const [configTempSchedule, setConfigTempSchedule] = useState(null)
   const [deleteTempSchedule, setDeleteTempSchedule] = useState(null)
 
-  const onNewTempSched = useMemo(() => () => setConfigTempSchedule(true), [
-    scheduleID,
-  ])
+  const onNewTempSched = useMemo(() => () => setConfigTempSchedule(true), [])
   const onEditTempSched = useMemo(
     () => (sched) => setConfigTempSchedule(sched),
-    [scheduleID],
+    [],
   )
   const onDeleteTempSched = useMemo(
     () => (sched) => setDeleteTempSchedule(sched),
-    [scheduleID],
+    [],
   )
 
   const resetFilter = useResetURLParams(

--- a/web/src/app/schedules/ScheduleDetails.js
+++ b/web/src/app/schedules/ScheduleDetails.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useCallback } from 'react'
 import p from 'prop-types'
 import gql from 'graphql-tag'
 import { useQuery } from 'react-apollo'
@@ -46,13 +46,13 @@ export default function ScheduleDetails({ scheduleID }) {
   const [configTempSchedule, setConfigTempSchedule] = useState(null)
   const [deleteTempSchedule, setDeleteTempSchedule] = useState(null)
 
-  const onNewTempSched = useMemo(() => () => setConfigTempSchedule(true), [])
-  const onEditTempSched = useMemo(
-    () => (sched) => setConfigTempSchedule(sched),
+  const onNewTempSched = useCallback(() => setConfigTempSchedule(true), [])
+  const onEditTempSched = useCallback(
+    (sched) => setConfigTempSchedule(sched),
     [],
   )
-  const onDeleteTempSched = useMemo(
-    () => (sched) => setDeleteTempSchedule(sched),
+  const onDeleteTempSched = useCallback(
+    (sched) => setDeleteTempSchedule(sched),
     [],
   )
 

--- a/web/src/app/schedules/ScheduleDetails.js
+++ b/web/src/app/schedules/ScheduleDetails.js
@@ -47,14 +47,8 @@ export default function ScheduleDetails({ scheduleID }) {
   const [deleteTempSchedule, setDeleteTempSchedule] = useState(null)
 
   const onNewTempSched = useCallback(() => setConfigTempSchedule(true), [])
-  const onEditTempSched = useCallback(
-    (sched) => setConfigTempSchedule(sched),
-    [],
-  )
-  const onDeleteTempSched = useCallback(
-    (sched) => setDeleteTempSchedule(sched),
-    [],
-  )
+  const onEditTempSched = useCallback(setConfigTempSchedule, [])
+  const onDeleteTempSched = useCallback(setDeleteTempSchedule, [])
 
   const resetFilter = useResetURLParams(
     'userFilter',


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
To prevent unnecessary remounting of calendar event wrappers, we can memoize the event handlers here

Fixes #959 