### PR TITLE
fix: disable arrow keys on swipable temp schedule dialog

### DIFF
--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -6,13 +6,13 @@ import FormDialog from '../../dialogs/FormDialog'
 import { Shift, Value } from './sharedUtils'
 import _ from 'lodash-es'
 import { FormContainer } from '../../forms'
-import { bindKeyboard, virtualize } from 'react-swipeable-views-utils'
+import { virtualize } from 'react-swipeable-views-utils'
 import SwipeableViews from 'react-swipeable-views'
 import TempSchedAddShiftsStep from './TempSchedAddShiftsStep'
 import TempSchedTimesStep from './TempSchedTimesStep'
 import { parseInterval } from '../../util/shifts'
 // allows changing the index programatically
-const VirtualizeAnimatedViews = bindKeyboard(virtualize(SwipeableViews))
+const VirtualizeAnimatedViews = virtualize(SwipeableViews)
 
 const mutation = gql`
   mutation($input: SetTemporaryScheduleInput!) {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Disable arrow key navigation on swipable dialog views since it is unexpected behavior which can lead to confusing states for a user e.g. bypassing form validation