### PR TITLE
ui: convert to controlled tooltip in calendar

### DIFF
--- a/web/src/app/schedules/CalendarEventWrapper.js
+++ b/web/src/app/schedules/CalendarEventWrapper.js
@@ -226,10 +226,7 @@ export default class CalendarEventWrapper extends Component {
         title={this.renderInteractiveTooltip()}
       >
         {React.cloneElement(children, {
-          onClick: () => {
-            children.props.onClick() // toggles selected
-            this.handleClickTooltip() // toggles tooltip
-          },
+          onMouseUp: this.handleClickTooltip,
           onFocus: this.handleFocusTooltip,
           onBlur: this.handleBlurTooltip,
           role: 'button',

--- a/web/src/app/schedules/CalendarEventWrapper.js
+++ b/web/src/app/schedules/CalendarEventWrapper.js
@@ -232,6 +232,7 @@ export default class CalendarEventWrapper extends Component {
           },
           onFocus: this.handleFocusTooltip,
           onBlur: this.handleBlurTooltip,
+          role: 'button',
         })}
       </Tooltip>
     )

--- a/web/src/cypress/integration/scheduleCalendar.ts
+++ b/web/src/cypress/integration/scheduleCalendar.ts
@@ -87,7 +87,7 @@ function testCalendar(screen: ScreenFormat): void {
   })
 
   it(`should view a shift's tooltip`, () => {
-    cy.get('div').contains(rot.users[0].name).trigger('mouseover')
+    cy.get('div').contains(rot.users[0].name).click()
     cy.get('div[data-cy="shift-tooltip"]').should('be.visible')
     cy.get('button[data-cy="replace-override"]').should('be.visible')
     cy.get('button[data-cy="remove-override"]').should('be.visible')
@@ -191,7 +191,7 @@ function testCalendar(screen: ScreenFormat): void {
       cy.get('[data-cy=calendar]')
         .should('contain', name)
         .contains('div', name)
-        .trigger('mouseover')
+        .click()
       cy.get('div[data-cy="shift-tooltip"]').should('be.visible')
       cy.get('button[data-cy="replace-override"]').click()
       cy.dialogTitle('Replace a User')
@@ -206,7 +206,7 @@ function testCalendar(screen: ScreenFormat): void {
     cy.get('[data-cy=calendar]')
       .should('contain', name)
       .contains('div', name)
-      .trigger('mouseover')
+      .click()
     cy.get('div[data-cy="shift-tooltip"]').should('be.visible')
     cy.get('button[data-cy="remove-override"]').click()
     cy.dialogTitle('Remove a User')


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR converts the tooltips for each shift in the calendar to appear when clicked. This allows more accurate viewing of shifts in busy calendars, and addresses a bug where the popover would display overtop dialogs if the mouse position does not change.