### PR TITLE
fix: add shift form validation

### DIFF
--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
@@ -140,8 +140,6 @@ export default function TempSchedAddShiftsStep({
 
     if (!isISOAfter(shift.end, shift.start)) {
       add('end', 'must be after shift start time')
-    }
-    if (!isISOBefore(shift.start, shift.end)) {
       add('start', 'must be before shift end time')
     }
     if (isISOBefore(shift.start, start)) {

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
@@ -126,52 +126,29 @@ export default function TempSchedAddShiftsStep({
   // that makes the network request.
   function fieldErrors(s = submitted): FieldError[] {
     const result: FieldError[] = []
-
-    if (!shift) {
-      return result
+    const requiredMsg = 'this field is required'
+    const add = (field: string, message: string): void => {
+      result.push({ field, message } as FieldError)
     }
 
+    if (!shift) return result
     if (s) {
-      const message = 'this field is required'
-      if (!shift.userID) {
-        result.push({
-          field: 'userID',
-          message,
-        } as FieldError)
-      }
-      if (!shift.start) {
-        result.push({
-          field: 'start',
-          message,
-        } as FieldError)
-      }
-      if (!shift.end) {
-        result.push({
-          field: 'end',
-          message,
-        } as FieldError)
-      }
-
-      return result
+      if (!shift.userID) add('userID', requiredMsg)
+      if (!shift.start) add('start', requiredMsg)
+      if (!shift.end) add('end', requiredMsg)
     }
 
-    if (!isISOAfter(shift.end, shift?.start)) {
-      result.push({
-        field: 'end',
-        message: 'must be after shift start time',
-      } as FieldError)
+    if (!isISOAfter(shift.end, shift.start)) {
+      add('end', 'must be after shift start time')
+    }
+    if (!isISOBefore(shift.start, shift.end)) {
+      add('start', 'must be before shift end time')
     }
     if (isISOBefore(shift.start, start)) {
-      result.push({
-        field: 'start',
-        message: 'must not be before temporary schedule start time',
-      } as FieldError)
+      add('start', 'must not be before temporary schedule start time')
     }
     if (isISOAfter(shift.end, end)) {
-      result.push({
-        field: 'end',
-        message: 'must not extend beyond temporary schedule end time',
-      } as FieldError)
+      add('end', 'must not extend beyond temporary schedule end time')
     }
     return result
   }
@@ -239,9 +216,12 @@ export default function TempSchedAddShiftsStep({
         <Grid item xs={2} className={classes.addButtonContainer}>
           <Fab
             className={classes.addButton}
+            aria-label='Add Shift'
+            title='Add Shift'
             onClick={handleAddShift}
             size='medium'
             color='primary'
+            type='button'
             disabled={Boolean(fieldErrors().length)}
           >
             <AddIcon />

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
@@ -242,6 +242,7 @@ export default function TempSchedAddShiftsStep({
             onClick={handleAddShift}
             size='medium'
             color='primary'
+            disabled={Boolean(fieldErrors().length)}
           >
             <AddIcon />
           </Fab>


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Current state: 
When filling out the Add Shift form, users may add an "invalid shift". The user must ultimately either:
- delete and create new shift
- edit schedule bounds

New state:
When filling out the Add Shift form, users may only add shifts that are valid with respect to the stateful temp sched start/end times.

Net effect:
This only changes the UX. If a user creates an invalid state at any point in time, the ultimate form submit will prevent form submission and provide relevant error messaging. 