### PR TITLE
temp-schedules: fix shift sort order

### DIFF
--- a/schedule/fixedshift.go
+++ b/schedule/fixedshift.go
@@ -75,10 +75,13 @@ func mergeShifts(shifts []FixedShift) []FixedShift {
 		result = append(result, mergeShiftsByTime(s)...)
 	}
 
-	// Return deterministic output by sorting by UserID
-	// if the Start times are equal.
-	sort.SliceStable(result, func(i, j int) bool {
-		return result[i].Start.Equal(result[j].Start) && result[i].UserID < result[j].UserID
+	// Return deterministic output by sorting by Start,
+	// or UserID if the Start times are equal.
+	sort.Slice(result, func(i, j int) bool {
+		if !result[i].Start.Equal(result[j].Start) {
+			return result[i].Start.Before(result[j].Start)
+		}
+		return result[i].UserID < result[j].UserID
 	})
 
 	return result

--- a/schedule/fixedshift.go
+++ b/schedule/fixedshift.go
@@ -75,5 +75,11 @@ func mergeShifts(shifts []FixedShift) []FixedShift {
 		result = append(result, mergeShiftsByTime(s)...)
 	}
 
+	// Return deterministic output by sorting by UserID
+	// if the Start times are equal.
+	sort.SliceStable(result, func(i, j int) bool {
+		return result[i].Start.Equal(result[j].Start) && result[i].UserID < result[j].UserID
+	})
+
 	return result
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Fixes a bug where the order of shifts within a temporary schedule was not deterministic, caught by a unit test that sometimes failed.