### PR TITLE
ui/safari: fix dialog overflow in temp schedules shifts step

### DIFF
--- a/web/src/app/dialogs/FormDialog.js
+++ b/web/src/app/dialogs/FormDialog.js
@@ -26,6 +26,7 @@ const styles = (theme) => {
       height: '100%', // pushes caption to bottom if room is available
     },
     dialogContent: {
+      height: '100%', // parents of form need height set to properly function in Safari
       padding: 0,
     },
     formContainer: {

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
@@ -30,9 +30,13 @@ const useStyles = makeStyles((theme) => ({
   avatar: {
     backgroundColor: theme.palette.primary.main,
   },
-  listContainer: {
+  listOuterContainer: {
     position: 'relative',
     overflowY: 'auto',
+  },
+  listInnerContainer: {
+    position: 'absolute',
+    width: '100%',
   },
   mainContainer: {
     height: '100%',
@@ -227,8 +231,8 @@ export default function TempSchedAddShiftsStep({
         </Grid>
 
         {/* shifts list container */}
-        <Grid item xs={5} className={classes.listContainer}>
-          <div style={{ position: 'absolute', width: '100%' }}>
+        <Grid item xs={5} className={classes.listOuterContainer}>
+          <div className={classes.listInnerContainer}>
             <TempSchedShiftsList
               value={value}
               start={start}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Fixes an issue where form height was not stretched to fill the height of its parent container in Safari.
