### PR TITLE
cypress: use reasonable limits for calendar tests

### DIFF
--- a/web/src/cypress/integration/rotations.ts
+++ b/web/src/cypress/integration/rotations.ts
@@ -69,7 +69,7 @@ function testRotations(): void {
   describe('Details Page', () => {
     let rot: Rotation
     beforeEach(() =>
-      cy.createRotation({ count: 3 }).then((r: Rotation) => {
+      cy.createRotation({ numUsers: 3 }).then((r: Rotation) => {
         rot = r
         return cy.visit(`/rotations/${r.id}`)
       }),

--- a/web/src/cypress/integration/scheduleCalendar.ts
+++ b/web/src/cypress/integration/scheduleCalendar.ts
@@ -1,6 +1,9 @@
+import { Chance } from 'chance'
 import { testScreen } from '../support'
 import { DateTime } from 'luxon'
 import { Schedule } from '../../schema'
+
+const c = new Chance()
 
 const monthHeaderFormat = (t: DateTime): string => t.toFormat('MMMM')
 const weekHeaderFormat = (t: DateTime): string => {
@@ -33,9 +36,11 @@ function testCalendar(screen: ScreenFormat): void {
       sched = s
 
       cy.createRotation({
-        count: 3,
+        numUsers: 3,
         type: 'hourly',
-        shiftLength: 1,
+        // based on production data, roughly 50% of hourly rotations have
+        // a 12 hour shiftLength. pick that or 4-12 hours, outliers excluded
+        shiftLength: c.pickone([c.integer({ min: 4, max: 12 }), 12]),
       }).then((r: Rotation) => {
         rot = r
 

--- a/web/src/cypress/integration/scheduleCalendar.ts
+++ b/web/src/cypress/integration/scheduleCalendar.ts
@@ -38,9 +38,9 @@ function testCalendar(screen: ScreenFormat): void {
       cy.createRotation({
         numUsers: 3,
         type: 'hourly',
-        // based on production data, roughly 50% of hourly rotations have
-        // a 12 hour shiftLength. pick that or 4-12 hours, outliers excluded
-        shiftLength: c.pickone([c.integer({ min: 4, max: 12 }), 12]),
+        // based on production data the majority of rotations have a shiftLength of
+        // 4-12 hours. ~50% of these have are 12 hours, pick between 12 or 4-11 hours
+        shiftLength: c.pickone([c.integer({ min: 4, max: 11 }), 12]),
       }).then((r: Rotation) => {
         rot = r
 
@@ -65,29 +65,11 @@ function testCalendar(screen: ScreenFormat): void {
     })
   })
 
-  it('should view shifts', () => {
-    let check = rot.users.length
-    // TODO: This could still fail between 10pm and 11:59pm
-    // on the last day of the month (since the next day/shift isn't rendered)
-    //
-    // Once the calendar render fixes are in, it could still happen if the last day
-    // of the month is a Saturday.
-    //
-    // Until then, it will also fail on the last day of any month based on the current time.
-    //
-    // Proper fix would be to control the time (frontend and backend) when these tests are run
-    // to explicitly (and predictably) check these edge cases.
+  it('should view shifts in month view', () => {
+    cy.get('button[data-cy="next"]').click() // view shifts within the scope of a full month
 
-    if (now.endOf('month').day === now.day) {
-      if (now.hour >= 11) {
-        check = 1
-      } else if (now.hour >= 10) {
-        check = 2
-      }
-    }
-
-    for (let i = 0; i < check; i++) {
-      cy.get('body').should('contain', rot.users[i].name)
+    for (let i = 0; i < rot.users.length; i++) {
+      cy.get('body [data-cy="calendar"]').should('contain', rot.users[i].name)
     }
   })
 

--- a/web/src/cypress/integration/scheduleCalendar.ts
+++ b/web/src/cypress/integration/scheduleCalendar.ts
@@ -39,7 +39,7 @@ function testCalendar(screen: ScreenFormat): void {
         numUsers: 3,
         type: 'hourly',
         // based on production data the majority of rotations have a shiftLength of
-        // 4-12 hours. ~50% of these have are 12 hours, pick between 12 or 4-11 hours
+        // 4-12 hours. Roughly 50% of these are 12 hours, so pick between 12 or 4-11 hours
         shiftLength: c.pickone([c.integer({ min: 4, max: 11 }), 12]),
       }).then((r: Rotation) => {
         rot = r

--- a/web/src/cypress/support/rotation.ts
+++ b/web/src/cypress/support/rotation.ts
@@ -25,7 +25,7 @@ function createRotation(rot?: RotationOptions): Cypress.Chainable<Rotation> {
 
   return cy.fixture('users').then((users: Profile[]) => {
     if (!rot) rot = {}
-    const ids = c.pickset(users, rot.count).map((usr: Profile) => usr.id)
+    const ids = c.pickset(users, rot.numUsers).map((usr: Profile) => usr.id)
 
     return cy
       .graphql(query, {

--- a/web/src/cypress/types/rotation.d.ts
+++ b/web/src/cypress/types/rotation.d.ts
@@ -36,5 +36,5 @@ interface RotationOptions {
   favorite?: boolean
 
   /** Number of participants to add to the rotation. */
-  count?: number
+  numUsers?: number
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adjusts the `shiftLength` limit of the hourly rotations created while testing the schedule calendar because of a performance issue mainly noticeable within our CI testing environment. **Schedules with a rotation assignment handing off every hour may lead to performance issues and should still be addressed.** The decision was made to continue forward with this milestone while addressing the performance degradation in CI first.