### PR TITLE
alert log: return no status if message is unavailable

### DIFF
--- a/graphql2/graphqlapp/alert.go
+++ b/graphql2/graphqlapp/alert.go
@@ -105,6 +105,9 @@ func (a *AlertLogEntry) notificationSentState(ctx context.Context, obj *alertlog
 	if err != nil {
 		return nil, errors.Wrap(err, "find alert log state")
 	}
+	if s == nil {
+		return nil, nil
+	}
 
 	return notificationStateFromStatus(*s), nil
 }

--- a/web/src/cypress/support/form.ts
+++ b/web/src/cypress/support/form.ts
@@ -81,7 +81,7 @@ function materialCalendar(date: string | DateTime): void {
         .should(
           'contain',
           displayedDT
-            .plus({ months: (diff < 0 ? -1 : 1) * i + 1 })
+            .plus({ months: (diff < 0 ? -1 : 1) * (i + 1) })
             .toFormat('MMMM'),
         )
         .should(


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes a nil pointer exception when the message status is no longer available from the alert log.