### PR TITLE
graphql: make timestamps always in UTC

### DIFF
--- a/graphql2/isotimestamp.go
+++ b/graphql2/isotimestamp.go
@@ -16,7 +16,7 @@ func MarshalISOTimestamp(t time.Time) graphql.Marshaler {
 			io.WriteString(w, "null")
 			return
 		}
-		io.WriteString(w, `"`+t.Format(time.RFC3339Nano)+`"`)
+		io.WriteString(w, `"`+t.UTC().Format(time.RFC3339Nano)+`"`)
 	})
 }
 func UnmarshalISOTimestamp(v interface{}) (time.Time, error) {

--- a/smoketest/graphqlupdaterotation_test.go
+++ b/smoketest/graphqlupdaterotation_test.go
@@ -170,7 +170,7 @@ func TestGraphQLUpdateRotation(t *testing.T) {
 	assert.Equal(t, "new name", updatedRotation.Rotation.Name)
 	assert.Equal(t, "new description", updatedRotation.Rotation.Description)
 	assert.Equal(t, "America/New_York", updatedRotation.Rotation.TimeZone)
-	assert.Equal(t, "1997-11-26T12:08:00-05:00", updatedRotation.Rotation.Start) // truncate to minute
+	assert.Equal(t, "1997-11-26T17:08:00Z", updatedRotation.Rotation.Start) // truncate to minute
 	assert.Equal(t, "hourly", updatedRotation.Rotation.Type)
 	assert.Equal(t, 12, updatedRotation.Rotation.ShiftLength)
 	assert.Equal(t, 0, updatedRotation.Rotation.ActiveUserIndex)


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Small change to ensure all returned ISO timestamps from GraphQL calls are in the UTC offset.

This makes comparing output, sorting, etc.. easier.