### PR TITLE
temp schedules: include history when calculating shifts

### DIFF
--- a/oncall/state.go
+++ b/oncall/state.go
@@ -161,7 +161,7 @@ func (s *state) CalculateShifts(start, end time.Time) []Shift {
 		onCall := rules.ActiveUsers()
 
 		// apply any overrides
-		setOnCall(overrides.MapUsers(onCall), nil)
+		setOnCall(overrides.MapUsers(onCall), hist.ActiveTimes())
 	}
 
 	// remaining shifts are truncated


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR includes history when calculating shifts to match the business logic in current master when querying for shifts that have a start time in the past.