### PR TITLE
cypress: block outgoing requests to gravatar

### DIFF
--- a/web/src/cypress.json
+++ b/web/src/cypress.json
@@ -10,5 +10,6 @@
   "retries": {
     "runMode": 2,
     "openMode": 0
-  }
+  },
+  "blockHosts": ["gravatar.com"]
 }

--- a/web/src/cypress/integration/rotations.ts
+++ b/web/src/cypress/integration/rotations.ts
@@ -106,7 +106,6 @@ function testRotations(): void {
     it('should allow re-ordering participants', () => {
       // ensure list has fully loaded before drag/drop
       cy.get('ul[data-cy=users]').find('li').should('have.length', 4)
-      cy.get('[data-cy=avatar-fallback]').should('not.exist')
 
       cy.get('ul[data-cy=users]')
         .find('li')


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This configures cypress to block outgoing requests to gravatar. This is necessary because the current version of cypress (5.5.0) is unfortunately spamming thousands of requests for static assets. Performance impact is expected to be negligible, but it would be courteous of us to not hammer gravatar's servers/cache whenever we run our tests.