### PR TITLE
fix: material select shows selected option in dropdown for single-select

### DIFF
--- a/web/src/app/selection/MaterialSelect.tsx
+++ b/web/src/app/selection/MaterialSelect.tsx
@@ -105,22 +105,26 @@ export default function MaterialSelect(
     _setInputValue(input)
     onInputChange(input)
   }
+
+  const multi = multiple ? { multiple: true, filterSelectedOptions: true } : {}
+
   useEffect(() => {
     if (multiple) return
     if (!value) setInputValue('')
     if (!inputValue && value) setInputValue(getInputLabel())
   }, [value, multiple])
 
-  const multi = multiple ? { multiple: true } : {}
-
-  // merge selected values with options to avoid annoying mui warnings while dropdown is closed
+  // merge selected values with options to avoid annoying mui warnings
   // https://github.com/mui-org/material-ui/issues/18514
-  // be sure to keep the props `filterSelectedOptions` set to hide selected value from dropdown
-  // and `getOptionSelected` to ensure what shows as selected for all incoming values
-  let options: SelectOption[] = _options
-  if (value) {
-    // merge options with value
-    options = options.concat(Array.isArray(value) ? value : [value])
+  let options = _options
+  if (value && Array.isArray(value)) {
+    options = [...options, ...value]
+  } else if (
+    value &&
+    !Array.isArray(value) &&
+    options.every((opt) => opt.value !== value.value)
+  ) {
+    options = [value, ...options]
   }
 
   return (
@@ -131,12 +135,11 @@ export default function MaterialSelect(
         option: classes.option,
         clearIndicator: classes.clearIndicator,
       }}
-      {...multi} // multiple: true | undefined
+      {...multi}
       value={value}
       inputValue={inputValue}
       disableClearable={required}
       disabled={disabled}
-      filterSelectedOptions
       getOptionSelected={(opt, val) => opt.value === val.value}
       noOptionsText={noOptionsText}
       onChange={(

--- a/web/src/cypress/integration/materialSelect.ts
+++ b/web/src/cypress/integration/materialSelect.ts
@@ -96,6 +96,22 @@ function testMaterialSelect(): void {
       })
     })
   })
+
+  describe('render options', () => {
+    it.only('should show selected value as an option in single-select mode', () => {
+      cy.visit('/wizard')
+
+      cy.form({ 'primarySchedule.timeZone': 'America/Chicago' })
+
+      cy.get(`input[name="primarySchedule.timeZone"]`)
+        .should('have.value', 'America/Chicago')
+        .click()
+
+      cy.get('[data-cy=select-dropdown]')
+        .should('exist')
+        .contains('America/Chicago')
+    })
+  })
 }
 
 testScreen('Material Select', testMaterialSelect)

--- a/web/src/cypress/integration/materialSelect.ts
+++ b/web/src/cypress/integration/materialSelect.ts
@@ -98,7 +98,7 @@ function testMaterialSelect(): void {
   })
 
   describe('render options', () => {
-    it.only('should show selected value as an option in single-select mode', () => {
+    it('should show selected value as an option in single-select mode', () => {
       cy.visit('/wizard')
 
       cy.form({ 'primarySchedule.timeZone': 'America/Chicago' })


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes an issue in the autocomplete select component in which the stateful selected option would not render as an option in the dropdown.

**Which issue(s) this PR fixes:**
Closes #994 and closes #958

**Screenshots:**
<img width="669" alt="Screen Shot 2020-11-05 at 11 53 26 AM" src="https://user-images.githubusercontent.com/17692467/98277941-8a70cd00-1f5d-11eb-91c0-e371c86b733f.png">
