### PR TITLE
dev: add pgdump-lite tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ $(BIN_DIR)/integration/goalert/cypress: web/src/node_modules web/src/webpack.cyp
 	cp -r web/src/cypress/fixtures bin/integration/goalert/cypress/
 	touch $@
 
-$(BIN_DIR)/integration/goalert/bin: $(BIN_DIR)/goalert-linux-amd64 $(BIN_DIR)/goalert-smoketest-linux-amd64 $(BIN_DIR)/mockslack-linux-amd64 $(BIN_DIR)/simpleproxy-linux-amd64 $(BIN_DIR)/waitfor-linux-amd64 $(BIN_DIR)/runjson-linux-amd64 $(BIN_DIR)/psql-lite-linux-amd64 $(BIN_DIR)/procwrap-linux-amd64
+$(BIN_DIR)/integration/goalert/bin: $(BIN_DIR)/goalert-linux-amd64 $(BIN_DIR)/goalert-smoketest-linux-amd64 $(BIN_DIR)/mockslack-linux-amd64 $(BIN_DIR)/simpleproxy-linux-amd64 $(BIN_DIR)/pgdump-lite-linux-amd64 $(BIN_DIR)/waitfor-linux-amd64 $(BIN_DIR)/runjson-linux-amd64 $(BIN_DIR)/psql-lite-linux-amd64 $(BIN_DIR)/procwrap-linux-amd64
 	rm -rf $@
 	mkdir -p bin/integration/goalert/bin
 	cp bin/*-linux-amd64 bin/integration/goalert/bin/

--- a/devtools/ci/tasks/scripts/test-integration.sh
+++ b/devtools/ci/tasks/scripts/test-integration.sh
@@ -17,7 +17,7 @@ then
   DEBUG_SUFFIX=mobile
 fi
 
-trap "pg_dump >cypress/db.sql; cp -r logs cypress/; stop_postgres; tar czf ../../debug/debug-$(date +%Y%m%d%H%M%S)-$COMMIT-$DEBUG_SUFFIX.tgz cypress" EXIT
+trap "pgdump-lite -a >cypress/db.sql; cp -r logs cypress/; stop_postgres; tar czf ../../debug/debug-$(date +%Y%m%d%H%M%S)-$COMMIT-$DEBUG_SUFFIX.tgz cypress" EXIT
 
 mockslack \
   -client-id=000000000000.000000000000 \

--- a/devtools/pgdump-lite/cmd/pgdump-lite/main.go
+++ b/devtools/pgdump-lite/cmd/pgdump-lite/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/target/goalert/devtools/pgdump-lite"
+)
+
+func main() {
+	log.SetFlags(log.Lshortfile)
+	file := flag.String("f", "", "Output file (default is stdout).")
+	db := flag.String("d", os.Getenv("DBURL"), "DB URL") // use same env var as pg_dump
+	dataOnly := flag.Bool("a", false, "dump only the data, not the schema")
+	flag.Parse()
+
+	out := os.Stdout
+	if *file != "" {
+		fd, err := os.Create(*file)
+		if err != nil {
+			log.Fatalln("ERROR: open output:", err)
+		}
+		out = fd
+		defer fd.Close()
+	}
+
+	ctx := context.Background()
+	cfg, err := pgx.ParseConfig(*db)
+	if err != nil {
+		log.Fatalln("ERROR: invalid db url:", err)
+	}
+
+	conn, err := pgx.ConnectConfig(ctx, cfg)
+	if err != nil {
+		log.Fatalln("ERROR: connect:", err)
+	}
+	defer conn.Close(ctx)
+
+	err = pgdump.DumpData(ctx, conn, out)
+	if err != nil {
+		log.Fatalln("ERROR: dump data:", err)
+	}
+
+	if *dataOnly {
+		return
+	}
+
+	// TODO: dump schema
+}

--- a/devtools/pgdump-lite/dumpdata.go
+++ b/devtools/pgdump-lite/dumpdata.go
@@ -2,6 +2,7 @@ package pgdump
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -90,6 +91,9 @@ func DumpData(ctx context.Context, conn *pgx.Conn, out io.Writer) error {
 				tbl.table_name = $1 and
 				constraint_type = 'PRIMARY KEY'
 		`, table)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("read primary key for '%s': %w", table, err)
+		}
 		sortColumns(primaryCols)
 
 		colNames := strings.Join(columns, ", ")

--- a/devtools/pgdump-lite/dumpdata.go
+++ b/devtools/pgdump-lite/dumpdata.go
@@ -1,0 +1,138 @@
+package pgdump
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/jackc/pgtype"
+	"github.com/jackc/pgx/v4"
+)
+
+func sortColumns(columns []string) {
+	// alphabetical, but with id first
+	sort.Slice(columns, func(i, j int) bool {
+		ci, cj := columns[i], columns[j]
+		if ci == cj {
+			return false
+		}
+		if ci == "id" {
+			return true
+		}
+		if cj == "id" {
+			return false
+		}
+
+		return ci < cj
+	})
+}
+
+func queryStrings(ctx context.Context, tx pgx.Tx, sql string, args ...interface{}) ([]string, error) {
+	rows, err := tx.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []string
+	for rows.Next() {
+		var value string
+		err = rows.Scan(&value)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, value)
+	}
+
+	return result, nil
+}
+
+type scannable string
+
+func (s *scannable) DecodeText(ci *pgtype.ConnInfo, src []byte) error {
+	if src == nil {
+		*s = "\\N"
+	} else {
+		*s = scannable(strings.ReplaceAll(string(src), "\\", "\\\\"))
+	}
+
+	return nil
+}
+
+func DumpData(ctx context.Context, conn *pgx.Conn, out io.Writer) error {
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead})
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	tables, err := queryStrings(ctx, tx, "select table_name from information_schema.tables where table_schema = 'public'")
+	if err != nil {
+		return fmt.Errorf("read tables: %w", err)
+	}
+	sort.Strings(tables)
+
+	for _, table := range tables {
+		columns, err := queryStrings(ctx, tx, "select column_name from information_schema.columns where table_schema = 'public' and table_name = $1 order by ordinal_position", table)
+		if err != nil {
+			return fmt.Errorf("read columns for '%s': %w", table, err)
+		}
+
+		primaryCols, err := queryStrings(ctx, tx, `
+			select col.column_name
+			from information_schema.table_constraints tbl
+			join information_schema.constraint_column_usage col on
+				col.table_schema = 'public' and
+				col.constraint_name = tbl.constraint_name
+			where
+				tbl.table_schema = 'public' and
+				tbl.table_name = $1 and
+				constraint_type = 'PRIMARY KEY'
+		`, table)
+		sortColumns(primaryCols)
+
+		colNames := strings.Join(columns, ", ")
+		orderBy := strings.Join(primaryCols, ",")
+		if orderBy == "" {
+			orderBy = colNames
+		}
+
+		fmt.Fprintf(out, "COPY %s (%s) FROM stdin;\n", table, colNames)
+		rows, err := tx.Query(ctx,
+			fmt.Sprintf("select %s from %s order by %s",
+				colNames,
+				table,
+				orderBy,
+			),
+			pgx.QuerySimpleProtocol(true),
+		)
+		if err != nil {
+			return fmt.Errorf("read data on '%s': %w", table, err)
+		}
+		defer rows.Close()
+		vals := make([]interface{}, len(columns))
+
+		for i := range vals {
+			vals[i] = new(scannable)
+		}
+		for rows.Next() {
+			err = rows.Scan(vals...)
+			if err != nil {
+				return fmt.Errorf("read data on '%s': %w", table, err)
+			}
+			for i, v := range vals {
+				if i > 0 {
+					io.WriteString(out, "\t")
+				}
+				io.WriteString(out, string(*v.(*scannable)))
+			}
+			io.WriteString(out, "\n")
+		}
+		rows.Close()
+
+		fmt.Fprintf(out, "\\.\n\n")
+	}
+
+	return tx.Commit(ctx)
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adds a new tool `pgdump-lite` that is able to dump DB data for test debugging without depending on `pg_dump`

It also results in no longer getting the circular dependency spam when running smoketests.

**Out of Scope:**
It is still required to have `pg_dump` for the migration test, schema, sequence, etc.. output is out-of-scope.
