### PR TITLE
logs: always log notification sent info

### DIFF
--- a/notification/manager.go
+++ b/notification/manager.go
@@ -198,7 +198,7 @@ func (m *Manager) Send(ctx context.Context, msg Message) (*MessageStatus, error)
 			log.Log(sendCtx, errors.Wrap(err, "send notification"))
 			continue
 		}
-		log.Debugf(sendCtx, "notification sent")
+		log.Logf(sendCtx, "notification sent")
 		// status already wrapped via namedSender
 		return status, nil
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR updates `notification/manager.go` to always log `notification sent` entries (instead of only when in debug mode).  The following is an example of what information is logged (useful for tracking what notification types are used):

`Backend  (err): time="2020-11-24T10:53:29-06:00" level=info msg="notification sent" AlertID=79672 AuthSource="SourceTypeContactMethod{00000000-0000-0000-0000-000000000000}" AuthSystemComponent=Engine AuthUserID=00000000-0000-0000-0000-000000000000 CallbackID=00000000-0000-0000-0000-000000000000 DestType=DestTypeSMS DestTypeID=00000000-0000-0000-0000-000000000000 ProviderName=Twilio-SMS ProviderType=DestTypeSMS Trigger=INTERVAL`