### PR TITLE
db: check for ErrNoRows on carrier lookup

### DIFF
--- a/notification/twilio/carrier.go
+++ b/notification/twilio/carrier.go
@@ -126,7 +126,11 @@ func (c Config) FetchCarrierInfo(ctx context.Context, number string) (*CarrierIn
 	m.CarrierV1.MobileNetworkCode = result.Carrier.MobileNetworkCode
 
 	err = c.CMStore.SetCarrierV1MetadataByTypeValue(ctx, nil, contactmethod.TypeSMS, number, &m)
-	if err != nil {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		log.Log(ctx, err)
+	}
+	err = c.CMStore.SetCarrierV1MetadataByTypeValue(ctx, nil, contactmethod.TypeVoice, number, &m)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Log(ctx, err)
 	}
 

--- a/user/contactmethod/store.go
+++ b/user/contactmethod/store.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"time"
 
 	"github.com/target/goalert/permission"
@@ -136,10 +135,6 @@ func (db *DB) MetadataByTypeValue(ctx context.Context, tx *sql.Tx, typ Type, val
 	var data json.RawMessage
 	var t time.Time
 	err = wrapTx(ctx, tx, db.metaTV).QueryRowContext(ctx, typ, value).Scan(&data, &t)
-	if errors.Is(err, sql.ErrNoRows) {
-		data = []byte("{}")
-		err = nil
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/user/contactmethod/store.go
+++ b/user/contactmethod/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/target/goalert/permission"
@@ -135,6 +136,10 @@ func (db *DB) MetadataByTypeValue(ctx context.Context, tx *sql.Tx, typ Type, val
 	var data json.RawMessage
 	var t time.Time
 	err = wrapTx(ctx, tx, db.metaTV).QueryRowContext(ctx, typ, value).Scan(&data, &t)
+	if errors.Is(err, sql.ErrNoRows) {
+		data = []byte("{}")
+		err = nil
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/web/src/app/admin/AdminNumberLookup.tsx
+++ b/web/src/app/admin/AdminNumberLookup.tsx
@@ -53,7 +53,7 @@ export default function AdminNumberLookup(): JSX.Element {
   const [lastError, setLastError] = useState(null as null | ApolloError)
 
   const { data: numData } = useQuery(numInfoQuery, {
-    variables: { number: '+' + number },
+    variables: { number },
     pollInterval: 0,
     onError: (err) => setLastError(err),
   })
@@ -62,7 +62,7 @@ export default function AdminNumberLookup(): JSX.Element {
   const [lookup, { data: carrData, loading: carrLoading }] = useMutation(
     carrierInfoMut,
     {
-      variables: { number: '+' + number },
+      variables: { number },
       onError: (err) => setLastError(err),
     },
   )


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This fixes a `sql.ErrNoRows` error that prevented carrier info from being saved as well as ensuring both SMS and Voice metadata is updated where appropriate.