### PR TITLE
ui/users: fix race condition; check for session readiness

### DIFF
--- a/web/src/app/users/UserDetails.js
+++ b/web/src/app/users/UserDetails.js
@@ -96,18 +96,25 @@ function serviceCount(onCallSteps = []) {
 export default function UserDetails(props) {
   const classes = useStyles()
 
-  const { userID: currentUserID, isAdmin } = useSessionInfo()
+  const {
+    userID: currentUserID,
+    isAdmin,
+    ready: isSessionReady,
+  } = useSessionInfo()
   const [disclaimer] = useConfigValue('General.NotificationDisclaimer')
   const [createCM, setCreateCM] = useState(false)
   const [createNR, setCreateNR] = useState(false)
   const [showVerifyDialogByID, setShowVerifyDialogByID] = useState(null)
 
-  const { data, loading, error } = useQuery(
+  const { data, loading: isQueryLoading, error } = useQuery(
     isAdmin || props.userID === currentUserID ? profileQuery : userQuery,
     {
       variables: { id: props.userID },
+      skip: !isSessionReady,
     },
   )
+
+  const loading = !isSessionReady || isQueryLoading
 
   if (error) return <GenericError error={error.message} />
   if (!_.get(data, 'user.id')) return loading ? <Spinner /> : <ObjectNotFound />


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This fixes the issue linked below. The business logic for this code is the following: "you're only authorized to view your own sessions unless you're an admin"
There are two solutions for this:
1. Query everything but the sessions until it is confirmed that the current user is an admin. Then if confirmed, query for sessions.
2. Wait to confirm whether current user is an admin. Then perform appropriate query.

This PR implements the second solution which has a slower TTI, but is a more reliable experience. I'm open to more discussion on the tradeoffs here.

**Which issue(s) this PR fixes:**
Fixes #1072 
