### PR TITLE
repo: add stale bot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,24 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+daysUntilStale: 30
+staleLabel: stale # Label to use when marking as stale
+limitPerRun: 30 # Limit the number of actions per hour, from 1-30. Default is 30
+exemptLabels:
+  - security
+
+pulls:
+  daysUntilClose: 90
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+  closeComment: false
+
+issues:
+  daysUntilClose: 365
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity.
+  closeComment: >
+    This issue has been automatically closed because it has not had any activity within
+    the past year. Thank you for your contributions.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,24 +1,18 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
-daysUntilStale: 30
 staleLabel: stale # Label to use when marking as stale
 limitPerRun: 30 # Limit the number of actions per hour, from 1-30. Default is 30
 exemptLabels:
   - security
 
 pulls:
-  daysUntilClose: 90
+  daysUntilStale: 30
   markComment: >
     This pull request has been automatically marked as stale because it has not had
-    recent activity. It will be closed if no further activity occurs. Thank you
-    for your contributions.
-  closeComment: false
+    recent activity. Thank you for your contributions.
 
 issues:
-  daysUntilClose: 365
+  daysUntilStale: 180
   markComment: >
     This issue has been automatically marked as stale because it has not had
     recent activity.
-  closeComment: >
-    This issue has been automatically closed because it has not had any activity within
-    the past year. Thank you for your contributions.


### PR DESCRIPTION
Adds [Stale](https://github.com/apps/stale) to our repo which will manage stale issues and pull requests. I aimed to use some reasonable defaults for now as we are still growing within the open-source community:

- Issues and PRs will be labeled with (stale) after 30 days and a comment will be added.
- Issues will be closed after 1 year.
- PRs will be closed after 3 months.

With our current workflow and pace of incoming external support, this seems to be a good default for how we currently operate in real time when while managing our backlog.