### PR TITLE
ui/escalation-policies: use NumberField for delay minutes

### DIFF
--- a/web/src/app/escalation-policies/PolicyStepForm.js
+++ b/web/src/app/escalation-policies/PolicyStepForm.js
@@ -7,7 +7,6 @@ import Stepper from '@material-ui/core/Stepper'
 import Step from '@material-ui/core/Step'
 import StepButton from '@material-ui/core/StepButton'
 import StepContent from '@material-ui/core/StepContent'
-import TextField from '@material-ui/core/TextField'
 import Typography from '@material-ui/core/Typography'
 import { makeStyles } from '@material-ui/core/styles'
 import {
@@ -24,6 +23,7 @@ import {
 } from '@material-ui/icons'
 import { SlackBW as SlackIcon } from '../icons/components/Icons'
 import { Config } from '../util/RequireConfig'
+import NumberField from '../util/NumberField'
 
 const useStyles = makeStyles(() => ({
   badge: {
@@ -232,7 +232,7 @@ function PolicyStepForm(props) {
         </Grid>
         <Grid item xs={12}>
           <FormField
-            component={TextField}
+            component={NumberField}
             disabled={disabled}
             fullWidth
             label='Delay (minutes)'

--- a/web/src/app/escalation-policies/PolicyStepForm.js
+++ b/web/src/app/escalation-policies/PolicyStepForm.js
@@ -238,8 +238,6 @@ function PolicyStepForm(props) {
             label='Delay (minutes)'
             name='delayMinutes'
             required
-            type='number'
-            mapOnChangeValue={(value) => value.toString()}
             min={1}
             max={9000}
             hint={


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR has the delay minutes form field use the `NumberField` component making it unclearable, preventing invalid hint text.

**Which issue(s) this PR fixes:**
Fixes #1055

**Describe any introduced user-facing changes:**
Users can't clear the field since it is required.