### PR TITLE
ui/alerts: hide "include all services" filter on service's alerts view

### DIFF
--- a/web/src/app/alerts/AlertsList.js
+++ b/web/src/app/alerts/AlertsList.js
@@ -279,7 +279,7 @@ export default function AlertsList(props) {
           selectable: a.status !== 'StatusClosed',
         })}
         variables={variables}
-        filter={<AlertsListFilter />}
+        filter={<AlertsListFilter serviceID={props.serviceID} />}
         cardHeader={
           <Hidden mdDown>
             <AlertsListControls />


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR hides the "include all services" filter on a single service's alerts list view

**Which issue(s) this PR fixes:**
Fixes #1064 
