### PR TITLE
graphql: consider parse error as client error

### DIFF
--- a/graphql2/graphqlapp/app.go
+++ b/graphql2/graphqlapp/app.go
@@ -9,6 +9,7 @@ import (
 	"github.com/target/goalert/notice"
 
 	"github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/graphql/errcode"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/apollotracing"
 	"github.com/pkg/errors"
@@ -147,7 +148,7 @@ func isGQLValidation(gqlErr *gqlerror.Error) bool {
 		return false
 	}
 
-	return code == "GRAPHQL_VALIDATION_FAILED"
+	return code == errcode.ValidationFailed || code == errcode.ParseFailed
 }
 
 func (a *App) Handler() http.Handler {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR updates the `isGQLValidation` helper function to handle parse errors as GraphQL client errors.

**Which issue(s) this PR fixes:**
Fixes #1101 
