### PR TITLE
repo: disable days until close in Stale config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,6 +4,7 @@ staleLabel: stale # Label to use when marking as stale
 limitPerRun: 30 # Limit the number of actions per hour, from 1-30. Default is 30
 exemptLabels:
   - security
+daysUntilClose: false
 
 pulls:
   daysUntilStale: 30


### PR DESCRIPTION
Explicitly disables `daysUntilClose` within Stale as the bot will still close issues and PRs automatically even when unset.