### PR TITLE
cypress/schedules: fix - should add a rotation as an assignment

### DIFF
--- a/web/src/cypress/integration/schedules.ts
+++ b/web/src/cypress/integration/schedules.ts
@@ -163,16 +163,16 @@ function testSchedules(screen: ScreenFormat): void {
     })
 
     it('should add a rotation as an assignment', () => {
-      const name = rot.name
+      cy.createRotation().then(({ name }: Rotation) => {
+        cy.get('ul').should('not.contain', name)
 
-      cy.get('body').should('not.contain', name)
+        cy.pageFab('Rotation')
+        cy.dialogTitle('Add Rotation to Schedule')
+        cy.dialogForm({ targetID: name })
+        cy.dialogFinish('Submit')
 
-      cy.pageFab('Rotation')
-      cy.dialogTitle('Add Rotation to Schedule')
-      cy.dialogForm({ targetID: name })
-      cy.dialogFinish('Submit')
-
-      cy.get('body').contains('li', name)
+        cy.get('body').contains('li', name)
+      })
     })
 
     it('should add a user as an assignment', () => {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes the test for adding a schedule assignment which was passing as a false positive.  In the `beforeEach` hook, we add a rotation to a schedule. The old test code was trying to re-add this rotation. The new test code creates an entirely new rotation altogether.

`cy.get('body').should('not.contain', name)` was only asserting on top-level `body` element and wasn't drilling down into the child nodes. 

The new code scans `cy.get('ul')` which behaves correctly and also enforces semantic html. We should avoid asserting on the `body` element in general.
