### PR TITLE
cypress: upgrade to 6.2.0

### DIFF
--- a/devtools/ci/dockerfiles/cypress-env/Dockerfile
+++ b/devtools/ci/dockerfiles/cypress-env/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/included:5.6.0
+FROM cypress/included:6.2.0
 ENTRYPOINT [ "/bin/sh" ]
 RUN apt-get update && apt-get install -y --no-install-recommends postgresql postgresql-contrib && rm -rf /var/lib/apt/lists/*
 ENV PGDATA=/var/lib/postgresql/data PGUSER=postgres DB_URL=postgresql://postgres@

--- a/devtools/ci/tasks/test-integration.yml
+++ b/devtools/ci/tasks/test-integration.yml
@@ -7,7 +7,7 @@ outputs:
   - name: debug
 image_resource:
   type: registry-image
-  source: { repository: goalert/cypress-env, tag: v5.6.0 }
+  source: { repository: goalert/cypress-env, tag: v6.2.0 }
 run:
   path: sh
   dir: integration/goalert

--- a/web/src/cypress/integration/alerts.ts
+++ b/web/src/cypress/integration/alerts.ts
@@ -240,6 +240,7 @@ function testAlerts(screen: ScreenFormat): void {
       )
 
       // ack all three
+      cy.reload()
       cy.get(`span[data-cy=item-${alert1.id}] input`).check()
       cy.get(`span[data-cy=item-${alert2.id}] input`).check()
       cy.get(`span[data-cy=item-${alert3.id}] input`).check()

--- a/web/src/cypress/integration/materialSelect.ts
+++ b/web/src/cypress/integration/materialSelect.ts
@@ -3,7 +3,7 @@ import { testScreen } from '../support'
 const c = new Chance()
 
 function testMaterialSelect(): void {
-  describe('Clear Fields', () => {
+  describe('Clear Optional Fields', () => {
     describe('Escalation Policy Steps', () => {
       let ep: EP
       beforeEach(() => {
@@ -20,21 +20,19 @@ function testMaterialSelect(): void {
           cy.pageFab()
           cy.dialogTitle('Create Step')
 
+          // populate users
           cy.get('button[data-cy="users-step"]').click()
           cy.dialogForm({ users: [u1.name, u2.name] })
 
-          // Should clear field
+          // clear field
           cy.dialogForm({ users: '' })
-          cy.get(`[role=dialog] #dialog-form input[name="rotations"]`)
+          cy.get(`input[name="users"]`)
             .should('not.contain', u1.name)
             .should('not.contain', u2.name)
 
-          cy.get(
-            `[role=dialog] #dialog-form input[name="delayMinutes"]`,
-          ).click()
-
-          // Field should remian clear
-          cy.get(`[role=dialog] #dialog-form input[name="rotations"]`)
+          // unfocus
+          cy.get(`input[name="users"]`).blur()
+          cy.get(`input[name="users"]`)
             .should('not.contain', u1.name)
             .should('not.contain', u2.name)
 

--- a/web/src/cypress/support/form.ts
+++ b/web/src/cypress/support/form.ts
@@ -146,7 +146,7 @@ function fillFormField(
               cy.get(selector).type(`{backspace}`)
             })
 
-          return cy.get(selector).clear()
+          return cy.get(selector)
         }
 
         if (DateTime.isDateTime(value)) {

--- a/web/src/cypress/support/form.ts
+++ b/web/src/cypress/support/form.ts
@@ -136,7 +136,18 @@ function fillFormField(
         .data('cyFallbackType')
 
       if (isSelect) {
-        if (value === '') return cy.get(selector).clear()
+        if (value === '') {
+          cy.get(selector).clear()
+
+          // clear chips on multi-select
+          el.parent()
+            .find('[data-cy="multi-value"] > svg')
+            .each(() => {
+              cy.get(selector).type(`{backspace}`)
+            })
+
+          return cy.get(selector).clear()
+        }
 
         if (DateTime.isDateTime(value)) {
           throw new TypeError(

--- a/web/src/cypress/support/form.ts
+++ b/web/src/cypress/support/form.ts
@@ -141,7 +141,7 @@ function fillFormField(
 
           // clear chips on multi-select
           el.parent()
-            .find('[data-cy="multi-value"] > svg')
+            .find('[data-cy="multi-value"]')
             .each(() => {
               cy.get(selector).type(`{backspace}`)
             })

--- a/web/src/package.json
+++ b/web/src/package.json
@@ -127,7 +127,7 @@
     "css-loader": "5.0.1",
     "cssnano": "4.1.10",
     "eslint": "7.13.0",
-    "cypress": "5.6.0",
+    "cypress": "6.2.0",
     "eslint-config-prettier": "7.0.0",
     "eslint-config-standard": "16.0.2",
     "eslint-config-standard-jsx": "10.0.0",

--- a/web/src/yarn.lock
+++ b/web/src/yarn.lock
@@ -3876,10 +3876,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-5.6.0.tgz#6781755c3ddfd644ce3179fcd7389176c0c82280"
-  integrity sha512-cs5vG3E2JLldAc16+5yQxaVRLLqMVya5RlrfPWkC72S5xrlHFdw7ovxPb61s4wYweROKTyH01WQc2PFzwwVvyQ==
+cypress@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.2.0.tgz#1a8a7dd5bd08db3064551a9f12072963cc9337bf"
+  integrity sha512-m/rkcogYM9MTy8rbsZgyS5wT2L/J+B5V2bY2ztkDNMyqhk/oZgUF4KTWVLzkW2I+scg0iAddca95tLlt7XnAtw==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
- Followed the [migration guide](https://docs.cypress.io/guides/references/migration-guide.html#Migrating-to-Cypress-6-0) from v5 to v6
- Reviewed full [changelog](https://docs.cypress.io/guides/references/changelog.html#6-2-0)
- Bug fix: multi select fields were not truly clearable. Now the input text will be cleared and the inline chips will be deleted when using `cy.form({inputName: ''})`
- Stability fix: added a `cy.reload()` before making assertions on the alerts page. While this may not be ideal, this is the precedent set in that test suite. I'm open to investigating this more, but IMO we are still exercising our code well enough. The main downside is the small perf impact for doing 3 page reloads