### PR TITLE
auth/github: fix missing github auth errors

### DIFF
--- a/auth/github/identityprovider.go
+++ b/auth/github/identityprovider.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/binary"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -127,6 +128,7 @@ func (p *Provider) ExtractIdentity(route *auth.RouteInfo, w http.ResponseWriter,
 
 	tok, err := oaCfg.Exchange(ctx, req.FormValue("code"))
 	if err != nil {
+		log.Log(ctx, fmt.Errorf("github: exchange token: %w", err))
 		return nil, auth.Error("Failed to get token from GitHub.")
 	}
 
@@ -145,7 +147,7 @@ func (p *Provider) ExtractIdentity(route *auth.RouteInfo, w http.ResponseWriter,
 
 	u, _, err := g.Users.Get(ctx, "")
 	if err != nil {
-		log.Debug(ctx, errors.Wrap(err, "fetch GitHub user"))
+		log.Log(ctx, fmt.Errorf("github: fetch user: %w", err))
 		return nil, auth.Error("Failed to fetch user profile from GitHub.")
 	}
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes a couple of places in the GitHub auth provider that were not properly logging errors.