### PR TITLE
ui/util: use typescript for speed dial

### DIFF
--- a/web/src/app/util/SpeedDial.tsx
+++ b/web/src/app/util/SpeedDial.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from 'react'
-import p from 'prop-types'
-import { SpeedDial, SpeedDialIcon, SpeedDialAction } from '@material-ui/lab'
+import {
+  SpeedDial,
+  SpeedDialIcon,
+  SpeedDialAction,
+  SpeedDialActionProps,
+  SpeedDialProps,
+} from '@material-ui/lab'
 import { makeStyles } from '@material-ui/styles'
 
 const useStyles = makeStyles({
@@ -20,16 +25,31 @@ const useStyles = makeStyles({
   },
 })
 
-export default function CustomSpeedDial(props) {
+interface CustomSpeedDialProps {
+  label: SpeedDialProps['ariaLabel']
+  actions: {
+    icon: SpeedDialActionProps['icon']
+    onClick: NonNullable<SpeedDialActionProps['onClick']>
+    label: SpeedDialActionProps['tooltipTitle'] &
+      SpeedDialActionProps['aria-label']
+    disabled?: boolean
+  }[]
+}
+
+export default function CustomSpeedDial(
+  props: CustomSpeedDialProps,
+): JSX.Element {
   const [open, setOpen] = useState(false)
   const classes = useStyles()
 
   return (
     <SpeedDial
       ariaLabel={props.label}
-      FabProps={{
-        'data-cy': 'page-fab',
-      }}
+      FabProps={
+        {
+          'data-cy': 'page-fab',
+        } as SpeedDialProps['FabProps']
+      }
       icon={<SpeedDialIcon />}
       onClick={() => setOpen(!open)}
       onClose={() => setOpen(false)}
@@ -59,22 +79,10 @@ export default function CustomSpeedDial(props) {
                 e.stopPropagation()
                 return
               }
-              action.onClick()
+              action.onClick(e)
             }}
           />
         ))}
     </SpeedDial>
   )
-}
-
-CustomSpeedDial.propsTypes = {
-  label: p.string.isRequired,
-  disabled: p.bool,
-  actions: p.arrayOf(
-    p.shape({
-      icon: p.element.isRequired,
-      onClick: p.func.isRequired,
-      label: p.string.isRequired,
-    }),
-  ).isRequired,
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This converts the `CustomSpeedDial` component to typescript.
The `SpeedDial` component has compatibility issues with react/react-dom v17. While investigating this, I converted this component. The original issue remains unresolved.
