### PR TITLE
alerts smtp: add config validation 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -340,6 +340,7 @@ func (cfg Config) Validate() error {
 		),
 		validateEnable("SMTP", cfg.SMTP.Enable,
 			"From", cfg.SMTP.From,
+			"Address", cfg.SMTP.Address,
 		),
 	)
 

--- a/config/config.go
+++ b/config/config.go
@@ -305,6 +305,9 @@ func (cfg Config) Validate() error {
 	if cfg.Mailgun.EmailDomain != "" {
 		err = validate.Many(err, validate.Email("Mailgun.EmailDomain", "example@"+cfg.Mailgun.EmailDomain))
 	}
+	if cfg.SMTP.From != "" {
+		err = validate.Many(err, validate.Email("SMTP.From", cfg.SMTP.From))
+	}
 
 	err = validate.Many(
 		err,

--- a/config/config.go
+++ b/config/config.go
@@ -335,6 +335,9 @@ func (cfg Config) Validate() error {
 			"ClientID", cfg.OIDC.ClientID,
 			"ClientSecret", cfg.OIDC.ClientSecret,
 		),
+		validateEnable("SMTP", cfg.SMTP.Enable,
+			"From", cfg.SMTP.From,
+		),
 	)
 
 	if cfg.Feedback.OverrideURL != "" {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adds validation for the config changes for smtp, when enabled. 
Validating that the `from` email address is a valid email and `SMTP` when enabled, makes sure that `from` and `address` fields are also specified.
