### PR TITLE
remote monitor: support for bundled sms messages

### DIFF
--- a/remotemonitor/sms.go
+++ b/remotemonitor/sms.go
@@ -45,7 +45,7 @@ func (m *Monitor) sendSMS(to, body string) {
 	log.Printf("SENT SMS: %s -> %s %s; SID=%s; Status=%s\n", msg.From, msg.To, strconv.Quote(body), msg.SID, msg.Status)
 }
 
-var actionRx = regexp.MustCompile(`'(\d+c)'`)
+var actionRx = regexp.MustCompile(`'(\d+c+)'`)
 
 func (m *Monitor) processSMS(from, body string) {
 	log.Println("INCOMING SMS:", from, strconv.Quote(body))


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR closes #1195 by tweaking the remote monitor's regex to allow matches for bundled message close codes (where the close action code = `cc` (instead of just `c` for single alert notifications).