### PR TITLE
add CalcRotationHandoffTimesInput from parameter

### DIFF
--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -3649,6 +3649,7 @@ input RotationSearchOptions {
 
 input CalcRotationHandoffTimesInput {
   handoff: ISOTimestamp!
+  from: ISOTimestamp
   timeZone: String!
   shiftLengthHours: Int!
   count: Int!
@@ -16316,6 +16317,14 @@ func (ec *executionContext) unmarshalInputCalcRotationHandoffTimesInput(ctx cont
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("handoff"))
 			it.Handoff, err = ec.unmarshalNISOTimestamp2timeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "from":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("from"))
+			it.From, err = ec.unmarshalOISOTimestamp2ᚖtimeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/graphql2/graphqlapp/rotation.go
+++ b/graphql2/graphqlapp/rotation.go
@@ -401,6 +401,10 @@ func (a *Query) CalcRotationHandoffTimes(ctx context.Context, input *graphql2.Ca
 	}
 
 	t := time.Now()
+	if input.From != nil {
+		t = input.From.In(loc)
+	}
+
 	for len(result) < input.Count {
 		t = rot.EndTime(t)
 		result = append(result, t)

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -59,10 +59,11 @@ type AuthSubjectConnection struct {
 }
 
 type CalcRotationHandoffTimesInput struct {
-	Handoff          time.Time `json:"handoff"`
-	TimeZone         string    `json:"timeZone"`
-	ShiftLengthHours int       `json:"shiftLengthHours"`
-	Count            int       `json:"count"`
+	Handoff          time.Time  `json:"handoff"`
+	From             *time.Time `json:"from"`
+	TimeZone         string     `json:"timeZone"`
+	ShiftLengthHours int        `json:"shiftLengthHours"`
+	Count            int        `json:"count"`
 }
 
 type ConfigHint struct {

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -659,6 +659,7 @@ input RotationSearchOptions {
 
 input CalcRotationHandoffTimesInput {
   handoff: ISOTimestamp!
+  from: ISOTimestamp
   timeZone: String!
   shiftLengthHours: Int!
   count: Int!

--- a/web/src/app/rotations/RotationForm.js
+++ b/web/src/app/rotations/RotationForm.js
@@ -73,6 +73,7 @@ export default function RotationForm(props) {
     variables: {
       input: {
         handoff: value.start,
+        from: value.start,
         timeZone: value.timeZone,
         shiftLengthHours: getHours(value.shiftLength, value.type),
         count: 3,

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -505,6 +505,7 @@ export interface RotationSearchOptions {
 
 export interface CalcRotationHandoffTimesInput {
   handoff: ISOTimestamp
+  from?: ISOTimestamp
   timeZone: string
   shiftLengthHours: number
   count: number


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Which issue(s) this PR fixes:**
Closes #1141 

**Describe any introduced user-facing changes:**
When selecting a rotation handoff time in the future, the displayed "upcoming handoffs" will always be after the selected time (current behavior displays relative to `now`)

**Describe any introduced API changes:**
CalcRotationHandoffTimesInput includes an optional `from: ISO Timestamp` paramter that defaults to `now`
