### PR TITLE
ui: dependabot ignore @date-io/luxon@2

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -5,9 +5,10 @@ update_configs:
     update_schedule: 'daily'
     ignored_updates:
       # see https://github.com/target/goalert/pull/625
+      # and https://material-ui-pickers.dev/getting-started/installation
       - match:
           dependency_name: '@date-io/luxon'
-          version_requirement: '<=2.6.0'
+          version_requirement: '<=3.0.0'
       # react, react-dom, and @hot-loader/react-dom should be upgraded all at once
       - match:
           dependency_name: 'react'


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
There is an incompatibility between `date-io/luxon@2` and `material-pickers@3`. 
`material-pickers@4` is supposed to ship and be included in `material-ui/core@5` which will should be released within 6 months or so. Until then, we should ignore `date-io/luxon`
