### PR TITLE
ui: fix user email rendering

### DIFF
--- a/web/src/app/details/DetailsPage.js
+++ b/web/src/app/details/DetailsPage.js
@@ -16,7 +16,6 @@ import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
 import ListSubheader from '@material-ui/core/ListSubheader'
 import IconButton from '@material-ui/core/IconButton'
 import Notices from './Notices'
-import Markdown from '../util/Markdown'
 import AppLink from '../util/AppLink'
 import useWidth from '../util/useWidth'
 
@@ -54,6 +53,9 @@ const useStyles = makeStyles((theme) => ({
   },
   quickLinksList: {
     width: '100%',
+  },
+  userEmail: {
+    margin: '1rem 0',
   },
 }))
 
@@ -154,7 +156,9 @@ export default function DetailsPage(props) {
                   variant='subtitle1'
                   component='div'
                 >
-                  <Markdown value={details} />
+                  <Typography className={classes.userEmail}>
+                    {details}
+                  </Typography>
                 </Typography>
                 {titleFooter && (
                   <Typography


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
- fixes a regression in how we render emails on user profiles
- render emails as plain text (not links using the mailto protocol)

Before:
<img width="612" alt="Screen Shot 2021-02-17 at 1 53 58 PM" src="https://user-images.githubusercontent.com/17692467/108260465-fb607d00-7127-11eb-9e7d-5169b3892811.png">

After:
<img width="569" alt="Screen Shot 2021-02-17 at 1 58 40 PM" src="https://user-images.githubusercontent.com/17692467/108260691-424e7280-7128-11eb-9f72-82e2d9309135.png">

