### PR TITLE
graphql explorer: require `trace=1` before enabling gql tracing

### DIFF
--- a/graphql2/graphqlapp/app.go
+++ b/graphql2/graphqlapp/app.go
@@ -114,17 +114,18 @@ type fieldErr struct {
 
 type apolloTracer struct {
 	apollotracing.Tracer
+	shouldTrace func(context.Context) bool
 }
 
 func (a apolloTracer) InterceptField(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
-	if !permission.Admin(ctx) {
+	if !a.shouldTrace(ctx) {
 		return next(ctx)
 	}
 
 	return a.Tracer.InterceptField(ctx, next)
 }
 func (a apolloTracer) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
-	if !permission.Admin(ctx) {
+	if !a.shouldTrace(ctx) {
 		return next(ctx)
 	}
 
@@ -157,7 +158,12 @@ func (a *App) Handler() http.Handler {
 	h := handler.NewDefaultServer(
 		graphql2.NewExecutableSchema(graphql2.Config{Resolvers: a}),
 	)
-	h.Use(apolloTracer{Tracer: apollotracing.Tracer{}})
+
+	type hasTraceKey int
+	h.Use(apolloTracer{Tracer: apollotracing.Tracer{}, shouldTrace: func(ctx context.Context) bool {
+		enabled, ok := ctx.Value(hasTraceKey(1)).(bool)
+		return ok && enabled
+	}})
 
 	h.AroundFields(func(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
 		defer func() {
@@ -246,6 +252,10 @@ func (a *App) Handler() http.Handler {
 		}
 
 		ctx = a.registerLoaders(ctx)
+
+		if req.URL.Query().Get("trace") == "1" && permission.Admin(ctx) {
+			ctx = context.WithValue(ctx, hasTraceKey(1), true)
+		}
 
 		h.ServeHTTP(w, req.WithContext(ctx))
 	})


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Currently, all requests made by an admin have tracing turned on for performance information. This PR updates the requirement so that request additionally requires the query parameter `trace=1`. This prevents devoting memory/resources to tracing for normal application usage while allowing admins/devs to collect performance information when necessary.
