### PR TITLE
graphql: lazy-dataloaders

### DIFF
--- a/dataloader/alertloader.go
+++ b/dataloader/alertloader.go
@@ -2,9 +2,10 @@ package dataloader
 
 import (
 	"context"
-	"github.com/target/goalert/alert"
 	"strconv"
 	"time"
+
+	"github.com/target/goalert/alert"
 )
 
 type AlertLoader struct {
@@ -31,6 +32,12 @@ func NewAlertLoader(ctx context.Context, store alert.Store) *AlertLoader {
 		FetchFunc: p.fetchAlertsState,
 	})
 	return p
+}
+
+func (l *AlertLoader) Close() error {
+	l.alertLoader.Close()
+	l.stateLoader.Close()
+	return nil
 }
 
 func (l *AlertLoader) FetchOneAlert(ctx context.Context, id int) (*alert.Alert, error) {

--- a/dataloader/loader.go
+++ b/dataloader/loader.go
@@ -35,7 +35,6 @@ type loader struct {
 
 	cfg   loaderConfig
 	cache map[string]*loaderEntry
-	err   error
 
 	start sync.Once
 

--- a/graphql2/graphqlapp/app.go
+++ b/graphql2/graphqlapp/app.go
@@ -246,6 +246,7 @@ func (a *App) Handler() http.Handler {
 		}
 
 		ctx = a.registerLoaders(ctx)
+		defer a.closeLoaders(ctx)
 
 		h.ServeHTTP(w, req.WithContext(ctx))
 	})

--- a/graphql2/graphqlapp/dataloaders.go
+++ b/graphql2/graphqlapp/dataloaders.go
@@ -40,6 +40,7 @@ func (a *App) registerLoaders(ctx context.Context) context.Context {
 	ctx = context.WithValue(ctx, dataLoaderKeyUser, dataloader.NewUserLoader(ctx, a.UserStore))
 	ctx = context.WithValue(ctx, dataLoaderKeyCM, dataloader.NewCMLoader(ctx, a.CMStore))
 	ctx = context.WithValue(ctx, dataLoaderKeyNotificationMessageStatus, dataloader.NewNotificationMessageStatusLoader(ctx, a.NotificationStore))
+	ctx = context.WithValue(ctx, dataLoaderKeyHeartbeatMonitor, dataloader.NewHeartbeatMonitorLoader(ctx, a.HeartbeatStore))
 	return ctx
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR updates the graphql dataloaders to only initialize & allocate memory when they are first used, as well as guarantee a cleanup when the request (or it's context) ends.