### PR TITLE
notification: don't require stubbed methods for Sender

### DIFF
--- a/app/initengine.go
+++ b/app/initengine.go
@@ -31,13 +31,13 @@ func (app *App) initEngine(ctx context.Context) error {
 	}
 
 	app.Engine, err = engine.NewEngine(ctx, app.db, &engine.Config{
-		AlertStore:         app.AlertStore,
-		AlertLogStore:      app.AlertLogStore,
-		ContactMethodStore: app.ContactMethodStore,
-		NotificationSender: app.notificationManager,
-		UserStore:          app.UserStore,
-		NotificationStore:  app.NotificationStore,
-		NCStore:            app.NCStore,
+		AlertStore:          app.AlertStore,
+		AlertLogStore:       app.AlertLogStore,
+		ContactMethodStore:  app.ContactMethodStore,
+		NotificationManager: app.notificationManager,
+		UserStore:           app.UserStore,
+		NotificationStore:   app.NotificationStore,
+		NCStore:             app.NCStore,
 
 		ConfigSource: app.ConfigStore,
 

--- a/engine/config.go
+++ b/engine/config.go
@@ -13,13 +13,13 @@ import (
 
 // Config contains parameters for controlling how the Engine operates.
 type Config struct {
-	AlertLogStore      alertlog.Store
-	AlertStore         alert.Store
-	ContactMethodStore contactmethod.Store
-	NotificationSender notification.Sender
-	UserStore          user.Store
-	NotificationStore  notification.Store
-	NCStore            notificationchannel.Store
+	AlertLogStore       alertlog.Store
+	AlertStore          alert.Store
+	ContactMethodStore  contactmethod.Store
+	NotificationManager *notification.Manager
+	UserStore           user.Store
+	NotificationStore   notification.Store
+	NCStore             notificationchannel.Store
 
 	ConfigSource config.Source
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -191,7 +191,7 @@ func (p *Engine) processMessages(ctx context.Context) {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
-	err := p.msg.SendMessages(ctx, p.sendMessage, p.cfg.NotificationSender.Status)
+	err := p.msg.SendMessages(ctx, p.sendMessage, p.cfg.NotificationManager.Status)
 	if errors.Is(err, processinglock.ErrNoLock) {
 		return
 	}

--- a/engine/sendmessage.go
+++ b/engine/sendmessage.go
@@ -118,7 +118,7 @@ func (p *Engine) sendMessage(ctx context.Context, msg *message.Message) (*notifi
 		MessageID: msg.ID,
 	}
 
-	status, err := p.cfg.NotificationSender.Send(ctx, notifMsg)
+	status, err := p.cfg.NotificationManager.Send(ctx, notifMsg)
 	if err != nil {
 		return nil, err
 	}

--- a/notification/email/sender.go
+++ b/notification/email/sender.go
@@ -178,11 +178,3 @@ func (s *Sender) Send(ctx context.Context, msg notification.Message) (*notificat
 
 	return &notification.MessageStatus{ID: msg.ID(), State: notification.MessageStateSent, ProviderMessageID: msg.ID()}, nil
 }
-
-// Status is not supported by the email provider and will aways return an error.
-func (s *Sender) Status(ctx context.Context, id, providerID string) (*notification.MessageStatus, error) {
-	return nil, errors.New("notification/email: status not supported")
-}
-
-func (s *Sender) ListenStatus() <-chan *notification.MessageStatus     { return nil }
-func (s *Sender) ListenResponse() <-chan *notification.MessageResponse { return nil }

--- a/notification/namedsender.go
+++ b/notification/namedsender.go
@@ -5,12 +5,12 @@ import (
 )
 
 type namedSender struct {
-	SendResponder
+	Sender
 	name     string
 	destType DestType
 }
 
 func (s *namedSender) Send(ctx context.Context, msg Message) (*MessageStatus, error) {
-	status, err := s.SendResponder.Send(ctx, msg)
+	status, err := s.Sender.Send(ctx, msg)
 	return status.wrap(ctx, s), err
 }

--- a/notification/notifier.go
+++ b/notification/notifier.go
@@ -31,15 +31,20 @@ type Sender interface {
 	// Send should return nil if the notification was sent successfully. It should be expected
 	// that a returned error means that the notification should be attempted again.
 	Send(context.Context, Message) (*MessageStatus, error)
-
-	Status(ctx context.Context, id, providerID string) (*MessageStatus, error)
 }
 
-// A SendResponder can send messages and provide status and responses
-type SendResponder interface {
-	Sender
+// A StatusChecker allows checking the status of a sent message.
+type StatusChecker interface {
+	Status(ctx context.Context, messageID, providerMessageID string) (*MessageStatus, error)
+}
 
+// StatusUpdater will provide status updates for messages.
+type StatusUpdater interface {
 	ListenStatus() <-chan *MessageStatus
+}
+
+// A Responder will provide message responses.
+type Responder interface {
 	ListenResponse() <-chan *MessageResponse
 }
 

--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -33,7 +33,7 @@ type ChannelSender struct {
 	chanMx sync.Mutex
 }
 
-var _ notification.SendResponder = &ChannelSender{}
+var _ notification.Sender = &ChannelSender{}
 
 func NewChannelSender(ctx context.Context, cfg Config) (*ChannelSender, error) {
 	return &ChannelSender{
@@ -312,9 +312,3 @@ func (s *ChannelSender) Send(ctx context.Context, msg notification.Message) (*no
 		State:             notification.MessageStateDelivered,
 	}, nil
 }
-func (s *ChannelSender) Status(ctx context.Context, id, providerID string) (*notification.MessageStatus, error) {
-	return nil, errors.New("not implemented")
-}
-
-func (s *ChannelSender) ListenStatus() <-chan *notification.MessageStatus     { return s.status }
-func (s *ChannelSender) ListenResponse() <-chan *notification.MessageResponse { return s.resp }

--- a/notification/stubsender.go
+++ b/notification/stubsender.go
@@ -3,13 +3,12 @@ package notification
 import (
 	"context"
 
-	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 )
 
 type stubSender struct{}
 
-var _ SendResponder = stubSender{}
+var _ Sender = stubSender{}
 
 func (stubSender) Send(ctx context.Context, msg Message) (*MessageStatus, error) {
 	return &MessageStatus{
@@ -19,8 +18,3 @@ func (stubSender) Send(ctx context.Context, msg Message) (*MessageStatus, error)
 		State:             MessageStateDelivered,
 	}, nil
 }
-func (stubSender) Status(ctx context.Context, id, providerID string) (*MessageStatus, error) {
-	return nil, errors.New("not implemented")
-}
-func (stubSender) ListenStatus() <-chan *MessageStatus     { return make(chan *MessageStatus) }
-func (stubSender) ListenResponse() <-chan *MessageResponse { return make(chan *MessageResponse) }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR updates the notification manager interfaces to only require methods actually needed, making additional interfaces optional.

This removes the overhead of implementing empty stub methods and simplifies new provider implementations