### PR TITLE
ui/util: links to slack channels

### DIFF
--- a/web/src/app/util/Chips.tsx
+++ b/web/src/app/util/Chips.tsx
@@ -104,7 +104,8 @@ export function ScheduleChip(props: WithID<ChipProps>): JSX.Element {
   )
 }
 
-export function SlackChip(props: ChipProps): JSX.Element {
+export function SlackChip(props: WithID<ChipProps>): JSX.Element {
+  const { id: channelID } = props
   return (
     <Chip
       data-cy='slack-chip'
@@ -112,6 +113,9 @@ export function SlackChip(props: ChipProps): JSX.Element {
         <Avatar>
           <SlackBW />
         </Avatar>
+      }
+      onClick={() =>
+        window.open(`https://slack.com/app_redirect?channel=${channelID}`)
       }
       {...props}
     />

--- a/web/src/cypress/integration/escalationPolicySteps.ts
+++ b/web/src/cypress/integration/escalationPolicySteps.ts
@@ -114,7 +114,7 @@ function testSteps(): void {
         })
     })
 
-    it('should add and then remove a slack channel', () => {
+    it('should add, click, and remove a slack channel', () => {
       cy.updateConfig({ Slack: { Enable: true } })
       cy.reload()
 
@@ -133,6 +133,13 @@ function testSteps(): void {
       cy.get('body').should('contain', 'Step #1:')
       cy.get('div[data-cy=slack-chip]').should('contain', '#general')
       cy.get('div[data-cy=slack-chip]').should('contain', '#foobar')
+
+      // verify clickability
+      cy.window().then((win) => {
+        cy.stub(win, 'open').as('slackRedirect')
+      })
+      cy.get('div[data-cy=slack-chip]').first().click()
+      cy.get('@slackRedirect').should('be.called')
 
       // open edit step dialog
       cy.get('ul[data-cy=steps-list] :nth-child(1) li')


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This adds links to Slack `<Chip />` components that redirect users to the native app if installed, else the slack web interface. The first time a user clicks such a link, they will have a choice of opening in either the browser or natively.


**Which issue(s) this PR fixes:**
Closes #1235 

**Describe any introduced user-facing changes:**
Micro-improvement for UX, allowing user to click on slack chip

**Additional Info:**
See https://api.slack.com/reference/deep-linking#slack_apps
