### PR TITLE
notification/slack: fix missing Slack scope error

### DIFF
--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -250,7 +250,7 @@ func (s *ChannelSender) loadChannels(ctx context.Context) ([]Channel, error) {
 		if !resData.OK {
 			acceptedScopes := resp.Header.Get("X-Accepted-Oauth-Scopes")
 			providedScopes := resp.Header.Get("X-Oauth-Scopes")
-			log.Log(ctx, errors.New("Slack app scopes must include one of: "+acceptedScopes+"; got: "+providedScopes))
+			log.Log(ctx, errors.New("Slack app scopes must include one of: ["+acceptedScopes+"]; got: ["+providedScopes+"]"))
 			return nil, wrapError(resData.Error, "list Slack channels")
 		}
 

--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -232,7 +232,7 @@ func (s *ChannelSender) loadChannels(ctx context.Context) ([]Channel, error) {
 			return nil, errors.New("non-200 response from Slack: " + resp.Status)
 		}
 
-		var resData struct {
+		var respBody struct {
 			OK       bool
 			Error    string
 			Channels []Channel
@@ -241,23 +241,23 @@ func (s *ChannelSender) loadChannels(ctx context.Context) ([]Channel, error) {
 			} `json:"response_metadata"`
 		}
 
-		err = json.NewDecoder(resp.Body).Decode(&resData)
+		err = json.NewDecoder(resp.Body).Decode(&respBody)
 		resp.Body.Close()
 		if err != nil {
 			return nil, errors.Wrap(err, "parse JSON")
 		}
 
-		if !resData.OK {
-			return nil, wrapError(resData.Error, "list Slack channels")
+		if !respBody.OK {
+			return nil, wrapError(respBody.Error, "list Slack channels")
 		}
 
-		channels = append(channels, resData.Channels...)
+		channels = append(channels, respBody.Channels...)
 
-		if resData.Meta.NextCursor == "" {
+		if respBody.Meta.NextCursor == "" {
 			break
 		}
 
-		v.Set("cursor", resData.Meta.NextCursor)
+		v.Set("cursor", respBody.Meta.NextCursor)
 	}
 
 	for i := range channels {

--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -159,7 +159,7 @@ func (s *ChannelSender) loadChannel(ctx context.Context, channelID string) (*Cha
 	}
 
 	if !resData.OK {
-		return nil, fmt.Errorf("lookup Slack channels: %w", &apiError{msg: resData.Error, header: resp.Header})
+		return nil, fmt.Errorf("lookup Slack channel: %w", &apiError{msg: resData.Error, header: resp.Header})
 	}
 
 	return &Channel{

--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -78,7 +78,7 @@ func mapError(ctx context.Context, err error) error {
 	case "channel_not_found":
 		return validation.NewFieldError("ChannelID", "Invalid Slack channel ID.")
 	case "invalid_auth", "account_inactive", "token_revoked", "not_authed":
-		log.Log(ctx, fmt.Errorf("unable to authenticate to Slack: %v", apiError.msg))
+		log.Log(ctx, err)
 		return validation.NewFieldError("ChannelID", "Permission Denied.")
 	}
 

--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -232,7 +232,7 @@ func (s *ChannelSender) loadChannels(ctx context.Context) ([]Channel, error) {
 			return nil, errors.New("non-200 response from Slack: " + resp.Status)
 		}
 
-		var respBody struct {
+		var resData struct {
 			OK       bool
 			Error    string
 			Channels []Channel
@@ -241,23 +241,23 @@ func (s *ChannelSender) loadChannels(ctx context.Context) ([]Channel, error) {
 			} `json:"response_metadata"`
 		}
 
-		err = json.NewDecoder(resp.Body).Decode(&respBody)
+		err = json.NewDecoder(resp.Body).Decode(&resData)
 		resp.Body.Close()
 		if err != nil {
 			return nil, errors.Wrap(err, "parse JSON")
 		}
 
-		if !respBody.OK {
-			return nil, wrapError(respBody.Error, "list Slack channels")
+		if !resData.OK {
+			return nil, wrapError(resData.Error, "list Slack channels")
 		}
 
-		channels = append(channels, respBody.Channels...)
+		channels = append(channels, resData.Channels...)
 
-		if respBody.Meta.NextCursor == "" {
+		if resData.Meta.NextCursor == "" {
 			break
 		}
 
-		v.Set("cursor", respBody.Meta.NextCursor)
+		v.Set("cursor", resData.Meta.NextCursor)
 	}
 
 	for i := range channels {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x]  Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Example log message: 
- `error="Slack: missing_scope; need one of channels:read,groups:read,mpim:read,im:read but got app_mentions:read"`
- `error="unable to authenticate to Slack: token_revoked"`

Fixes #1246 

**Describe any introduced user-facing changes:**
- User will see "Permission Denied" instead of "Only Channels Supported" when Slack app has misconfigured scopes
- User will see "Permission Denied" instead of "User account must be linked" when goalert is unable to authenticate to the Slack app
