### PR TITLE
ui: reorder select fields in policy step dialog

### DIFF
--- a/web/src/app/escalation-policies/PolicyStepForm.js
+++ b/web/src/app/escalation-policies/PolicyStepForm.js
@@ -113,38 +113,10 @@ function PolicyStepForm(props) {
                 <Step>
                   <StepButton
                     aria-expanded={(step === 0).toString()}
-                    data-cy='rotations-step'
-                    icon={<RotationsIcon />}
-                    optional={optionalText}
-                    onClick={() => handleStepChange(0)}
-                    tabIndex='-1'
-                  >
-                    {badgeMeUpScotty(
-                      getTargetsByType('rotation')(value.targets).length,
-                      'Add Rotations',
-                    )}
-                  </StepButton>
-                  <StepContent>
-                    <FormField
-                      component={RotationSelect}
-                      disabled={disabled}
-                      fieldName='targets'
-                      fullWidth
-                      label='Select Rotation(s)'
-                      multiple
-                      name='rotations'
-                      mapValue={getTargetsByType('rotation')}
-                      mapOnChangeValue={setTargetType('rotation')}
-                    />
-                  </StepContent>
-                </Step>
-                <Step>
-                  <StepButton
-                    aria-expanded={(step === 1).toString()}
                     data-cy='schedules-step'
                     icon={<SchedulesIcon />}
                     optional={optionalText}
-                    onClick={() => handleStepChange(1)}
+                    onClick={() => handleStepChange(0)}
                     tabIndex='-1'
                   >
                     {badgeMeUpScotty(
@@ -169,11 +141,11 @@ function PolicyStepForm(props) {
                 {cfg['Slack.Enable'] && (
                   <Step>
                     <StepButton
-                      aria-expanded={(step === 2).toString()}
+                      aria-expanded={(step === 1).toString()}
                       data-cy='slack-channels-step'
                       icon={<SlackIcon />}
                       optional={optionalText}
-                      onClick={() => handleStepChange(2)}
+                      onClick={() => handleStepChange(1)}
                       tabIndex='-1'
                     >
                       {badgeMeUpScotty(
@@ -198,12 +170,14 @@ function PolicyStepForm(props) {
                 )}
                 <Step>
                   <StepButton
-                    aria-expanded={(step === 3).toString()}
+                    aria-expanded={(
+                      step === (cfg['Slack.Enable'] ? 2 : 1)
+                    ).toString()}
                     data-cy='users-step'
                     icon={<UsersIcon />}
                     optional={optionalText}
                     onClick={() =>
-                      handleStepChange(cfg['Slack.Enable'] ? 3 : 2)
+                      handleStepChange(cfg['Slack.Enable'] ? 2 : 1)
                     }
                     tabIndex='-1'
                   >
@@ -223,6 +197,38 @@ function PolicyStepForm(props) {
                       name='users'
                       mapValue={getTargetsByType('user')}
                       mapOnChangeValue={setTargetType('user')}
+                    />
+                  </StepContent>
+                </Step>
+                <Step>
+                  <StepButton
+                    aria-expanded={(
+                      step === (cfg['Slack.Enable'] ? 3 : 2)
+                    ).toString()}
+                    data-cy='rotations-step'
+                    icon={<RotationsIcon />}
+                    optional={optionalText}
+                    onClick={() =>
+                      handleStepChange(cfg['Slack.Enable'] ? 3 : 2)
+                    }
+                    tabIndex='-1'
+                  >
+                    {badgeMeUpScotty(
+                      getTargetsByType('rotation')(value.targets).length,
+                      'Add Rotations',
+                    )}
+                  </StepButton>
+                  <StepContent>
+                    <FormField
+                      component={RotationSelect}
+                      disabled={disabled}
+                      fieldName='targets'
+                      fullWidth
+                      label='Select Rotation(s)'
+                      multiple
+                      name='rotations'
+                      mapValue={getTargetsByType('rotation')}
+                      mapOnChangeValue={setTargetType('rotation')}
                     />
                   </StepContent>
                 </Step>

--- a/web/src/cypress/integration/escalationPolicySteps.ts
+++ b/web/src/cypress/integration/escalationPolicySteps.ts
@@ -40,16 +40,15 @@ function testSteps(): void {
 
         cy.pageFab()
         cy.dialogTitle('Create Step')
-        cy.dialogForm({ rotations: [r1.name, r2.name] })
-
-        cy.get('button[data-cy="schedules-step"]').click()
         cy.dialogForm({ schedules: [s1.name, s2.name] })
 
         cy.get('button[data-cy="users-step"]').click()
-        cy.dialogForm({
-          users: [u1.name, u2.name],
-          delayMinutes: delay.toString(),
-        })
+        cy.dialogForm({ users: [u1.name, u2.name] })
+
+        cy.get('button[data-cy="rotations-step"]').click()
+        cy.dialogForm({ rotations: [r1.name, r2.name] })
+
+        cy.dialogForm({ delayMinutes: delay.toString() })
         cy.dialogFinish('Submit')
 
         // verify data integrity
@@ -97,7 +96,7 @@ function testSteps(): void {
 
           cy.dialogTitle('Edit Step')
           cy.dialogForm({
-            rotations: r1.name,
+            schedules: s1.name,
             delayMinutes: delay.toString(),
           })
 
@@ -106,7 +105,7 @@ function testSteps(): void {
           // verify data integrity
           cy.get('body').should('contain', 'Notify the following:')
           cy.get('body').should('contain', 'Step #1:')
-          cy.get('div[data-cy=rotation-chip]').should('contain', r1.name)
+          cy.get('div[data-cy=schedule-chip]').should('contain', s1.name)
           cy.get('body').should(
             'contain',
             `Go back to step #1 after ${delay.toString()} minutes`,

--- a/web/src/cypress/integration/favorites.ts
+++ b/web/src/cypress/integration/favorites.ts
@@ -106,6 +106,8 @@ function testFavorites(): void {
           return cy.visit(`/escalation-policies/${e.id}`)
         })
         .pageFab()
+        .get('[data-cy="rotations-step"]')
+        .click()
         .get('input[name=rotations]'),
   )
 
@@ -123,8 +125,6 @@ function testFavorites(): void {
           return cy.visit(`/escalation-policies/${e.id}`)
         })
         .pageFab()
-        .get('[data-cy="schedules-step"]')
-        .click()
         .get('input[name=schedules]'),
   )
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Reorders the stepper within the Policy Step Form so that selecting a Schedule over a Rotation is more obvious to the end user.

This change comes as a hopeful adjustment to mitigate instances where users have a misconfigured EP (adding their rotation instead of their schedule) and later noticing that their schedule overrides are not working as they intended.

**Which issue(s) this PR fixes:**
Closes #1362

**Screenshots:**
![image](https://user-images.githubusercontent.com/11381794/112866128-48f8cf80-906e-11eb-89f2-7a3a3645e56c.png)
