### PR TITLE
smoketest: FastForward after creating alert

### DIFF
--- a/smoketest/prioritization_test.go
+++ b/smoketest/prioritization_test.go
@@ -69,10 +69,9 @@ func TestPrioritization(t *testing.T) {
 
 	d1.ExpectSMS("service-1-alert")
 
-	// account for throttling
-	h.FastForward(10 * time.Minute)
-
 	h.CreateAlert(h.UUID("s2"), "service-2-alert")
+	// account for throttling
+	h.FastForward(15 * time.Minute)
 
 	d1.ExpectSMS("service-2-alert")
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR attempts to fix the flaky prioritization test by increasing the FastForward time and ensuring it happens after the second alert is created.