### PR TITLE
oncall: fix panic for out-of-order shift spans

### DIFF
--- a/oncall/activecalculator.go
+++ b/oncall/activecalculator.go
@@ -97,14 +97,15 @@ func (act *ActiveCalculator) set(t time.Time, isStart bool) {
 	if len(act.states) > 0 && isStart == act.states[len(act.states)-1].IsStart {
 		panic("must not overlap shifts")
 	}
-	if len(act.states) > 0 && id <= act.states[len(act.states)-1].T {
-		panic(fmt.Sprintf("shifts must be registered in order: got %d, want > %d in %#v", id, act.states[len(act.states)-1].T, act.states))
-	}
 
 	if len(act.states) > 0 && isStart && id == act.states[len(act.states)-1].T {
 		// starting a shift at the same time one ends, so just delete the end marker
 		act.states = act.states[:len(act.states)-1]
 		return
+	}
+
+	if len(act.states) > 0 && id <= act.states[len(act.states)-1].T {
+		panic(fmt.Sprintf("shifts must be registered in order: got %d, want > %d in %#v", id, act.states[len(act.states)-1].T, act.states))
 	}
 
 	act.states = append(act.states, activeCalcValue{T: id, IsStart: isStart})

--- a/oncall/activecalculator.go
+++ b/oncall/activecalculator.go
@@ -1,7 +1,7 @@
 package oncall
 
 import (
-	"sort"
+	"fmt"
 	"sync"
 	"time"
 )
@@ -25,9 +25,6 @@ type ActiveCalculator struct {
 type activeCalcValue struct {
 	T       int64
 	IsStart bool
-
-	// OriginalT is the original time of this value (e.g., historic start time vs. start of calculation).
-	OriginalT int64
 }
 
 // NewActiveCalculator will create a new ActiveCalculator bound to the TimeIterator.
@@ -41,14 +38,20 @@ func (t *TimeIterator) NewActiveCalculator() *ActiveCalculator {
 	return act
 }
 
+func (act *ActiveCalculator) StartUnix() (start int64) {
+	if len(act.states) == 0 {
+		return 0
+	}
+
+	return act.states[0].T
+}
+
 // Init should be called after all SetSpan calls have been completed and before Next().
 func (act *ActiveCalculator) Init() *ActiveCalculator {
 	if act.init {
 		return act
 	}
 	act.init = true
-
-	sort.Slice(act.states, func(i, j int) bool { return act.states[i].T < act.states[j].T })
 
 	return act
 }
@@ -69,8 +72,8 @@ func (act *ActiveCalculator) SetSpan(start, end time.Time) {
 		return
 	}
 
-	// Skip if the length of the span is <= 0.
-	if !end.IsZero() && !end.After(start) {
+	// Skip if the length of the span is less than 1 minute.
+	if !end.IsZero() && end.Sub(start) < time.Minute {
 		return
 	}
 
@@ -87,9 +90,15 @@ func (act *ActiveCalculator) SetSpan(start, end time.Time) {
 
 func (act *ActiveCalculator) set(t time.Time, isStart bool) {
 	id := t.Truncate(act.Step()).Unix()
-	originalID := id
-	if isStart && t.Before(act.Start()) {
-		id = act.Start().Unix()
+
+	if len(act.states) == 0 && !isStart {
+		panic("end registered before start")
+	}
+	if len(act.states) > 0 && isStart == act.states[len(act.states)-1].IsStart {
+		panic("must not overlap shifts")
+	}
+	if len(act.states) > 0 && id <= act.states[len(act.states)-1].T {
+		panic(fmt.Sprintf("shifts must be registered in order: got %d, want > %d in %#v", id, act.states[len(act.states)-1].T, act.states))
 	}
 
 	if len(act.states) > 0 && isStart && id == act.states[len(act.states)-1].T {
@@ -97,7 +106,7 @@ func (act *ActiveCalculator) set(t time.Time, isStart bool) {
 		return
 	}
 
-	act.states = append(act.states, activeCalcValue{T: id, IsStart: isStart, OriginalT: originalID})
+	act.states = append(act.states, activeCalcValue{T: id, IsStart: isStart})
 }
 
 // Process implements the SubIterator.Process method.
@@ -138,14 +147,3 @@ func (act *ActiveCalculator) Active() bool { return act.active.IsStart }
 
 // Changed will return true if the current tick changed the Active() state.
 func (act *ActiveCalculator) Changed() bool { return act.changed }
-
-// ActiveTime returns the original start time of the current Active() state.
-//
-// If Active() is false, it returns a zero value.
-func (act *ActiveCalculator) ActiveTime() time.Time {
-	if !act.Active() {
-		return time.Time{}
-	}
-
-	return time.Unix(act.active.OriginalT, 0).UTC()
-}

--- a/oncall/activecalculator.go
+++ b/oncall/activecalculator.go
@@ -102,6 +102,7 @@ func (act *ActiveCalculator) set(t time.Time, isStart bool) {
 	}
 
 	if len(act.states) > 0 && isStart && id == act.states[len(act.states)-1].T {
+		// starting a shift at the same time one ends, so just delete the end marker
 		act.states = act.states[:len(act.states)-1]
 		return
 	}

--- a/oncall/activecalculator.go
+++ b/oncall/activecalculator.go
@@ -64,6 +64,8 @@ func (act *ActiveCalculator) SetSpan(start, end time.Time) {
 	if act.init {
 		panic("cannot add spans after Init")
 	}
+	start = start.Truncate(act.Step())
+	end = end.Truncate(act.Step())
 
 	// Skip if the span ends before the iterator start time.
 	//
@@ -89,7 +91,7 @@ func (act *ActiveCalculator) SetSpan(start, end time.Time) {
 }
 
 func (act *ActiveCalculator) set(t time.Time, isStart bool) {
-	id := t.Truncate(act.Step()).Unix()
+	id := t.Unix()
 
 	if len(act.states) == 0 && !isStart {
 		panic("end registered before start")

--- a/oncall/state_test.go
+++ b/oncall/state_test.go
@@ -228,12 +228,7 @@ func TestState_CalculateShifts(t *testing.T) {
 			},
 		},
 		[]Shift{
-			{
-				Start:     time.Date(2018, 1, 1, 7, 0, 0, 0, time.UTC),
-				End:       time.Date(2018, 1, 1, 8, 0, 0, 0, time.UTC),
-				Truncated: false,
-				UserID:    "foobar",
-			},
+			// no shift is expected since it ended before/at the start time
 		},
 	)
 

--- a/oncall/state_test.go
+++ b/oncall/state_test.go
@@ -205,6 +205,38 @@ func TestState_CalculateShifts(t *testing.T) {
 		})
 	}
 
+	check("HistoryRemainder",
+		time.Date(2018, 1, 1, 8, 0, 0, 0, time.UTC), // 8:00AM
+		time.Date(2018, 1, 1, 9, 0, 0, 0, time.UTC), // 9:00AM
+		&state{
+			now: time.Date(2018, 1, 1, 9, 0, 0, 0, time.UTC),
+			loc: time.UTC,
+			history: []Shift{
+				{
+					UserID: "foobar",
+					Start:  time.Date(2018, 1, 1, 7, 0, 0, 0, time.UTC),
+					End:    time.Date(2018, 1, 1, 8, 0, 0, 1, time.UTC), // will be truncated to 8
+				},
+			},
+			rules: []ResolvedRule{
+				{Rule: rule.Rule{
+					WeekdayFilter: rule.WeekdayFilter{1, 1, 1, 1, 1, 1, 1},
+					Start:         timeutil.NewClock(8, 0),
+					End:           timeutil.NewClock(10, 0),
+					Target:        assignment.UserTarget("foobar"),
+				}},
+			},
+		},
+		[]Shift{
+			{
+				Start:     time.Date(2018, 1, 1, 7, 0, 0, 0, time.UTC),
+				End:       time.Date(2018, 1, 1, 8, 0, 0, 0, time.UTC),
+				Truncated: false,
+				UserID:    "foobar",
+			},
+		},
+	)
+
 	check("Simple",
 		time.Date(2018, 1, 1, 8, 0, 0, 0, time.UTC), // 8:00AM
 		time.Date(2018, 1, 1, 9, 0, 0, 0, time.UTC), // 9:00AM

--- a/oncall/timeiterator.go
+++ b/oncall/timeiterator.go
@@ -67,11 +67,11 @@ func (iter *TimeIterator) Register(sub SubIterator) { iter.sub = append(iter.sub
 func (iter *TimeIterator) Next() bool {
 	if !iter.init {
 		for _, s := range iter.sub {
-			sp, ok := s.(Startable)
+			st, ok := s.(Startable)
 			if !ok {
 				continue
 			}
-			start := sp.StartUnix()
+			start := st.StartUnix()
 			start = start - start%iter.step
 			if start != 0 && start < iter.start {
 				iter.start = start

--- a/oncall/usercalculator.go
+++ b/oncall/usercalculator.go
@@ -115,12 +115,3 @@ func (u *UserCalculator) ActiveUsers() []string { return u.active }
 
 // Changed will return true if there has been any change this tick.
 func (u *UserCalculator) Changed() bool { return u.changed }
-
-// ActiveTimes will return the original start time for all ActiveUsers.
-func (u *UserCalculator) ActiveTimes() []time.Time {
-	times := make([]time.Time, len(u.active))
-	for i, id := range u.active {
-		times[i] = u.m[id].ActiveTime()
-	}
-	return times
-}

--- a/oncall/usercalculator_test.go
+++ b/oncall/usercalculator_test.go
@@ -40,15 +40,22 @@ func TestUserCalculator(t *testing.T) {
 
 			iter.Init()
 
-			var results []result
+			var count int
 			for iter.Next() {
-				results = append(results, result{
-					Time:  time.Unix(iter.Unix(), 0).UTC(),
-					Value: cloneSlice(iter.ActiveUsers()),
-				})
+				i := count
+				count++
+				if count > len(expected) {
+					t.Errorf("unexpected result: Value=%v, Time=%d", iter.ActiveUsers(), iter.Unix())
+					continue
+				}
+				if len(expected[i].Value) > 0 || len(iter.ActiveUsers()) > 0 {
+					assert.EqualValuesf(t, expected[i].Value, iter.ActiveUsers(), "result[%d].Value", i)
+				}
+				assert.Equalf(t, expected[i].Time.String(), time.Unix(iter.Unix(), 0).UTC().String(), "result[%d].Time", i)
 			}
-
-			assert.EqualValues(t, expected, results)
+			if count != len(expected) {
+				t.Errorf("got %d results; want %d", count, len(expected))
+			}
 		})
 	}
 
@@ -74,7 +81,7 @@ func TestUserCalculator(t *testing.T) {
 
 	check("at-start",
 		[]result{
-			{Time: start, Value: []string{"foo"}},
+			{Time: time.Date(2000, 1, 2, 3, 3, 0, 0, time.UTC), Value: []string{"foo"}},
 			{Time: time.Date(2000, 1, 2, 3, 7, 0, 0, time.UTC)},
 			{Time: end},
 		},

--- a/oncall/usercalculator_test.go
+++ b/oncall/usercalculator_test.go
@@ -8,15 +8,6 @@ import (
 	"github.com/target/goalert/oncall"
 )
 
-func cloneSlice(a []string) []string {
-	if len(a) == 0 {
-		return nil
-	}
-	s := make([]string, len(a))
-	copy(s, a)
-	return s
-}
-
 func TestUserCalculator(t *testing.T) {
 	type result struct {
 		Time  time.Time


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes a panic issue when calculating shifts that include time in the past that overlap current rulesets.

- The `oncall.TimeIterator` will now automatically extend the start time based on provided rules (eliminating the need for `ActiveTime`)
- `oncall.ActiveCalculator` no longer tracks "original" or "historic" times to simplify logic
- `oncall.ActiveCalculator` now explicitly requires spans to be set in order without overlap