### PR TITLE
ui/selection: handle empty input values, incoming `props.value`

### DIFF
--- a/web/src/app/selection/MaterialSelect.tsx
+++ b/web/src/app/selection/MaterialSelect.tsx
@@ -99,6 +99,7 @@ export default function MaterialSelect(
   const getInputLabel = (): string =>
     multiple || Array.isArray(value) ? '' : value?.label || ''
 
+  const [focus, setFocus] = useState(false)
   const [inputValue, _setInputValue] = useState(getInputLabel())
 
   const setInputValue = (input: string): void => {
@@ -109,10 +110,10 @@ export default function MaterialSelect(
   const multi = multiple ? { multiple: true, filterSelectedOptions: true } : {}
 
   useEffect(() => {
+    if (!focus) setInputValue(getInputLabel())
     if (multiple) return
     if (!value) setInputValue('')
-    if (!inputValue && value) setInputValue(getInputLabel())
-  }, [value, multiple])
+  }, [value, multiple, focus])
 
   // merge selected values with options to avoid annoying mui warnings
   // https://github.com/mui-org/material-ui/issues/18514
@@ -163,7 +164,8 @@ export default function MaterialSelect(
           setInputValue('')
         }
       }}
-      onBlur={() => setInputValue(getInputLabel())}
+      onFocus={() => setFocus(true)}
+      onBlur={() => setFocus(false)}
       loading={isLoading}
       getOptionLabel={(option) => option?.label ?? ''}
       options={options}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
1. Currently, when using a select field e.g. in the Wizard, once a value has been selected, the input field cannot be cleared to allow for a new value. This PR fixes that, while still preserving the underlying state on blur events.
2. This PR updates the displayed input value when the component receives a new props.value but only if the component is not currently in use i.e. focused. 

**Describe any introduced user-facing changes:**
Users will be able to clear the input field
