### PR TITLE
ui: resolve conflicting `NODE_ENV` names

### DIFF
--- a/web/src/webpack.config.js
+++ b/web/src/webpack.config.js
@@ -89,7 +89,7 @@ module.exports = (env = { GOALERT_VERSION: 'dev' }) => ({
   plugins: [
     new webpack.DefinePlugin({
       'process.env': {
-        NODE_ENV: JSON.stringify('local'), // eslint-disable-line quote-props
+        NODE_ENV: JSON.stringify('development'), // eslint-disable-line quote-props
         GOALERT_VERSION: JSON.stringify(env.GOALERT_VERSION), // eslint-disable-line quote-props
       },
     }),


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
The Define webpack plugin is warning about inconsistent `NODE_ENV` naming. This PR makes it `'development'` when working locally

**Additional Info:**
console warning:
`Object { message: "DefinePlugin\nConflicting values for 'process.env.NODE_ENV'" }`