### PR TITLE
ui/forms: copy values into mutable object

### DIFF
--- a/web/src/app/forms/FormContainer.js
+++ b/web/src/app/forms/FormContainer.js
@@ -89,9 +89,12 @@ export class FormContainer extends React.PureComponent {
     const {
       mapValue,
       mapOnChangeValue,
-      value: oldValue,
+      value: _value,
       removeFalseyIdxs,
     } = this.props
+
+    // copy into a mutable object
+    const oldValue = JSON.parse(JSON.stringify(_value))
 
     let value = e
     if (e && e.target) value = e.target.value

--- a/web/src/app/forms/FormContainer.js
+++ b/web/src/app/forms/FormContainer.js
@@ -3,7 +3,7 @@ import p from 'prop-types'
 import MountWatcher from '../util/MountWatcher'
 
 import { FormContext, FormContainerContext } from './context'
-import { get, set } from 'lodash'
+import { get, set, cloneDeep } from 'lodash'
 
 // FormContainer handles grouping multiple FormFields.
 // It works with the Form component to handle validation.
@@ -94,7 +94,7 @@ export class FormContainer extends React.PureComponent {
     } = this.props
 
     // copy into a mutable object
-    const oldValue = JSON.parse(JSON.stringify(_value))
+    const oldValue = cloneDeep(_value)
 
     let value = e
     if (e && e.target) value = e.target.value
@@ -118,20 +118,12 @@ export class FormContainer extends React.PureComponent {
       })
 
       return this.props.onChange(
-        mapOnChangeValue(set(mapValue({ ...oldValue }), arrayPath, newArr)),
+        mapOnChangeValue(set(mapValue(oldValue), arrayPath, newArr)),
       )
     }
 
     return this.props.onChange(
-      mapOnChangeValue(
-        set(
-          mapValue({
-            ...oldValue,
-          }),
-          fieldName,
-          value,
-        ),
-      ),
+      mapOnChangeValue(set(mapValue(oldValue), fieldName, value)),
     )
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR will copy form values into a mutable object. Without this, we are unable to initialize forms with values from Apollo that may be frozen in the cache

**Describe any introduced user-facing changes:**
Users can toggle existing checkboxes when editing a schedule assignment

**Additional Info:**
This may introduce a performance hit unfortunately, but for the time being correctness is more important for UX.
