### PR TITLE
ui/loading: update spinner styles

### DIFF
--- a/web/src/app/loading/components/Spinner.js
+++ b/web/src/app/loading/components/Spinner.js
@@ -36,7 +36,12 @@ export default function Spinner(props) {
         display: 'flex',
         alignItems: 'center',
       }
-    : { position: 'absolute', top: '50%', left: '50%' }
+    : {
+        position: 'absolute',
+        top: 'calc(50% - 20px)',
+        left: 'calc(50% - 20px)',
+        zIndex: 99999,
+      }
 
   return (
     <div style={style}>

--- a/web/src/app/main/App.js
+++ b/web/src/app/main/App.js
@@ -40,6 +40,7 @@ const useStyles = makeStyles((theme) => ({
     overflowY: 'auto',
     marginTop: '64px',
   },
+  mainContainer: { position: 'relative', height: '100%' },
   appBar: {
     zIndex: theme.zIndex.drawer + 1,
   },
@@ -119,7 +120,11 @@ export default function App() {
           <main id='content' className={classes.main} style={{ marginLeft }}>
             <ErrorBoundary>
               <LazyNewUserSetup />
-              <Grid container justify='center'>
+              <Grid
+                container
+                justify='center'
+                className={classes.mainContainer}
+              >
                 <Grid className={classes.containerClass} item>
                   <Switch>
                     {renderRoutes(routeConfig)}

--- a/web/src/app/util/SetFavoriteButton.tsx
+++ b/web/src/app/util/SetFavoriteButton.tsx
@@ -3,7 +3,6 @@ import IconButton from '@material-ui/core/IconButton'
 import FavoriteFilledIcon from '@material-ui/icons/Star'
 import FavoriteBorderIcon from '@material-ui/icons/StarBorder'
 import Tooltip from '@material-ui/core/Tooltip'
-import Spinner from '../loading/components/Spinner'
 
 interface SetFavoriteButtonProps {
   typeName: 'rotation' | 'service' | 'schedule'
@@ -17,11 +16,12 @@ export function SetFavoriteButton({
   isFavorite,
   loading,
   onClick,
-}: SetFavoriteButtonProps): JSX.Element {
-  let icon = isFavorite ? <FavoriteFilledIcon /> : <FavoriteBorderIcon />
+}: SetFavoriteButtonProps): JSX.Element | null {
   if (loading) {
-    icon = <Spinner />
+    return null
   }
+
+  const icon = isFavorite ? <FavoriteFilledIcon /> : <FavoriteBorderIcon />
 
   const content = (
     <form


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [ ] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [ ] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [ ] All new and existing tests passed.
- [ ] Added comments in the code, where necessary.
- [ ] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR:
1. Updates `Spinner` so it is truly centered in the user's main content pane as opposed to the full screen
2. Removes the spinner when loading the favorite toggle button icon. There is currently an issue with the way this spinner renders (see image below) with respect to color conflict and placement
<img width="101" alt="Screen Shot 2021-04-01 at 2 41 35 PM" src="https://user-images.githubusercontent.com/17692467/113345671-650fa180-92f8-11eb-8eda-a846d6a0dcb4.png">

