### PR TITLE
oncall: fix shift calculation with gaps

### DIFF
--- a/oncall/activecalculator.go
+++ b/oncall/activecalculator.go
@@ -85,9 +85,7 @@ func (act *ActiveCalculator) SetSpan(start, end time.Time) {
 	}
 
 	act.set(start, true)
-	if !end.IsZero() {
-		act.set(end, false)
-	}
+	act.set(end, false)
 }
 
 func (act *ActiveCalculator) set(t time.Time, isStart bool) {

--- a/oncall/state.go
+++ b/oncall/state.go
@@ -113,6 +113,8 @@ func (s *state) CalculateShifts(start, end time.Time) []Shift {
 		hist.SetSpan(s.Start, s.End, s.UserID)
 	}
 	hist.Init()
+	// sort overrides so that overlapping spans are merged properly
+	sort.Slice(s.overrides, func(i, j int) bool { return s.overrides[i].Start.Before(s.overrides[j].Start) })
 	overrides := t.NewOverrideCalculator(s.overrides)
 	rules := t.NewRulesCalculator(s.loc, s.rules)
 

--- a/oncall/state.go
+++ b/oncall/state.go
@@ -146,7 +146,7 @@ func (s *state) CalculateShifts(start, end time.Time) []Shift {
 			}
 
 			// no longer on call
-			if !now.Before(start) {
+			if now.After(start) {
 				s.End = now
 				shifts = append(shifts, *s)
 			}

--- a/oncall/state.go
+++ b/oncall/state.go
@@ -91,13 +91,25 @@ func sortShifts(s []Shift) {
 }
 
 func (s *state) CalculateShifts(start, end time.Time) []Shift {
-	t := NewTimeIterator(start, end, time.Minute)
+	start = start.Truncate(time.Minute)
+	end = end.Truncate(time.Minute)
+	tiStart := start
+	if !s.now.IsZero() && s.now.Before(start) {
+		tiStart = s.now.Truncate(time.Minute)
+	}
+	historyCutoff := s.now.Truncate(time.Minute).Add(time.Minute)
+	t := NewTimeIterator(tiStart, end, time.Minute)
 	defer t.Close()
 
 	hist := t.NewUserCalculator()
 	// sort history so that overlapping spans are merged properly
 	sort.Slice(s.history, func(i, j int) bool { return s.history[i].Start.Before(s.history[j].Start) })
 	for _, s := range s.history {
+		if s.End.IsZero() {
+			// have currently active shifts "end"
+			// at the cutoff.
+			s.End = historyCutoff
+		}
 		hist.SetSpan(s.Start, s.End, s.UserID)
 	}
 	hist.Init()
@@ -132,14 +144,16 @@ func (s *state) CalculateShifts(start, end time.Time) []Shift {
 			}
 
 			// no longer on call
-			s.End = now
-			shifts = append(shifts, *s)
+			if !now.Before(start) {
+				s.End = now
+				shifts = append(shifts, *s)
+			}
 			delete(isOnCall, id)
 		}
 	}
 
 	for t.Next() {
-		if !time.Unix(t.Unix(), 0).After(s.now) {
+		if time.Unix(t.Unix(), 0).Before(historyCutoff) {
 			// use history if in the past
 			setOnCall(hist.ActiveUsers())
 			continue

--- a/oncall/state_test.go
+++ b/oncall/state_test.go
@@ -238,16 +238,16 @@ func TestState_CalculateShifts(t *testing.T) {
 		},
 		[]Shift{
 			{
-				Start:     time.Date(2018, 1, 1, 8, 30, 0, 0, time.UTC),
-				End:       time.Date(2018, 1, 1, 9, 0, 0, 0, time.UTC),
-				Truncated: true,
-				UserID:    "has-gap",
-			},
-			{
 				Start:     time.Date(2018, 1, 1, 6, 0, 0, 0, time.UTC),
 				End:       time.Date(2018, 1, 1, 9, 0, 0, 0, time.UTC),
 				Truncated: true,
 				UserID:    "still-active",
+			},
+			{
+				Start:     time.Date(2018, 1, 1, 8, 30, 0, 0, time.UTC),
+				End:       time.Date(2018, 1, 1, 9, 0, 0, 0, time.UTC),
+				Truncated: true,
+				UserID:    "has-gap",
 			},
 		},
 	)

--- a/oncall/state_test.go
+++ b/oncall/state_test.go
@@ -205,6 +205,53 @@ func TestState_CalculateShifts(t *testing.T) {
 		})
 	}
 
+	check("ActiveFuture",
+		time.Date(2018, 1, 1, 8, 0, 0, 0, time.UTC), // 8:00AM
+		time.Date(2018, 1, 1, 9, 0, 0, 0, time.UTC), // 9:00AM
+		&state{
+			loc: time.UTC,
+			now: time.Date(2018, 1, 1, 7, 0, 0, 0, time.UTC),
+			history: []Shift{
+				{
+					UserID: "still-active",
+					Start:  time.Date(2018, 1, 1, 6, 0, 0, 0, time.UTC),
+				},
+				{
+					UserID: "has-gap",
+					Start:  time.Date(2018, 1, 1, 6, 0, 0, 0, time.UTC),
+				},
+			},
+			rules: []ResolvedRule{
+				{Rule: rule.Rule{
+					WeekdayFilter: rule.WeekdayFilter{1, 1, 1, 1, 1, 1, 1},
+					Start:         timeutil.NewClock(0, 0),
+					End:           timeutil.NewClock(0, 0),
+					Target:        assignment.UserTarget("still-active"),
+				}},
+				{Rule: rule.Rule{
+					WeekdayFilter: rule.WeekdayFilter{0, 1, 0, 0, 0, 0, 0},
+					Start:         timeutil.NewClock(8, 30),
+					End:           timeutil.NewClock(10, 0),
+					Target:        assignment.UserTarget("has-gap"),
+				}},
+			},
+		},
+		[]Shift{
+			{
+				Start:     time.Date(2018, 1, 1, 8, 30, 0, 0, time.UTC),
+				End:       time.Date(2018, 1, 1, 9, 0, 0, 0, time.UTC),
+				Truncated: true,
+				UserID:    "has-gap",
+			},
+			{
+				Start:     time.Date(2018, 1, 1, 6, 0, 0, 0, time.UTC),
+				End:       time.Date(2018, 1, 1, 9, 0, 0, 0, time.UTC),
+				Truncated: true,
+				UserID:    "still-active",
+			},
+		},
+	)
+
 	check("HistoryRemainder",
 		time.Date(2018, 1, 1, 8, 0, 0, 0, time.UTC), // 8:00AM
 		time.Date(2018, 1, 1, 9, 0, 0, 0, time.UTC), // 9:00AM

--- a/oncall/state_test.go
+++ b/oncall/state_test.go
@@ -419,9 +419,21 @@ func TestState_CalculateShifts(t *testing.T) {
 					Start:     time.Date(2018, 1, 1, 8, 30, 0, 0, time.UTC),
 					End:       time.Date(2018, 1, 1, 8, 45, 0, 0, time.UTC),
 				},
+
+				{
+					AddUserID: "binbaz",
+					Start:     time.Date(2018, 1, 1, 8, 0, 0, 0, time.UTC),
+					End:       time.Date(2018, 1, 1, 8, 15, 0, 0, time.UTC),
+				},
 			},
 		},
 		[]Shift{
+			{
+				Start:     time.Date(2018, 1, 1, 8, 0, 0, 0, time.UTC),
+				End:       time.Date(2018, 1, 1, 8, 15, 0, 0, time.UTC),
+				Truncated: false,
+				UserID:    "binbaz",
+			},
 			{
 				Start:     time.Date(2018, 1, 1, 8, 0, 0, 0, time.UTC),
 				End:       time.Date(2018, 1, 1, 9, 0, 0, 0, time.UTC),


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes two issues with the new `oncall` code:
- Out-of-order overrides would cause shift calculation to fail, they are now sorted like history entries
- Calculating future shifts would sometimes connect to current on-call shifts, time between `now()` and `Start` is now processed to determine actual start times
