### PR TITLE
migrate: no migrations for api only

### DIFF
--- a/app/cmd.go
+++ b/app/cmd.go
@@ -114,7 +114,7 @@ var RootCmd = &cobra.Command{
 		if cfg.APIOnly {
 			err = migrate.VerifyAll(log.EnableDebug(ctx), cfg.DBURL)
 			if err != nil {
-				return errors.Wrap(err, "apply migrations")
+				return errors.Wrap(err, "verify migrations")
 			}
 		} else {
 			s := time.Now()

--- a/app/cmd.go
+++ b/app/cmd.go
@@ -113,6 +113,9 @@ var RootCmd = &cobra.Command{
 
 		if cfg.APIOnly {
 			err = migrate.VerifyAll(log.EnableDebug(ctx), cfg.DBURL)
+			if err != nil {
+				return errors.Wrap(err, "apply migrations")
+			}
 		} else {
 			s := time.Now()
 			n, err := migrate.ApplyAll(log.EnableDebug(ctx), cfg.DBURL)

--- a/app/cmd.go
+++ b/app/cmd.go
@@ -111,13 +111,17 @@ var RootCmd = &cobra.Command{
 		u.RawQuery = q.Encode()
 		cfg.DBURL = u.String()
 
-		s := time.Now()
-		n, err := migrate.ApplyAll(log.EnableDebug(ctx), cfg.DBURL)
-		if err != nil {
-			return errors.Wrap(err, "apply migrations")
-		}
-		if n > 0 {
-			log.Logf(ctx, "Applied %d migrations in %s.", n, time.Since(s))
+		if cfg.APIOnly {
+			err = migrate.VerifyAll(log.EnableDebug(ctx), cfg.DBURL)
+		} else {
+			s := time.Now()
+			n, err := migrate.ApplyAll(log.EnableDebug(ctx), cfg.DBURL)
+			if err != nil {
+				return errors.Wrap(err, "apply migrations")
+			}
+			if n > 0 {
+				log.Logf(ctx, "Applied %d migrations in %s.", n, time.Since(s))
+			}
 		}
 
 		dbc, err := wrappedDriver.OpenConnector(cfg.DBURL)

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -91,7 +91,6 @@ func getConn(ctx context.Context, url string) (*pgx.Conn, error) {
 		conn, err = pgx.Connect(ctx, url)
 		return err
 	},
-		retry.Log(ctx),
 		retry.Limit(12),
 		retry.FibBackoff(time.Millisecond*100),
 	)

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -53,6 +53,32 @@ func migrationID(name string) (int, string) {
 	return -1, ""
 }
 
+// VerifyAll will verify all migrations have already been applied.
+func VerifyAll(ctx context.Context, url string) error {
+	targetName := migrationName(Files[len(Files)-1].Name)
+	targetIndex, targetID := migrationID(targetName)
+	if targetIndex == -1 {
+		return errors.Errorf("unknown migration target name '%s'", targetName)
+	}
+
+	conn, err := getConn(ctx, url)
+	if err != nil {
+		return err
+	}
+	defer conn.Close(ctx)
+
+	var hasLatest bool
+	err = conn.QueryRow(ctx, `select true from gorp_migrations where id = $1`, targetID).Scan(&hasLatest)
+	if err != nil {
+		return err
+	}
+	if hasLatest {
+		return nil
+	}
+
+	return errors.Errorf("latest migration '%s' has not been applied", targetName)
+}
+
 // ApplyAll will atomically perform all UP migrations.
 func ApplyAll(ctx context.Context, url string) (int, error) {
 	return Up(ctx, url, "")


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR disables migrations when in `--api-only` mode. This ensures only instances running an engine loop can apply a new migration, ensuring messages always go out.

Additionally, retry messages are suppressed when applying migrations. Only the final error will be reported (if it fails).