### PR TITLE
ui: appease apollo cache warnings

### DIFF
--- a/web/src/app/apollo.js
+++ b/web/src/app/apollo.js
@@ -102,16 +102,15 @@ const simpleCacheTypes = [
 // NOTE: see https://www.apollographql.com/docs/react/caching/advanced-topics/#cache-redirects-using-field-policy-read-functions
 const typePolicyQueryFields = {}
 simpleCacheTypes.forEach((name) => {
-  typePolicyQueryFields[camelCase(name)] = function (
-    existingData,
-    { args, toReference, canRead },
-  ) {
-    return canRead(existingData)
-      ? existingData
-      : toReference({
-          __typename: name,
-          id: args?.id,
-        })
+  typePolicyQueryFields[camelCase(name)] = {
+    read(existingData, { args, toReference, canRead }) {
+      return canRead(existingData)
+        ? existingData
+        : toReference({
+            __typename: name,
+            id: args?.id,
+          })
+    },
   }
 })
 
@@ -119,6 +118,56 @@ const cache = new InMemoryCache({
   typePolicies: {
     Query: {
       fields: typePolicyQueryFields,
+    },
+    EscalationPolicy: {
+      fields: {
+        steps: {
+          merge: false,
+        },
+      },
+    },
+    Rotation: {
+      fields: {
+        users: {
+          merge: false,
+        },
+      },
+    },
+    Schedule: {
+      fields: {
+        targets: {
+          merge: false,
+        },
+      },
+    },
+    Service: {
+      fields: {
+        heartbeatMonitors: {
+          merge: false,
+        },
+        integrationKeys: {
+          merge: false,
+        },
+        labels: {
+          merge: false,
+        },
+      },
+    },
+    User: {
+      fields: {
+        calendarSubscriptions: {
+          merge: false,
+        },
+        contactMethods: {
+          merge: false,
+        },
+        notificationRules: {
+          merge: false,
+        },
+        sessions: {
+          merge: false,
+        },
+      },
     },
   },
 })

--- a/web/src/app/apollo.js
+++ b/web/src/app/apollo.js
@@ -5,7 +5,6 @@ import {
   createHttpLink,
 } from '@apollo/client'
 import { RetryLink } from '@apollo/client/link/retry'
-import { camelCase } from 'lodash'
 import { authLogout } from './actions'
 
 import reduxStore from './reduxStore'
@@ -89,20 +88,20 @@ const graphql2HttpLink = createHttpLink({
 const graphql2Link = ApolloLink.from([retryLink, graphql2HttpLink])
 
 const simpleCacheTypes = [
-  'Alert',
-  'Rotation',
-  'Schedule',
-  'EscalationPolicy',
-  'Service',
-  'User',
-  'SlackChannel',
-  'PhoneNumberInfo',
+  'alert',
+  'rotation',
+  'schedule',
+  'escalationPolicy',
+  'service',
+  'user',
+  'slackChannel',
+  'phoneNumberInfo',
 ]
 
 // NOTE: see https://www.apollographql.com/docs/react/caching/advanced-topics/#cache-redirects-using-field-policy-read-functions
 const typePolicyQueryFields = {}
 simpleCacheTypes.forEach((name) => {
-  typePolicyQueryFields[camelCase(name)] = {
+  typePolicyQueryFields[name] = {
     read(existingData, { args, toReference, canRead }) {
       return canRead(existingData)
         ? existingData


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR updates the apollo cache configuration to suppress apollo warnings in the console. No perf or behavior change is expected. We are just making the default behavior explicit.

**Screenshots:**
Example warning:
<img width="1197" alt="Screen Shot 2021-04-14 at 10 20 44 AM" src="https://user-images.githubusercontent.com/17692467/114736037-6040e980-9d0b-11eb-8d81-c185d7f7a777.png">
In this case, we deleted one `contactMethod` and want to use the `incoming` data (nothing to merge).
