### PR TITLE
temp-schedules: always display start/end times in shift list

### DIFF
--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -104,17 +104,6 @@ export default function TempSchedShiftsList({
 
     const result: FlatListListItem[] = []
 
-    // render no coverage/get started below start time if no shifts
-    if (!sortedShifts.length) {
-      result.push({
-        id: 'no-coverage',
-        type: 'INFO',
-        message: 'No coverage',
-        transition: true,
-        details: 'Add a shift to get started',
-      })
-    }
-
     const days = displaySpan.splitBy({ days: 1 })
     days.forEach((dayInterval, dayIdx) => {
       const dayShifts = sortedShifts.filter((s) =>

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -41,16 +41,6 @@ type TempSchedShiftsListProps = {
   end: string
 }
 
-type TempSchedShift = {
-  added: boolean
-  shift: Shift
-  isValid: boolean
-  start: DateTime
-  end: DateTime
-  interval: Interval
-  id: string
-}
-
 export default function TempSchedShiftsList({
   start,
   end,
@@ -78,21 +68,20 @@ export default function TempSchedShiftsList({
       ]
     }
 
-    let sortedShifts: TempSchedShift[] = []
-    if (_shifts.length) {
-      sortedShifts = _.sortBy(_shifts, 'start').map((s) => ({
-        id: s.start + s.userID,
-        shift: s,
-        start: DateTime.fromISO(s.start, { zone }),
-        end: DateTime.fromISO(s.end, { zone }),
-        added: false,
-        interval: Interval.fromDateTimes(
-          DateTime.fromISO(s.start, { zone }),
-          DateTime.fromISO(s.end, { zone }),
-        ),
-        isValid: schedInterval.engulfs(parseInterval(s)),
-      }))
-    }
+    const sortedShifts = _shifts.length
+      ? _.sortBy(_shifts, 'start').map((s) => ({
+          id: s.start + s.userID,
+          shift: s,
+          start: DateTime.fromISO(s.start, { zone }),
+          end: DateTime.fromISO(s.end, { zone }),
+          added: false,
+          interval: Interval.fromDateTimes(
+            DateTime.fromISO(s.start, { zone }),
+            DateTime.fromISO(s.end, { zone }),
+          ),
+          isValid: schedInterval.engulfs(parseInterval(s)),
+        }))
+      : []
 
     const firstShiftStart = sortedShifts.length
       ? sortedShifts[0].start

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -157,7 +157,6 @@ export default function TempSchedShiftsList({
         })
       }
 
-      // for temp scheds with at least 1 shift
       // render no coverage and continue if no shifts for the given day
       if (dayShifts.length === 0) {
         return result.push({

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -41,6 +41,16 @@ type TempSchedShiftsListProps = {
   end: string
 }
 
+type TempSchedShift = {
+  added: boolean
+  shift: Shift
+  isValid: boolean
+  start: DateTime
+  end: DateTime
+  interval: Interval
+  id: string
+}
+
 export default function TempSchedShiftsList({
   start,
   end,
@@ -68,40 +78,35 @@ export default function TempSchedShiftsList({
       ]
     }
 
-    // render no coverage/get started below start time if no shifts
-    if (!_shifts.length) {
-      return [
-        {
-          id: 'no-coverage',
-          type: 'INFO',
-          message: 'No coverage',
-          transition: true,
-          details: 'Add a shift to get started',
-        },
-      ]
+    let sortedShifts: TempSchedShift[] = []
+    if (_shifts.length) {
+      sortedShifts = _.sortBy(_shifts, 'start').map((s) => ({
+        id: s.start + s.userID,
+        shift: s,
+        start: DateTime.fromISO(s.start, { zone }),
+        end: DateTime.fromISO(s.end, { zone }),
+        added: false,
+        interval: Interval.fromDateTimes(
+          DateTime.fromISO(s.start, { zone }),
+          DateTime.fromISO(s.end, { zone }),
+        ),
+        isValid: schedInterval.engulfs(parseInterval(s)),
+      }))
     }
 
-    const sortedShifts = _.sortBy(_shifts, 'start').map((s) => ({
-      id: s.start + s.userID,
-      shift: s,
-      start: DateTime.fromISO(s.start, { zone }),
-      end: DateTime.fromISO(s.end, { zone }),
-      added: false,
-      interval: Interval.fromDateTimes(
-        DateTime.fromISO(s.start, { zone }),
-        DateTime.fromISO(s.end, { zone }),
-      ),
-      isValid: schedInterval.engulfs(parseInterval(s)),
-    }))
-
-    const firstShiftStart = sortedShifts[0].start
+    const firstShiftStart = sortedShifts.length
+      ? sortedShifts[0].start
+      : schedInterval.start
 
     // get farthest out end time
     // although shifts are sorted, the last shift may not necessarily end last
-    const lastShiftEnd = sortedShifts.reduce(
-      (result, candidate) => (candidate.end > result.end ? candidate : result),
-      sortedShifts[0],
-    ).end
+    const lastShiftEnd = sortedShifts.length
+      ? sortedShifts.reduce(
+          (result, candidate) =>
+            candidate.end > result.end ? candidate : result,
+          sortedShifts[0],
+        ).end
+      : schedInterval.end
 
     const displaySpan = Interval.fromDateTimes(
       DateTime.min(schedInterval.start, firstShiftStart).startOf('day'),
@@ -109,16 +114,23 @@ export default function TempSchedShiftsList({
     )
 
     const result: FlatListListItem[] = []
+
+    // render no coverage/get started below start time if no shifts
+    if (!sortedShifts.length) {
+      result.push({
+        id: 'no-coverage',
+        type: 'INFO',
+        message: 'No coverage',
+        transition: true,
+        details: 'Add a shift to get started',
+      })
+    }
+
     const days = displaySpan.splitBy({ days: 1 })
     days.forEach((dayInterval, dayIdx) => {
       const dayShifts = sortedShifts.filter((s) =>
         dayInterval.overlaps(s.interval),
       )
-
-      // if no shifts, only render the start and end day subheaders
-      if (!sortedShifts.length && dayIdx > 0 && dayIdx < days.length - 1) {
-        return
-      }
 
       // render subheader for each day
       result.push({
@@ -147,7 +159,7 @@ export default function TempSchedShiftsList({
 
       // for temp scheds with at least 1 shift
       // render no coverage and continue if no shifts for the given day
-      if (dayShifts.length === 0 && sortedShifts.length > 0) {
+      if (dayShifts.length === 0) {
         return result.push({
           id: 'day-no-coverage_' + start,
           type: 'WARNING',


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Shift list in the temporary schedule now always displays the start/end times and days with no coverage.
