### PR TITLE
oncall: Fix oncall order panic

### DIFF
--- a/oncall/overridecalculator.go
+++ b/oncall/overridecalculator.go
@@ -1,6 +1,7 @@
 package oncall
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/target/goalert/override"
@@ -31,6 +32,7 @@ func (t *TimeIterator) NewOverrideCalculator(overrides []override.UserOverride) 
 		mapUsers: make([]string, 0, 20),
 	}
 
+	sort.Slice(overrides, func(i, j int) bool { return overrides[i].Start.Before(overrides[j].Start) })
 	for _, o := range overrides {
 		if o.AddUserID != "" && o.RemoveUserID != "" {
 			// We need both remove & add, so store them with a newline separator REMOVE/REPLACE

--- a/oncall/state.go
+++ b/oncall/state.go
@@ -104,6 +104,7 @@ func (s *state) CalculateShifts(start, end time.Time) []Shift {
 	defer t.Close()
 
 	hist := t.NewUserCalculator()
+	sort.Slice(s.history, func(i, j int) bool { return s.history[i].Start.Before(s.history[j].Start) })
 	for _, s := range s.history {
 		if s.End.IsZero() {
 			// have currently active shifts "end"
@@ -115,7 +116,7 @@ func (s *state) CalculateShifts(start, end time.Time) []Shift {
 	hist.Init()
 	tempScheds := t.NewTemporaryScheduleCalculator(s.tempScheds)
 	// sort overrides so that overlapping spans are merged properly
-	sort.Slice(s.overrides, func(i, j int) bool { return s.overrides[i].Start.Before(s.overrides[j].Start) })
+
 	overrides := t.NewOverrideCalculator(s.overrides)
 	rules := t.NewRulesCalculator(s.loc, s.rules)
 

--- a/oncall/temporaryschedulecalculator.go
+++ b/oncall/temporaryschedulecalculator.go
@@ -1,6 +1,8 @@
 package oncall
 
 import (
+	"sort"
+
 	"github.com/target/goalert/schedule"
 )
 
@@ -20,9 +22,12 @@ func (t *TimeIterator) NewTemporaryScheduleCalculator(tempScheds []schedule.Temp
 		usr:          t.NewUserCalculator(),
 	}
 
+	sort.Slice(tempScheds, func(i, j int) bool { return tempScheds[i].Start.Before(tempScheds[j].Start) })
+
 	for _, temp := range tempScheds {
 		ts.act.SetSpan(temp.Start, temp.End)
 
+		sort.Slice(temp.Shifts, func(i, j int) bool { return temp.Shifts[i].Start.Before(temp.Shifts[j].Start) })
 		for _, s := range temp.Shifts {
 			ts.usr.SetSpan(s.Start, s.End, s.UserID)
 		}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Fixes issues where out-of-order temp schedules could cause a panic (e.g., after deleting with multiple)