### PR TITLE
ui/temp sched: remove redundant validation on add shift step

### DIFF
--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
@@ -148,12 +148,7 @@ export default function TempSchedAddShiftsStep({
       add('end', 'must be after shift start time')
       add('start', 'must be before shift end time')
     }
-    if (isISOBefore(shift.start, start)) {
-      add('start', 'must not be before temporary schedule start time')
-    }
-    if (isISOAfter(shift.end, end)) {
-      add('end', 'must not extend beyond temporary schedule end time')
-    }
+
     return result
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR removes the validation when adding a shift on step two for a temporary schedule regarding final start/end times. These errors are handled elsewhere in the form.
