### PR TITLE
pgdump-lite: set client_encoding to UTF8

### DIFF
--- a/devtools/pgdump-lite/cmd/pgdump-lite/main.go
+++ b/devtools/pgdump-lite/cmd/pgdump-lite/main.go
@@ -32,6 +32,7 @@ func main() {
 	if err != nil {
 		log.Fatalln("ERROR: invalid db url:", err)
 	}
+	cfg.RuntimeParams["client_encoding"] = "UTF8"
 
 	conn, err := pgx.ConnectConfig(ctx, cfg)
 	if err != nil {

--- a/devtools/pgdump-lite/dumpdata.go
+++ b/devtools/pgdump-lite/dumpdata.go
@@ -109,7 +109,7 @@ func DumpData(ctx context.Context, conn *pgx.Conn, out io.Writer) error {
 			orderBy = colNames
 		}
 
-		fmt.Fprintf(out, "COPY %s (%s) FROM stdin;\n", table, colNames)
+		fmt.Fprintf(out, "COPY %s (%s) FROM stdin;\n", pgx.Identifier{table}.Sanitize(), colNames)
 		rows, err := tx.Query(ctx,
 			fmt.Sprintf("select %s from %s order by %s",
 				colNames,

--- a/devtools/pgdump-lite/dumpdata.go
+++ b/devtools/pgdump-lite/dumpdata.go
@@ -29,6 +29,11 @@ func sortColumns(columns []string) {
 		return ci < cj
 	})
 }
+func quoteNames(names []string) {
+	for i, n := range names {
+		names[i] = pgx.Identifier{n}.Sanitize()
+	}
+}
 
 func queryStrings(ctx context.Context, tx pgx.Tx, sql string, args ...interface{}) ([]string, error) {
 	rows, err := tx.Query(ctx, sql, args...)
@@ -79,6 +84,7 @@ func DumpData(ctx context.Context, conn *pgx.Conn, out io.Writer) error {
 		if err != nil {
 			return fmt.Errorf("read columns for '%s': %w", table, err)
 		}
+		quoteNames(columns)
 
 		primaryCols, err := queryStrings(ctx, tx, `
 			select col.column_name
@@ -95,6 +101,7 @@ func DumpData(ctx context.Context, conn *pgx.Conn, out io.Writer) error {
 			return fmt.Errorf("read primary key for '%s': %w", table, err)
 		}
 		sortColumns(primaryCols)
+		quoteNames(primaryCols)
 
 		colNames := strings.Join(columns, ", ")
 		orderBy := strings.Join(primaryCols, ",")


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
The default encoding in PostgreSQL is set to SQL_ASCII, but `pgx` requires UTF-8

