### PR TITLE
schedule: retain temp schedules

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Chat for questions and support
     url: https://gophers.slack.com/archives/CJQGZPYLV
-    about: "This issue tracker is not for support questions. Visit the gophers community Slack and the #goalert channel for assistance!"
+    about: 'This issue tracker is not for support questions. Visit the gophers community Slack and the #goalert channel for assistance!'

--- a/devtools/ci/tasks/scripts/build-binaries.sh
+++ b/devtools/ci/tasks/scripts/build-binaries.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -ex
 PREFIX=$1
-make check test bin/goalert BUNDLE=1 && ./bin/goalert self-test --offline
+make check test bin/goalert BUNDLE=1
+./bin/goalert self-test --offline
 VERSION=$(./bin/goalert version | head -n 1 |awk '{print $2}')
 BVERSION=$(date +%s)-$(git rev-parse --short HEAD)
 

--- a/engine/cleanupmanager/db.go
+++ b/engine/cleanupmanager/db.go
@@ -60,7 +60,7 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 
 		schedData: p.P(`
 			select schedule_id, data from schedule_data
-			where data notnull and (last_cleanup_at isnull or last_cleanup_at <= now() - '1 day'::interval)
+			where data notnull and (last_cleanup_at isnull or last_cleanup_at <= now() - '1 month'::interval)
 			order by last_cleanup_at asc nulls first
 			for update
 			limit 100

--- a/engine/cleanupmanager/update.go
+++ b/engine/cleanupmanager/update.go
@@ -146,7 +146,6 @@ func cleanupScheduleData(data *schedule.Data, userMap map[string]struct{}, cutof
 		filtered = append(filtered, temp)
 	}
 	data.V1.TemporarySchedules = filtered
-
 }
 
 // getUsers retrieves the current set of user IDs

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
@@ -15,7 +15,7 @@ import TempSchedAddShiftForm from './TempSchedAddShiftForm'
 import { ScheduleTZFilter } from '../ScheduleTZFilter'
 import { DateTime, Interval } from 'luxon'
 import { FieldError } from '../../util/errutil'
-import { isISOAfter, isISOBefore } from '../../util/shifts'
+import { isISOAfter } from '../../util/shifts'
 
 const useStyles = makeStyles((theme) => ({
   contentText,

--- a/web/src/app/styles/base/elements.css
+++ b/web/src/app/styles/base/elements.css
@@ -22,6 +22,7 @@ a:hover {
 .rbc-time-content .rbc-current-time-indicator {
   background-color: #343434;
 }
+
 .rbc-time-content .rbc-current-time-indicator::before {
   content: '';
   display: inline-block;

--- a/web/src/cypress/support/schedule.ts
+++ b/web/src/cypress/support/schedule.ts
@@ -202,7 +202,7 @@ interface SetTemporarySchedule {
 
 function createTemporarySchedule(
   opts: Partial<SetTemporarySchedule> = {},
-): Cypress.Chainable<null> {
+): Cypress.Chainable<void> {
   const mutation = `
     mutation($input: SetTemporaryScheduleInput!) {
       setTemporarySchedule(input: $input)
@@ -257,7 +257,7 @@ function createTemporarySchedule(
       shifts,
     }
 
-    return cy.graphql(mutation, { input })
+    return cy.graphql(mutation, { input }) as void
   })
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR updates the temporary schedule code to perform cleanup once per month, per schedule (vs. every day). Additionally, schedules are no longer trimmed to the current timestamp, but rather dropped entirely once their end time has expired.

An issue with `make check` was also resolved with the relevant formatting/type fixes added.