### PR TITLE
migrate: fix error text in api-only mode

### DIFF
--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -88,7 +88,7 @@ func VerifyAll(ctx context.Context, url string) error {
 
 	var hasLatest bool
 	err = conn.QueryRow(ctx, `select true from gorp_migrations where id = $1`, targetID).Scan(&hasLatest)
-	if err != nil {
+	if !errors.Is(err, pgx.ErrNoRows) && err != nil {
 		return err
 	}
 	if hasLatest {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Fixes an issue where the error message was "no rows in result set" instead of "latest migration 'x' has not been applied"