### PR TITLE
ui/transitions: use fade in for desktop UX

### DIFF
--- a/web/src/app/dialogs/FormDialog.js
+++ b/web/src/app/dialogs/FormDialog.js
@@ -8,7 +8,7 @@ import Typography from '@material-ui/core/Typography'
 import { makeStyles } from '@material-ui/core/styles'
 import { isWidthUp } from '@material-ui/core/withWidth/index'
 
-import { DefaultTransition, FullscreenTransition } from '../util/Transitions'
+import { FadeTransition, SlideTransition } from '../util/Transitions'
 import LoadingButton from '../loading/components/LoadingButton'
 import DialogTitleWrapper from './components/DialogTitleWrapper'
 import DialogContentError from './components/DialogContentError'
@@ -157,7 +157,9 @@ function FormDialog(props) {
       fullWidth
       open={!isUnmounting}
       onClose={onClose}
-      TransitionComponent={fs ? FullscreenTransition : DefaultTransition}
+      TransitionComponent={
+        isWideScreen || confirm ? FadeTransition : SlideTransition
+      }
       {...dialogProps}
     >
       <Notices notices={notices} />

--- a/web/src/app/util/Transitions.tsx
+++ b/web/src/app/util/Transitions.tsx
@@ -2,29 +2,20 @@ import React, { ReactElement } from 'react'
 import Fade from '@material-ui/core/Fade'
 import Slide from '@material-ui/core/Slide'
 
-export const DefaultTransition = React.forwardRef(
+export const FadeTransition = React.forwardRef(
   ({ children, ...props }, ref) => (
     <Fade {...props} ref={ref}>
       {children as ReactElement}
     </Fade>
   ),
 )
-DefaultTransition.displayName = 'DefaultTransition'
+FadeTransition.displayName = 'FadeTransition'
 
-export const FullscreenTransition = React.forwardRef(
+export const SlideTransition = React.forwardRef(
   ({ children, ...props }, ref) => (
     <Slide {...props} direction='left' ref={ref}>
       {children as ReactElement}
     </Slide>
   ),
 )
-FullscreenTransition.displayName = 'FullscreenTransition'
-
-export const FullscreenExpansion = React.forwardRef(
-  ({ children, ...props }, ref) => (
-    <Slide {...props} direction='right' ref={ref}>
-      {children as ReactElement}
-    </Slide>
-  ),
-)
-FullscreenExpansion.displayName = 'FullscreenExpansion'
+SlideTransition.displayName = 'SlideTransition'


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR renames the transitions, and using FadeTransition for the temp sched dialog since that is our convention on desktop screen sizes

**Describe any introduced user-facing changes:**
Temp sched dialog fades in and out, as opposed to sliding in