### PR TITLE
dev: lock build-env version

### DIFF
--- a/devtools/ci/dockerfiles/all-in-one/Dockerfile
+++ b/devtools/ci/dockerfiles/all-in-one/Dockerfile
@@ -1,4 +1,4 @@
-FROM goalert/build-env AS build
+FROM goalert/build-env:go1.16.3-postgres13 AS build
 
 COPY Makefile /goalert/Makefile
 COPY yarn.lock package.json /goalert/

--- a/devtools/ci/dockerfiles/all-in-one/Dockerfile.buildx
+++ b/devtools/ci/dockerfiles/all-in-one/Dockerfile.buildx
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM goalert/build-env AS binaries
+FROM --platform=$BUILDPLATFORM goalert/build-env:go1.16.3-postgres13 AS binaries
 ARG BUILDPLATFORM
 COPY bin/goalert-linux-arm /linux/arm/v7/goalert
 COPY bin/resetdb-linux-arm /linux/arm/v7/resetdb

--- a/devtools/ci/dockerfiles/goalert/Dockerfile.buildx
+++ b/devtools/ci/dockerfiles/goalert/Dockerfile.buildx
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM goalert/build-env AS binaries
+FROM --platform=$BUILDPLATFORM goalert/build-env:go1.16.3-postgres13 AS binaries
 ARG BUILDPLATFORM
 COPY bin/goalert-linux-arm /linux/arm/v7/goalert
 COPY bin/goalert-linux-arm64 /linux/arm64/goalert

--- a/devtools/ci/tasks/build-binaries.yml
+++ b/devtools/ci/tasks/build-binaries.yml
@@ -13,8 +13,7 @@ outputs:
   - name: bin
 image_resource:
   type: registry-image
-  source:
-    repository: goalert/build-env
+  source: { repository: goalert/build-env, tag: go1.16.3-postgres13 }
 run:
   path: sh
   dir: goalert

--- a/devtools/ci/tasks/scripts/codecheck.sh
+++ b/devtools/ci/tasks/scripts/codecheck.sh
@@ -20,6 +20,33 @@ if [ "$PKG_JSON_VER" != "$DOCKERFILE_VER" ]; then
   exit 1
 fi
 
+# assert build-env versions are identical
+BUILD_ENV_VER=go1.16.3-postgres13
+for file in $(find devtools -name 'Dockerfile*')
+do
+  if ! grep -q "goalert/build-env" "$file"; then
+    continue
+  fi
+  if ! grep -q "goalert/build-env:$BUILD_ENV_VER" "$file"; then
+    echo "build-env version mismatch, expected $BUILD_ENV_VER"
+    echo "  $file:"
+    echo "  $(grep goalert/build-env "$file")"
+    exit 1
+  fi
+done
+for file in $(find devtools -name '*.yml')
+do
+  if ! grep -q "goalert/build-env" "$file"; then
+    continue
+  fi
+  if ! grep -q "goalert/build-env, tag: $BUILD_ENV_VER" "$file"; then
+    echo "build-env version mismatch, expected $BUILD_ENV_VER"
+    echo "  $file:"
+    echo "  $(grep goalert/build-env "$file")"
+    exit 1
+  fi
+done
+
 # taskfile contains quotes
 if [ "'$PKG_JSON_VER'" != "$TASKFILE_VER" ]; then
   echo "Cypress versions do not match:"

--- a/devtools/ci/tasks/test-smoketest.yml
+++ b/devtools/ci/tasks/test-smoketest.yml
@@ -8,7 +8,7 @@ outputs:
   - name: debug
 image_resource:
   type: registry-image
-  source: { repository: goalert/build-env }
+  source: { repository: goalert/build-env, tag: go1.16.3-postgres13 }
 run:
   path: sh
   dir: goalert


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Updates Dockerfiles and task files to use a versioned tag of the build-env image.
