### PR TITLE
notification: Use methods instead of channels for incoming messages

### DIFF
--- a/app/shutdown.go
+++ b/app/shutdown.go
@@ -43,7 +43,6 @@ func (app *App) _Shutdown(ctx context.Context) error {
 	shut(app.srv, "HTTP server")
 	shut(app.Engine, "engine")
 	shut(app.events, "event listener")
-	shut(app.notificationManager, "notification manager")
 	shut(app.SessionKeyring, "session keyring")
 	shut(app.OAuthKeyring, "oauth keyring")
 	shut(app.APIKeyring, "API keyring")

--- a/notification/manager.go
+++ b/notification/manager.go
@@ -45,18 +45,6 @@ func (mgr *Manager) SetStubNotifiers() {
 	mgr.stubNotifiers = true
 }
 
-func bgSpan(ctx context.Context, name string) (context.Context, *trace.Span) {
-	var sp *trace.Span
-	if ctx != nil {
-		sp = trace.FromContext(ctx)
-	}
-	if sp == nil {
-		return trace.StartSpan(context.Background(), name)
-	}
-
-	return trace.StartSpanWithRemoteParent(context.Background(), name, sp.SpanContext())
-}
-
 // Shutdown will stop the manager, waiting for pending background operations to finish.
 func (mgr *Manager) Shutdown(context.Context) error {
 	close(mgr.shutdownCh)

--- a/notification/manager.go
+++ b/notification/manager.go
@@ -91,7 +91,7 @@ func (mgr *Manager) RegisterSender(t DestType, name string, s Sender) {
 	mgr.searchOrder = append(mgr.searchOrder, n)
 
 	if rs, ok := s.(ReceiverSetter); ok {
-		rs.SetReceiver(mgr)
+		rs.SetReceiver(&namedReceiver{ns: n, Receiver: mgr})
 	}
 }
 

--- a/notification/notifier.go
+++ b/notification/notifier.go
@@ -37,27 +37,13 @@ type Sender interface {
 	Send(context.Context, Message) (*MessageStatus, error)
 }
 
+// ReceiverSetter allows setting a Receiver and should be implemented by a Sender that
+// supports two-way interaction.
+type ReceiverSetter interface {
+	SetReceiver(Receiver)
+}
+
 // A StatusChecker allows checking the status of a sent message.
 type StatusChecker interface {
 	Status(ctx context.Context, messageID, providerMessageID string) (*MessageStatus, error)
-}
-
-// StatusUpdater will provide status updates for messages, it should never be closed.
-type StatusUpdater interface {
-	ListenStatus() <-chan *MessageStatus
-}
-
-// A Responder will provide message responses, it should never be closed.
-type Responder interface {
-	ListenResponse() <-chan *MessageResponse
-}
-
-// MessageResponse represents a received response from a user.
-type MessageResponse struct {
-	Ctx    context.Context
-	ID     string
-	From   Dest
-	Result Result
-
-	Err chan error
 }

--- a/notification/notifier.go
+++ b/notification/notifier.go
@@ -14,8 +14,6 @@ type Result int
 const (
 	ResultAcknowledge Result = iota
 	ResultResolve
-	ResultStart
-	ResultStop
 )
 
 // ErrStatusUnsupported should be returned when a Status() check is not supported by the provider.

--- a/notification/result_string.go
+++ b/notification/result_string.go
@@ -10,13 +10,11 @@ func _() {
 	var x [1]struct{}
 	_ = x[ResultAcknowledge-0]
 	_ = x[ResultResolve-1]
-	_ = x[ResultStart-2]
-	_ = x[ResultStop-3]
 }
 
-const _Result_name = "ResultAcknowledgeResultResolveResultStartResultStop"
+const _Result_name = "ResultAcknowledgeResultResolve"
 
-var _Result_index = [...]uint8{0, 17, 30, 41, 51}
+var _Result_index = [...]uint8{0, 17, 30}
 
 func (i Result) String() string {
 	if i < 0 || i >= Result(len(_Result_index)-1) {

--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -19,9 +19,7 @@ import (
 )
 
 type ChannelSender struct {
-	cfg    Config
-	resp   chan *notification.MessageResponse
-	status chan *notification.MessageStatus
+	cfg Config
 
 	chanTht *throttle
 	listTht *throttle
@@ -37,9 +35,7 @@ var _ notification.Sender = &ChannelSender{}
 
 func NewChannelSender(ctx context.Context, cfg Config) (*ChannelSender, error) {
 	return &ChannelSender{
-		cfg:    cfg,
-		resp:   make(chan *notification.MessageResponse),
-		status: make(chan *notification.MessageStatus),
+		cfg: cfg,
 
 		chanTht: newThrottle(time.Minute / 50),
 		listTht: newThrottle(time.Minute / 50),

--- a/notification/statusmanager.go
+++ b/notification/statusmanager.go
@@ -1,0 +1,14 @@
+package notification
+
+import "context"
+
+type namedReceiver struct {
+	Receiver
+	ns *namedSender
+}
+
+// UpdateStatus calls the underlying UpdateStatus method after wrapping the status for the
+// namedSender.
+func (nr *namedReceiver) UpdateStatus(ctx context.Context, status *MessageStatus) error {
+	return nr.Receiver.UpdateStatus(ctx, status.wrap(ctx, nr.ns))
+}

--- a/notification/twilio/sms.go
+++ b/notification/twilio/sms.go
@@ -34,9 +34,6 @@ type SMS struct {
 	b *dbSMS
 	c *Config
 
-	respCh chan *notification.MessageResponse
-	statCh chan *notification.MessageStatus
-
 	ban *dbBan
 }
 
@@ -49,10 +46,8 @@ func NewSMS(ctx context.Context, db *sql.DB, c *Config) (*SMS, error) {
 	}
 
 	s := &SMS{
-		b:      b,
-		c:      c,
-		respCh: make(chan *notification.MessageResponse),
-		statCh: make(chan *notification.MessageStatus, 10),
+		b: b,
+		c: c,
 	}
 	s.ban, err = newBanDB(ctx, db, c, "twilio_sms_errors")
 	if err != nil {
@@ -70,12 +65,6 @@ func (s *SMS) Status(ctx context.Context, id, providerID string) (*notification.
 	}
 	return msg.messageStatus(id), nil
 }
-
-// ListenStatus will return a channel that is fed async status updates.
-func (s *SMS) ListenStatus() <-chan *notification.MessageStatus { return s.statCh }
-
-// ListenResponse will return a channel that is fed async message responses.
-func (s *SMS) ListenResponse() <-chan *notification.MessageResponse { return s.respCh }
 
 // Send implements the notification.Sender interface.
 func (s *SMS) Send(ctx context.Context, msg notification.Message) (*notification.MessageStatus, error) {

--- a/notification/twilio/sms.go
+++ b/notification/twilio/sms.go
@@ -39,6 +39,7 @@ type SMS struct {
 }
 
 var _ notification.ReceiverSetter = &SMS{}
+var _ notification.Sender = &SMS{}
 
 // NewSMS performs operations like validating essential parameters, registering the Twilio client and db
 // and adding routes for successful and unsuccessful message delivery to Twilio


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This work simplifies the notification package interfaces by allowing incoming messages/status to be handled through method calls instead of embedded channels. It's part of a cleanup effort for advanced notification provider functionality.