### PR TITLE
ui: load lodash in strict mode

### DIFF
--- a/web/src/package.json
+++ b/web/src/package.json
@@ -53,7 +53,8 @@
     "react-transition-group": "4.4.1",
     "redux-thunk": "2.3.0",
     "remark-gfm": "1.0.0",
-    "reselect": "4.0.0"
+    "reselect": "4.0.0",
+    "strict-loader": "1.2.0"
   },
   "devDependencies": {
     "@babel/cli": "7.13.14",

--- a/web/src/webpack.config.js
+++ b/web/src/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = (env = { GOALERT_VERSION: 'dev' }) => ({
   // Loaders for processing different file types
   module: {
     rules: [
+      { test: /lodash/, loader: 'strict-loader' },
       {
         test: /\.(t|j)sx?$/,
         use: [

--- a/web/src/webpack.cypress.js
+++ b/web/src/webpack.cypress.js
@@ -22,6 +22,7 @@ module.exports = {
   // Loaders for processing different file types
   module: {
     rules: [
+      { test: /lodash/, loader: 'strict-loader' },
       {
         test: /\.json$/,
         loader: 'json-loader',

--- a/web/src/webpack.prod.config.js
+++ b/web/src/webpack.prod.config.js
@@ -24,6 +24,7 @@ module.exports = (env) => ({
   },
   module: {
     rules: [
+      { test: /lodash/, loader: 'strict-loader' },
       {
         test: /\.(t|j)sx?$/,
         use: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -9684,7 +9684,7 @@ stealthy-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
-strict-loader@^1.2.0:
+strict-loader@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/strict-loader/-/strict-loader-1.2.0.tgz#ec53f0feeea4c38ebcd560a1d5d592326955277c"
   integrity sha1-7FPw/u6kw4681WCh1dWSMmlVJ3w=

--- a/yarn.lock
+++ b/yarn.lock
@@ -4464,6 +4464,11 @@ espree@^7.3.0, espree@^7.3.1:
     acorn-jsx "^5.3.1"
     eslint-visitor-keys "^1.3.0"
 
+esprima@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+  integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
+
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
@@ -9678,6 +9683,15 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
+strict-loader@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/strict-loader/-/strict-loader-1.2.0.tgz#ec53f0feeea4c38ebcd560a1d5d592326955277c"
+  integrity sha1-7FPw/u6kw4681WCh1dWSMmlVJ3w=
+  dependencies:
+    esprima "^3.1.3"
+    loader-utils "^1.1.0"
+    source-map "^0.5.6"
 
 string-length@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Forces lodash functions to be run in strict mode, preventing silent errors (e.g. Apollo cache bug)