### PR TITLE
ui/escalation-policies: sort services by name

### DIFF
--- a/web/src/app/escalation-policies/PolicyServicesCard.tsx
+++ b/web/src/app/escalation-policies/PolicyServicesCard.tsx
@@ -24,7 +24,7 @@ function PolicyServicesCard(props: PolicyServicesCardProps): JSX.Element {
     }))
 
     // case-insensitive sort
-    return _.sortBy(items, (i) => i.title.toLowerCase())
+    return _.sortBy(items, (i) => i.title.toLowerCase(), ['title'])
   }
 
   return (

--- a/web/src/app/escalation-policies/PolicyServicesCard.tsx
+++ b/web/src/app/escalation-policies/PolicyServicesCard.tsx
@@ -24,7 +24,7 @@ function PolicyServicesCard(props: PolicyServicesCardProps): JSX.Element {
     }))
 
     // case-insensitive sort
-    return _.sortBy(items, (i) => i.title.toLowerCase(), ['title'])
+    return _.sortBy(items, (i) => i.title.toLowerCase())
   }
 
   return (

--- a/web/src/app/escalation-policies/PolicyServicesCard.tsx
+++ b/web/src/app/escalation-policies/PolicyServicesCard.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import Card from '@material-ui/core/Card'
 import { makeStyles } from '@material-ui/core/styles'
 import FlatList, { FlatListListItem } from '../lists/FlatList'
-import { Target } from '../../schema'
 import _ from 'lodash'
 
 const useStyles = makeStyles(() => ({
@@ -12,7 +11,7 @@ const useStyles = makeStyles(() => ({
 }))
 
 interface PolicyServicesCardProps {
-  services: Partial<Target>[]
+  services: { id: string; name: string }[]
 }
 
 function PolicyServicesCard(props: PolicyServicesCardProps): JSX.Element {

--- a/web/src/app/escalation-policies/PolicyServicesCard.tsx
+++ b/web/src/app/escalation-policies/PolicyServicesCard.tsx
@@ -23,7 +23,8 @@ function PolicyServicesCard(props: PolicyServicesCardProps): JSX.Element {
       url: `/services/${service.id}`,
     }))
 
-    return _.sortBy(items, 'title')
+    // case-insensitive sort
+    return _.sortBy(items, (i) => i.title.toLowerCase())
   }
 
   return (

--- a/web/src/app/escalation-policies/PolicyServicesCard.tsx
+++ b/web/src/app/escalation-policies/PolicyServicesCard.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { PropTypes as p } from 'prop-types'
 import Card from '@material-ui/core/Card'
 import { makeStyles } from '@material-ui/core/styles'
-import FlatList from '../lists/FlatList'
+import FlatList, { FlatListListItem } from '../lists/FlatList'
+import { Target } from '../../schema'
+import _ from 'lodash'
 
 const useStyles = makeStyles(() => ({
   card: {
@@ -10,15 +11,22 @@ const useStyles = makeStyles(() => ({
   },
 }))
 
-function PolicyServicesCard(props) {
+interface PolicyServicesCardProps {
+  services: Partial<Target>[]
+}
+
+function PolicyServicesCard(props: PolicyServicesCardProps): JSX.Element {
   const classes = useStyles()
 
-  function getServicesItems() {
-    return props.services.map((service) => ({
+  function getServicesItems(): FlatListListItem[] {
+    const items = props.services.map((service) => ({
       title: service.name,
       url: `/services/${service.id}`,
     }))
+
+    return _.sortBy(items, 'name')
   }
+
   return (
     <Card className={classes.card}>
       <FlatList
@@ -27,15 +35,6 @@ function PolicyServicesCard(props) {
       />
     </Card>
   )
-}
-
-PolicyServicesCard.propTypes = {
-  services: p.arrayOf(
-    p.shape({
-      id: p.string.isRequired,
-      name: p.string.isRequired,
-    }),
-  ).isRequired,
 }
 
 export default PolicyServicesCard

--- a/web/src/app/escalation-policies/PolicyServicesCard.tsx
+++ b/web/src/app/escalation-policies/PolicyServicesCard.tsx
@@ -23,7 +23,7 @@ function PolicyServicesCard(props: PolicyServicesCardProps): JSX.Element {
       url: `/services/${service.id}`,
     }))
 
-    return _.sortBy(items, 'name')
+    return _.sortBy(items, 'title')
   }
 
   return (


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This sorts the policy services by name to prevent shuffling by apollo polling

**Which issue(s) this PR fixes:**
fixes #1460 

**Describe any introduced user-facing changes:**
Users will not see the listed items spontaneously change order
