### PR TITLE
schedules: fix breaking potential issues with temporary schedules

### DIFF
--- a/graphql2/graphqlapp/mutation.go
+++ b/graphql2/graphqlapp/mutation.go
@@ -7,6 +7,7 @@ import (
 	"github.com/target/goalert/assignment"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/permission"
+	"github.com/target/goalert/schedule"
 	"github.com/target/goalert/user"
 	"github.com/target/goalert/validation"
 
@@ -32,7 +33,11 @@ func (a *Mutation) SetFavorite(ctx context.Context, input graphql2.SetFavoriteIn
 }
 func (a *Mutation) SetTemporarySchedule(ctx context.Context, input graphql2.SetTemporaryScheduleInput) (bool, error) {
 	err := withContextTx(ctx, a.DB, func(ctx context.Context, tx *sql.Tx) error {
-		return a.ScheduleStore.SetTemporarySchedule(ctx, tx, input.ScheduleID, input.Start, input.End, input.Shifts)
+		return a.ScheduleStore.SetTemporarySchedule(ctx, tx, input.ScheduleID, schedule.TemporarySchedule{
+			Start:  input.Start,
+			End:    input.End,
+			Shifts: input.Shifts,
+		})
 	})
 
 	return err == nil, err

--- a/oncall/activecalculator.go
+++ b/oncall/activecalculator.go
@@ -67,19 +67,17 @@ func (act *ActiveCalculator) SetSpan(start, end time.Time) {
 	start = start.Truncate(act.Step())
 	end = end.Truncate(act.Step())
 
-	// Skip if the span ends before the iterator start time.
-	//
-	// A zero end time indicates infinity (e.g. current shift from history).
-	if !end.After(act.Start()) && !end.IsZero() {
+	// Skip if the span is < 1 step (after truncation).
+	if !end.After(start) {
 		return
 	}
 
-	// Skip if the length of the span is less than 1 minute.
-	if !end.IsZero() && end.Sub(start) < time.Minute {
+	// Skip if the span ends before or at the iterator start time.
+	if !end.After(act.Start()) {
 		return
 	}
 
-	// Skip if the span starts after the calculator end time.
+	// Skip if the span starts at or after the calculator end time.
 	if !start.Before(act.End()) {
 		return
 	}

--- a/oncall/temporaryschedulecalculator.go
+++ b/oncall/temporaryschedulecalculator.go
@@ -23,14 +23,16 @@ func (t *TimeIterator) NewTemporaryScheduleCalculator(tempScheds []schedule.Temp
 	}
 
 	sort.Slice(tempScheds, func(i, j int) bool { return tempScheds[i].Start.Before(tempScheds[j].Start) })
+	var allShifts []schedule.FixedShift
 
 	for _, temp := range tempScheds {
 		ts.act.SetSpan(temp.Start, temp.End)
+		allShifts = append(allShifts, temp.Shifts...)
+	}
+	sort.Slice(allShifts, func(i, j int) bool { return allShifts[i].Start.Before(allShifts[j].Start) })
 
-		sort.Slice(temp.Shifts, func(i, j int) bool { return temp.Shifts[i].Start.Before(temp.Shifts[j].Start) })
-		for _, s := range temp.Shifts {
-			ts.usr.SetSpan(s.Start, s.End, s.UserID)
-		}
+	for _, s := range allShifts {
+		ts.usr.SetSpan(s.Start, s.End, s.UserID)
 	}
 	ts.act.Init()
 	ts.usr.Init()

--- a/schedule/storetemporaryschedules.go
+++ b/schedule/storetemporaryschedules.go
@@ -66,6 +66,8 @@ func (store *Store) TemporarySchedules(ctx context.Context, tx *sql.Tx, schedule
 		data.V1.TemporarySchedules[i] = tmp
 	}
 
+	data.V1.TemporarySchedules = MergeTemporarySchedules(data.V1.TemporarySchedules)
+
 	return data.V1.TemporarySchedules, nil
 }
 

--- a/schedule/storetemporaryschedules.go
+++ b/schedule/storetemporaryschedules.go
@@ -132,7 +132,7 @@ func (store *Store) updateFixedShifts(ctx context.Context, tx *sql.Tx, scheduleI
 }
 
 func validateRecent(fieldName string, t time.Time) error {
-	if time.Since(t) >= 24*time.Hour {
+	if time.Since(t) < 24*time.Hour {
 		return nil
 	}
 	return validation.NewFieldError(fieldName, "too far in the past")

--- a/schedule/storetemporaryschedules.go
+++ b/schedule/storetemporaryschedules.go
@@ -131,46 +131,40 @@ func (store *Store) updateFixedShifts(ctx context.Context, tx *sql.Tx, scheduleI
 	return nil
 }
 
-func validateRecent(fieldName string, t time.Time) error {
-	if time.Since(t) < 24*time.Hour {
-		return nil
-	}
-	return validation.NewFieldError(fieldName, "too far in the past")
-}
-
 func validateFuture(fieldName string, t time.Time) error {
-	if t.After(time.Now()) {
+	if time.Until(t) > 5*time.Minute {
 		return nil
 	}
-	return validation.NewFieldError(fieldName, "must be in the future")
+	return validation.NewFieldError(fieldName, "must be at least 5 min the future")
 }
 
 // SetTemporarySchedule will cause the schedule to use only, and exactly, the provided set of shifts between the provided start and end times.
-func (store *Store) SetTemporarySchedule(ctx context.Context, tx *sql.Tx, scheduleID string, start, end time.Time, shifts []FixedShift) error {
+func (store *Store) SetTemporarySchedule(ctx context.Context, tx *sql.Tx, scheduleID string, temp TemporarySchedule) error {
 	err := permission.LimitCheckAny(ctx, permission.User)
 	if err != nil {
 		return err
 	}
-	start = start.Truncate(time.Minute)
-	end = end.Truncate(time.Minute)
-	for i := range shifts {
-		shifts[i].Start = shifts[i].Start.Truncate(time.Minute)
-		shifts[i].End = shifts[i].End.Truncate(time.Minute)
+	temp.Start = temp.Start.Truncate(time.Minute)
+	temp.End = temp.End.Truncate(time.Minute)
+	for i := range temp.Shifts {
+		temp.Shifts[i].Start = temp.Shifts[i].Start.Truncate(time.Minute)
+		temp.Shifts[i].End = temp.Shifts[i].End.Truncate(time.Minute)
 	}
 
 	err = validate.Many(
-		validateRecent("Start", start),
-		validateFuture("End", end),
-		validateTimeRange("", start, end),
+		validateFuture("End", temp.End),
+		validateTimeRange("", temp.Start, temp.End),
 		validate.UUID("ScheduleID", scheduleID),
-		store.validateShifts(ctx, "Shifts", FixedShiftsPerTemporaryScheduleLimit, shifts, start, end),
+		store.validateShifts(ctx, "Shifts", FixedShiftsPerTemporaryScheduleLimit, temp.Shifts, temp.Start, temp.End),
 	)
 	if err != nil {
 		return err
 	}
 
+	// truncate to current timestamp
+	temp.TrimStart(time.Now())
 	return store.updateFixedShifts(ctx, tx, scheduleID, func(data *Data) error {
-		data.V1.TemporarySchedules = setFixedShifts(data.V1.TemporarySchedules, start, end, shifts)
+		data.V1.TemporarySchedules = setFixedShifts(data.V1.TemporarySchedules, temp)
 		return nil
 	})
 }
@@ -189,6 +183,9 @@ func (store *Store) ClearTemporarySchedules(ctx context.Context, tx *sql.Tx, sch
 	)
 	if err != nil {
 		return err
+	}
+	if time.Since(start) > 0 {
+		start = time.Now()
 	}
 
 	return store.updateFixedShifts(ctx, tx, scheduleID, func(data *Data) error {

--- a/schedule/temporaryschedule.go
+++ b/schedule/temporaryschedule.go
@@ -96,9 +96,9 @@ func MergeTemporarySchedules(tempScheds []TemporarySchedule) []TemporarySchedule
 	return result
 }
 
-func setFixedShifts(tempScheds []TemporarySchedule, start, end time.Time, shifts []FixedShift) []TemporarySchedule {
-	tempScheds = deleteFixedShifts(tempScheds, start, end)
-	tempScheds = append(tempScheds, TemporarySchedule{Start: start, End: end, Shifts: shifts})
+func setFixedShifts(tempScheds []TemporarySchedule, newSched TemporarySchedule) []TemporarySchedule {
+	tempScheds = deleteFixedShifts(tempScheds, newSched.Start, newSched.End)
+	tempScheds = append(tempScheds, newSched)
 	return MergeTemporarySchedules(tempScheds)
 }
 

--- a/web/src/app/schedules/CalendarEventWrapper.js
+++ b/web/src/app/schedules/CalendarEventWrapper.js
@@ -67,6 +67,10 @@ export default function CalendarEventWrapper({
   }
 
   function renderTempSchedButtons() {
+    if (DateTime.fromISO(event.end) <= DateTime.utc()) {
+      // no actions on past events
+      return
+    }
     return (
       <React.Fragment>
         <Grid item>

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
@@ -236,6 +236,7 @@ export default function TempSchedAddShiftsStep({
                 setShift(shift)
                 onChange(value.filter((s) => !shiftEquals(shift, s)))
               }}
+              edit={edit}
             />
           </div>
         </Grid>

--- a/web/src/app/schedules/temp-sched/TempSchedDeleteConfirmation.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDeleteConfirmation.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useMutation, gql } from '@apollo/client'
 import FormDialog from '../../dialogs/FormDialog'
 import { fmt, Value } from './sharedUtils'
+import { DateTime } from 'luxon'
 
 const mutation = gql`
   mutation($input: ClearTemporarySchedulesInput!) {
@@ -25,18 +26,23 @@ export default function TempSchedDeleteConfirmation({
     variables: {
       input: {
         scheduleID: scheduleID,
-        start: value.start,
+        start: value.start, // actual truncation will be handled by backend
         end: value.end,
       },
     },
   })
+
+  const start = DateTime.max(
+    DateTime.fromISO(value.start),
+    DateTime.utc(),
+  ).toISO()
 
   return (
     <FormDialog
       title='Are you sure?'
       confirm
       subTitle={`This will clear all temporary schedule data from ${fmt(
-        value.start,
+        start,
       )} to ${fmt(value.end)}.`}
       loading={loading}
       errors={error ? [error] : []}

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -10,6 +10,7 @@ import SwipeableViews from 'react-swipeable-views'
 import TempSchedAddShiftsStep from './TempSchedAddShiftsStep'
 import TempSchedTimesStep from './TempSchedTimesStep'
 import { parseInterval } from '../../util/shifts'
+import { DateTime } from 'luxon'
 // allows changing the index programatically
 const VirtualizeAnimatedViews = virtualize(SwipeableViews)
 
@@ -118,6 +119,19 @@ export default function TempSchedDialog({
       onClose={onClose}
       loading={loading}
       errors={errs}
+      notices={
+        !value.start ||
+        DateTime.fromISO(value.start) > DateTime.utc().minus({ hour: 1 })
+          ? []
+          : [
+              {
+                type: 'WARNING',
+                message: 'Start time occurs in the past',
+                details:
+                  'Any shifts or changes made to shifts in the past will be ignored when submitting.',
+              },
+            ]
+      }
       form={
         <FormContainer
           optionalLabels

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -121,7 +121,8 @@ export default function TempSchedDialog({
       errors={errs}
       notices={
         !value.start ||
-        DateTime.fromISO(value.start) > DateTime.utc().minus({ hour: 1 })
+        DateTime.fromISO(value.start) > DateTime.utc().minus({ hour: 1 }) ||
+        edit
           ? []
           : [
               {

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -105,8 +105,14 @@ export default function TempSchedShiftsList({
         ).end
       : schedInterval.end
 
+    let spanStart = DateTime.min(schedInterval.start, firstShiftStart).startOf(
+      'day',
+    )
+    if (edit)
+      spanStart = DateTime.max(spanStart, DateTime.utc().startOf('hour'))
+
     const displaySpan = Interval.fromDateTimes(
-      DateTime.min(schedInterval.start, firstShiftStart).startOf('day'),
+      spanStart,
       DateTime.max(schedInterval.end, lastShiftEnd).endOf('day'),
     )
 

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -51,7 +51,7 @@ export default function TempSchedShiftsList({
   onRemove,
 }: TempSchedShiftsListProps): JSX.Element {
   const classes = useStyles()
-  let shifts = useUserInfo(value)
+  const _shifts = useUserInfo(value)
   const [zone] = useURLParam('tz', 'local')
   const schedInterval = parseInterval({ start, end })
 
@@ -71,13 +71,8 @@ export default function TempSchedShiftsList({
       ]
     }
 
-    // purge historical shifts if editing
-    if (edit) {
-      shifts = shifts.filter((s) => DateTime.fromISO(s.end) > DateTime.utc())
-    }
-
-    const sortedShifts = shifts.length
-      ? _.sortBy(shifts, 'start').map((s) => ({
+    const sortedShifts = _shifts.length
+      ? _.sortBy(_shifts, 'start').map((s) => ({
           id: s.start + s.userID,
           shift: s,
           start: DateTime.fromISO(s.start, { zone }),
@@ -159,10 +154,6 @@ export default function TempSchedShiftsList({
 
       // render no coverage and continue if no shifts for the given day
       if (dayShifts.length === 0) {
-        if (edit && dayInterval.end < DateTime.utc()) {
-          return
-        }
-
         return result.push({
           id: 'day-no-coverage_' + start,
           type: 'WARNING',

--- a/web/src/cypress/integration/temporarySchedule.ts
+++ b/web/src/cypress/integration/temporarySchedule.ts
@@ -197,7 +197,7 @@ function testTemporarySchedule(screen: string): void {
 
   it('should delete a temporary schedule', () => {
     cy.createTemporarySchedule({
-      start: DateTime.utc().toISO(),
+      start: DateTime.utc().plus({ hour: 1 }).toISO(),
       scheduleID: schedule.id,
     }).then(() => {
       cy.reload()


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
- Fixes an issue where temp schedule shifts could be processed out-of-order.
- Fixes related issues where invalid data could cause the schedule page to break
- Ensure past data is not changed when updating/deleting temp schedule info
- When editing, historical shifts are no longer shown in the edit dialog
- Disables Edit and Delete on past shifts/temp schedules
