### PR TITLE
users: fix fkey and rotation issues when deleting a user

### DIFF
--- a/user/store.go
+++ b/user/store.go
@@ -6,10 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	"github.com/golang/groupcache"
 	uuid "github.com/satori/go.uuid"
 	"github.com/target/goalert/permission"
+	"github.com/target/goalert/retry"
 	"github.com/target/goalert/util"
 	"github.com/target/goalert/util/sqlutil"
 	"github.com/target/goalert/validation/validate"
@@ -45,14 +47,19 @@ type DB struct {
 
 	ids *sql.Stmt
 
-	insert  *sql.Stmt
-	update  *sql.Stmt
-	delete  *sql.Stmt
+	insert *sql.Stmt
+	update *sql.Stmt
+
 	findOne *sql.Stmt
 	findAll *sql.Stmt
 
-	findMany   *sql.Stmt
-	deleteMany *sql.Stmt
+	findMany *sql.Stmt
+
+	deleteOne          *sql.Stmt
+	userRotations      *sql.Stmt
+	rotationParts      *sql.Stmt
+	updateRotationPart *sql.Stmt
+	deleteRotationPart *sql.Stmt
 
 	findOneForUpdate *sql.Stmt
 
@@ -95,18 +102,22 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 			WHERE id = $1
 		`),
 
-		delete: p.P(`
-			DELETE FROM users
-			WHERE id = $1
-		`),
-
 		findMany: p.P(`
 			SELECT
 				id, name, email, avatar_url, role, alert_status_log_contact_method_id
 			FROM users
 			WHERE id = any($1)
 		`),
-		deleteMany: p.P(`DELETE FROM users WHERE id = any($1)`),
+
+		deleteOne: p.P(`DELETE FROM users WHERE id = $1`),
+		userRotations: p.P(`
+			SELECT DISTINCT rotation_id
+			FROM rotation_state state
+			WHERE EXISTS (SELECT 1 FROM rotation_participants WHERE rotation_id = state.rotation_id AND user_id = $1)
+		`),
+		rotationParts:      p.P(`SELECT id, user_id FROM rotation_participants WHERE rotation_id = $1 ORDER BY position`),
+		updateRotationPart: p.P(`UPDATE rotation_participants SET user_id = $2 WHERE id = $1`),
+		deleteRotationPart: p.P(`DELETE FROM rotation_participants WHERE id = $1`),
 
 		findOne: p.P(`
 			SELECT
@@ -162,7 +173,7 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 }
 
 func (db *DB) DeleteManyTx(ctx context.Context, tx *sql.Tx, ids []string) error {
-	err := permission.LimitCheckAny(ctx, permission.System)
+	err := permission.LimitCheckAny(ctx, permission.System, permission.Admin)
 	if err != nil {
 		return err
 	}
@@ -175,13 +186,28 @@ func (db *DB) DeleteManyTx(ctx context.Context, tx *sql.Tx, ids []string) error 
 		return err
 	}
 
-	del := db.deleteMany
-	if tx != nil {
-		tx.StmtContext(ctx, del)
+	var ownsTx bool
+	if tx == nil {
+		ownsTx = true
+		tx, err = db.db.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
 	}
 
-	_, err = del.ExecContext(ctx, sqlutil.UUIDArray(ids))
-	return err
+	for _, id := range ids {
+		err = db.retryDeleteTx(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+	}
+
+	if ownsTx {
+		return tx.Commit()
+	}
+
+	return nil
 }
 
 // InsertTx implements the Store interface by inserting the new User into the database.
@@ -227,18 +253,143 @@ func (db *DB) Insert(ctx context.Context, u *User) (*User, error) {
 	return u, nil
 }
 
+func (db *DB) DeleteTx(ctx context.Context, tx *sql.Tx, id string) error {
+	err := permission.LimitCheckAny(ctx, permission.System, permission.Admin)
+	if err != nil {
+		return err
+	}
+
+	err = validate.UUID("UserID", id)
+	if err != nil {
+		return err
+	}
+	return db.retryDeleteTx(ctx, tx, id)
+}
+
+func (db *DB) retryDeleteTx(ctx context.Context, tx *sql.Tx, id string) error {
+	return retry.DoTemporaryError(func(int) error {
+		err := db._deleteTx(ctx, tx, id)
+		sqlErr := sqlutil.MapError(err)
+		if sqlErr != nil && sqlErr.Code == "23503" {
+			// retry foreign key errors when deleting a user
+			err = retry.TemporaryError(err)
+		}
+		return err
+	},
+		retry.Log(ctx),
+		retry.Limit(5),
+		retry.FibBackoff(250*time.Millisecond),
+	)
+}
+
+func (db *DB) _deleteTx(ctx context.Context, tx *sql.Tx, id string) error {
+	// cleanup rotations first
+	rows, err := tx.StmtContext(ctx, db.userRotations).QueryContext(ctx, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		err = nil
+	}
+	if err != nil {
+		return fmt.Errorf("lookup user rotations: %w", err)
+	}
+	defer rows.Close()
+
+	var rotationIDs []string
+	for rows.Next() {
+		var rID string
+		err = rows.Scan(&rID)
+		if err != nil {
+			return fmt.Errorf("scan user rotation id: %w", err)
+		}
+		rotationIDs = append(rotationIDs, rID)
+	}
+
+	for _, rID := range rotationIDs {
+		err = db.removeUserFromRotation(ctx, tx, id, rID)
+		if err != nil {
+			return fmt.Errorf("remove user '%s' from rotation '%s': %w", id, rID, err)
+		}
+	}
+
+	_, err = tx.StmtContext(ctx, db.deleteOne).ExecContext(ctx, id)
+	if err != nil {
+		return fmt.Errorf("delete user row: %w", err)
+	}
+	return nil
+}
+
+func (db *DB) removeUserFromRotation(ctx context.Context, tx *sql.Tx, userID, rotationID string) error {
+	type part struct {
+		ID     string
+		UserID string
+	}
+	var participants []part
+	rows, err := tx.StmtContext(ctx, db.rotationParts).QueryContext(ctx, rotationID)
+	if err != nil {
+		return fmt.Errorf("query participants: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var p part
+		err = rows.Scan(&p.ID, &p.UserID)
+		if err != nil {
+			return fmt.Errorf("scan participant %d: %w", len(participants), err)
+		}
+		participants = append(participants, p)
+	}
+
+	// update participant user IDs
+	var skipped bool
+	curIndex := -1
+	updatePart := tx.StmtContext(ctx, db.updateRotationPart)
+	for _, p := range participants {
+		if p.UserID == userID {
+			skipped = true
+			continue
+		}
+		curIndex++
+		if skipped {
+			_, err = updatePart.ExecContext(ctx, participants[curIndex].ID, p.UserID)
+			if err != nil {
+				return fmt.Errorf("update participant %d to user '%s': %w", curIndex, p.UserID, err)
+			}
+		}
+	}
+
+	// delete in reverse order from the end
+	deletePart := tx.StmtContext(ctx, db.deleteRotationPart)
+	for i := len(participants) - 1; i > curIndex; i-- {
+		_, err = deletePart.ExecContext(ctx, participants[i].ID)
+		if err != nil {
+			return fmt.Errorf("delete participant %d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
 // Delete implements the UserStore interface.
 func (db *DB) Delete(ctx context.Context, id string) error {
-	err := validate.UUID("UserID", id)
+	err := permission.LimitCheckAny(ctx, permission.System, permission.Admin)
 	if err != nil {
 		return err
 	}
-	err = permission.LimitCheckAny(ctx, permission.System, permission.Admin)
+
+	err = validate.UUID("UserID", id)
 	if err != nil {
 		return err
 	}
-	_, err = db.delete.ExecContext(ctx, id)
-	return err
+
+	tx, err := db.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	err = db.retryDeleteTx(ctx, tx, id)
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // Update implements the Store interface. Only admins can update user roles.

--- a/user/store.go
+++ b/user/store.go
@@ -109,12 +109,8 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 			WHERE id = any($1)
 		`),
 
-		deleteOne: p.P(`DELETE FROM users WHERE id = $1`),
-		userRotations: p.P(`
-			SELECT DISTINCT rotation_id
-			FROM rotation_state state
-			WHERE EXISTS (SELECT 1 FROM rotation_participants WHERE rotation_id = state.rotation_id AND user_id = $1)
-		`),
+		deleteOne:          p.P(`DELETE FROM users WHERE id = $1`),
+		userRotations:      p.P(`SELECT DISTINCT rotation_id FROM rotation_participants WHERE user_id = $1`),
 		rotationParts:      p.P(`SELECT id, user_id FROM rotation_participants WHERE rotation_id = $1 ORDER BY position`),
 		updateRotationPart: p.P(`UPDATE rotation_participants SET user_id = $2 WHERE id = $1`),
 		deleteRotationPart: p.P(`DELETE FROM rotation_participants WHERE id = $1`),


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Fixes issues when deleting a user:
- User is removed from all rotations prior to deleting the row (works around rotation trigger conflicts for multi-row)
- Attempt is retried up to 5 times in case of temporary or fkey errors