### PR TITLE
notification: remove Ctx from MessageStatus

### DIFF
--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -736,7 +736,6 @@ func (db *DB) refreshMessageState(ctx context.Context, statusFn StatusFunc, id, 
 		stat.State = notification.MessageStateFailedPerm
 	}
 	stat.Sequence = -1
-	stat.Ctx = ctx
 	res <- &stat
 }
 func (db *DB) updateStuckMessages(ctx context.Context, statusFn StatusFunc) error {

--- a/engine/sendmessage.go
+++ b/engine/sendmessage.go
@@ -46,7 +46,6 @@ func (p *Engine) sendMessage(ctx context.Context, msg *message.Message) (*notifi
 		if count == 0 {
 			// already acked/closed, don't send bundled notification
 			return &notification.MessageStatus{
-				Ctx:     ctx,
 				ID:      msg.ID,
 				Details: "alerts acked/closed before message sent",
 				State:   notification.MessageStateFailedPerm,

--- a/notification/messagestatus.go
+++ b/notification/messagestatus.go
@@ -4,9 +4,6 @@ import "context"
 
 // MessageStatus represents the state of an outgoing message.
 type MessageStatus struct {
-	// Ctx is the context of this status update (used for tracing if provided).
-	Ctx context.Context
-
 	// ID is the GoAlert message ID.
 	ID string
 
@@ -31,9 +28,6 @@ func (stat *MessageStatus) wrap(ctx context.Context, n *namedSender) *MessageSta
 	}
 
 	s := *stat
-	if ctx != nil {
-		s.Ctx = ctx
-	}
 	s.ProviderMessageID = n.name + ":" + s.ProviderMessageID
 	return &s
 }

--- a/notification/stubsender.go
+++ b/notification/stubsender.go
@@ -12,7 +12,6 @@ var _ Sender = stubSender{}
 
 func (stubSender) Send(ctx context.Context, msg Message) (*MessageStatus, error) {
 	return &MessageStatus{
-		Ctx:               ctx,
 		ProviderMessageID: "stub_" + uuid.NewV4().String(),
 		ID:                msg.ID(),
 		State:             MessageStateDelivered,


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Removes the unused `Ctx` field from `notification.MessageStatus`