### PR TITLE
ui: remove terser-webpack-plugin

### DIFF
--- a/web/src/package.json
+++ b/web/src/package.json
@@ -102,7 +102,6 @@
     "redux": "4.0.5",
     "redux-devtools-extension": "2.13.9",
     "style-loader": "2.0.0",
-    "terser-webpack-plugin": "5.1.1",
     "webpack": "5.37.0",
     "webpack-cli": "4.7.0",
     "webpack-dev-server": "3.11.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10184,7 +10184,7 @@ terminal-link@^2.0.0:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
-terser-webpack-plugin@5.1.1, terser-webpack-plugin@^5.1.1:
+terser-webpack-plugin@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.1.1.tgz#7effadee06f7ecfa093dbbd3e9ab23f5f3ed8673"
   integrity sha512-5XNNXZiR8YO6X6KhSGXfY0QrGrCRlSwAEjIIrlRQR4W8nP69TaJUlh3bkuac6zzgspiGPfKEHcY295MMVExl5Q==


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**

> If you are using webpack v5 or above you do not need to install this plugin. Webpack v5 comes with the latest terser-webpack-plugin out of the box.

**Which issue(s) this PR fixes:**
Closes #1542

**Additional Info:**
I verified there is no change to our bundle size
