### PR TITLE
dev: add explicit option to prevent babel warning spam

### DIFF
--- a/web/src/babel.config.js
+++ b/web/src/babel.config.js
@@ -4,6 +4,7 @@ const plugins = [
   '@babel/plugin-syntax-dynamic-import',
   ['@babel/plugin-proposal-decorators', { legacy: true }],
   ['@babel/plugin-proposal-class-properties', { loose: true }],
+  ['@babel/plugin-proposal-private-methods', { loose: true }],
 ]
 if (process.env.NODE_ENV !== 'production') {
   plugins.push('babel-plugin-typescript-to-proptypes')


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
The recent babel update produces ridiculous amounts of spam when running `make start` this is the requested change from the warning.

```
        UI         (err): Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
        UI         (err): The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
        UI         (err):       ["@babel/plugin-proposal-private-methods", { "loose": true }]
        UI         (err): to the "plugins" section of your Babel config.
```