### PR TITLE
api: disable old graphql endpoint by default

### DIFF
--- a/app/middleware.go
+++ b/app/middleware.go
@@ -36,7 +36,7 @@ func graphQLV1DeprecationMiddleware() func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 			cfg := config.FromContext(ctx)
-			if cfg.General.DisableV1GraphQL && strings.HasPrefix(r.URL.Path, "/v1/graphql") {
+			if !cfg.General.EnableV1GraphQL && strings.HasPrefix(r.URL.Path, "/v1/graphql") {
 				http.NotFound(w, r)
 				return
 			}

--- a/assignment/target.go
+++ b/assignment/target.go
@@ -6,9 +6,9 @@ type Target interface {
 	TargetID() string
 }
 type RawTarget struct {
-	Type TargetType `json:"target_type"`
-	ID   string     `json:"target_id"`
-	Name string     `json:"target_name"`
+	Type TargetType
+	ID   string
+	Name string `json:"-"`
 }
 
 func NewRawTarget(t Target) RawTarget {

--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ type Config struct {
 		DisableSMSLinks              bool   `public:"true" info:"If set, SMS messages will not contain a URL pointing to GoAlert."`
 		DisableLabelCreation         bool   `public:"true" info:"Disables the ability to create new labels for services."`
 		DisableCalendarSubscriptions bool   `public:"true" info:"If set, disables all active calendar subscriptions as well as the ability to create new calendar subscriptions."`
-		DisableV1GraphQL             bool   `info:"Disables the deprecated /v1/graphql endpoint (replaced by /api/graphql)."`
+		EnableV1GraphQL              bool   `info:"Enables the deprecated /v1/graphql endpoint (replaced by /api/graphql)."`
 	}
 
 	Maintenance struct {

--- a/graphql/createall.go
+++ b/graphql/createall.go
@@ -242,7 +242,7 @@ func parseTarget(_m interface{}) assignment.Target {
 	if !ok {
 		return nil
 	}
-	var raw assignment.RawTarget
+	var raw RawTarget
 	raw.ID, _ = m["target_id"].(string)
 	raw.Type, _ = m["target_type"].(assignment.TargetType)
 

--- a/graphql/createallutil.go
+++ b/graphql/createallutil.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"context"
+
 	"github.com/target/goalert/assignment"
 	"github.com/target/goalert/escalation"
 	"github.com/target/goalert/heartbeat"
@@ -56,7 +57,7 @@ func (c *Config) createAll(ctx context.Context, data *createAllData) (*createAll
 	getTarget := func(tgt assignment.Target) assignment.Target {
 		id, ok := ids[tgt.TargetID()]
 		if ok {
-			return &assignment.RawTarget{
+			return &RawTarget{
 				ID:   id,
 				Type: tgt.TargetType(),
 			}

--- a/graphql/escalation.go
+++ b/graphql/escalation.go
@@ -350,7 +350,7 @@ func (h *Handler) addEscalationPolicyStepTargetField() *g.Field {
 			if !ok {
 				return nil, errors.New("invalid input type")
 			}
-			var tgt assignment.RawTarget
+			var tgt RawTarget
 			tgt.ID, _ = m["target_id"].(string)
 			tgt.Type, _ = m["target_type"].(assignment.TargetType)
 			stepID, _ := m["step_id"].(string)
@@ -391,7 +391,7 @@ func (h *Handler) deleteEscalationPolicyStepTargetField() *g.Field {
 			if !ok {
 				return nil, errors.New("invalid input type")
 			}
-			var tgt assignment.RawTarget
+			var tgt RawTarget
 			tgt.ID, _ = m["target_id"].(string)
 			tgt.Type, _ = m["target_type"].(assignment.TargetType)
 			stepID, _ := m["step_id"].(string)
@@ -481,9 +481,9 @@ func (h *Handler) createOrUpdateEscalationPolicyStepField() *g.Field {
 				return scrub(nil, err)
 			}
 
-			added := make(map[assignment.RawTarget]bool, len(asn))
+			added := make(map[RawTarget]bool, len(asn))
 			for _, tgt := range asn {
-				added[assignment.RawTarget{Type: tgt.TargetType(), ID: tgt.TargetID()}] = true
+				added[RawTarget{Type: tgt.TargetType(), ID: tgt.TargetID()}] = true
 				err = h.c.EscalationStore.AddStepTarget(p.Context, r.S.ID, tgt)
 				if err != nil {
 					return scrub(nil, err)
@@ -491,7 +491,7 @@ func (h *Handler) createOrUpdateEscalationPolicyStepField() *g.Field {
 			}
 
 			for _, tgt := range old {
-				if added[assignment.RawTarget{Type: tgt.TargetType(), ID: tgt.TargetID()}] {
+				if added[RawTarget{Type: tgt.TargetType(), ID: tgt.TargetID()}] {
 					continue
 				}
 				if tgt.TargetType() == assignment.TargetTypeRotation {

--- a/graphql/label.go
+++ b/graphql/label.go
@@ -43,7 +43,7 @@ func (h *Handler) setLabelField() *g.Field {
 
 			var lbl label.Label
 
-			var tgt assignment.RawTarget
+			var tgt RawTarget
 			tgt.ID, _ = m["target_id"].(string)
 			tgt.Type, _ = m["target_type"].(assignment.TargetType)
 			lbl.Target = tgt

--- a/graphql/rawtarget.go
+++ b/graphql/rawtarget.go
@@ -1,0 +1,16 @@
+package graphql
+
+import "github.com/target/goalert/assignment"
+
+type RawTarget struct {
+	Type assignment.TargetType `json:"target_type"`
+	ID   string                `json:"target_id"`
+	Name string                `json:"target_name"`
+}
+
+func (rt RawTarget) TargetType() assignment.TargetType {
+	return rt.Type
+}
+func (rt RawTarget) TargetID() string {
+	return rt.ID
+}

--- a/graphql/scheduleassignment.go
+++ b/graphql/scheduleassignment.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"fmt"
+
 	"github.com/target/goalert/assignment"
 	"github.com/target/goalert/schedule/shiftcalc"
 	"github.com/target/goalert/util/log"
@@ -119,7 +120,7 @@ func (h *Handler) deleteScheduleAssignmentField() *g.Field {
 
 			var ctx = log.WithField(p.Context, "ScheduleID", schedID)
 
-			var asnTarget assignment.RawTarget
+			var asnTarget RawTarget
 			asnTarget.ID, _ = m["target_id"].(string)
 			asnTarget.Type, _ = m["target_type"].(assignment.TargetType)
 

--- a/graphql/schedulerule.go
+++ b/graphql/schedulerule.go
@@ -118,7 +118,7 @@ func (h *Handler) createScheduleRuleField() *g.Field {
 				return nil, err
 			}
 
-			var asnTarget assignment.RawTarget
+			var asnTarget RawTarget
 			asnTarget.Type, _ = m["target_type"].(assignment.TargetType)
 			asnTarget.ID, _ = m["target_id"].(string)
 			err = validate.UUID("target_id", asnTarget.ID)

--- a/graphql/userfavorite.go
+++ b/graphql/userfavorite.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"errors"
+
 	"github.com/target/goalert/assignment"
 	"github.com/target/goalert/permission"
 
@@ -29,7 +30,7 @@ func (h *Handler) setUserFavoriteField() *g.Field {
 				return nil, errors.New("invalid input type")
 			}
 
-			var tgt assignment.RawTarget
+			var tgt RawTarget
 			tgt.Type, _ = m["target_type"].(assignment.TargetType)
 			tgt.ID, _ = m["target_id"].(string)
 
@@ -62,7 +63,7 @@ func (h *Handler) unsetUserFavoriteField() *g.Field {
 				return nil, errors.New("invalid input type")
 			}
 
-			var tgt assignment.RawTarget
+			var tgt RawTarget
 			tgt.Type, _ = m["target_type"].(assignment.TargetType)
 			tgt.ID, _ = m["target_id"].(string)
 

--- a/graphql/useroverride.go
+++ b/graphql/useroverride.go
@@ -2,10 +2,11 @@ package graphql
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/target/goalert/assignment"
 	"github.com/target/goalert/override"
 	"github.com/target/goalert/validation"
-	"time"
 
 	g "github.com/graphql-go/graphql"
 	"github.com/pkg/errors"
@@ -130,7 +131,7 @@ func (h *Handler) updateUserOverrideField() *g.Field {
 
 			var o override.UserOverride
 
-			var tgt assignment.RawTarget
+			var tgt RawTarget
 			tgt.ID, _ = m["target_id"].(string)
 			tgt.Type, _ = m["target_type"].(assignment.TargetType)
 			o.Target = tgt

--- a/graphql2/mapconfig.go
+++ b/graphql2/mapconfig.go
@@ -32,7 +32,7 @@ func MapConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "General.DisableSMSLinks", Type: ConfigTypeBoolean, Description: "If set, SMS messages will not contain a URL pointing to GoAlert.", Value: fmt.Sprintf("%t", cfg.General.DisableSMSLinks)},
 		{ID: "General.DisableLabelCreation", Type: ConfigTypeBoolean, Description: "Disables the ability to create new labels for services.", Value: fmt.Sprintf("%t", cfg.General.DisableLabelCreation)},
 		{ID: "General.DisableCalendarSubscriptions", Type: ConfigTypeBoolean, Description: "If set, disables all active calendar subscriptions as well as the ability to create new calendar subscriptions.", Value: fmt.Sprintf("%t", cfg.General.DisableCalendarSubscriptions)},
-		{ID: "General.DisableV1GraphQL", Type: ConfigTypeBoolean, Description: "Disables the deprecated /v1/graphql endpoint (replaced by /api/graphql).", Value: fmt.Sprintf("%t", cfg.General.DisableV1GraphQL)},
+		{ID: "General.EnableV1GraphQL", Type: ConfigTypeBoolean, Description: "Enables the deprecated /v1/graphql endpoint (replaced by /api/graphql).", Value: fmt.Sprintf("%t", cfg.General.EnableV1GraphQL)},
 		{ID: "Maintenance.AlertCleanupDays", Type: ConfigTypeInteger, Description: "Closed alerts will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.AlertCleanupDays)},
 		{ID: "Maintenance.APIKeyExpireDays", Type: ConfigTypeInteger, Description: "Unused calendar API keys will be disabled after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.APIKeyExpireDays)},
 		{ID: "Auth.RefererURLs", Type: ConfigTypeStringList, Description: "Allowed referer URLs for auth and redirects.", Value: strings.Join(cfg.Auth.RefererURLs, "\n")},
@@ -169,12 +169,12 @@ func ApplyConfigValues(cfg config.Config, vals []ConfigValueInput) (config.Confi
 				return cfg, err
 			}
 			cfg.General.DisableCalendarSubscriptions = val
-		case "General.DisableV1GraphQL":
+		case "General.EnableV1GraphQL":
 			val, err := parseBool(v.ID, v.Value)
 			if err != nil {
 				return cfg, err
 			}
-			cfg.General.DisableV1GraphQL = val
+			cfg.General.EnableV1GraphQL = val
 		case "Maintenance.AlertCleanupDays":
 			val, err := parseInt(v.ID, v.Value)
 			if err != nil {

--- a/smoketest/grahpqlv1deprecation_test.go
+++ b/smoketest/grahpqlv1deprecation_test.go
@@ -19,14 +19,14 @@ func TestGraphQLV1Deprecation(t *testing.T) {
 	url := h.URL() + "/v1/graphql"
 
 	// ensure api is enabled
-	h.SetConfigValue("General.DisableV1GraphQL", "false")
+	h.SetConfigValue("General.EnableV1GraphQL", "true")
 
 	// test graphql v1 endpoint returns successfully (unauthorized status code)
 	resp, _ := http.Get(url)
 	assert.Equal(t, resp.StatusCode, 401)
 
 	// disable api
-	h.SetConfigValue("General.DisableV1GraphQL", "true")
+	h.SetConfigValue("General.EnableV1GraphQL", "false")
 
 	// test graphql v1 endpoint returns not found status code
 	resp, _ = http.Get(url)

--- a/smoketest/harness/harness.go
+++ b/smoketest/harness/harness.go
@@ -234,7 +234,6 @@ func (h *Harness) Start() {
 	h.t.Helper()
 
 	var cfg config.Config
-	cfg.General.DisableV1GraphQL = true
 	cfg.Slack.Enable = true
 	cfg.Slack.AccessToken = h.slackApp.AccessToken
 	cfg.Slack.ClientID = h.slackApp.ClientID

--- a/web/src/app/admin/AdminConfig.tsx
+++ b/web/src/app/admin/AdminConfig.tsx
@@ -76,7 +76,7 @@ interface ConfigValues {
 function formatHeading(s = ''): string {
   return startCase(s)
     .replace(/\bTwo Way\b/, 'Two-Way')
-    .replace('Disable V 1 Graph QL', 'Disable V1 GraphQL')
+    .replace('Enable V 1 Graph QL', 'Enable V1 GraphQL')
     .replace('Git Hub', 'GitHub')
     .replace(/R Ls\b/, 'RLs') // fix usages of `URLs`
 }

--- a/web/src/app/rotations/RotationForm.js
+++ b/web/src/app/rotations/RotationForm.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useState } from 'react'
 import p from 'prop-types'
 import {
   TextField,

--- a/web/src/app/rotations/RotationForm.js
+++ b/web/src/app/rotations/RotationForm.js
@@ -64,11 +64,6 @@ export default function RotationForm(props) {
   const [configInZone, setConfigInZone] = useState(false)
   const configZone = configInZone ? value.timeZone : 'local'
 
-  const [minStart, maxStart] = useMemo(() => [
-    DateTime.local().minus({ year: 1 }),
-    DateTime.local().plus({ year: 1 }),
-  ])
-
   const { data, loading, error } = useQuery(query, {
     variables: {
       input: {
@@ -176,8 +171,6 @@ export default function RotationForm(props) {
             timeZone={configZone}
             label='Handoff Time'
             name='start'
-            min={minStart.toISO()}
-            max={maxStart.toISO()}
             required
           />
         </Grid>

--- a/web/src/cypress/support/config.ts
+++ b/web/src/cypress/support/config.ts
@@ -3,7 +3,7 @@ interface General {
   DisableLabelCreation: boolean
   NotificationDisclaimer: string
   DisableCalendarSubscriptions: boolean
-  DisableV1GraphQL: boolean
+  EnableV1GraphQL: boolean
 }
 
 interface Auth {

--- a/web/src/cypress/support/config.ts
+++ b/web/src/cypress/support/config.ts
@@ -104,7 +104,7 @@ function resetConfig(): Cypress.Chainable<Config> {
   const base = String(Cypress.config('baseUrl'))
 
   return setConfig({
-    General: { PublicURL: base, DisableV1GraphQL: true },
+    General: { PublicURL: base },
     Slack: {
       Enable: true,
       ClientID: '000000000000.000000000000',

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -899,7 +899,7 @@ type ConfigID =
   | 'General.DisableSMSLinks'
   | 'General.DisableLabelCreation'
   | 'General.DisableCalendarSubscriptions'
-  | 'General.DisableV1GraphQL'
+  | 'General.EnableV1GraphQL'
   | 'Maintenance.AlertCleanupDays'
   | 'Maintenance.APIKeyExpireDays'
   | 'Auth.RefererURLs'


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Defaults the `/v1/graphql` endpoint to be disabled (returning a 404) and decouples `assignment.RawTarget` from the old code.