### PR TITLE
overrides: lock table before duplicate check

### DIFF
--- a/migrate/migrations/20210601113520-override-lock.sql
+++ b/migrate/migrations/20210601113520-override-lock.sql
@@ -4,9 +4,8 @@
 CREATE OR REPLACE FUNCTION fn_enforce_user_overide_no_conflict() RETURNS trigger AS $$
 DECLARE
     conflict UUID := NULL;
-    _lock INT := NULL;
 BEGIN
-    SELECT 1 INTO _lock FROM schedules WHERE id = NEW.tgt_schedule_id FOR UPDATE;
+    EXECUTE 'LOCK user_overrides IN EXCLUSIVE MODE';
 
     SELECT id INTO conflict
     FROM user_overrides

--- a/migrate/migrations/20210601113520-override-lock.sql
+++ b/migrate/migrations/20210601113520-override-lock.sql
@@ -4,8 +4,9 @@
 CREATE OR REPLACE FUNCTION fn_enforce_user_overide_no_conflict() RETURNS trigger AS $$
 DECLARE
     conflict UUID := NULL;
+    _lock INT := NULL;
 BEGIN
-    EXECUTE 'LOCK user_overrides IN EXCLUSIVE MODE';
+    SELECT 1 INTO _lock FROM schedules WHERE id = NEW.tgt_schedule_id FOR UPDATE;
 
     SELECT id INTO conflict
     FROM user_overrides
@@ -17,7 +18,6 @@ BEGIN
             remove_user_id in (NEW.remove_user_id, NEW.add_user_id)
         ) AND
         (start_time, end_time) OVERLAPS (NEW.start_time, NEW.end_time)
-    FOR UPDATE
     LIMIT 1;
   
     IF conflict NOTNULL THEN

--- a/migrate/migrations/20210601113520-override-lock.sql
+++ b/migrate/migrations/20210601113520-override-lock.sql
@@ -1,0 +1,58 @@
+-- +migrate Up
+
+-- +migrate StatementBegin
+CREATE OR REPLACE FUNCTION fn_enforce_user_overide_no_conflict() RETURNS trigger AS $$
+DECLARE
+    conflict UUID := NULL;
+BEGIN
+    EXECUTE 'LOCK user_overrides IN EXCLUSIVE MODE';
+
+    SELECT id INTO conflict
+    FROM user_overrides
+    WHERE
+        id != NEW.id AND
+        tgt_schedule_id = NEW.tgt_schedule_id AND
+        (
+            add_user_id in (NEW.remove_user_id, NEW.add_user_id) OR
+            remove_user_id in (NEW.remove_user_id, NEW.add_user_id)
+        ) AND
+        (start_time, end_time) OVERLAPS (NEW.start_time, NEW.end_time)
+    FOR UPDATE
+    LIMIT 1;
+  
+    IF conflict NOTNULL THEN
+        RAISE 'override conflict' USING ERRCODE='check_violation', CONSTRAINT='user_override_no_conflict_allowed', HINT='CONFLICTING_ID='||conflict::text;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +migrate StatementEnd
+
+-- +migrate Down
+
+-- +migrate StatementBegin
+CREATE OR REPLACE FUNCTION fn_enforce_user_overide_no_conflict() RETURNS trigger AS $$
+DECLARE
+    conflict UUID := NULL;
+BEGIN
+    SELECT id INTO conflict
+    FROM user_overrides
+    WHERE
+        id != NEW.id AND
+        tgt_schedule_id = NEW.tgt_schedule_id AND
+        (
+            add_user_id in (NEW.remove_user_id, NEW.add_user_id) OR
+            remove_user_id in (NEW.remove_user_id, NEW.add_user_id)
+        ) AND
+        (start_time, end_time) OVERLAPS (NEW.start_time, NEW.end_time)
+    LIMIT 1;
+  
+    IF conflict NOTNULL THEN
+        RAISE 'override conflict' USING ERRCODE='check_violation', CONSTRAINT='user_override_no_conflict_allowed', HINT='CONFLICTING_ID='||conflict::text;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +migrate StatementEnd

--- a/smoketest/harness/harness.go
+++ b/smoketest/harness/harness.go
@@ -120,6 +120,8 @@ func NewHarness(t *testing.T, initSQL, migrationName string) *Harness {
 	return h
 }
 
+func (h *Harness) App() *app.App { return h.backend }
+
 func NewHarnessWithData(t *testing.T, initSQL string, sqlData interface{}, migrationName string) *Harness {
 	t.Helper()
 	h := NewStoppedHarness(t, initSQL, sqlData, migrationName)

--- a/smoketest/overrideconflict_test.go
+++ b/smoketest/overrideconflict_test.go
@@ -69,6 +69,7 @@ func TestOverrideConflict(t *testing.T) {
 
 		errCh <- tx2.Commit()
 	}()
+	time.Sleep(3 * time.Second)
 	require.NoError(t, tx1.Commit())
 	require.Error(t, <-errCh)
 }

--- a/smoketest/overrideconflict_test.go
+++ b/smoketest/overrideconflict_test.go
@@ -1,0 +1,74 @@
+package smoketest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/assignment"
+	"github.com/target/goalert/override"
+	"github.com/target/goalert/permission"
+	"github.com/target/goalert/smoketest/harness"
+)
+
+func TestOverrideConflict(t *testing.T) {
+	t.Parallel()
+
+	sql := `
+	insert into users (id, name, email) 
+	values
+		({{uuid "u1"}}, 'bob', 'bob@example.com');
+
+	insert into schedules (id, name, time_zone) 
+	values
+		({{uuid "sid"}}, 'schedule', 'UTC');
+	`
+
+	h := harness.NewHarness(t, sql, "sched-module-v3")
+	defer h.Close()
+
+	db := h.App().DB()
+
+	ctx := permission.SystemContext(context.Background(), "Smoketest")
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	tx1, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer tx1.Rollback()
+
+	tx2, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer tx2.Rollback()
+
+	start := time.Now().Add(-time.Hour)
+	end := start.Add(8 * time.Hour)
+
+	_, err = h.App().OverrideStore.CreateUserOverrideTx(ctx, tx1, &override.UserOverride{
+		AddUserID: h.UUID("u1"),
+		Target:    assignment.ScheduleTarget(h.UUID("sid")),
+		Start:     start,
+		End:       end,
+	})
+	require.NoError(t, err)
+
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(errCh)
+		_, err := h.App().OverrideStore.CreateUserOverrideTx(ctx, tx2, &override.UserOverride{
+			AddUserID: h.UUID("u1"),
+			Target:    assignment.ScheduleTarget(h.UUID("sid")),
+			Start:     start,
+			End:       end,
+		})
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		errCh <- tx2.Commit()
+	}()
+	require.NoError(t, tx1.Commit())
+	require.Error(t, <-errCh)
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
It's currently possible for duplicate/overlapping overrides to be entered if they are done simultaneously. This PR resolves the issue by adding a lock to the validation trigger.

A new smoketest was added for this case, removing line 8 of the new migration should cause the test to fail.