### PR TITLE
ui/schedules: calendar toolbar design

### DIFF
--- a/web/src/app/schedules/CalendarToolbar.tsx
+++ b/web/src/app/schedules/CalendarToolbar.tsx
@@ -12,7 +12,7 @@ import { useCalendarNavigation } from './hooks'
 
 const useStyles = makeStyles((theme) => ({
   container: {
-    paddingBottom: '1em',
+    paddingBottom: theme.spacing(2),
   },
   labelGridItem: {
     alignItems: 'center',

--- a/web/src/app/schedules/CalendarToolbar.tsx
+++ b/web/src/app/schedules/CalendarToolbar.tsx
@@ -33,15 +33,19 @@ function CalendarToolbar(props: CalendarToolbarProps): JSX.Element {
   const classes = useStyles()
   const { weekly, setWeekly, start, setStart } = useCalendarNavigation()
 
-  const getLabel = (): string => {
+  const getHeader = (): string => {
     if (weekly) {
-      const begin = getStartOfWeek(DateTime.fromISO(start))
-        .toLocal()
-        .toFormat('LLLL d')
-      const end = getEndOfWeek(DateTime.fromISO(start))
-        .toLocal()
-        .toFormat('LLLL d')
-      return `${begin} — ${end}`
+      const begin = getStartOfWeek(DateTime.fromISO(start)).toLocal()
+      const end = getEndOfWeek(DateTime.fromISO(start)).toLocal()
+
+      if (begin.month === end.month) {
+        return `${end.monthLong} ${end.year}`
+      }
+      if (begin.year === end.year) {
+        return `${begin.monthShort} — ${end.monthShort} ${end.year}`
+      }
+
+      return `${begin.monthShort} ${begin.year} — ${end.monthShort} ${end.year}`
     }
 
     return DateTime.fromISO(start).toLocal().toFormat('LLLL yyyy')
@@ -130,26 +134,30 @@ function CalendarToolbar(props: CalendarToolbarProps): JSX.Element {
             data-cy='show-today'
             onClick={handleTodayClick}
             variant='outlined'
-            size='large'
+            title={DateTime.local().toFormat('cccc, LLLL d')}
           >
             Today
           </Button>
 
           <div className={classes.arrowBtns}>
             <IconButton
-              title='Previous'
+              title='Previous month'
               data-cy='back'
               onClick={handleBackClick}
             >
               <LeftIcon />
             </IconButton>
-            <IconButton title='Next' data-cy='next' onClick={handleNextClick}>
+            <IconButton
+              title='Next month'
+              data-cy='next'
+              onClick={handleNextClick}
+            >
               <RightIcon />
             </IconButton>
           </div>
 
           <Typography component='h2' data-cy='calendar-header' variant='h5'>
-            {getLabel()}
+            {getHeader()}
           </Typography>
         </Grid>
       </Grid>

--- a/web/src/app/schedules/CalendarToolbar.tsx
+++ b/web/src/app/schedules/CalendarToolbar.tsx
@@ -3,46 +3,29 @@ import {
   Button,
   ButtonGroup,
   Grid,
+  IconButton,
   makeStyles,
   Typography,
 } from '@material-ui/core'
 import { DateTime } from 'luxon'
 import { getEndOfWeek, getStartOfWeek } from '../util/luxon-helpers'
 import { useCalendarNavigation } from './hooks'
+import LeftIcon from '@material-ui/icons/ChevronLeft'
+import RightIcon from '@material-ui/icons/ChevronRight'
 
 const useStyles = makeStyles((theme) => ({
+  arrowBtns: {
+    marginLeft: theme.spacing(1.75),
+    marginRight: theme.spacing(1.75),
+  },
   container: {
     paddingBottom: theme.spacing(2),
-  },
-  labelGridItem: {
-    alignItems: 'center',
-    display: 'flex',
-    justifyContent: 'center',
-    order: 3,
-    [theme.breakpoints.up('lg')]: {
-      order: 2,
-    },
-  },
-  primaryNavBtnGroup: {
-    flex: 1,
-    display: 'flex',
-    justifyContent: 'flex-start',
-    order: 1,
-  },
-  secondaryBtnGroup: {
-    display: 'flex',
-    justifyContent: 'flex-start',
-    order: 2,
-    [theme.breakpoints.up('lg')]: {
-      justifyContent: 'flex-end',
-      order: 3,
-    },
   },
 }))
 
 type ViewType = 'month' | 'week'
 interface CalendarToolbarProps {
-  startAdornment?: React.ReactNode
+  filter?: React.ReactNode
   endAdornment?: React.ReactNode
 }
 
@@ -134,49 +117,67 @@ function CalendarToolbar(props: CalendarToolbarProps): JSX.Element {
   }
 
   return (
-    <Grid container spacing={2} className={classes.container}>
-      <Grid item xs={12} lg={4} className={classes.primaryNavBtnGroup}>
-        {props.startAdornment}
-        <ButtonGroup color='primary' aria-label='Calendar Navigation'>
-          <Button data-cy='show-today' onClick={handleTodayClick}>
+    <Grid
+      container
+      spacing={2}
+      className={classes.container}
+      justify='space-between'
+      alignItems='center'
+    >
+      <Grid item>
+        <Grid container alignItems='center'>
+          <Button
+            data-cy='show-today'
+            onClick={handleTodayClick}
+            variant='outlined'
+            size='large'
+          >
             Today
           </Button>
-          <Button data-cy='back' onClick={handleBackClick}>
-            Back
-          </Button>
-          <Button data-cy='next' onClick={handleNextClick}>
-            Next
-          </Button>
-        </ButtonGroup>
+
+          <div className={classes.arrowBtns}>
+            <IconButton
+              title='Previous'
+              data-cy='back'
+              onClick={handleBackClick}
+            >
+              <LeftIcon />
+            </IconButton>
+            <IconButton title='Next' data-cy='next' onClick={handleNextClick}>
+              <RightIcon />
+            </IconButton>
+          </div>
+
+          <Typography component='h2' data-cy='calendar-header' variant='h5'>
+            {getLabel()}
+          </Typography>
+        </Grid>
       </Grid>
 
-      <Grid item xs={12} lg={4} className={classes.labelGridItem}>
-        <Typography component='p' data-cy='calendar-header' variant='subtitle1'>
-          {getLabel()}
-        </Typography>
-      </Grid>
-
-      <Grid item xs={12} lg={4} className={classes.secondaryBtnGroup}>
-        <ButtonGroup
-          color='primary'
-          aria-label='Toggle between Monthly and Weekly views'
-        >
-          <Button
-            data-cy='show-month'
-            disabled={!weekly}
-            onClick={() => onView('month')}
+      <Grid item>
+        <Grid container alignItems='center' justify='flex-end'>
+          {props.filter}
+          <ButtonGroup
+            color='primary'
+            aria-label='Toggle between Monthly and Weekly views'
           >
-            Month
-          </Button>
-          <Button
-            data-cy='show-week'
-            disabled={weekly}
-            onClick={() => onView('week')}
-          >
-            Week
-          </Button>
-        </ButtonGroup>
-        {props.endAdornment}
+            <Button
+              data-cy='show-month'
+              disabled={!weekly}
+              onClick={() => onView('month')}
+            >
+              Month
+            </Button>
+            <Button
+              data-cy='show-week'
+              disabled={weekly}
+              onClick={() => onView('week')}
+            >
+              Week
+            </Button>
+          </ButtonGroup>
+          {props.endAdornment}
+        </Grid>
       </Grid>
     </Grid>
   )

--- a/web/src/app/schedules/CalendarToolbar.tsx
+++ b/web/src/app/schedules/CalendarToolbar.tsx
@@ -173,6 +173,7 @@ function CalendarToolbar(props: CalendarToolbarProps): JSX.Element {
               data-cy='show-month'
               disabled={!weekly}
               onClick={() => onView('month')}
+              title='Month view'
             >
               Month
             </Button>
@@ -180,6 +181,7 @@ function CalendarToolbar(props: CalendarToolbarProps): JSX.Element {
               data-cy='show-week'
               disabled={weekly}
               onClick={() => onView('week')}
+              title='Week view'
             >
               Week
             </Button>

--- a/web/src/app/schedules/CalendarToolbar.tsx
+++ b/web/src/app/schedules/CalendarToolbar.tsx
@@ -141,14 +141,14 @@ function CalendarToolbar(props: CalendarToolbarProps): JSX.Element {
 
           <div className={classes.arrowBtns}>
             <IconButton
-              title='Previous month'
+              title={`Previous ${weekly ? 'week' : 'month'}`}
               data-cy='back'
               onClick={handleBackClick}
             >
               <LeftIcon />
             </IconButton>
             <IconButton
-              title='Next month'
+              title={`Next ${weekly ? 'week' : 'month'}`}
               data-cy='next'
               onClick={handleNextClick}
             >

--- a/web/src/app/schedules/ScheduleCalendar.js
+++ b/web/src/app/schedules/ScheduleCalendar.js
@@ -171,7 +171,7 @@ function ScheduleCalendar(props) {
               onClick={onNewTempSched}
               className={classes.tempSchedBtn}
               startIcon={<GroupAdd />}
-              title='Make temporary change to this schedule'
+              title='Make temporary change to schedule'
             >
               Temp Sched
             </Button>

--- a/web/src/app/schedules/ScheduleCalendar.js
+++ b/web/src/app/schedules/ScheduleCalendar.js
@@ -24,11 +24,8 @@ import { useCalendarNavigation } from './hooks'
 const localizer = LuxonLocalizer(DateTime, { firstDayOfWeek: 0 })
 
 const useStyles = makeStyles((theme) => ({
-  calendarContainer: {
-    padding: '1em',
-  },
   card: {
-    marginTop: 4,
+    padding: theme.spacing(2),
   },
   filterBtn: {
     marginRight: theme.spacing(1.75),
@@ -122,7 +119,6 @@ function ScheduleCalendar(props) {
   const {
     shifts,
     temporarySchedules,
-    CardProps,
     onNewTempSched,
     onEditTempSched,
     onDeleteTempSched,
@@ -135,87 +131,85 @@ function ScheduleCalendar(props) {
           Times shown are in {Intl.DateTimeFormat().resolvedOptions().timeZone}
         </i>
       </Typography>
-      <Card className={classes.card} {...CardProps}>
-        <div data-cy='calendar' className={classes.calendarContainer}>
-          <CalendarToolbar
-            startAdornment={
-              <FilterContainer
-                onReset={resetFilter}
-                iconButtonProps={{
-                  size: 'small',
-                  className: classes.filterBtn,
-                }}
-              >
-                <Grid item xs={12}>
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={activeOnly}
-                        onChange={(e) => setActiveOnly(e.target.checked)}
-                        value='activeOnly'
-                      />
-                    }
-                    label='Active shifts only'
-                  />
-                </Grid>
-                <Grid item xs={12}>
-                  <UserSelect
-                    label='Filter users...'
-                    multiple
-                    value={userFilter}
-                    onChange={setUserFilter}
-                  />
-                </Grid>
-              </FilterContainer>
-            }
-            endAdornment={
-              <Button
-                variant='contained'
-                size='small'
-                color='primary'
-                data-cy='new-temp-sched'
-                onClick={onNewTempSched}
-                className={classes.tempSchedBtn}
-                startIcon={<GroupAdd />}
-                title='Make temporary change to this schedule'
-              >
-                Temp Sched
-              </Button>
-            }
-          />
-          <Calendar
-            date={new Date(start)}
-            localizer={localizer}
-            events={getCalEvents(shifts, temporarySchedules)}
-            style={{
-              height: weekly ? '100%' : '45rem',
-              fontFamily: theme.typography.body2.fontFamily,
-              fontSize: theme.typography.body2.fontSize,
-            }}
-            tooltipAccessor={() => null}
-            views={['month', 'week']}
-            view={weekly ? 'week' : 'month'}
-            showAllEvents
-            eventPropGetter={eventStyleGetter}
-            onNavigate={() => {}} // stub to hide false console err
-            onView={() => {}} // stub to hide false console err
-            components={{
-              eventWrapper: function calEventWrapper(props) {
-                return (
-                  <CalendarEventWrapper
-                    onOverrideClick={(overrideDialog) =>
-                      setOverrideDialog(overrideDialog)
-                    }
-                    onEditTempSched={onEditTempSched}
-                    onDeleteTempSched={onDeleteTempSched}
-                    {...props}
-                  />
-                )
-              },
-              toolbar: () => null,
-            }}
-          />
-        </div>
+      <Card className={classes.card} data-cy='calendar'>
+        <CalendarToolbar
+          startAdornment={
+            <FilterContainer
+              onReset={resetFilter}
+              iconButtonProps={{
+                size: 'small',
+                className: classes.filterBtn,
+              }}
+            >
+              <Grid item xs={12}>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={activeOnly}
+                      onChange={(e) => setActiveOnly(e.target.checked)}
+                      value='activeOnly'
+                    />
+                  }
+                  label='Active shifts only'
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <UserSelect
+                  label='Filter users...'
+                  multiple
+                  value={userFilter}
+                  onChange={setUserFilter}
+                />
+              </Grid>
+            </FilterContainer>
+          }
+          endAdornment={
+            <Button
+              variant='contained'
+              size='small'
+              color='primary'
+              data-cy='new-temp-sched'
+              onClick={onNewTempSched}
+              className={classes.tempSchedBtn}
+              startIcon={<GroupAdd />}
+              title='Make temporary change to this schedule'
+            >
+              Temp Sched
+            </Button>
+          }
+        />
+        <Calendar
+          date={new Date(start)}
+          localizer={localizer}
+          events={getCalEvents(shifts, temporarySchedules)}
+          style={{
+            height: weekly ? '100%' : '45rem',
+            fontFamily: theme.typography.body2.fontFamily,
+            fontSize: theme.typography.body2.fontSize,
+          }}
+          tooltipAccessor={() => null}
+          views={['month', 'week']}
+          view={weekly ? 'week' : 'month'}
+          showAllEvents
+          eventPropGetter={eventStyleGetter}
+          onNavigate={() => {}} // stub to hide false console err
+          onView={() => {}} // stub to hide false console err
+          components={{
+            eventWrapper: function calEventWrapper(props) {
+              return (
+                <CalendarEventWrapper
+                  onOverrideClick={(overrideDialog) =>
+                    setOverrideDialog(overrideDialog)
+                  }
+                  onEditTempSched={onEditTempSched}
+                  onDeleteTempSched={onDeleteTempSched}
+                  {...props}
+                />
+              )
+            },
+            toolbar: () => null,
+          }}
+        />
       </Card>
       {Boolean(overrideDialog) && (
         <ScheduleOverrideCreateDialog
@@ -234,7 +228,6 @@ ScheduleCalendar.propTypes = {
   scheduleID: p.string.isRequired,
   shifts: p.array.isRequired,
   temporarySchedules: p.array,
-  CardProps: p.object, // todo: use CardProps from types once TS
 }
 
 export default ScheduleCalendar

--- a/web/src/app/schedules/ScheduleCalendar.js
+++ b/web/src/app/schedules/ScheduleCalendar.js
@@ -133,7 +133,7 @@ function ScheduleCalendar(props) {
       </Typography>
       <Card className={classes.card} data-cy='calendar'>
         <CalendarToolbar
-          startAdornment={
+          filter={
             <FilterContainer
               onReset={resetFilter}
               iconButtonProps={{
@@ -166,7 +166,6 @@ function ScheduleCalendar(props) {
           endAdornment={
             <Button
               variant='contained'
-              size='small'
               color='primary'
               data-cy='new-temp-sched'
               onClick={onNewTempSched}

--- a/web/src/cypress/integration/scheduleCalendar.ts
+++ b/web/src/cypress/integration/scheduleCalendar.ts
@@ -8,10 +8,15 @@ const c = new Chance()
 const monthHeaderFormat = (t: DateTime): string => t.toFormat('MMMM')
 const weekHeaderFormat = (t: DateTime): string => {
   const start = t.startOf('week').minus({ day: 1 })
-
   const end = t.endOf('week').minus({ day: 1 })
+  if (start.month === end.month) {
+    return start.toFormat('MMMM yyyy')
+  }
+  if (start.year === end.year) {
+    return `${start.monthShort} — ${end.monthShort} ${end.year}`
+  }
 
-  return start.toFormat('MMMM d — ') + end.toFormat('MMMM d')
+  return `${start.monthShort} ${start.year} — ${end.monthShort} ${end.year}`
 }
 
 const weekSpansTwoMonths = (t: DateTime): boolean => {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR proposes a new calendar toolbar design that better aligns with Material's Design spec. It also includes fixes for some existing alignment and a11y issues

**Screenshots:**
Month view:
<img width="1007" alt="Screen Shot 2021-06-04 at 11 13 06 AM" src="https://user-images.githubusercontent.com/17692467/120834744-11544b00-c529-11eb-9893-c84a6dd5fcc1.png">
Week that starts and ends in same month:
<img width="1008" alt="Screen Shot 2021-06-04 at 11 12 43 AM" src="https://user-images.githubusercontent.com/17692467/120834746-11ece180-c529-11eb-94a2-8f23ede569be.png">
Week that starts and ends in different month, same year:
<img width="1001" alt="Screen Shot 2021-06-04 at 11 12 56 AM" src="https://user-images.githubusercontent.com/17692467/120834748-12857800-c529-11eb-83c2-6f2db0f57c1b.png">
Week that starts and ends in different month, different year:
<img width="1011" alt="Screen Shot 2021-06-04 at 11 13 25 AM" src="https://user-images.githubusercontent.com/17692467/120834750-12857800-c529-11eb-871e-0161ebb87c35.png">

**Describe any introduced user-facing changes:**
New Calendar toolbar design; same functionality.