### PR TITLE
temp-schedules: use UUIDs and generalize data update method

### DIFF
--- a/graphql2/graphqlapp/mutation.go
+++ b/graphql2/graphqlapp/mutation.go
@@ -32,8 +32,13 @@ func (a *Mutation) SetFavorite(ctx context.Context, input graphql2.SetFavoriteIn
 	return true, nil
 }
 func (a *Mutation) SetTemporarySchedule(ctx context.Context, input graphql2.SetTemporaryScheduleInput) (bool, error) {
-	err := withContextTx(ctx, a.DB, func(ctx context.Context, tx *sql.Tx) error {
-		return a.ScheduleStore.SetTemporarySchedule(ctx, tx, input.ScheduleID, schedule.TemporarySchedule{
+	schedID, err := parseUUID("ScheduleID", input.ScheduleID)
+	if err != nil {
+		return false, err
+	}
+
+	err = withContextTx(ctx, a.DB, func(ctx context.Context, tx *sql.Tx) error {
+		return a.ScheduleStore.SetTemporarySchedule(ctx, tx, schedID, schedule.TemporarySchedule{
 			Start:  input.Start,
 			End:    input.End,
 			Shifts: input.Shifts,
@@ -43,8 +48,13 @@ func (a *Mutation) SetTemporarySchedule(ctx context.Context, input graphql2.SetT
 	return err == nil, err
 }
 func (a *Mutation) ClearTemporarySchedules(ctx context.Context, input graphql2.ClearTemporarySchedulesInput) (bool, error) {
-	err := withContextTx(ctx, a.DB, func(ctx context.Context, tx *sql.Tx) error {
-		return a.ScheduleStore.ClearTemporarySchedules(ctx, tx, input.ScheduleID, input.Start, input.End)
+	schedID, err := parseUUID("ScheduleID", input.ScheduleID)
+	if err != nil {
+		return false, err
+	}
+
+	err = withContextTx(ctx, a.DB, func(ctx context.Context, tx *sql.Tx) error {
+		return a.ScheduleStore.ClearTemporarySchedules(ctx, tx, schedID, input.Start, input.End)
 	})
 
 	return err == nil, err

--- a/graphql2/graphqlapp/parseuuid.go
+++ b/graphql2/graphqlapp/parseuuid.go
@@ -1,0 +1,15 @@
+package graphqlapp
+
+import (
+	uuid "github.com/satori/go.uuid"
+	"github.com/target/goalert/validation"
+)
+
+func parseUUID(fname, u string) (uuid.UUID, error) {
+	id, err := uuid.FromString(u)
+	if err != nil {
+		return uuid.UUID{}, validation.NewFieldError(fname, "must be a valid UUID: "+err.Error())
+	}
+
+	return id, nil
+}

--- a/graphql2/graphqlapp/schedule.go
+++ b/graphql2/graphqlapp/schedule.go
@@ -53,7 +53,11 @@ func (s *Schedule) Shifts(ctx context.Context, raw *schedule.Schedule, start, en
 }
 
 func (s *Schedule) TemporarySchedules(ctx context.Context, raw *schedule.Schedule) ([]schedule.TemporarySchedule, error) {
-	return s.ScheduleStore.TemporarySchedules(ctx, nil, raw.ID)
+	id, err := parseUUID("ScheduleID", raw.ID)
+	if err != nil {
+		return nil, err
+	}
+	return s.ScheduleStore.TemporarySchedules(ctx, nil, id)
 }
 
 func (s *Schedule) Target(ctx context.Context, raw *schedule.Schedule, input assignment.RawTarget) (*graphql2.ScheduleTarget, error) {

--- a/oncall/store.go
+++ b/oncall/store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"time"
 
+	uuid "github.com/satori/go.uuid"
 	"github.com/target/goalert/assignment"
 	"github.com/target/goalert/override"
 	"github.com/target/goalert/permission"
@@ -270,7 +271,11 @@ func (db *DB) HistoryBySchedule(ctx context.Context, scheduleID string, start, e
 		ov.RemoveUserID = rem.String
 		overrides = append(overrides, ov)
 	}
-	tempScheds, err := db.schedStore.TemporarySchedules(ctx, tx, scheduleID)
+	id, err := uuid.FromString(scheduleID)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse schedule ID")
+	}
+	tempScheds, err := db.schedStore.TemporarySchedules(ctx, tx, id)
 	if err != nil {
 		return nil, errors.Wrap(err, "lookup temporary schedules")
 	}

--- a/schedule/storedata.go
+++ b/schedule/storedata.go
@@ -1,0 +1,91 @@
+package schedule
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/target/goalert/util/jsonutil"
+)
+
+func (store *Store) scheduleData(ctx context.Context, tx *sql.Tx, scheduleID uuid.UUID) (*Data, error) {
+	stmt := store.findData
+	if tx != nil {
+		stmt = tx.StmtContext(ctx, stmt)
+	}
+	var rawData json.RawMessage
+	err := stmt.QueryRowContext(ctx, scheduleID).Scan(&rawData)
+	if err == sql.ErrNoRows {
+		err = nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var data Data
+	if len(rawData) > 0 {
+		err = json.Unmarshal(rawData, &data)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &data, nil
+}
+
+func (store *Store) updateScheduleData(ctx context.Context, tx *sql.Tx, scheduleID uuid.UUID, apply func(data *Data) error) error {
+	var err error
+	externalTx := tx != nil
+	if !externalTx {
+		tx, err = store.db.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+	}
+
+	var rawData json.RawMessage
+	// Select for update, if it does not exist try inserting, if that fails due to a race, re-try select for update
+	err = tx.StmtContext(ctx, store.findUpdData).QueryRowContext(ctx, scheduleID).Scan(&rawData)
+	if err == sql.ErrNoRows {
+		_, err = tx.StmtContext(ctx, store.insertData).ExecContext(ctx, scheduleID)
+		if isDataPkeyConflict(err) {
+			// insert happened after orig. select for update and our subsequent insert, re-try select for update
+			err = tx.StmtContext(ctx, store.findUpdData).QueryRowContext(ctx, scheduleID).Scan(&rawData)
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	var data Data
+	if len(rawData) > 0 {
+		err = json.Unmarshal(rawData, &data)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = apply(&data)
+	if err != nil {
+		return err
+	}
+
+	// preserve unknown fields
+	rawData, err = jsonutil.Apply(rawData, data)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.StmtContext(ctx, store.updateData).ExecContext(ctx, scheduleID, rawData)
+	if err != nil {
+		return err
+	}
+
+	if !externalTx {
+		return tx.Commit()
+	}
+
+	return nil
+}

--- a/schedule/storetemporaryschedules.go
+++ b/schedule/storetemporaryschedules.go
@@ -3,11 +3,10 @@ package schedule
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"time"
 
+	uuid "github.com/satori/go.uuid"
 	"github.com/target/goalert/permission"
-	"github.com/target/goalert/util/jsonutil"
 	"github.com/target/goalert/util/sqlutil"
 	"github.com/target/goalert/validation"
 	"github.com/target/goalert/validation/validate"
@@ -17,36 +16,15 @@ import (
 const FixedShiftsPerTemporaryScheduleLimit = 150
 
 // TemporarySchedules will return the current set for the provided scheduleID.
-func (store *Store) TemporarySchedules(ctx context.Context, tx *sql.Tx, scheduleID string) ([]TemporarySchedule, error) {
+func (store *Store) TemporarySchedules(ctx context.Context, tx *sql.Tx, scheduleID uuid.UUID) ([]TemporarySchedule, error) {
 	err := permission.LimitCheckAny(ctx, permission.User)
 	if err != nil {
 		return nil, err
 	}
 
-	err = validate.UUID("ScheduleID", scheduleID)
+	data, err := store.scheduleData(ctx, tx, scheduleID)
 	if err != nil {
 		return nil, err
-	}
-
-	stmt := store.findData
-	if tx != nil {
-		stmt = tx.StmtContext(ctx, stmt)
-	}
-	var rawData json.RawMessage
-	err = stmt.QueryRowContext(ctx, scheduleID).Scan(&rawData)
-	if err == sql.ErrNoRows {
-		err = nil
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	var data Data
-	if len(rawData) > 0 {
-		err = json.Unmarshal(rawData, &data)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	check, err := store.usr.UserExists(ctx)
@@ -79,61 +57,6 @@ func isDataPkeyConflict(err error) bool {
 	}
 	return dbErr.ConstraintName == "schedule_data_pkey"
 }
-func (store *Store) updateFixedShifts(ctx context.Context, tx *sql.Tx, scheduleID string, apply func(data *Data) error) error {
-	var err error
-	externalTx := tx != nil
-	if !externalTx {
-		tx, err = store.db.BeginTx(ctx, nil)
-		if err != nil {
-			return err
-		}
-		defer tx.Rollback()
-	}
-
-	var rawData json.RawMessage
-	// Select for update, if it does not exist try inserting, if that fails due to a race, re-try select for update
-	err = tx.StmtContext(ctx, store.findUpdData).QueryRowContext(ctx, scheduleID).Scan(&rawData)
-	if err == sql.ErrNoRows {
-		_, err = tx.StmtContext(ctx, store.insertData).ExecContext(ctx, scheduleID)
-		if isDataPkeyConflict(err) {
-			// insert happened after orig. select for update and our subsequent insert, re-try select for update
-			err = tx.StmtContext(ctx, store.findUpdData).QueryRowContext(ctx, scheduleID).Scan(&rawData)
-		}
-	}
-	if err != nil {
-		return err
-	}
-
-	var data Data
-	if len(rawData) > 0 {
-		err = json.Unmarshal(rawData, &data)
-		if err != nil {
-			return err
-		}
-	}
-
-	err = apply(&data)
-	if err != nil {
-		return err
-	}
-
-	// preserve unknown fields
-	rawData, err = jsonutil.Apply(rawData, data)
-	if err != nil {
-		return err
-	}
-
-	_, err = tx.StmtContext(ctx, store.updateData).ExecContext(ctx, scheduleID, rawData)
-	if err != nil {
-		return err
-	}
-
-	if !externalTx {
-		return tx.Commit()
-	}
-
-	return nil
-}
 
 func validateFuture(fieldName string, t time.Time) error {
 	if time.Until(t) > 5*time.Minute {
@@ -143,7 +66,7 @@ func validateFuture(fieldName string, t time.Time) error {
 }
 
 // SetTemporarySchedule will cause the schedule to use only, and exactly, the provided set of shifts between the provided start and end times.
-func (store *Store) SetTemporarySchedule(ctx context.Context, tx *sql.Tx, scheduleID string, temp TemporarySchedule) error {
+func (store *Store) SetTemporarySchedule(ctx context.Context, tx *sql.Tx, scheduleID uuid.UUID, temp TemporarySchedule) error {
 	err := permission.LimitCheckAny(ctx, permission.User)
 	if err != nil {
 		return err
@@ -158,7 +81,6 @@ func (store *Store) SetTemporarySchedule(ctx context.Context, tx *sql.Tx, schedu
 	err = validate.Many(
 		validateFuture("End", temp.End),
 		validateTimeRange("", temp.Start, temp.End),
-		validate.UUID("ScheduleID", scheduleID),
 		store.validateShifts(ctx, "Shifts", FixedShiftsPerTemporaryScheduleLimit, temp.Shifts, temp.Start, temp.End),
 	)
 	if err != nil {
@@ -167,14 +89,14 @@ func (store *Store) SetTemporarySchedule(ctx context.Context, tx *sql.Tx, schedu
 
 	// truncate to current timestamp
 	temp.TrimStart(time.Now())
-	return store.updateFixedShifts(ctx, tx, scheduleID, func(data *Data) error {
+	return store.updateScheduleData(ctx, tx, scheduleID, func(data *Data) error {
 		data.V1.TemporarySchedules = setFixedShifts(data.V1.TemporarySchedules, temp)
 		return nil
 	})
 }
 
 // ClearTemporarySchedules will clear out (or split, if needed) any defined TemporarySchedules that exist between the start and end time.
-func (store *Store) ClearTemporarySchedules(ctx context.Context, tx *sql.Tx, scheduleID string, start, end time.Time) error {
+func (store *Store) ClearTemporarySchedules(ctx context.Context, tx *sql.Tx, scheduleID uuid.UUID, start, end time.Time) error {
 	err := permission.LimitCheckAny(ctx, permission.User)
 	if err != nil {
 		return err
@@ -183,7 +105,6 @@ func (store *Store) ClearTemporarySchedules(ctx context.Context, tx *sql.Tx, sch
 	err = validate.Many(
 		validateFuture("End", end),
 		validateTimeRange("", start, end),
-		validate.UUID("ScheduleID", scheduleID),
 	)
 	if err != nil {
 		return err
@@ -192,7 +113,7 @@ func (store *Store) ClearTemporarySchedules(ctx context.Context, tx *sql.Tx, sch
 		start = time.Now()
 	}
 
-	return store.updateFixedShifts(ctx, tx, scheduleID, func(data *Data) error {
+	return store.updateScheduleData(ctx, tx, scheduleID, func(data *Data) error {
 		data.V1.TemporarySchedules = deleteFixedShifts(data.V1.TemporarySchedules, start, end)
 		return nil
 	})

--- a/util/sqlutil/nulluuid.go
+++ b/util/sqlutil/nulluuid.go
@@ -1,0 +1,45 @@
+package sqlutil
+
+import (
+	"database/sql/driver"
+	"fmt"
+
+	uuid "github.com/satori/go.uuid"
+)
+
+type NullUUID struct {
+	UUID  uuid.UUID
+	Valid bool
+}
+
+func (u NullUUID) Value() (driver.Value, error) {
+	if !u.Valid {
+		return nil, nil
+	}
+
+	return u.UUID.Bytes(), nil
+}
+
+func (u *NullUUID) Scan(src interface{}) (err error) {
+	if src == nil {
+		u.Valid = false
+		u.UUID = uuid.UUID{}
+		return nil
+	}
+
+	switch s := src.(type) {
+	case string:
+		u.UUID, err = uuid.FromString(s)
+	case []byte:
+		if len(s) == 16 {
+			u.UUID, err = uuid.FromBytes(s)
+			break
+		}
+		u.UUID, err = uuid.FromString(string(s))
+	default:
+		return fmt.Errorf("unknown format for UUID: %T", s)
+	}
+	u.Valid = err == nil
+
+	return err
+}

--- a/util/timeutil/clock.go
+++ b/util/timeutil/clock.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
+	"github.com/target/goalert/validation"
 )
 
 // Clock represents wall-clock time. It is a duration since midnight.
@@ -23,6 +24,9 @@ var _ graphql.Unmarshaler = new(Clock)
 // ParseClock will return a new Clock value given a value in the format of '15:04' or '15:04:05'.
 // The resulting value will be truncated to the minute.
 func ParseClock(value string) (Clock, error) {
+	if value == "" {
+		return 0, errors.New("invalid time format")
+	}
 	var h, m int
 	var s float64
 	n, err := fmt.Sscanf(value, "%d:%d:%f", &h, &m, &s)
@@ -166,7 +170,13 @@ func (c *Clock) UnmarshalGQL(v interface{}) error {
 	if err != nil {
 		return err
 	}
-	return c.UnmarshalText([]byte(s))
+
+	err = c.UnmarshalText([]byte(s))
+	if err != nil {
+		return validation.WrapError(err)
+	}
+
+	return nil
 }
 
 // NewClock returns a Clock value equal to the provided 24-hour value and minute.


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR makes schedule data helpers more generic and switches to using UUID's directly for Temp Schedules methods. This is in prep for schedule notifications.