### PR TITLE
notificationchannel: ensure only a single copy of a type/value is created

### DIFF
--- a/notificationchannel/store.go
+++ b/notificationchannel/store.go
@@ -3,6 +3,10 @@ package notificationchannel
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
+
+	uuid "github.com/satori/go.uuid"
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/util"
 	"github.com/target/goalert/util/sqlutil"
@@ -11,9 +15,10 @@ import (
 
 type Store interface {
 	FindAll(context.Context) ([]Channel, error)
-	FindOne(context.Context, string) (*Channel, error)
-	CreateTx(context.Context, *sql.Tx, *Channel) (*Channel, error)
+	FindOne(context.Context, uuid.UUID) (*Channel, error)
 	DeleteManyTx(context.Context, *sql.Tx, []string) error
+
+	MapToID(context.Context, *sql.Tx, *Channel) (uuid.UUID, error)
 }
 
 type DB struct {
@@ -23,6 +28,10 @@ type DB struct {
 	findOne    *sql.Stmt
 	create     *sql.Stmt
 	deleteMany *sql.Stmt
+
+	updateName  *sql.Stmt
+	findByValue *sql.Stmt
+	lock        *sql.Stmt
 }
 
 func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
@@ -41,27 +50,97 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 			insert into notification_channels (id, name, type, value)
 			values ($1, $2, $3, $4)
 		`),
+		updateName: p.P(`update notification_channels set name = $2 where id = $1`),
 		deleteMany: p.P(`DELETE FROM notification_channels WHERE id = any($1)`),
+
+		findByValue: p.P(`select id, name from notification_channels where type = $1 and value = $2`),
+
+		// Lock the table so only one tx can insert/update at a time, but allows the above SELECT FOR UPDATE to run
+		// so only required changes block.
+		lock: p.P(`LOCK notification_channels IN SHARE ROW EXCLUSIVE MODE`),
 	}, p.Err
 }
 
-func (db *DB) CreateTx(ctx context.Context, tx *sql.Tx, c *Channel) (*Channel, error) {
+func stmt(ctx context.Context, tx *sql.Tx, stmt *sql.Stmt) *sql.Stmt {
+	if tx == nil {
+		return stmt
+	}
+
+	return tx.StmtContext(ctx, stmt)
+}
+func (db *DB) MapToID(ctx context.Context, tx *sql.Tx, c *Channel) (uuid.UUID, error) {
 	err := permission.LimitCheckAny(ctx, permission.System, permission.User)
 	if err != nil {
-		return nil, err
+		return uuid.UUID{}, err
 	}
 
 	n, err := c.Normalize()
 	if err != nil {
-		return nil, err
+		return uuid.UUID{}, err
 	}
 
-	_, err = tx.StmtContext(ctx, db.create).ExecContext(ctx, n.ID, n.Name, n.Type, n.Value)
+	var id sqlutil.NullUUID
+	var name sql.NullString
+	err = stmt(ctx, tx, db.findByValue).QueryRowContext(ctx, n.Type, n.Value).Scan(&id, &name)
+	if errors.Is(err, sql.ErrNoRows) {
+		err = nil
+	}
 	if err != nil {
-		return nil, err
+		return uuid.UUID{}, fmt.Errorf("lookup existing entry: %w", err)
 	}
 
-	return n, nil
+	if id.Valid && name.String == c.Name {
+		// short-circuit if it already exists and is up-to-date.
+		return id.UUID, nil
+	}
+
+	var ownTx bool
+	if tx == nil {
+		ownTx = true
+		tx, err = db.db.BeginTx(ctx, nil)
+		if err != nil {
+			return uuid.UUID{}, fmt.Errorf("start tx: %w", err)
+		}
+		defer tx.Rollback()
+	}
+
+	_, err = tx.StmtContext(ctx, db.lock).ExecContext(ctx)
+	if err != nil {
+		return uuid.UUID{}, fmt.Errorf("aqcuire lock: %w", err)
+	}
+
+	// try again after exclusive lock
+	err = tx.StmtContext(ctx, db.findByValue).QueryRowContext(ctx, n.Type, n.Value).Scan(&id, &name)
+	if errors.Is(err, sql.ErrNoRows) {
+		err = nil
+	}
+	if err != nil {
+		return uuid.UUID{}, fmt.Errorf("lookup existing entry exclusively: %w", err)
+	}
+	if id.Valid && name.String == c.Name {
+		// short-circuit if it already exists and is up-to-date.
+		return id.UUID, nil
+	}
+	if !id.Valid {
+		// create new one
+		id.Valid = true
+		id.UUID = uuid.NewV4()
+		_, err = tx.StmtContext(ctx, db.create).ExecContext(ctx, id, n.Name, n.Type, n.Value)
+		if err != nil {
+			return uuid.UUID{}, fmt.Errorf("create new NC: %w", err)
+		}
+	} else {
+		// update existing name
+		_, err = tx.StmtContext(ctx, db.updateName).ExecContext(ctx, id, n.Name)
+		if err != nil {
+			return uuid.UUID{}, fmt.Errorf("update NC name: %w", err)
+		}
+	}
+
+	if ownTx {
+		return id.UUID, tx.Commit()
+	}
+	return id.UUID, nil
 }
 
 func (db *DB) DeleteManyTx(ctx context.Context, tx *sql.Tx, ids []string) error {
@@ -84,13 +163,8 @@ func (db *DB) DeleteManyTx(ctx context.Context, tx *sql.Tx, ids []string) error 
 	return err
 }
 
-func (db *DB) FindOne(ctx context.Context, id string) (*Channel, error) {
+func (db *DB) FindOne(ctx context.Context, id uuid.UUID) (*Channel, error) {
 	err := permission.LimitCheckAny(ctx, permission.System, permission.User)
-	if err != nil {
-		return nil, err
-	}
-
-	err = validate.UUID("ChannelID", id)
 	if err != nil {
 		return nil, err
 	}

--- a/notificationchannel/store.go
+++ b/notificationchannel/store.go
@@ -106,7 +106,7 @@ func (db *DB) MapToID(ctx context.Context, tx *sql.Tx, c *Channel) (uuid.UUID, e
 
 	_, err = tx.StmtContext(ctx, db.lock).ExecContext(ctx)
 	if err != nil {
-		return uuid.UUID{}, fmt.Errorf("aqcuire lock: %w", err)
+		return uuid.UUID{}, fmt.Errorf("acquire lock: %w", err)
 	}
 
 	// try again after exclusive lock

--- a/util/sqlutil/nulluuid.go
+++ b/util/sqlutil/nulluuid.go
@@ -1,0 +1,45 @@
+package sqlutil
+
+import (
+	"database/sql/driver"
+	"fmt"
+
+	uuid "github.com/satori/go.uuid"
+)
+
+type NullUUID struct {
+	UUID  uuid.UUID
+	Valid bool
+}
+
+func (u NullUUID) Value() (driver.Value, error) {
+	if !u.Valid {
+		return nil, nil
+	}
+
+	return u.UUID.Bytes(), nil
+}
+
+func (u *NullUUID) Scan(src interface{}) (err error) {
+	if src == nil {
+		u.Valid = false
+		u.UUID = uuid.UUID{}
+		return nil
+	}
+
+	switch s := src.(type) {
+	case string:
+		u.UUID, err = uuid.FromString(s)
+	case []byte:
+		if len(s) == 16 {
+			u.UUID, err = uuid.FromBytes(s)
+			break
+		}
+		u.UUID, err = uuid.FromString(string(s))
+	default:
+		return fmt.Errorf("unknown format for UUID: %T", s)
+	}
+	u.Valid = err == nil
+
+	return err
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Reworks how notification channels are created from an always-create method to re-using existing if possible.