### PR TITLE
ui: add aria labels to detail page quick links

### DIFF
--- a/web/src/app/details/DetailsPage.tsx
+++ b/web/src/app/details/DetailsPage.tsx
@@ -43,6 +43,7 @@ const useStyles = makeStyles({
 type Link = {
   url: string
   label: string
+  ariaLabel: string
   subText?: string
   status?: 'ok' | 'warn' | 'err'
 }
@@ -171,7 +172,11 @@ export default function DetailsPage(p: DetailsPageProps): JSX.Element {
                     secondary={li.subText}
                   />
                   <ListItemSecondaryAction>
-                    <IconButton component={AppLink} to={li.url}>
+                    <IconButton
+                      component={AppLink}
+                      to={li.url}
+                      aria-label={li.ariaLabel}
+                    >
                       <ChevronRight />
                     </IconButton>
                   </ListItemSecondaryAction>

--- a/web/src/app/details/DetailsPage.tsx
+++ b/web/src/app/details/DetailsPage.tsx
@@ -1,6 +1,6 @@
 import React, { cloneElement } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
-import { isWidthDown } from '@material-ui/core'
+import { isWidthDown, isWidthUp } from '@material-ui/core'
 import Card from '@material-ui/core/Card'
 import CardHeader from '@material-ui/core/CardHeader'
 import CardContent from '@material-ui/core/CardContent'
@@ -21,32 +21,6 @@ import AppLink from '../util/AppLink'
 import useWidth from '../util/useWidth'
 import statusStyles from '../util/statusStyles'
 
-interface DetailsPageProps {
-  title: string
-
-  // optional content
-  avatar?: JSX.Element // placement for an icon or image
-  subheader?: string | JSX.Element
-  details?: string
-  notices?: Array<Notice>
-  links?: Array<Link>
-  pageContent?: JSX.Element
-  primaryActions?: Array<Action | JSX.Element>
-  secondaryActions?: Array<Action | JSX.Element>
-}
-
-type LinkStatus = 'ok' | 'warn' | 'err'
-type Link = {
-  url: string
-  label: string
-  subText?: string
-  status?: LinkStatus
-}
-
-function isDesktopMode(width: string): boolean {
-  return width === 'md' || width === 'lg' || width === 'xl'
-}
-
 const useStyles = makeStyles({
   ...statusStyles,
   flexHeight: {
@@ -66,11 +40,32 @@ const useStyles = makeStyles({
   },
 })
 
+type Link = {
+  url: string
+  label: string
+  subText?: string
+  status?: 'ok' | 'warn' | 'err'
+}
+
+interface DetailsPageProps {
+  title: string
+
+  avatar?: JSX.Element
+  subheader?: string | JSX.Element
+  details?: string
+  notices?: Array<Notice>
+  links?: Array<Link>
+  pageContent?: JSX.Element
+  primaryActions?: Array<Action | JSX.Element>
+  secondaryActions?: Array<Action | JSX.Element>
+}
+
 export default function DetailsPage(p: DetailsPageProps): JSX.Element {
   const classes = useStyles()
   const width = useWidth()
+  const isDesktop = isWidthUp('md', width)
 
-  const linkClassName = (status?: LinkStatus): string => {
+  const linkClassName = (status?: Link['status']): string => {
     if (status === 'ok') return classes.statusOK
     if (status === 'warn') return classes.statusWarning
     if (status === 'err') return classes.statusError
@@ -94,7 +89,7 @@ export default function DetailsPage(p: DetailsPageProps): JSX.Element {
       )}
 
       {/* Header card */}
-      <Grid item xs={12} lg={isDesktopMode(width) && p.links?.length ? 8 : 12}>
+      <Grid item xs={12} lg={isDesktop && p.links?.length ? 8 : 12}>
         <Card className={classes.fullHeight}>
           <Grid
             className={classes.fullHeight}
@@ -150,11 +145,7 @@ export default function DetailsPage(p: DetailsPageProps): JSX.Element {
 
       {/* Quick Links */}
       {p.links?.length && (
-        <Grid
-          item
-          xs={12}
-          lg={isDesktopMode(width) && p.links?.length ? 4 : 12}
-        >
+        <Grid item xs={12} lg={isDesktop && p.links?.length ? 4 : 12}>
           <Card className={classes.fullHeight}>
             <CardHeader
               title='Quick Links'
@@ -175,7 +166,7 @@ export default function DetailsPage(p: DetailsPageProps): JSX.Element {
                   <ListItemText
                     primary={li.label}
                     primaryTypographyProps={
-                      isDesktopMode(width) ? undefined : { variant: 'h5' }
+                      isDesktop ? undefined : { variant: 'h5' }
                     }
                     secondary={li.subText}
                   />

--- a/web/src/app/escalation-policies/PolicyDetails.js
+++ b/web/src/app/escalation-policies/PolicyDetails.js
@@ -93,6 +93,7 @@ export default function PolicyDetails(props) {
             label: 'Services',
             url: 'services',
             subText: 'Find services that link to this policy',
+            ariaLabel: 'Go to escalation policy services',
           },
         ]}
       />

--- a/web/src/app/schedules/ScheduleDetails.js
+++ b/web/src/app/schedules/ScheduleDetails.js
@@ -127,21 +127,25 @@ export default function ScheduleDetails({ scheduleID }) {
             label: 'Assignments',
             url: 'assignments',
             subText: 'Manage rules for rotations and users',
+            ariaLabel: 'Go to schedule assignments',
           },
           {
             label: 'Escalation Policies',
             url: 'escalation-policies',
             subText: 'Find escalation policies that link to this schedule',
+            ariaLabel: 'Go to schedule escalation policies',
           },
           {
             label: 'Overrides',
             url: 'overrides',
             subText: 'Add, remove, or replace a user temporarily',
+            ariaLabel: 'Go to schedule overrides',
           },
           {
             label: 'Shifts',
             url: 'shifts',
             subText: 'Review a list of past and future on-call shifts',
+            ariaLabel: 'Go to schedule shifts',
           },
         ]}
       />

--- a/web/src/app/services/ServiceDetails.js
+++ b/web/src/app/services/ServiceDetails.js
@@ -125,22 +125,26 @@ export default function ServiceDetails({ serviceID }) {
             status: alertStatus(_.get(data, 'alerts.nodes')),
             url: 'alerts',
             subText: 'Manage alerts specific to this service',
+            ariaLabel: 'Go to service alerts',
           },
           {
             label: 'Heartbeat Monitors',
             url: 'heartbeat-monitors',
             status: hbStatus(_.get(data, 'service.heartbeatMonitors')),
             subText: 'Manage endpoints monitored for you',
+            ariaLabel: 'Go to service heartbeat monitors',
           },
           {
             label: 'Integration Keys',
             url: 'integration-keys',
             subText: 'Manage keys used to create alerts',
+            ariaLabel: 'Go to service integration keys',
           },
           {
             label: 'Labels',
             url: 'labels',
             subText: 'Group together services',
+            ariaLabel: 'Go to service labels',
           },
         ]}
       />

--- a/web/src/app/users/UserDetails.js
+++ b/web/src/app/users/UserDetails.js
@@ -127,6 +127,7 @@ export default function UserDetails(props) {
       subText: svcCount
         ? `On-call for ${svcCount} service${svcCount > 1 ? 's' : ''}`
         : 'Not currently on-call',
+      ariaLabel: 'Go to on call assignments',
     },
   ]
 
@@ -135,6 +136,7 @@ export default function UserDetails(props) {
       label: 'Schedule Calendar Subscriptions',
       url: 'schedule-calendar-subscriptions',
       subText: 'Manage schedules you have subscribed to',
+      ariaLabel: 'Go to calendar subscriptions',
     })
   }
 
@@ -145,6 +147,7 @@ export default function UserDetails(props) {
       subText: `${sessCount || 'No'} active session${
         sessCount === 1 ? '' : 's'
       }`,
+      ariaLabel: 'Go to active sessions',
     })
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
The quick links have a role of "button" but do not have a name available to an accessibility API. Valid names are: element content, aria-label, aria-labelledby.

**Describe any introduced user-facing changes:**
Users with screen readers can 

**Additional Info:**
https://www.w3.org/TR/WCAG21/#name-role-value
