### PR TITLE
ui: prevent screen reader stutter on quick links

### DIFF
--- a/web/src/app/details/DetailsPage.tsx
+++ b/web/src/app/details/DetailsPage.tsx
@@ -10,8 +10,6 @@ import { ChevronRight } from '@material-ui/icons'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
-import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
-import IconButton from '@material-ui/core/IconButton'
 import { ReactNode } from 'react-markdown'
 
 import Notices, { Notice } from './Notices'
@@ -179,11 +177,7 @@ export default function DetailsPage(p: DetailsPageProps): JSX.Element {
                     }
                     secondary={li.subText}
                   />
-                  <ListItemSecondaryAction>
-                    <IconButton component={AppLink} to={li.url}>
-                      <ChevronRight />
-                    </IconButton>
-                  </ListItemSecondaryAction>
+                  <ChevronRight />
                 </ListItem>
               ))}
             </List>

--- a/web/src/app/details/DetailsPage.tsx
+++ b/web/src/app/details/DetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement } from 'react'
+import React, { cloneElement, forwardRef } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { isWidthDown } from '@material-ui/core'
 import Card from '@material-ui/core/Card'
@@ -15,7 +15,7 @@ import { ReactNode } from 'react-markdown'
 import Notices, { Notice } from './Notices'
 import Markdown from '../util/Markdown'
 import CardActions, { Action } from './CardActions'
-import AppLink from '../util/AppLink'
+import AppLink, { AppLinkProps } from '../util/AppLink'
 import useWidth from '../util/useWidth'
 import statusStyles from '../util/statusStyles'
 
@@ -63,6 +63,16 @@ const useStyles = makeStyles({
     marginBottom: 64,
   },
 })
+
+const LIApplink = forwardRef<HTMLAnchorElement, AppLinkProps>(
+  function LIApplink(props, ref): JSX.Element {
+    return (
+      <li>
+        <AppLink ref={ref} {...props} />
+      </li>
+    )
+  },
+)
 
 export default function DetailsPage(p: DetailsPageProps): JSX.Element {
   const classes = useStyles()
@@ -166,7 +176,7 @@ export default function DetailsPage(p: DetailsPageProps): JSX.Element {
                 <ListItem
                   key={idx}
                   className={linkClassName(li.status)}
-                  component={AppLink}
+                  component={LIApplink}
                   to={li.url}
                   button
                 >


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR converts list item icon buttons into simple icons in the lists of quick links

<img width="349" alt="Screen Shot 2021-06-10 at 3 56 34 PM" src="https://user-images.githubusercontent.com/17692467/121595943-72d25900-ca04-11eb-8ce2-bd6087d1501d.png">

**Additional Info:**
https://github.com/target/goalert/pull/1614
