### PR TITLE
ui/users: fix secondary action rendering in safari

### DIFF
--- a/web/src/app/lists/FlatList.tsx
+++ b/web/src/app/lists/FlatList.tsx
@@ -74,7 +74,7 @@ export interface FlatListItem {
   title?: string
   highlight?: boolean
   subText?: JSX.Element | string
-  icon?: JSX.Element
+  icon?: JSX.Element | null
   secondaryAction?: JSX.Element | null
   url?: string
   id?: string

--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -107,7 +107,7 @@ export default function UserContactMethodList(
 
   function getSecondaryAction(cm: UserContactMethod): JSX.Element {
     return (
-      <Grid container spacing={2}>
+      <Grid container spacing={2} alignItems='center' wrap='nowrap'>
         {cm.disabled && !props.readOnly && isWidthUp('md', width) && (
           <Grid item>
             <Button

--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { gql, useQuery } from '@apollo/client'
-import p from 'prop-types'
 import FlatList from '../lists/FlatList'
 import { Button, Card, CardHeader, Grid, IconButton } from '@material-ui/core'
 
@@ -11,12 +10,11 @@ import UserContactMethodDeleteDialog from './UserContactMethodDeleteDialog'
 import UserContactMethodEditDialog from './UserContactMethodEditDialog'
 import { Warning } from '../icons'
 import UserContactMethodVerificationDialog from './UserContactMethodVerificationDialog'
-import { makeStyles, createStyles } from '@material-ui/core/styles'
-import { styles as globalStyles } from '../styles/materialStyles'
 import useWidth from '../util/useWidth'
 import Spinner from '../loading/components/Spinner'
 import { GenericError, ObjectNotFound } from '../error-pages'
 import SendTestDialog from './SendTestDialog'
+import { UserContactMethod } from '../../schema'
 
 const query = gql`
   query cmList($id: ID!) {
@@ -34,27 +32,24 @@ const query = gql`
   }
 `
 
-const useStyles = makeStyles((theme) => {
-  const { cardHeader } = globalStyles(theme)
+interface ListItemAction {
+  label: string
+  onClick: () => void
+}
 
-  return createStyles({
-    actionGrid: {
-      display: 'flex',
-      alignItems: 'center',
-    },
-    cardHeader,
-  })
-})
+interface UserContactMethodListProps {
+  userID: string
+  readOnly?: true
+}
 
-export default function UserContactMethodList(props) {
-  const classes = useStyles()
+export default function UserContactMethodList(
+  props: UserContactMethodListProps,
+): JSX.Element {
   const width = useWidth()
-
-  const [showVerifyDialogByID, setShowVerifyDialogByID] = useState(null)
-  const [showEditDialogByID, setShowEditDialogByID] = useState(null)
-  const [showDeleteDialogByID, setShowDeleteDialogByID] = useState(null)
-
-  const [showSendTestByID, setShowSendTestByID] = useState(null)
+  const [showVerifyDialogByID, setShowVerifyDialogByID] = useState('')
+  const [showEditDialogByID, setShowEditDialogByID] = useState('')
+  const [showDeleteDialogByID, setShowDeleteDialogByID] = useState('')
+  const [showSendTestByID, setShowSendTestByID] = useState('')
 
   const { loading, error, data } = useQuery(query, {
     variables: {
@@ -63,12 +58,12 @@ export default function UserContactMethodList(props) {
   })
 
   if (loading && !data) return <Spinner />
-  if (!data.user) return <ObjectNotFound type='user' />
+  if (data && !data.user) return <ObjectNotFound type='user' />
   if (error) return <GenericError error={error.message} />
 
   const contactMethods = data.user.contactMethods
 
-  const getIcon = (cm) => {
+  const getIcon = (cm: UserContactMethod): JSX.Element | null => {
     if (!cm.disabled) return null
     if (props.readOnly) {
       return <Warning message='Contact method disabled' />
@@ -79,7 +74,6 @@ export default function UserContactMethodList(props) {
         data-cy='cm-disabled'
         aria-label='Reactivate contact method'
         onClick={() => setShowVerifyDialogByID(cm.id)}
-        variant='contained'
         color='primary'
         disabled={props.readOnly}
       >
@@ -88,7 +82,7 @@ export default function UserContactMethodList(props) {
     )
   }
 
-  function getActionMenuItems(cm) {
+  function getActionMenuItems(cm: UserContactMethod): ListItemAction[] {
     const actions = [
       { label: 'Edit', onClick: () => setShowEditDialogByID(cm.id) },
       {
@@ -111,9 +105,9 @@ export default function UserContactMethodList(props) {
     return actions
   }
 
-  function getSecondaryAction(cm) {
+  function getSecondaryAction(cm: UserContactMethod): JSX.Element {
     return (
-      <Grid container spacing={2} className={classes.actionGrid}>
+      <Grid container spacing={2}>
         {cm.disabled && !props.readOnly && isWidthUp('md', width) && (
           <Grid item>
             <Button
@@ -139,8 +133,7 @@ export default function UserContactMethodList(props) {
     <Grid item xs={12}>
       <Card>
         <CardHeader
-          className={classes.cardHeader}
-          component='h3'
+          titleTypographyProps={{ component: 'h2', variant: 'h5' }}
           title='Contact Methods'
         />
         <FlatList
@@ -156,33 +149,28 @@ export default function UserContactMethodList(props) {
         {showVerifyDialogByID && (
           <UserContactMethodVerificationDialog
             contactMethodID={showVerifyDialogByID}
-            onClose={() => setShowVerifyDialogByID(null)}
+            onClose={() => setShowVerifyDialogByID('')}
           />
         )}
         {showEditDialogByID && (
           <UserContactMethodEditDialog
             contactMethodID={showEditDialogByID}
-            onClose={() => setShowEditDialogByID(null)}
+            onClose={() => setShowEditDialogByID('')}
           />
         )}
         {showDeleteDialogByID && (
           <UserContactMethodDeleteDialog
             contactMethodID={showDeleteDialogByID}
-            onClose={() => setShowDeleteDialogByID(null)}
+            onClose={() => setShowDeleteDialogByID('')}
           />
         )}
         {showSendTestByID && (
           <SendTestDialog
             messageID={showSendTestByID}
-            onClose={() => setShowSendTestByID(null)}
+            onClose={() => setShowSendTestByID('')}
           />
         )}
       </Card>
     </Grid>
   )
-}
-
-UserContactMethodList.propTypes = {
-  userID: p.string.isRequired,
-  readOnly: p.bool,
 }

--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -39,7 +39,7 @@ interface ListItemAction {
 
 interface UserContactMethodListProps {
   userID: string
-  readOnly?: true
+  readOnly?: boolean
 }
 
 export default function UserContactMethodList(

--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -1,7 +1,14 @@
 import React, { useState } from 'react'
 import { gql, useQuery } from '@apollo/client'
 import FlatList from '../lists/FlatList'
-import { Button, Card, CardHeader, Grid, IconButton } from '@material-ui/core'
+import {
+  Button,
+  Card,
+  CardHeader,
+  Grid,
+  IconButton,
+  makeStyles,
+} from '@material-ui/core'
 
 import { isWidthUp } from '@material-ui/core/withWidth'
 import { sortContactMethods } from './util'
@@ -14,6 +21,7 @@ import useWidth from '../util/useWidth'
 import Spinner from '../loading/components/Spinner'
 import { GenericError, ObjectNotFound } from '../error-pages'
 import SendTestDialog from './SendTestDialog'
+import { styles as globalStyles } from '../styles/materialStyles'
 import { UserContactMethod } from '../../schema'
 
 const query = gql`
@@ -42,9 +50,14 @@ interface UserContactMethodListProps {
   readOnly?: boolean
 }
 
+const useStyles = makeStyles((theme) => ({
+  cardHeader: globalStyles(theme).cardHeader,
+}))
+
 export default function UserContactMethodList(
   props: UserContactMethodListProps,
 ): JSX.Element {
+  const classes = useStyles()
   const width = useWidth()
   const [showVerifyDialogByID, setShowVerifyDialogByID] = useState('')
   const [showEditDialogByID, setShowEditDialogByID] = useState('')
@@ -133,6 +146,7 @@ export default function UserContactMethodList(
     <Grid item xs={12}>
       <Card>
         <CardHeader
+          className={classes.cardHeader}
           titleTypographyProps={{ component: 'h2', variant: 'h5' }}
           title='Contact Methods'
         />

--- a/web/src/app/users/UserNotificationRuleList.js
+++ b/web/src/app/users/UserNotificationRuleList.js
@@ -71,7 +71,7 @@ export default class UserNotificationRuleList extends React.PureComponent {
         <Card>
           <CardHeader
             className={classes.cardHeader}
-            component='h3'
+            titleTypographyProps={{ component: 'h2', variant: 'h5' }}
             title='Notification Rules'
           />
           <FlatList


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes a CSS issue in Safari when rendering wider secondary list actions. It solves the immediate problem of the content wrapping, but there is some outstanding work to be done preventing longer list item text from rendering behind the secondary action. See additional info below for more context. This is an existing bug today, so a separate PR will address it.

**Which issue(s) this PR fixes:**
Fixes #1500 

**Describe any introduced user-facing changes:**
Safari users can manage contact methods

**Additional Info:**
https://github.com/mui-org/material-ui/issues/13597
https://github.com/mui-org/material-ui/issues/13495
