### PR TITLE
smoketest: sync slack assertions

### DIFF
--- a/devtools/mockslack/server.go
+++ b/devtools/mockslack/server.go
@@ -198,6 +198,29 @@ func (st *state) Messages(chanID string) []Message {
 	return result
 }
 
+// DeleteMessage will delete a message from channel history.
+func (st *state) DeleteMessage(chanID, ts string) bool {
+	st.mx.Lock()
+	defer st.mx.Unlock()
+	ch := st.channels[chanID]
+	if ch == nil {
+		return false
+	}
+
+	var deleted bool
+	msgs := ch.Messages[:0]
+	for _, m := range ch.Messages {
+		if m.TS == ts {
+			deleted = true
+			continue
+		}
+		msgs = append(msgs, m)
+	}
+	ch.Messages = msgs
+
+	return deleted
+}
+
 // ServeHTTP serves the Slack API.
 func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	log.Printf("%s %s", req.Method, req.URL.Path)

--- a/smoketest/harness/harness.go
+++ b/smoketest/harness/harness.go
@@ -403,7 +403,7 @@ func (h *Harness) execQuery(sql string, data interface{}) {
 
 	err = ExecSQLBatch(context.Background(), h.dbURL, b.String())
 	if err != nil {
-		h.t.Fatalf("failed to exec query: %v", err)
+		h.t.Fatalf("failed to exec query: %v\n%s", err, b.String())
 	}
 }
 

--- a/smoketest/harness/slack.go
+++ b/smoketest/harness/slack.go
@@ -38,17 +38,25 @@ type slackChannel struct {
 func (h *Harness) Slack() SlackServer { return h.slack }
 
 func (s *slackServer) WaitAndAssert() {
+	s.h.t.Helper()
 	timeout := time.NewTimer(15 * time.Second)
 	defer timeout.Stop()
 
 	t := time.NewTicker(time.Millisecond)
 	defer t.Stop()
 
-	for _, ch := range s.channels {
-		for !ch.waitAndAssert(timeout.C) {
-			<-t.C
+	for i := 0; i < 3; i++ {
+		s.h.Trigger()
+		var hasFailure bool
+		for _, ch := range s.channels {
+			hasFailure = hasFailure || ch.hasUnexpectedMessages()
+		}
+
+		if hasFailure {
+			s.h.t.FailNow()
 		}
 	}
+
 }
 
 func (s *slackServer) Channel(name string) SlackChannel {
@@ -68,38 +76,45 @@ func (s *slackServer) Channel(name string) SlackChannel {
 func (ch *slackChannel) ID() string   { return ch.id }
 func (ch *slackChannel) Name() string { return ch.name }
 func (ch *slackChannel) ExpectMessage(keywords ...string) {
-	ch.expected = append(ch.expected, keywords)
-}
+	ch.h.t.Helper()
 
-func (ch *slackChannel) waitAndAssert(timeout <-chan time.Time) bool {
-	msgs := ch.h.slack.Messages(ch.id)
+	timeout := time.NewTimer(15 * time.Second)
+	defer timeout.Stop()
 
-	check := func(keywords []string) bool {
+	for {
 	msgLoop:
-		for i, msg := range msgs {
+		for _, msg := range ch.h.slack.Messages(ch.id) {
 			for _, w := range keywords {
 				if !strings.Contains(msg.Text, w) {
 					continue msgLoop
 				}
 			}
-			msgs = append(msgs[:i], msgs[i+1:]...)
-			return true
-		}
-		return false
-	}
 
-	for i, exp := range ch.expected {
+			ch.h.t.Logf("received Slack message to %s: %s", ch.name, msg.Text)
+			ch.h.slack.DeleteMessage(ch.id, msg.TS)
+			return
+		}
+
 		select {
-		case <-timeout:
-			ch.h.t.Fatalf("timeout waiting for slack message: channel=%s; ID=%s; message=%d keywords=%v\nGot: %s", ch.name, ch.id, i, exp, msgs)
+		case <-timeout.C:
+			ch.h.t.Fatalf("timeout waiting for slack message: Channel=%s; ID=%s; keywords=%v\nGot: %#v", ch.name, ch.id, keywords, ch.h.slack.Messages(ch.id))
 		default:
 		}
-		if !check(exp) {
-			return false
-		}
+
+		ch.h.Trigger()
+	}
+}
+
+func (ch *slackChannel) hasUnexpectedMessages() bool {
+	ch.h.t.Helper()
+
+	var hasFailure bool
+	for _, msg := range ch.h.slack.Messages(ch.id) {
+		ch.h.t.Errorf("unexpected slack message: Channel=%s; ID=%s; Text=%s", ch.name, ch.id, msg.Text)
+		hasFailure = true
 	}
 
-	return true
+	return hasFailure
 }
 
 func (h *Harness) initSlack() {

--- a/smoketest/harness/slack.go
+++ b/smoketest/harness/slack.go
@@ -31,8 +31,6 @@ type slackChannel struct {
 	h    *Harness
 	name string
 	id   string
-
-	expected [][]string
 }
 
 func (h *Harness) Slack() SlackServer { return h.slack }

--- a/smoketest/slackaddtoepstep_test.go
+++ b/smoketest/slackaddtoepstep_test.go
@@ -2,8 +2,9 @@ package smoketest
 
 import (
 	"fmt"
-	"github.com/target/goalert/smoketest/harness"
 	"testing"
+
+	"github.com/target/goalert/smoketest/harness"
 )
 
 // TestSlackAddToEPStep tests that slack channels can be added to an EPStep.
@@ -51,7 +52,7 @@ func TestSlackAddToEPStep(t *testing.T) {
 		}
 	`, h.UUID("eid"), channel.ID()))
 
-	channel.ExpectMessage("testing")
 	h.CreateAlert(h.UUID("sid"), "testing")
+	channel.ExpectMessage("testing")
 
 }

--- a/smoketest/slacknotification_test.go
+++ b/smoketest/slacknotification_test.go
@@ -1,8 +1,9 @@
 package smoketest
 
 import (
-	"github.com/target/goalert/smoketest/harness"
 	"testing"
+
+	"github.com/target/goalert/smoketest/harness"
 )
 
 // TestSlackNotification tests that slack channels are returned for configured users.
@@ -32,6 +33,6 @@ func TestSlackNotification(t *testing.T) {
 	h := harness.NewHarness(t, sql, "slack-user-link")
 	defer h.Close()
 
-	h.Slack().Channel("test").ExpectMessage("testing")
 	h.CreateAlert(h.UUID("sid"), "testing")
+	h.Slack().Channel("test").ExpectMessage("testing")
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Changes slack `ExpectMessage` assertion to be blocking, providing more useful errors and line numbers on failure.