### PR TITLE
ui/details: prevent rendering 0

### DIFF
--- a/web/src/app/details/DetailsPage.tsx
+++ b/web/src/app/details/DetailsPage.tsx
@@ -159,7 +159,7 @@ export default function DetailsPage(p: DetailsPageProps): JSX.Element {
       </Grid>
 
       {/* Quick Links */}
-      {links.length && (
+      {links.length > 0 && (
         <Grid item xs={12} lg={isDesktopMode(width) && links.length ? 4 : 12}>
           <Card className={classes.fullHeight}>
             <CardHeader


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes an issue in which we render the string `"0"` when there are no quick links e.g. rotation details

**Additional Info:**
JSX rules: https://reactjs.org/docs/jsx-in-depth.html#booleans-null-and-undefined-are-ignored
