### PR TITLE
smoketest: weekdayFilter should be all-true

### DIFF
--- a/smoketest/graphqlalert_test.go
+++ b/smoketest/graphqlalert_test.go
@@ -176,7 +176,7 @@ func TestGraphQLAlert(t *testing.T) {
 						rules: {
 							start: "00:00"
 							end: "23:00"
-							weekdayFilter: [true, true, true, true, true, false, false]
+							weekdayFilter: [true, true, true, true, true, true, true]
 						}
 					}
 				}

--- a/smoketest/graphqlcreatescheduledefaultrotation_test.go
+++ b/smoketest/graphqlcreatescheduledefaultrotation_test.go
@@ -64,7 +64,7 @@ func TestGraphQLCreateScheduleWithDefaultRotation(t *testing.T) {
 						rules: {
 							start: "01:00"
 							end: "23:00"
-							weekdayFilter: [true, true, true, true, true, false, false]
+							weekdayFilter: [true, true, true, true, true, true, true]
 						}
 					}
 				}

--- a/smoketest/graphqlupdaterotation_test.go
+++ b/smoketest/graphqlupdaterotation_test.go
@@ -75,7 +75,7 @@ func TestGraphQLUpdateRotation(t *testing.T) {
 						rules: {
 							start: "00:00"
 							end: "23:00"
-							weekdayFilter: [true, true, true, true, true, false, false]
+							weekdayFilter: [true, true, true, true, true, true, true]
 						}
 					}
 				}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Fixes a test issue introduced by #1580 

The PR made `weekdayFilter` validation strict, so tests had needed to be updated with missing bool values -- missing values were incorrectly assumed to be false, but `rule.NewAlwaysActive` has them all default to true. Updating the values fixes the issue where the smoketest(s) could fail at certain times.