### PR TITLE
ci: add frontend linting action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: reviewdog
+on: [pull_request]
+jobs:
+  node-checks:
+    name: Node checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: yarn install
+      - uses: reviewdog/action-eslint@v1
+        with:
+          reporter: github-pr-review
+          level: warning
+          fail_on_error: true
+      - uses: reviewdog/action-stylelint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          level: warning
+          fail_on_error: true
+      - name: tsc
+        run: yarn workspaces run check


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR uses a tool called reviewdog to give linting diagnostics for each push to an open pull request. For most cases, it will create a comment at the relevant line of code, but if it is unable to, the warning/error is found in the github actions log. This provides some redundancy with the `make check` command, but the developer experience is improved enough to justify such redundancy.

**Screenshots:**
eslint:
<img width="640" alt="Screen Shot 2021-07-09 at 4 27 25 PM" src="https://user-images.githubusercontent.com/17692467/125137646-baff9c80-e0d2-11eb-92d0-5e95c7291554.png">

prettier:
<img width="414" alt="Screen Shot 2021-07-09 at 4 27 45 PM" src="https://user-images.githubusercontent.com/17692467/125137647-bb983300-e0d2-11eb-9f5f-fae513d7578a.png">

stylelint:
<img width="434" alt="Screen Shot 2021-07-09 at 4 27 58 PM" src="https://user-images.githubusercontent.com/17692467/125137648-bb983300-e0d2-11eb-82be-b9b184283040.png">

typescript type checking (only reported in logs):
<img width="890" alt="Screen Shot 2021-07-09 at 4 28 19 PM" src="https://user-images.githubusercontent.com/17692467/125137645-baff9c80-e0d2-11eb-83c6-7c307dbd8f23.png">
