### PR TITLE
schedule/notifications: make notifications more readable

### DIFF
--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -332,10 +332,8 @@ func (s *ChannelSender) Send(ctx context.Context, msg notification.Message) (str
 	case notification.AlertBundle:
 		vals.Set("text", fmt.Sprintf("Service '%s' has %d unacknowledged alerts.\n\n<%s>", t.ServiceName, t.Count, cfg.CallbackURL("/services/"+t.ServiceID+"/alerts")))
 	case notification.ScheduleOnCallUsers:
-		var userStr string
-		if len(t.Users) == 0 {
-			userStr = "No users"
-		} else {
+		userStr := "No users are"
+		if len(t.Users) > 0 {
 			teamID, err := s.TeamID(ctx)
 			if err != nil {
 				log.Log(ctx, fmt.Errorf("lookup team ID: %w", err))
@@ -367,10 +365,19 @@ func (s *ChannelSender) Send(ctx context.Context, msg notification.Message) (str
 
 				userLinks = append(userLinks, fmt.Sprintf("<@%s>", subjectID))
 			}
-			userStr = "Users: " + strings.Join(userLinks, ", ")
+			switch len(userLinks) {
+			case 1:
+				userStr = userLinks[0] + " is"
+			case 2:
+				userStr = strings.Join(userLinks, " and ") + " are"
+			default:
+				// 0 is already excluded so we know there are >=3
+				userStr = strings.Join(userLinks[:len(userLinks)-1], ", ")
+				userStr += ", and " + userLinks[len(userLinks)-1] + " are"
+			}
 		}
 
-		vals.Set("text", fmt.Sprintf("%s are on-call for Schedule: %s", userStr, fmt.Sprintf("<%s|%s>", t.ScheduleURL, t.ScheduleName)))
+		vals.Set("text", fmt.Sprintf("%s on-call for %s", userStr, fmt.Sprintf("<%s|%s>", t.ScheduleURL, t.ScheduleName)))
 	default:
 		return "", nil, errors.Errorf("unsupported message type: %T", t)
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Fixes grammar issues based on the number of on-call users in schedule notifications to make notifications read naturally.

Before:
`No users are on-call for Schedule: Primary Schedule`
`Users: Foo are on-call for Schedule: Primary Schedule`
`Users: Foo, Bar are on-call for Schedule: Primary Schedule`
`Users: Foo, Bar, Baz are on-call for Schedule: Primary Schedule`

After:
`No users are on-call for Primary Schedule`
`Foo is on-call for Primary Schedule`
`Foo and Bar are on-call for Primary Schedule`
`Foo, Bar, and Baz are on-call for Primary Schedule`
