### PR TITLE
slack: unit tests for on-call messages

### DIFF
--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/target/goalert/config"
 	"github.com/target/goalert/notification"
 	"github.com/target/goalert/permission"
-	"github.com/target/goalert/user"
 	"github.com/target/goalert/util/log"
 	"github.com/target/goalert/validation"
 	"golang.org/x/net/context/ctxhttp"
@@ -332,52 +330,7 @@ func (s *ChannelSender) Send(ctx context.Context, msg notification.Message) (str
 	case notification.AlertBundle:
 		vals.Set("text", fmt.Sprintf("Service '%s' has %d unacknowledged alerts.\n\n<%s>", t.ServiceName, t.Count, cfg.CallbackURL("/services/"+t.ServiceID+"/alerts")))
 	case notification.ScheduleOnCallUsers:
-		userStr := "No users are"
-		if len(t.Users) > 0 {
-			teamID, err := s.TeamID(ctx)
-			if err != nil {
-				log.Log(ctx, fmt.Errorf("lookup team ID: %w", err))
-			}
-
-			m := make(map[string]string, len(t.Users))
-			if teamID != "" {
-				userIDs := make([]string, len(t.Users))
-				for i, u := range t.Users {
-					userIDs[i] = u.ID
-				}
-				err = s.cfg.UserStore.AuthSubjectsFunc(ctx, "slack:"+teamID, func(sub user.AuthSubject) error {
-					m[sub.UserID] = sub.SubjectID
-					return nil
-				}, userIDs...)
-				if err != nil {
-					log.Log(ctx, fmt.Errorf("lookup auth subjects for slack: %w", err))
-				}
-			}
-
-			var userLinks []string
-			for _, u := range t.Users {
-				subjectID := m[u.ID]
-				if subjectID == "" {
-					// fallback to a link to the GoAlert user
-					userLinks = append(userLinks, fmt.Sprintf("<%s|%s>", u.URL, u.Name))
-					continue
-				}
-
-				userLinks = append(userLinks, fmt.Sprintf("<@%s>", subjectID))
-			}
-			switch len(userLinks) {
-			case 1:
-				userStr = userLinks[0] + " is"
-			case 2:
-				userStr = strings.Join(userLinks, " and ") + " are"
-			default:
-				// 0 is already excluded so we know there are >=3
-				userStr = strings.Join(userLinks[:len(userLinks)-1], ", ")
-				userStr += ", and " + userLinks[len(userLinks)-1] + " are"
-			}
-		}
-
-		vals.Set("text", fmt.Sprintf("%s on-call for %s", userStr, fmt.Sprintf("<%s|%s>", t.ScheduleURL, t.ScheduleName)))
+		vals.Set("text", s.onCallNotificationText(ctx, t))
 	default:
 		return "", nil, errors.Errorf("unsupported message type: %T", t)
 	}

--- a/notification/slack/oncallnotification.go
+++ b/notification/slack/oncallnotification.go
@@ -1,0 +1,78 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/target/goalert/notification"
+	"github.com/target/goalert/user"
+	"github.com/target/goalert/util/log"
+)
+
+// onCallNotificationText will return text intended to be sent to Slack representing a ScheduleOnCallUsers notification.
+//
+// It gracefully degrades to excluding slack IDs when there is an error fetching the required information (e.g., team ID or
+// auth subjects).
+func (s *ChannelSender) onCallNotificationText(ctx context.Context, t notification.ScheduleOnCallUsers) string {
+	if len(t.Users) == 0 {
+		return renderOnCallNotificationMessage(t, nil)
+	}
+
+	teamID, err := s.TeamID(ctx)
+	if err != nil {
+		log.Log(ctx, fmt.Errorf("lookup team ID: %w", err))
+		return renderOnCallNotificationMessage(t, nil)
+	}
+
+	userIDs := make([]string, len(t.Users))
+	for i, u := range t.Users {
+		userIDs[i] = u.ID
+	}
+
+	userSlackIDs := make(map[string]string, len(t.Users))
+	err = s.cfg.UserStore.AuthSubjectsFunc(ctx, "slack:"+teamID, func(sub user.AuthSubject) error {
+		userSlackIDs[sub.UserID] = sub.SubjectID
+		return nil
+	}, userIDs...)
+	if err != nil {
+		log.Log(ctx, fmt.Errorf("lookup auth subjects for slack: %w", err))
+		// handled error by logging, continue on to render message with any included slack IDs
+	}
+
+	return renderOnCallNotificationMessage(t, userSlackIDs)
+}
+
+// renderOnCallNotificationMessage will render a message for Slack including links for the schedule and any users.
+//
+// If a user's ID is available in userSlackIDs, an `@` user mention will be used in place of a link to the GoAlert user's detail page.
+func renderOnCallNotificationMessage(msg notification.ScheduleOnCallUsers, userSlackIDs map[string]string) string {
+	suffix := fmt.Sprintf("on-call for <%s|%s>", msg.ScheduleURL, msg.ScheduleName)
+
+	var userLinks []string
+	for _, u := range msg.Users {
+		var subjectID string
+		if userSlackIDs != nil {
+			subjectID = userSlackIDs[u.ID]
+		}
+		if subjectID == "" {
+			// fallback to a link to the GoAlert user
+			userLinks = append(userLinks, fmt.Sprintf("<%s|%s>", u.URL, u.Name))
+			continue
+		}
+
+		userLinks = append(userLinks, fmt.Sprintf("<@%s>", subjectID))
+	}
+
+	if len(userLinks) == 0 {
+		return "No users are " + suffix
+	}
+	if len(userLinks) == 1 {
+		return fmt.Sprintf("%s is %s", userLinks[0], suffix)
+	}
+	if len(userLinks) == 2 {
+		return fmt.Sprintf("%s and %s are %s", userLinks[0], userLinks[1], suffix)
+	}
+
+	return fmt.Sprintf("%s, and %s are %s", strings.Join(userLinks[:len(userLinks)-1], ", "), userLinks[len(userLinks)-1], suffix)
+}

--- a/notification/slack/oncallnotification_test.go
+++ b/notification/slack/oncallnotification_test.go
@@ -8,21 +8,27 @@ import (
 )
 
 func TestRenderOnCallNotification(t *testing.T) {
-	slackUserIDs := map[string]string{"slack.1": "slack.1.ID", "slack.2": "slack.2.ID", "slack.3": "slack.3.ID"}
+	// static user id -> slack ID mappings for testing
+	slackUserIDs := map[string]string{
+		"slack.1": "slack.1.SLACKID",
+		"slack.2": "slack.2.SLACKID",
+		"slack.3": "slack.3.SLACKID",
+	}
 	msg := notification.ScheduleOnCallUsers{
 		ScheduleName: "schedule.name",
 		ScheduleURL:  "schedule.url",
 	}
 
-	check := func(desc, expected string, users []string) {
+	// test with `msg` for the provided user ids
+	check := func(desc, expected string, userIDs []string) {
 		t.Helper()
 		t.Run(desc, func(t *testing.T) {
 			msg.Users = nil
-			for _, u := range users {
+			for _, id := range userIDs {
 				msg.Users = append(msg.Users, notification.User{
-					ID:   u,
-					Name: u,
-					URL:  u + ".url",
+					ID:   id,
+					Name: id + ".name",
+					URL:  id + ".url",
 				})
 			}
 			assert.Equal(t, expected, renderOnCallNotificationMessage(msg, slackUserIDs))
@@ -31,24 +37,24 @@ func TestRenderOnCallNotification(t *testing.T) {
 
 	check("empty", "No users are on-call for <schedule.url|schedule.name>", nil)
 
-	check("fallback", "<foo.url|foo> is on-call for <schedule.url|schedule.name>", []string{"foo"})
+	check("fallback", "<foo.url|foo.name> is on-call for <schedule.url|schedule.name>", []string{"foo"})
 
-	check("1 user", "<@slack.1.ID> is on-call for <schedule.url|schedule.name>", []string{"slack.1"})
+	check("1 user", "<@slack.1.SLACKID> is on-call for <schedule.url|schedule.name>", []string{"slack.1"})
 	check("2 users",
-		"<@slack.1.ID> and <@slack.2.ID> are on-call for <schedule.url|schedule.name>",
+		"<@slack.1.SLACKID> and <@slack.2.SLACKID> are on-call for <schedule.url|schedule.name>",
 		[]string{"slack.1", "slack.2"})
 	check("3 users",
-		"<@slack.1.ID>, <@slack.2.ID>, and <@slack.3.ID> are on-call for <schedule.url|schedule.name>",
+		"<@slack.1.SLACKID>, <@slack.2.SLACKID>, and <@slack.3.SLACKID> are on-call for <schedule.url|schedule.name>",
 		[]string{"slack.1", "slack.2", "slack.3"})
 
 	check("3 users with fallback",
-		"<@slack.1.ID>, <foo.url|foo>, and <@slack.3.ID> are on-call for <schedule.url|schedule.name>",
+		"<@slack.1.SLACKID>, <foo.url|foo.name>, and <@slack.3.SLACKID> are on-call for <schedule.url|schedule.name>",
 		[]string{"slack.1", "foo", "slack.3"})
 
 	t.Run("no panic on nil map", func(t *testing.T) {
-		msg.Users = []notification.User{{ID: "foo.id", Name: "foo", URL: "foo.url"}}
+		msg.Users = []notification.User{{ID: "foo.SLACKID", Name: "foo.name", URL: "foo.url"}}
 
-		assert.Equal(t, "<foo.url|foo> is on-call for <schedule.url|schedule.name>", renderOnCallNotificationMessage(msg, nil))
+		assert.Equal(t, "<foo.url|foo.name> is on-call for <schedule.url|schedule.name>", renderOnCallNotificationMessage(msg, nil))
 	})
 
 }

--- a/notification/slack/oncallnotification_test.go
+++ b/notification/slack/oncallnotification_test.go
@@ -1,0 +1,54 @@
+package slack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/target/goalert/notification"
+)
+
+func TestRenderOnCallNotification(t *testing.T) {
+	slackUserIDs := map[string]string{"slack.1": "slack.1.ID", "slack.2": "slack.2.ID", "slack.3": "slack.3.ID"}
+	msg := notification.ScheduleOnCallUsers{
+		ScheduleName: "schedule.name",
+		ScheduleURL:  "schedule.url",
+	}
+
+	check := func(desc, expected string, users []string) {
+		t.Helper()
+		t.Run(desc, func(t *testing.T) {
+			msg.Users = nil
+			for _, u := range users {
+				msg.Users = append(msg.Users, notification.User{
+					ID:   u,
+					Name: u,
+					URL:  u + ".url",
+				})
+			}
+			assert.Equal(t, expected, renderOnCallNotificationMessage(msg, slackUserIDs))
+		})
+	}
+
+	check("empty", "No users are on-call for <schedule.url|schedule.name>", nil)
+
+	check("fallback", "<foo.url|foo> is on-call for <schedule.url|schedule.name>", []string{"foo"})
+
+	check("1 user", "<@slack.1.ID> is on-call for <schedule.url|schedule.name>", []string{"slack.1"})
+	check("2 users",
+		"<@slack.1.ID> and <@slack.2.ID> are on-call for <schedule.url|schedule.name>",
+		[]string{"slack.1", "slack.2"})
+	check("3 users",
+		"<@slack.1.ID>, <@slack.2.ID>, and <@slack.3.ID> are on-call for <schedule.url|schedule.name>",
+		[]string{"slack.1", "slack.2", "slack.3"})
+
+	check("3 users with fallback",
+		"<@slack.1.ID>, <foo.url|foo>, and <@slack.3.ID> are on-call for <schedule.url|schedule.name>",
+		[]string{"slack.1", "foo", "slack.3"})
+
+	t.Run("no panic on nil map", func(t *testing.T) {
+		msg.Users = []notification.User{{ID: "foo.id", Name: "foo", URL: "foo.url"}}
+
+		assert.Equal(t, "<foo.url|foo> is on-call for <schedule.url|schedule.name>", renderOnCallNotificationMessage(msg, nil))
+	})
+
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Pulls the rendering logic out of the `Send` method for Slack on-call notifications into a unit-testable function and adds tests for edge cases.