### PR TITLE
admin/ui: fix SMS send tool

### DIFF
--- a/web/src/app/admin/AdminSMSSend.tsx
+++ b/web/src/app/admin/AdminSMSSend.tsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles({
 export default function AdminSMSSend(): JSX.Element {
   const classes = useStyles()
   const [cfgFromNumber] = useConfigValue('Twilio.FromNumber')
-  const [fromNumber, setFromNumber] = useState(cfgFromNumber)
+  const [fromNumber, setFromNumber] = useState(cfgFromNumber as string)
   const [toNumber, setToNumber] = useState('')
   const [body, setBody] = useState('')
   const [showErrorDialog, setShowErrorDialog] = useState(false)

--- a/web/src/app/admin/AdminSMSSend.tsx
+++ b/web/src/app/admin/AdminSMSSend.tsx
@@ -41,9 +41,7 @@ const useStyles = makeStyles({
 export default function AdminSMSSend(): JSX.Element {
   const classes = useStyles()
   const [cfgFromNumber] = useConfigValue('Twilio.FromNumber')
-  const [fromNumber, setFromNumber] = useState(
-    (cfgFromNumber as string).replace(/^\+/, ''),
-  )
+  const [fromNumber, setFromNumber] = useState(cfgFromNumber)
   const [toNumber, setToNumber] = useState('')
   const [body, setBody] = useState('')
   const [showErrorDialog, setShowErrorDialog] = useState(false)
@@ -51,7 +49,7 @@ export default function AdminSMSSend(): JSX.Element {
   const [send, sendStatus] = useMutation(sendSMSMutation, {
     variables: {
       input: {
-        from: '+' + fromNumber,
+        from: fromNumber,
         to: toNumber,
         body,
       },

--- a/web/src/app/admin/AdminSMSSend.tsx
+++ b/web/src/app/admin/AdminSMSSend.tsx
@@ -52,7 +52,7 @@ export default function AdminSMSSend(): JSX.Element {
     variables: {
       input: {
         from: '+' + fromNumber,
-        to: '+' + toNumber,
+        to: toNumber,
         body,
       },
     },


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes an issue where SMS messages cannot be sent from the admin toolbox page within the UI. The required `+` before the phone number was accidentally prepended to the input variable twice: once from the `TelTextField` component, and the second within the mutation variables.

**Screenshots:**
![Screen Shot 2021-07-14 at 1 03 35 PM](https://user-images.githubusercontent.com/11381794/125686034-f3c24cda-b35b-4aac-8511-74a1277cb063.png)
![Screen Shot 2021-07-14 at 1 03 27 PM](https://user-images.githubusercontent.com/11381794/125686039-2da3a4d9-498c-4c4b-8ffa-c356c4042b3e.png)
