### PR TITLE
engine/message: fix throttle delay bug

### DIFF
--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -410,10 +410,12 @@ func (db *DB) currentQueue(ctx context.Context, tx *sql.Tx, now time.Time) (*que
 		}
 
 		if !msg.SentAt.IsZero() {
+			// if the message was sent, just add it to the map
 			db.sentMessages[msg.ID] = msg
-		} else {
-			result = append(result, msg)
+			continue
 		}
+
+		result = append(result, msg)
 	}
 
 	for id, msg := range db.sentMessages {

--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -351,21 +351,13 @@ func (db *DB) currentQueue(ctx context.Context, tx *sql.Tx, now time.Time) (*que
 		sentSince = cutoff
 	}
 
-	result := make([]Message, 0, len(db.sentMessages))
-	for id, msg := range db.sentMessages {
-		if msg.SentAt.Before(cutoff) {
-			delete(db.sentMessages, id)
-			continue
-		}
-		result = append(result, msg)
-	}
-
 	rows, err := tx.StmtContext(ctx, db.messages).QueryContext(ctx, sentSince)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetch outgoing messages")
 	}
 	defer rows.Close()
 
+	result := make([]Message, 0, len(db.sentMessages))
 	for rows.Next() {
 		var msg Message
 		var destID, destValue, verifyID, userID, serviceID, cmType, chanType, scheduleID sql.NullString
@@ -417,10 +409,19 @@ func (db *DB) currentQueue(ctx context.Context, tx *sql.Tx, now time.Time) (*que
 			continue
 		}
 
-		result = append(result, msg)
 		if !msg.SentAt.IsZero() {
 			db.sentMessages[msg.ID] = msg
+		} else {
+			result = append(result, msg)
 		}
+	}
+
+	for id, msg := range db.sentMessages {
+		if msg.SentAt.Before(cutoff) {
+			delete(db.sentMessages, id)
+			continue
+		}
+		result = append(result, msg)
 	}
 	db.lastSent = now
 

--- a/engine/message/ratelimit_test.go
+++ b/engine/message/ratelimit_test.go
@@ -1,0 +1,85 @@
+package message_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/target/goalert/engine/message"
+	"github.com/target/goalert/notification"
+)
+
+// TestRateLimit checks known good message sequences are allowed by the rate limit config.
+func TestRateLimit(t *testing.T) {
+	validate := func(desc string, msgType notification.MessageType, destType notification.DestType, _times ...time.Time) {
+		t.Helper()
+		t.Run(desc, func(t *testing.T) {
+			for i := 2; i <= len(_times); i++ {
+				times := _times[:i]
+				last := times[len(times)-1]
+				th := message.NewThrottle(message.PerCMThrottle, last, false)
+				for _, tm := range times[:len(times)-1] {
+					th.Record(message.Message{Type: msgType, SentAt: tm, Dest: notification.Dest{Type: destType}})
+				}
+				assert.Falsef(t, th.InCooldown(message.Message{Type: msgType, Dest: notification.Dest{Type: destType}}), "message #%d should not be in cooldown", i)
+			}
+		})
+	}
+
+	validate("alert-voice",
+		notification.MessageTypeAlert, notification.DestTypeVoice,
+
+		// {Count: 3, Per: 15 * time.Minute},
+		// {Count: 7, Per: time.Hour, Smooth: true},
+		// {Count: 15, Per: 3 * time.Hour, Smooth: true},
+
+		time.Date(2015, time.May, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2015, time.May, 1, 0, 1, 0, 0, time.UTC),
+		time.Date(2015, time.May, 1, 0, 2, 0, 0, time.UTC), // 15 min limit; 13 minute gap max
+
+		time.Date(2015, time.May, 1, 0, 15, 0, 0, time.UTC),  // 15 min limit expired for first message
+		time.Date(2015, time.May, 1, 0, 26, 15, 0, time.UTC), // per hour rule active
+		time.Date(2015, time.May, 1, 0, 37, 30, 0, time.UTC), // 11.25 min max gap for hour
+		time.Date(2015, time.May, 1, 0, 48, 45, 0, time.UTC),
+
+		time.Date(2015, time.May, 1, 1, 0, 0, 0, time.UTC), // start of three hour window
+		time.Date(2015, time.May, 1, 1, 15, 0, 0, time.UTC),
+		time.Date(2015, time.May, 1, 1, 30, 0, 0, time.UTC),
+		time.Date(2015, time.May, 1, 1, 45, 0, 0, time.UTC),
+		time.Date(2015, time.May, 1, 2, 0, 0, 0, time.UTC),
+		time.Date(2015, time.May, 1, 2, 15, 0, 0, time.UTC),
+		time.Date(2015, time.May, 1, 2, 30, 0, 0, time.UTC),
+		time.Date(2015, time.May, 1, 2, 45, 0, 0, time.UTC),
+		time.Date(2015, time.May, 1, 3, 0, 0, 0, time.UTC),
+
+		time.Date(2015, time.May, 1, 3, 1, 0, 0, time.UTC), // out of window
+	)
+
+	validate("alert-voice-staggered",
+		notification.MessageTypeAlert, notification.DestTypeVoice,
+
+		// {Count: 3, Per: 15 * time.Minute},
+		// {Count: 7, Per: time.Hour, Smooth: true},
+		// {Count: 15, Per: 3 * time.Hour, Smooth: true},
+
+		time.Date(2021, 7, 9, 2, 18, 20, 0, time.UTC),
+		time.Date(2021, 7, 9, 3, 34, 25, 0, time.UTC),
+		time.Date(2021, 7, 9, 4, 6, 25, 0, time.UTC),
+		time.Date(2021, 7, 9, 4, 7, 30, 0, time.UTC),
+		time.Date(2021, 7, 9, 4, 8, 35, 0, time.UTC),
+		time.Date(2021, 7, 9, 4, 21, 28, 0, time.UTC),
+		time.Date(2021, 7, 9, 4, 34, 30, 0, time.UTC),
+		time.Date(2021, 7, 9, 5, 27, 25, 0, time.UTC),
+		time.Date(2021, 7, 9, 5, 28, 33, 0, time.UTC),
+		time.Date(2021, 7, 9, 6, 54, 40, 0, time.UTC),
+		time.Date(2021, 7, 9, 7, 7, 31, 0, time.UTC),
+		time.Date(2021, 7, 9, 7, 16, 40, 0, time.UTC),
+		time.Date(2021, 7, 9, 7, 21, 30, 0, time.UTC),
+		time.Date(2021, 7, 9, 7, 34, 35, 0, time.UTC),
+		time.Date(2021, 7, 9, 8, 19, 40, 0, time.UTC),
+		time.Date(2021, 7, 9, 8, 27, 28, 0, time.UTC),
+		time.Date(2021, 7, 9, 8, 37, 0, 0, time.UTC),
+
+		time.Date(2021, 7, 9, 8, 37+1, 0, 0, time.UTC),
+	)
+}

--- a/engine/message/throttle.go
+++ b/engine/message/throttle.go
@@ -69,7 +69,7 @@ func (tr *Throttle) Record(msg Message) {
 		key := ThrottleItem{Dest: msg.Dest, BucketDur: rule.Per}
 		tr.count[key]++
 		count := tr.count[key]
-		if tr.first[key].IsZero() {
+		if tr.first[key].IsZero() || msg.SentAt.Before(tr.first[key]) {
 			tr.first[key] = msg.SentAt
 		}
 

--- a/smoketest/manyalerts_test.go
+++ b/smoketest/manyalerts_test.go
@@ -1,0 +1,86 @@
+package smoketest
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/target/goalert/smoketest/harness"
+)
+
+// TestManyAlerts ensures repeated alert -> msg -> close sequences work properly as long as the delay between
+// outlasts max throttle delay.
+func TestManyAlerts(t *testing.T) {
+	t.Parallel()
+
+	const sql = `
+	insert into users (id, name, email, role)
+	values
+		({{uuid "user"}}, 'bob', 'joe', 'user');
+
+	insert into user_contact_methods (id, user_id, name, type, value)
+	values
+		({{uuid "cm1"}}, {{uuid "user"}}, 'personal', 'SMS', {{phone "1"}});
+
+	insert into user_notification_rules (user_id, contact_method_id, delay_minutes)
+	values
+		({{uuid "user"}}, {{uuid "cm1"}}, 0);
+
+	insert into escalation_policies (id, name, repeat)
+	values
+		({{uuid "eid"}}, 'esc policy', 3);
+
+	insert into escalation_policy_steps (id, escalation_policy_id, delay)
+	values
+		({{uuid "esid"}}, {{uuid "eid"}}, 1);
+
+	insert into escalation_policy_actions (escalation_policy_step_id, user_id)
+	values
+		({{uuid "esid"}}, {{uuid "user"}});
+
+	insert into services (id, escalation_policy_id, name)
+	values
+		({{uuid "sid"}}, {{uuid "eid"}}, 'service');
+
+	insert into integration_keys (id, type, name, service_id)
+	values
+		({{uuid "int_key"}}, 'generic', 'my key', {{uuid "sid"}});
+`
+	h := harness.NewHarness(t, sql, "add-generic-integration-key")
+	defer h.Close()
+
+	createAlert := func(summary string) {
+		t.Helper()
+		u := h.URL() + "/v1/api/alerts?key=" + h.UUID("int_key")
+		v := make(url.Values)
+		v.Set("summary", summary)
+		v.Set("details", "woot")
+
+		resp, err := http.PostForm(u, v)
+		if err != nil {
+			t.Fatal("post to generic endpoint failed:", err)
+		} else if resp.StatusCode/100 != 2 {
+			t.Fatal("non-2xx response:", resp.Status)
+		}
+		resp.Body.Close()
+	}
+
+	createAndClose := func(i int) {
+		t.Helper()
+		summary := fmt.Sprintf("hello-%d-", i)
+		createAlert(summary)
+		h.FastForward(1 * time.Minute)
+		h.FastForward(1 * time.Minute)
+		h.FastForward(1 * time.Minute)
+		h.Twilio(t).Device(h.Phone("1")).ExpectSMS(summary).ThenReply("c").ThenExpect("closed")
+		h.Twilio(t).Device(h.Phone("1")).IgnoreUnexpectedSMS(summary)
+		h.FastForward(20 * time.Minute)
+	}
+
+	for i := 0; i < 20; i++ {
+		createAndClose(i)
+	}
+
+}

--- a/smoketest/manyalerts_test.go
+++ b/smoketest/manyalerts_test.go
@@ -79,7 +79,7 @@ func TestManyAlerts(t *testing.T) {
 		h.FastForward(20 * time.Minute)
 	}
 
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 8; i++ {
 		createAndClose(i)
 	}
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes an issue where messages can be throttled too aggressively.

In `engine/message/throttle.go` the timestamp of the first message within the window for the current rule is used to derive the location in a sliding time-window. It assumed messages were always recorded in order, however, sent messages originate from a map iteration during each engine cycle, which randomizes the order. This caused the calculations to be off when there had been messages over a longer period of time (e.g. an alert every 20 minutes).

This PR adds a unit test for the configured rate limits in `ratelimit_test.go`, as well as a unit test and smoketest that exercises the bug and fix.

Additionally, it was identified that in rare circumstances a message could be counted twice (though only for a single cycle) and that has been corrected by de-duplicating all sent messages via the map before adding to the result list in `currentQueue()` in `engine/message/db.go`.

The fix for the delay bug is to replace the `first` timestamp if the `SentAt` value of the current message is before than the existing value.

This can be validated by reverting the change in `throttle.go` and running the unit test in `throttle_test.go` and/or the `manyalerts_test.go` smoketest.

