### PR TITLE
engine/message: dedup identical alert notifications

### DIFF
--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -311,9 +311,9 @@ func NewDB(ctx context.Context, db *sql.DB, a alertlog.Store, pausable lifecycle
 			set
 				last_status = 'bundled',
 				last_status_at = now(),
-				status_details = (select id from new_msg),
+				status_details = $1,
 				cycle_id = null
-			where id = any($1::uuid[])
+			where id = any($2::uuid[])
 		`),
 
 		messages: p.P(`
@@ -473,7 +473,7 @@ func (db *DB) currentQueue(ctx context.Context, tx *sql.Tx, now time.Time) (*que
 				return err
 			}
 
-			_, err = tx.StmtContext(ctx, db.bundleMessages).ExecContext(ctx, sqlutil.UUIDArray(ids))
+			_, err = tx.StmtContext(ctx, db.bundleMessages).ExecContext(ctx, msg.ID, sqlutil.UUIDArray(ids))
 			return err
 		})
 		if err != nil {

--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -60,7 +60,8 @@ type DB struct {
 	advLock        *sql.Stmt
 	advLockCleanup *sql.Stmt
 
-	insertAlertBundle *sql.Stmt
+	createAlertBundle *sql.Stmt
+	bundleMessages    *sql.Stmt
 
 	deleteAny *sql.Stmt
 
@@ -291,27 +292,28 @@ func NewDB(ctx context.Context, db *sql.DB, a alertlog.Store, pausable lifecycle
 			returning msg.id as msg_id, alert_id, msg.user_id, cm.id as cm_id
 		`),
 
-		insertAlertBundle: p.P(`
-			with new_msg as (
-				insert into outgoing_messages (
-					id,
-					created_at,
-					message_type,
-					contact_method_id,
-					channel_id,
-					user_id,
-					service_id
-				) values (
-					$1, $2, 'alert_notification_bundle', $3, $4, $5, $6
-				) returning (id)
+		createAlertBundle: p.P(`
+			insert into outgoing_messages (
+				id,
+				created_at,
+				message_type,
+				contact_method_id,
+				channel_id,
+				user_id,
+				service_id
+			) values (
+				$1, $2, 'alert_notification_bundle', $3, $4, $5, $6
 			)
+		`),
+
+		bundleMessages: p.P(`
 			update outgoing_messages
 			set
 				last_status = 'bundled',
 				last_status_at = now(),
 				status_details = (select id from new_msg),
 				cycle_id = null
-			where id = any($7::uuid[])
+			where id = any($1::uuid[])
 		`),
 
 		messages: p.P(`
@@ -444,6 +446,14 @@ func (db *DB) currentQueue(ctx context.Context, tx *sql.Tx, now time.Time) (*que
 		}
 	}
 
+	result, err = dedupAlerts(result, func(parentID string, duplicateIDs []string) error {
+		_, err = tx.StmtContext(ctx, db.bundleMessages).ExecContext(ctx, parentID, sqlutil.UUIDArray(duplicateIDs))
+		return fmt.Errorf("bundle '%v' by pointing to '%s': %w", duplicateIDs, parentID, err)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("dedup alerts: %w", err)
+	}
+
 	if cfg.General.MessageBundles {
 		result, err = bundleAlertMessages(result, func(msg Message, ids []string) error {
 			var cmID, chanID, userID sql.NullString
@@ -458,7 +468,12 @@ func (db *DB) currentQueue(ctx context.Context, tx *sql.Tx, now time.Time) (*que
 				chanID.Valid = true
 				chanID.String = msg.Dest.ID
 			}
-			_, err := tx.StmtContext(ctx, db.insertAlertBundle).ExecContext(ctx, msg.ID, msg.CreatedAt, cmID, chanID, userID, msg.ServiceID, sqlutil.UUIDArray(ids))
+			_, err := tx.StmtContext(ctx, db.createAlertBundle).ExecContext(ctx, msg.ID, msg.CreatedAt, cmID, chanID, userID, msg.ServiceID)
+			if err != nil {
+				return err
+			}
+
+			_, err = tx.StmtContext(ctx, db.bundleMessages).ExecContext(ctx, sqlutil.UUIDArray(ids))
 			return err
 		})
 		if err != nil {

--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -448,7 +448,11 @@ func (db *DB) currentQueue(ctx context.Context, tx *sql.Tx, now time.Time) (*que
 
 	result, err = dedupAlerts(result, func(parentID string, duplicateIDs []string) error {
 		_, err = tx.StmtContext(ctx, db.bundleMessages).ExecContext(ctx, parentID, sqlutil.UUIDArray(duplicateIDs))
-		return fmt.Errorf("bundle '%v' by pointing to '%s': %w", duplicateIDs, parentID, err)
+		if err != nil {
+			return fmt.Errorf("bundle '%v' by pointing to '%s': %w", duplicateIDs, parentID, err)
+		}
+
+		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("dedup alerts: %w", err)

--- a/engine/message/dedupalerts.go
+++ b/engine/message/dedupalerts.go
@@ -1,0 +1,63 @@
+package message
+
+import (
+	"sort"
+
+	"github.com/target/goalert/notification"
+)
+
+// dedupAlerts will "bundle" identical alert notifications and point them at the oldest pending notification.
+func dedupAlerts(msgs []Message, bundleFunc func(parentID string, duplicateIDs []string) error) ([]Message, error) {
+	if len(msgs) == 0 {
+		return msgs, nil
+	}
+
+	sort.Slice(msgs, func(i, j int) bool {
+		// if AlertID is the same, then sort by CreatedAt
+		if msgs[i].AlertID == msgs[j].AlertID {
+			return msgs[i].CreatedAt.Before(msgs[j].CreatedAt)
+		}
+		return msgs[i].AlertID < msgs[j].AlertID
+	})
+
+	type msgKey struct {
+		notification.Dest
+		AlertID int
+	}
+	alerts := make(map[msgKey]string, len(msgs))
+	duplicates := make(map[string][]string)
+
+	filtered := msgs[:0]
+	for _, msg := range msgs {
+		if msg.Type != notification.MessageTypeAlert {
+			// skip non-alert messages
+			filtered = append(filtered, msg)
+			continue
+		}
+		if !msg.SentAt.IsZero() {
+			// skip sent messages
+			filtered = append(filtered, msg)
+			continue
+		}
+
+		// check if we have seen this alert before
+		key := msgKey{msg.Dest, msg.AlertID}
+
+		if parentID, ok := alerts[key]; ok {
+			duplicates[parentID] = append(duplicates[parentID], msg.ID)
+			continue
+		}
+
+		alerts[key] = msg.ID
+		filtered = append(filtered, msg)
+	}
+
+	for parentID, duplicateIDs := range duplicates {
+		err := bundleFunc(parentID, duplicateIDs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return filtered, nil
+}

--- a/engine/message/dedupalerts_test.go
+++ b/engine/message/dedupalerts_test.go
@@ -1,0 +1,42 @@
+package message
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/target/goalert/notification"
+)
+
+func TestDedupAlerts(t *testing.T) {
+	messages := []Message{
+		{ID: "1", Type: notification.MessageTypeTest},
+		{ID: "2", Type: notification.MessageTypeAlertBundle},
+		{ID: "3", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 11, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "foo"}}, // duplicates 4 (same dest and alert, but newer)
+		{ID: "4", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 10, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "foo"}},
+		{ID: "5", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 12, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "foo"}}, // duplicates 4 (same dest and alert, but newer)
+		{ID: "6", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 9, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "bar"}},
+		{ID: "7", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 13, 0, 0, 0, time.UTC), AlertID: 2, Dest: notification.Dest{ID: "foo"}},
+	}
+
+	res, err := dedupAlerts(messages, func(parentID string, duplicates []string) error {
+		assert.Equal(t, "4", parentID)
+		sort.Strings(duplicates)
+		assert.EqualValues(t, []string{"3", "5"}, duplicates)
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Len(t, res, 5)
+	sort.Slice(res, func(i, j int) bool { return res[i].ID < res[j].ID })
+
+	assert.EqualValues(t,
+		[]Message{
+			{ID: "1", Type: notification.MessageTypeTest},
+			{ID: "2", Type: notification.MessageTypeAlertBundle},
+			{ID: "4", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 10, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "foo"}},
+			{ID: "6", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 9, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "bar"}},
+			{ID: "7", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 13, 0, 0, 0, time.UTC), AlertID: 2, Dest: notification.Dest{ID: "foo"}},
+		},
+		res)
+}

--- a/smoketest/escalationnotification_test.go
+++ b/smoketest/escalationnotification_test.go
@@ -62,8 +62,7 @@ func TestEscalationNotification(t *testing.T) {
 
 	h.FastForward(30 * time.Minute) // ensure both rules have elapsed
 
-	// 1 sms from the first step, 1 from the escalated one
-	d1.ExpectSMS("testing")
+	// 1 sms from the first step, 1 from the escalated one, should be de-duplicated
 	d1.ExpectSMS("testing")
 
 	h.Escalate(1, 1)


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
If multiple notifications are pending for the same destination (e.g. SMS/number combo) and alert ID, only the oldest message will be sent instead of duplicates.

Additionally, this resolves an issue with message bundling where multiple notifications for a single alert could cause a "bundle" to be sent -- which is intended for situations when more than one alert is unacknowledged for a service at a time.
