### PR TITLE
ui/materialUI justify->justifyContent

### DIFF
--- a/web/src/app/admin/AdminConfig.tsx
+++ b/web/src/app/admin/AdminConfig.tsx
@@ -136,7 +136,7 @@ export default function AdminConfig(): JSX.Element {
 
   return (
     <Grid container spacing={2}>
-      <Grid item xs={12} container justify='flex-end'>
+      <Grid item xs={12} container justifyContent='flex-end'>
         <ButtonGroup color='primary' variant='outlined'>
           <Button
             data-cy='reset'

--- a/web/src/app/lists/ControlledPaginatedList.tsx
+++ b/web/src/app/lists/ControlledPaginatedList.tsx
@@ -251,7 +251,13 @@ export default function ControlledPaginatedList(
 
   return (
     <React.Fragment>
-      <Grid container item xs={12} justify='flex-end' alignItems='center'>
+      <Grid
+        container
+        item
+        xs={12}
+        justifyContent='flex-end'
+        alignItems='center'
+      >
         {renderActions()}
         {secondaryActions}
         {!noSearch && (

--- a/web/src/app/lists/PaginatedList.tsx
+++ b/web/src/app/lists/PaginatedList.tsx
@@ -80,7 +80,7 @@ function PageControls(props: {
       xs={12}
       container // container for control items
       spacing={1}
-      justify='flex-end'
+      justifyContent='flex-end'
       alignItems='center'
       className={classes.controls}
     >

--- a/web/src/app/main/App.js
+++ b/web/src/app/main/App.js
@@ -115,7 +115,7 @@ export default function App() {
               <LazyNewUserSetup />
               <Grid
                 container
-                justify='center'
+                justifyContent='center'
                 className={classes.mainContainer}
               >
                 <Grid className={classes.containerClass} item>

--- a/web/src/app/rotations/RotationForm.js
+++ b/web/src/app/rotations/RotationForm.js
@@ -149,7 +149,7 @@ export default function RotationForm(props) {
         </Grid>
         {localZone !== value.timeZone && (
           <Grid item xs={6} className={classes.tzContainer}>
-            <Grid container justify='center'>
+            <Grid container justifyContent='center'>
               <FormControlLabel
                 control={
                   <Switch

--- a/web/src/app/schedules/CalendarToolbar.tsx
+++ b/web/src/app/schedules/CalendarToolbar.tsx
@@ -125,7 +125,7 @@ function CalendarToolbar(props: CalendarToolbarProps): JSX.Element {
       container
       spacing={2}
       className={classes.container}
-      justify='space-between'
+      justifyContent='space-between'
       alignItems='center'
     >
       <Grid item>
@@ -163,7 +163,7 @@ function CalendarToolbar(props: CalendarToolbarProps): JSX.Element {
       </Grid>
 
       <Grid item>
-        <Grid container alignItems='center' justify='flex-end'>
+        <Grid container alignItems='center' justifyContent='flex-end'>
           {props.filter}
           <ButtonGroup
             color='primary'

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsForm.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsForm.tsx
@@ -100,7 +100,7 @@ export default function ScheduleOnCallNotificationsForm(
               />
             </Grid>
             <Grid item xs={12} sm={7} md={8}>
-              <Grid container justify='space-between'>
+              <Grid container justifyContent='space-between'>
                 {days.map((day, i) => (
                   <FormControlLabel
                     key={i}

--- a/web/src/app/users/UserSessionList.tsx
+++ b/web/src/app/users/UserSessionList.tsx
@@ -120,7 +120,7 @@ export default function UserSessionList(
     <React.Fragment>
       <Grid container spacing={2}>
         {!userID && (
-          <Grid item xs={12} container justify='flex-end'>
+          <Grid item xs={12} container justifyContent='flex-end'>
             <Button
               color='primary'
               variant='outlined'


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**

Resolves task :
- The prop `justify` of `ForwardRef(Grid)` is deprecated. Use `justifyContent` instead, the prop was renamed. 
...from 'remove material-ui deprecation warnings' #1762

**Which issue(s) this PR fixes:**
Resolves a portion of 'remove material-ui deprecation warnings' #1762.

**Out of Scope:**
Other errors related to material ui v5 will be address in separate PRs

**Screenshots:**
N/A

**Describe any introduced user-facing changes:**
N/A

**Describe any introduced API changes:**
N/A

**Additional Info:**
Error regarding 'justify content' no longer present
