### PR TITLE
authtoken: add 0-length check to Parse

### DIFF
--- a/auth/authtoken/parse.go
+++ b/auth/authtoken/parse.go
@@ -19,6 +19,10 @@ func alwaysValid(Type, []byte, []byte) (bool, bool) { return true, false }
 // Parse will parse a token string, optionally verifying it's signature.
 // If verifyFn is nil, the signature is ignored.
 func Parse(s string, verifyFn VerifyFunc) (*Token, bool, error) {
+	if len(s) == 0 {
+		return nil, false, validation.NewGenericError("invalid length")
+	}
+
 	if len(s) == 36 {
 		// integration key type is the only one with possible length 36. Session keys, even if
 		// we switched to a 128-bit signature would be a minimum of 38 base64-encoded chars.


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Adds a 0-length check to the `auth/authtoken.Parse` function to prevent a possible panic found during fuzz-testing.