### PR TITLE
ui/materialUI createMuiTheme -> createTheme

### DIFF
--- a/web/src/app/mui.js
+++ b/web/src/app/mui.js
@@ -1,4 +1,4 @@
-import { createMuiTheme } from '@material-ui/core/styles'
+import { createTheme } from '@material-ui/core/styles'
 import grey from '@material-ui/core/colors/grey'
 import red from '@material-ui/core/colors/red'
 import { isCypress } from './env'
@@ -13,7 +13,7 @@ if (isCypress) {
   }
 }
 
-export const theme = createMuiTheme({
+export const theme = createTheme({
   palette: {
     primary: {
       ...grey,


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**

Resolves task :
- createMuiTheme function was renamed to createTheme
...from  #1762

**Which issue(s) this PR fixes:**
Resolves a portion of 'remove material-ui deprecation warnings' #1762.

**Out of Scope:**
Other errors related to material ui v5 will be addressed in separate PRs

**Screenshots:**
N/A

**Describe any introduced user-facing changes:**
N/A

**Describe any introduced API changes:**
N/A

**Additional Info:**
Error regarding 'createMuiTheme' no longer present