### PR TITLE
migrate: only insert non-null values for status update migration

### DIFF
--- a/migrate/migrations/20210623104111-alert-status-subscriptions.sql
+++ b/migrate/migrations/20210623104111-alert-status-subscriptions.sql
@@ -22,7 +22,7 @@ SELECT
         ELSE 'triggered'::enum_alert_status
     END
 FROM user_last_alert_log
-JOIN users u ON u.id = user_id
+JOIN users u ON u.id = user_id AND u.alert_status_log_contact_method_id NOTNULL
 JOIN alert_logs l ON l.id = log_id AND l.event != 'closed';
 
 DROP TABLE user_last_alert_log;


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes an issue that prevents migrate-up from finishing when `user_last_alert_log` contains an entry for a user who has status updates disabled.
