### PR TITLE
engine/message: don't dedup sent messages

### DIFF
--- a/engine/message/dedupalerts_test.go
+++ b/engine/message/dedupalerts_test.go
@@ -16,8 +16,11 @@ func TestDedupAlerts(t *testing.T) {
 		{ID: "3", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 11, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "foo"}}, // duplicates 4 (same dest and alert, but newer)
 		{ID: "4", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 10, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "foo"}},
 		{ID: "5", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 12, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "foo"}}, // duplicates 4 (same dest and alert, but newer)
-		{ID: "6", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 9, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "bar"}},
-		{ID: "7", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 13, 0, 0, 0, time.UTC), AlertID: 2, Dest: notification.Dest{ID: "foo"}},
+
+		{ID: "6", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 8, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "bar"}, SentAt: time.Unix(1, 0)}, // duplicates 7 but sent already
+
+		{ID: "7", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 9, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "bar"}},
+		{ID: "8", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 13, 0, 0, 0, time.UTC), AlertID: 2, Dest: notification.Dest{ID: "foo"}},
 	}
 
 	res, err := dedupAlerts(messages, func(parentID string, duplicates []string) error {
@@ -27,16 +30,16 @@ func TestDedupAlerts(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-	assert.Len(t, res, 5)
-	sort.Slice(res, func(i, j int) bool { return res[i].ID < res[j].ID })
+	assert.Len(t, res, 6)
 
-	assert.EqualValues(t,
+	assert.ElementsMatch(t,
 		[]Message{
 			{ID: "1", Type: notification.MessageTypeTest},
 			{ID: "2", Type: notification.MessageTypeAlertBundle},
 			{ID: "4", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 10, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "foo"}},
-			{ID: "6", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 9, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "bar"}},
-			{ID: "7", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 13, 0, 0, 0, time.UTC), AlertID: 2, Dest: notification.Dest{ID: "foo"}},
+			{ID: "7", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 9, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "bar"}},
+			{ID: "8", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 13, 0, 0, 0, time.UTC), AlertID: 2, Dest: notification.Dest{ID: "foo"}},
+			{ID: "6", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 8, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "bar"}, SentAt: time.Unix(1, 0)},
 		},
 		res)
 }

--- a/engine/message/dedupconcallnotifications_test.go
+++ b/engine/message/dedupconcallnotifications_test.go
@@ -43,5 +43,5 @@ func TestDedupOnCallNotifications(t *testing.T) {
 	for _, m := range out {
 		ids = append(ids, m.ID)
 	}
-	assert.Equal(t, []string{"b", "d", "a"}, ids)
+	assert.Equal(t, []string{"a", "b", "d"}, ids)
 }

--- a/engine/message/deduponcallnotifications.go
+++ b/engine/message/deduponcallnotifications.go
@@ -8,7 +8,8 @@ import (
 
 // dedupOnCallNotifications will remove old on-call notifications if a newer one exists for the same schedule & destination.
 func dedupOnCallNotifications(messages []Message) ([]Message, []string) {
-	sort.Slice(messages, func(i, j int) bool { return messages[i].CreatedAt.After(messages[j].CreatedAt) })
+	toProcess, result := splitPendingByType(messages, notification.MessageTypeScheduleOnCallUsers)
+	sort.Slice(toProcess, func(i, j int) bool { return toProcess[i].CreatedAt.After(toProcess[j].CreatedAt) })
 
 	type msgKey struct {
 		scheduleID string
@@ -17,12 +18,7 @@ func dedupOnCallNotifications(messages []Message) ([]Message, []string) {
 
 	m := make(map[msgKey]struct{})
 	var toDelete []string
-	filter := messages[:0]
-	for _, msg := range messages {
-		if msg.Type != notification.MessageTypeScheduleOnCallUsers {
-			filter = append(filter, msg)
-			continue
-		}
+	for _, msg := range toProcess {
 		key := msgKey{scheduleID: msg.ScheduleID, dest: msg.Dest}
 		if _, ok := m[key]; ok {
 			toDelete = append(toDelete, msg.ID)
@@ -30,8 +26,8 @@ func dedupOnCallNotifications(messages []Message) ([]Message, []string) {
 		}
 
 		m[key] = struct{}{}
-		filter = append(filter, msg)
+		result = append(result, msg)
 	}
 
-	return filter, toDelete
+	return result, toDelete
 }

--- a/engine/message/dedupstatusmessages_test.go
+++ b/engine/message/dedupstatusmessages_test.go
@@ -43,14 +43,32 @@ func TestDedupStatusMessages(t *testing.T) {
 			UserID:     "User A",
 			CreatedAt:  n.Add(time.Hour),
 		},
+		{
+			ID:         "e",
+			AlertLogID: 4,
+			AlertID:    4,
+			Type:       notification.MessageTypeAlertStatus,
+			UserID:     "User A",
+			CreatedAt:  n.Add(time.Hour),
+			SentAt:     n,
+		},
 	}
 
 	out, toDelete := dedupStatusMessages(msg)
-	assert.Len(t, out, 3, "output messages")
+	assert.Len(t, out, 4, "output messages")
 	assert.Len(t, toDelete, 1, "to delete")
 	assert.Equal(t, []string{"d"}, toDelete)
 
 	assert.Equal(t, []Message{
+		{
+			ID:         "e",
+			AlertLogID: 4,
+			AlertID:    4,
+			Type:       notification.MessageTypeAlertStatus,
+			UserID:     "User A",
+			CreatedAt:  n.Add(time.Hour),
+			SentAt:     n,
+		},
 		{
 			ID:         "b",
 			AlertLogID: 7,

--- a/engine/message/splitpendingbytype.go
+++ b/engine/message/splitpendingbytype.go
@@ -1,0 +1,31 @@
+package message
+
+import (
+	"github.com/target/goalert/notification"
+)
+
+// splitPendingByType will split a list of messages returning only unsent and matching at least one of the provided
+// types. Any sent or non-type-matching messages will be returned in the remainder.
+func splitPendingByType(messages []Message, types ...notification.MessageType) (matching, remainder []Message) {
+mainLoop:
+	for _, msg := range messages {
+		if !msg.SentAt.IsZero() {
+			remainder = append(remainder, msg)
+			continue
+		}
+
+		for _, t := range types {
+			if msg.Type != t {
+				continue
+			}
+
+			matching = append(matching, msg)
+			continue mainLoop
+		}
+
+		// doesn't match any specified types, keep it
+		remainder = append(remainder, msg)
+	}
+
+	return matching, remainder
+}

--- a/engine/message/splitpendingbytype_test.go
+++ b/engine/message/splitpendingbytype_test.go
@@ -1,0 +1,29 @@
+package message
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/target/goalert/notification"
+)
+
+func TestSplitPendingByType(t *testing.T) {
+	msgs := []Message{
+		{SentAt: time.Unix(1, 0), Type: notification.MessageTypeAlert},
+		{Type: notification.MessageTypeAlertBundle},
+		{Type: notification.MessageTypeAlert},
+		{Type: notification.MessageTypeTest},
+	}
+
+	match, remainder := splitPendingByType(msgs, notification.MessageTypeAlertBundle, notification.MessageTypeTest)
+	assert.ElementsMatch(t, []Message{
+		{Type: notification.MessageTypeAlertBundle},
+		{Type: notification.MessageTypeTest},
+	}, match)
+	assert.ElementsMatch(t, []Message{
+		{SentAt: time.Unix(1, 0), Type: notification.MessageTypeAlert},
+		{Type: notification.MessageTypeAlert},
+	}, remainder)
+
+}

--- a/smoketest/oncallnotify_test.go
+++ b/smoketest/oncallnotify_test.go
@@ -3,6 +3,7 @@ package smoketest
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -43,6 +44,8 @@ func TestOnCallNotify(t *testing.T) {
 	defer h.Close()
 
 	h.Slack().Channel("test").ExpectMessage("on-call", "testschedule", "bob")
+
+	h.FastForward(time.Hour)
 
 	ctx := permission.SystemContext(context.Background(), "Test")
 	_, err := h.App().ScheduleRuleStore.CreateRuleTx(ctx, nil, &rule.Rule{


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes a bug where some messages would be "de-duplicated" even after being sent (rather than only for `pending` messages)

A helper function that handles splitting messages by type and sent status was added and applied to the dedup and bundle methods.