### PR TITLE
ui/temporary schedules: adjust add button placement and header text

### DIFF
--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
@@ -184,7 +184,7 @@ export default function TempSchedAddShiftsStep({
           </Grid>
           <Grid item>
             <DialogContentText className={classes.contentText}>
-              The schedule will be exactly as configured on this step for the
+              The schedule will be exactly as configured here for the
               entire duration (ignoring all assignments and overrides).
             </DialogContentText>
           </Grid>

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
@@ -6,6 +6,7 @@ import {
   Typography,
   makeStyles,
 } from '@material-ui/core'
+import ArrowRightAltIcon from '@material-ui/icons/ArrowRightAlt'
 import { contentText, Shift, StepContainer } from './sharedUtils'
 import { FormContainer } from '../../forms'
 import _ from 'lodash'
@@ -207,6 +208,7 @@ export default function TempSchedAddShiftsStep({
               variant='contained'
               fullWidth
               onClick={handleAddShift}
+              endIcon={<ArrowRightAltIcon />}
             >
               Add Shift
             </Button>

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
@@ -184,8 +184,8 @@ export default function TempSchedAddShiftsStep({
           </Grid>
           <Grid item>
             <DialogContentText className={classes.contentText}>
-              The schedule will be exactly as configured here for the
-              entire duration (ignoring all assignments and overrides).
+              The schedule will be exactly as configured here for the entire
+              duration (ignoring all assignments and overrides).
             </DialogContentText>
           </Grid>
           <Grid item>

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect, useState } from 'react'
 import {
+  Button,
   DialogContentText,
-  Fab,
   Grid,
   Typography,
   makeStyles,
 } from '@material-ui/core'
-import { Add as AddIcon } from '@material-ui/icons'
 import { contentText, Shift, StepContainer } from './sharedUtils'
 import { FormContainer } from '../../forms'
 import _ from 'lodash'
@@ -19,14 +18,6 @@ import { isISOAfter } from '../../util/shifts'
 
 const useStyles = makeStyles((theme) => ({
   contentText,
-  addButton: {
-    boxShadow: 'none',
-  },
-  addButtonContainer: {
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
   avatar: {
     backgroundColor: theme.palette.primary.main,
   },
@@ -43,6 +34,7 @@ const useStyles = makeStyles((theme) => ({
   },
   shiftFormContainer: {
     maxHeight: '100%',
+    paddingRight: '2rem',
   },
 }))
 
@@ -177,7 +169,7 @@ export default function TempSchedAddShiftsStep({
         {/* title + fields container */}
         <Grid
           item
-          xs={5}
+          xs={6}
           container
           spacing={2}
           direction='column'
@@ -191,8 +183,8 @@ export default function TempSchedAddShiftsStep({
           </Grid>
           <Grid item>
             <DialogContentText className={classes.contentText}>
-              The schedule will be exactly as configured here for the entire
-              duration (ignoring all rules/overrides).
+              The schedule will be exactly as configured on this step for the
+              entire duration (ignoring all assignments and overrides).
             </DialogContentText>
           </Grid>
           <Grid item>
@@ -208,25 +200,20 @@ export default function TempSchedAddShiftsStep({
           >
             <TempSchedAddShiftForm min={edit ? start : undefined} />
           </FormContainer>
-        </Grid>
-
-        {/* add button container */}
-        <Grid item xs={2} className={classes.addButtonContainer}>
-          <Fab
-            className={classes.addButton}
-            aria-label='Add Shift'
-            title='Add Shift'
-            onClick={handleAddShift}
-            size='medium'
-            color='primary'
-            type='button'
-          >
-            <AddIcon />
-          </Fab>
+          <Grid item>
+            <Button
+              color='secondary'
+              variant='contained'
+              fullWidth
+              onClick={handleAddShift}
+            >
+              Add Shift
+            </Button>
+          </Grid>
         </Grid>
 
         {/* shifts list container */}
-        <Grid item xs={5} className={classes.listOuterContainer}>
+        <Grid item xs={6} className={classes.listOuterContainer}>
           <div className={classes.listInnerContainer}>
             <TempSchedShiftsList
               value={value}

--- a/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddShiftsStep.tsx
@@ -202,6 +202,7 @@ export default function TempSchedAddShiftsStep({
           </FormContainer>
           <Grid item>
             <Button
+              data-cy='add-shift'
               color='secondary'
               variant='contained'
               fullWidth

--- a/web/src/cypress/integration/temporarySchedule.ts
+++ b/web/src/cypress/integration/temporarySchedule.ts
@@ -141,7 +141,7 @@ function testTemporarySchedule(screen: string): void {
     cy.get(addShiftsSelector).should('be.visible.and.contain', 'STEP 2 OF 2')
     cy.dialogForm({ userID: manualAddUser.name }, addShiftsSelector)
     cy.get('[data-cy="shifts-list"]').should('not.contain', manualAddUser.name)
-    cy.get('button[title="Add Shift"]').click()
+    cy.get('button[data-cy="add-shift"]').click()
     cy.get('[data-cy="shifts-list"]').should('contain', manualAddUser.name)
     cy.dialogFinish('Submit')
     cy.visit('/schedules/' + schedule.id + '?start=' + start.toISO())
@@ -186,7 +186,7 @@ function testTemporarySchedule(screen: string): void {
         'not.contain',
         manualAddUser.name,
       )
-      cy.get('button[title="Add Shift"]').click()
+      cy.get('button[data-cy="add-shift"]').click()
       cy.get('[data-cy="shifts-list"]').should('contain', manualAddUser.name)
       cy.dialogFinish('Submit')
       cy.reload() // ensure calendar update
@@ -230,7 +230,7 @@ function testTemporarySchedule(screen: string): void {
       addShiftsSelector,
     )
     cy.get('[data-cy="shifts-list"]').should('not.contain', manualAddUser.name)
-    cy.get('button[title="Add Shift"]').click()
+    cy.get('button[data-cy="add-shift"]').click()
     cy.get('[data-cy="shifts-list"]').should('contain', manualAddUser.name)
     cy.dialogForm(
       {
@@ -239,7 +239,7 @@ function testTemporarySchedule(screen: string): void {
       addShiftsSelector,
     )
     cy.get('[data-cy="shifts-list"]').should('not.contain', graphQLAddUser.name)
-    cy.get('button[title="Add Shift"]').click()
+    cy.get('button[data-cy="add-shift"]').click()
     cy.get('[data-cy="shifts-list"]').should('contain', graphQLAddUser.name)
     cy.get('[data-cy="shifts-list"]').should('contain', manualAddUser.name)
   })


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Users have reported that the temporary schedule form can be confusing- especially when they only need to add one user as the add and submit buttons appear to do the same thing.

It was suggested that the submit button be disabled until at least one shift has been added, but currently we can't allow this as an empty Temporary Schedule is an acceptable way to block off time where nobody is on-call (for whatever reason).

**Screenshots:**
<img width="1349" alt="Screen Shot 2021-07-26 at 12 30 49 PM" src="https://user-images.githubusercontent.com/11381794/127047553-fefede9d-5a43-4bac-bb7f-2f848fb6a262.png">

**Describe any introduced user-facing changes:**
- Add shift fab removed from the middle
- Add shift text button added under shift fields
- Step 2 text adjusted

**Additional Info:**
The button renders as dark grey as that is what our secondary color in the theme is currently set to. I chose to use the secondary color to avoid adding tech debt for when we transition to use a proper theme.
