### PR TITLE
ui/wizard: remove usage of forceUpdate

### DIFF
--- a/web/src/app/wizard/WizardForm.js
+++ b/web/src/app/wizard/WizardForm.js
@@ -15,7 +15,7 @@ import { value as valuePropType } from './propTypes'
 import withStyles from '@material-ui/core/styles/withStyles'
 import withWidth, { isWidthDown } from '@material-ui/core/withWidth'
 import MaterialSelect from '../selection/MaterialSelect'
-import { set } from 'lodash'
+import * as _ from 'lodash'
 
 const styles = {
   fieldItem: {
@@ -42,8 +42,9 @@ export default class WizardForm extends React.PureComponent {
 
   handleSecondaryScheduleToggle = (e) => {
     const { onChange, value } = this.props
-    onChange(set(value, ['secondarySchedule', 'enable'], e.target.value))
-    this.forceUpdate()
+    const newVal = _.cloneDeep(value)
+    newVal.secondarySchedule.enable = e.target.value
+    onChange(newVal)
   }
 
   sectionHeading = (text) => {

--- a/web/src/app/wizard/WizardScheduleForm.js
+++ b/web/src/app/wizard/WizardScheduleForm.js
@@ -14,7 +14,7 @@ import InfoIcon from '@material-ui/icons/Info'
 import { TimeZoneSelect, UserSelect } from '../selection'
 import { FormField } from '../forms'
 import { value as valuePropType } from './propTypes'
-import { set } from 'lodash'
+import * as _ from 'lodash'
 import { ISODateTimePicker } from '../util/ISOPickers'
 
 const styles = {
@@ -50,20 +50,16 @@ export default class WizardScheduleForm extends React.Component {
 
   handleRotationTypeChange = (e) => {
     const { onChange, value } = this.props
-    onChange(set(value, [this.getKey(), 'rotation', 'type'], e.target.value))
-    this.forceUpdate()
+    const newVal = _.cloneDeep(value)
+    newVal[this.getKey()].rotation.type = e.target.value
+    onChange(newVal)
   }
 
   handleFollowTheSunToggle = (e) => {
     const { onChange, value } = this.props
-    onChange(
-      set(
-        value,
-        [this.getKey(), 'followTheSunRotation', 'enable'],
-        e.target.value,
-      ),
-    )
-    this.forceUpdate()
+    const newVal = _.cloneDeep(value)
+    newVal[this.getKey()].followTheSunRotation.enable = e.target.value
+    onChange(newVal)
   }
 
   /*


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [ ] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR refactors a few instances where props were being mutated and `this.forceUpdate` was being called as a work around. The fix uses lodash's `deepClone` to create a mutable form value object.

**Which issue(s) this PR fixes:**
This PR unblocks a couple of hooks conversions since there is no analog for `forceUpdate` in the functional paradigm. 
e.g. #1791 #1689
