### PR TITLE
ui/mui onExited of ForwardRef(Dialog) is deprecated

### DIFF
--- a/web/src/app/alerts/components/UpdateAlertsSnackbar.js
+++ b/web/src/app/alerts/components/UpdateAlertsSnackbar.js
@@ -68,8 +68,9 @@ function UpdateAlertsSnackbar({
       autoHideDuration={!errorMessage ? 3000 : null}
       open={open}
       onClose={onClose}
-      onExited={onExited}
-    >
+      TransitionProps={{
+        onExited
+      }}>
       <SnackbarContent
         className={errorMessage ? classes.error : classes.success}
         message={getMessage()}

--- a/web/src/app/alerts/components/UpdateAlertsSnackbar.js
+++ b/web/src/app/alerts/components/UpdateAlertsSnackbar.js
@@ -69,8 +69,9 @@ function UpdateAlertsSnackbar({
       open={open}
       onClose={onClose}
       TransitionProps={{
-        onExited
-      }}>
+        onExited,
+      }}
+    >
       <SnackbarContent
         className={errorMessage ? classes.error : classes.success}
         message={getMessage()}

--- a/web/src/app/dialogs/FormDialog.js
+++ b/web/src/app/dialogs/FormDialog.js
@@ -159,8 +159,9 @@ function FormDialog(props) {
       }
       {...dialogProps}
       TransitionProps={{
-        onExited: handleOnExited
-      }}>
+        onExited: handleOnExited,
+      }}
+    >
       <Notices notices={notices} />
       <DialogTitleWrapper
         fullScreen={fs}

--- a/web/src/app/dialogs/FormDialog.js
+++ b/web/src/app/dialogs/FormDialog.js
@@ -157,9 +157,10 @@ function FormDialog(props) {
       TransitionComponent={
         isWideScreen || confirm ? FadeTransition : SlideTransition
       }
-      onExited={handleOnExited}
       {...dialogProps}
-    >
+      TransitionProps={{
+        onExited: handleOnExited
+      }}>
       <Notices notices={notices} />
       <DialogTitleWrapper
         fullScreen={fs}

--- a/web/src/app/util/Options.js
+++ b/web/src/app/util/Options.js
@@ -260,8 +260,9 @@ export default class Options extends Component {
         key='error-dialog'
         open={this.state.showErrorDialog}
         onClose={() => this.setState({ showErrorDialog: false })}
-        onExited={() => this.setState({ errorMessage: '' })}
-      >
+        TransitionProps={{
+          onExited: () => this.setState({ errorMessage: '' })
+        }}>
         <DialogTitleWrapper
           fullScreen={isWidthDown('md', this.props.width)}
           title='An error occurred'

--- a/web/src/app/util/Options.js
+++ b/web/src/app/util/Options.js
@@ -261,8 +261,9 @@ export default class Options extends Component {
         open={this.state.showErrorDialog}
         onClose={() => this.setState({ showErrorDialog: false })}
         TransitionProps={{
-          onExited: () => this.setState({ errorMessage: '' })
-        }}>
+          onExited: () => this.setState({ errorMessage: '' }),
+        }}
+      >
         <DialogTitleWrapper
           fullScreen={isWidthDown('md', this.props.width)}
           title='An error occurred'


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
The prop `onExited` of `ForwardRef(Dialog)` is deprecated. Use the `TransitionProps` prop instead.
...from ui: remove material-ui deprecation warnings #1762

**Which issue(s) this PR fixes:**
Resolves a portion of 'remove material-ui deprecation warnings' #1762.

**Out of Scope:**
Other errors related to material ui v5 will be addressed in separate PRs

**Screenshots:**
N/A

**Describe any introduced user-facing changes:**
N/A

**Describe any introduced API changes:**
N/A

**Additional Info:**
Error regarding 'onExited' no longer present
