### PR TITLE
dev: ignore javascript dependency patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       timezone: 'America/Chicago'
     open-pull-requests-limit: 3
     ignore:
+      # ignore all patch updates
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
       - dependency-name: '@date-io/luxon'
         versions:
           - '<=3.0.0'


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR ignores patch updates for all javascript dependencies based on their semver. Security updates are not ignored. Dependabot is a great tool, but the patches can get noisy and are often entirely ineffectual, such as a typo fix in documentation.

Also see: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#specifying-dependencies-and-versions-to-ignore