### PR TITLE
ui/mui remove onEscapeKeyDown

### DIFF
--- a/web/src/app/main/App.js
+++ b/web/src/app/main/App.js
@@ -100,7 +100,6 @@ export default function App() {
               open={showMobile}
               onOpen={() => setShowMobile(true)}
               onClose={() => setShowMobile(false)}
-              onEscapeKeyDown={() => setShowMobile(false)}
             >
               <LazySideBarDrawerList
                 closeMobileSidebar={() => setShowMobile(false)}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Addresses Material UI warning:
```The prop `onEscapeKeyDown` of `ForwardRef(Modal)` is deprecated. Use the onClose prop with the `reason` argument to handle the `escapeKeyDown` events.```
...from ui: remove material-ui deprecation warnings #1762
Current usage appears to be redundant. Removed line.

**Which issue(s) this PR fixes:**
Resolves a portion of 'remove material-ui deprecation warnings' #1762.

**Out of Scope:**
Other errors related to material ui v5 will be addressed in separate PRs

**Screenshots:**
N/A

**Describe any introduced user-facing changes:**
N/A

**Describe any introduced API changes:**
N/A

**Additional Info:**
Error regarding 'onEscapeKeyDown' no longer present
