### PR TITLE
ui/tech debt: update CopyText interface

### DIFF
--- a/web/src/app/admin/AdminConfig.tsx
+++ b/web/src/app/admin/AdminConfig.tsx
@@ -240,7 +240,7 @@ export default function AdminConfig(): JSX.Element {
                       InputProps={{
                         endAdornment: (
                           <InputAdornment position='end'>
-                            <CopyText value={h.value} placement='left' />
+                            <CopyText value={h.value} placement='left' asURL />
                           </InputAdornment>
                         ),
                       }}

--- a/web/src/app/admin/AdminNumberLookup.tsx
+++ b/web/src/app/admin/AdminNumberLookup.tsx
@@ -75,9 +75,7 @@ export default function AdminNumberLookup(): JSX.Element {
         <ListItem>
           <ListItemText
             primary={label}
-            secondary={
-              (text && <CopyText title={text} value={text} textOnly />) || '?'
-            }
+            secondary={(text && <CopyText title={text} value={text} />) || '?'}
           />
         </ListItem>
       </React.Fragment>

--- a/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertListItem.js
+++ b/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertListItem.js
@@ -44,7 +44,7 @@ export default function CreateAlertListItem(props) {
         </span>
 
         <span className={classes.endLinks}>
-          <CopyText value={alertURL} placement='left' />
+          <CopyText value={alertURL} placement='left' asURL />
           <AppLink to={alertURL} newTab className={classes.openInNewTab}>
             <OpenInNewIcon fontSize='small' />
           </AppLink>

--- a/web/src/app/schedules/calendar-subscribe/CalendarSuccessForm.js
+++ b/web/src/app/schedules/calendar-subscribe/CalendarSuccessForm.js
@@ -42,7 +42,12 @@ export default function CalenderSuccessForm(props) {
       </Grid>
       <Grid item xs={12}>
         <Typography>
-          <CopyText title={props.url} value={props.url} placement='bottom' />
+          <CopyText
+            title={props.url}
+            value={props.url}
+            placement='bottom'
+            asURL
+          />
         </Typography>
         <FormHelperText>
           Some applications require you copy and paste the URL directly

--- a/web/src/app/services/HeartbeatMonitorList.js
+++ b/web/src/app/services/HeartbeatMonitorList.js
@@ -78,7 +78,7 @@ export default function HeartbeatMonitorList(props) {
               monitor.timeoutMinutes > 1 ? 's' : ''
             }`}
             <br />
-            <CopyText title='Copy URL' value={monitor.href} />
+            <CopyText title='Copy URL' value={monitor.href} asURL />
           </React.Fragment>
         ),
         secondaryAction: (

--- a/web/src/app/services/IntegrationKeyList.js
+++ b/web/src/app/services/IntegrationKeyList.js
@@ -56,7 +56,9 @@ const sortItems = (a, b) => {
 }
 
 export function IntegrationKeyDetails(props) {
-  let copyText = <CopyText title={'Copy ' + props.label} value={props.href} />
+  let copyText = (
+    <CopyText title={'Copy ' + props.label} value={props.href} asURL />
+  )
 
   // if link is not properly present, do not display to copy
   if (props.type === 'email' && !props.href.startsWith('mailto:')) {

--- a/web/src/app/util/CopyText.tsx
+++ b/web/src/app/util/CopyText.tsx
@@ -11,6 +11,7 @@ const useStyles = makeStyles({
     display: 'flex',
     width: 'fit-content',
     wordBreak: 'break-all',
+    cursor: 'pointer',
   },
   icon: {
     paddingRight: 4,

--- a/web/src/app/util/CopyText.tsx
+++ b/web/src/app/util/CopyText.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
-import p from 'prop-types'
 import copyToClipboard from './copyToClipboard'
 import ContentCopy from 'mdi-material-ui/ContentCopy'
 import AppLink from './AppLink'
@@ -22,7 +21,7 @@ interface CopyTextProps {
   placement?: TooltipProps['placement']
   title?: string
   value: string
-  textOnly?: boolean
+  asURL?: boolean
 }
 
 export default function CopyText(props: CopyTextProps): JSX.Element {
@@ -30,28 +29,7 @@ export default function CopyText(props: CopyTextProps): JSX.Element {
   const [copied, setCopied] = useState(false)
 
   let content
-  if (props.textOnly) {
-    content = (
-      <span
-        role='button'
-        tabIndex={0}
-        onClick={() => {
-          copyToClipboard(props.value)
-          setCopied(true)
-        }}
-        onKeyPress={(e) => {
-          if (e.key !== 'Enter') {
-            return
-          }
-
-          copyToClipboard(props.value)
-          setCopied(true)
-        }}
-      >
-        {props.title}
-      </span>
-    )
-  } else {
+  if (props.asURL) {
     content = (
       <AppLink
         className={classes.copyContainer}
@@ -68,6 +46,33 @@ export default function CopyText(props: CopyTextProps): JSX.Element {
         {props.title}
       </AppLink>
     )
+  } else {
+    content = (
+      <span
+        className={classes.copyContainer}
+        role='button'
+        tabIndex={0}
+        onClick={() => {
+          copyToClipboard(props.value)
+          setCopied(true)
+        }}
+        onKeyPress={(e) => {
+          if (e.key !== 'Enter') {
+            return
+          }
+
+          copyToClipboard(props.value)
+          setCopied(true)
+        }}
+      >
+        <ContentCopy
+          color='secondary'
+          className={props.title ? classes.icon : undefined}
+          fontSize='small'
+        />
+        {props.title}
+      </span>
+    )
   }
 
   return (
@@ -79,10 +84,4 @@ export default function CopyText(props: CopyTextProps): JSX.Element {
       {content}
     </Tooltip>
   )
-}
-
-CopyText.propTypes = {
-  placement: p.string,
-  title: p.string,
-  value: p.string.isRequired,
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
The `CopyText` component has a `textOnly` prop. After using this component for some time, I have been under the assumption that this prop was used to display the component without the icon (i.e. only the title text). However, this is _not_ the case and has to do with if the user is copying a URL or not so it can be properly encoded from the `href` event target. This small discrepancy caused me to lose a good chunk of time, so I propose we refresh the API a tad, to avoid something like this in the future.

**Describe any introduced API changes:**
- `textOnly` -> `asURL`, logic flipped