### PR TITLE
engine/message: track src_value of messages

### DIFF
--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -114,7 +114,8 @@ func NewDB(ctx context.Context, db *sql.DB, a alertlog.Store, pausable lifecycle
 			fired_at = null,
 			provider_msg_id = coalesce($2, provider_msg_id),
 			provider_seq = CASE WHEN $3 = -1 THEN provider_seq ELSE $3 END,
-			next_retry_at = null
+			next_retry_at = null,
+			src_value = coalesce($6, src_value)
 		where
 			(id = $1 or provider_msg_id = $2) and
 			(provider_seq <= $3 or $3 = -1) and
@@ -539,7 +540,13 @@ func (db *DB) _UpdateMessageStatus(ctx context.Context, status *notification.Sen
 		s = StatusDelivered
 	}
 
-	_, err = db.updateStatus.ExecContext(ctx, cbID, status.ProviderMessageID, status.Sequence, s, status.Details)
+	var srcValue sql.NullString
+	if status.SrcValue != "" {
+		srcValue.Valid = true
+		srcValue.String = status.SrcValue
+	}
+
+	_, err = db.updateStatus.ExecContext(ctx, cbID, status.ProviderMessageID, status.Sequence, s, status.Details, srcValue)
 	return err
 }
 

--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -74,7 +74,7 @@ type DB struct {
 func NewDB(ctx context.Context, db *sql.DB, a alertlog.Store, pausable lifecycle.Pausable) (*DB, error) {
 	lock, err := processinglock.NewLock(ctx, db, processinglock.Config{
 		Type:    processinglock.TypeMessage,
-		Version: 8,
+		Version: 9,
 	})
 	if err != nil {
 		return nil, err

--- a/migrate/migrations/20210806074405-outgoing-source-value.sql
+++ b/migrate/migrations/20210806074405-outgoing-source-value.sql
@@ -1,0 +1,16 @@
+-- +migrate Up
+UPDATE engine_processing_versions
+SET version = 9
+WHERE type_id = 'message';
+
+ALTER TABLE outgoing_messages
+    ADD COLUMN src_value TEXT;
+
+-- +migrate Down
+
+UPDATE engine_processing_versions
+SET version = 8
+WHERE type_id = 'message';
+
+ALTER TABLE outgoing_messages
+    DROP COLUMN src_value;

--- a/notification/namedsender.go
+++ b/notification/namedsender.go
@@ -11,19 +11,21 @@ type namedSender struct {
 }
 
 func (s *namedSender) Send(ctx context.Context, msg Message) (*SendResult, error) {
-	externalID, status, err := s.Sender.Send(ctx, msg)
+	sent, err := s.Sender.Send(ctx, msg)
 	if err != nil {
 		return nil, err
 	}
 
-	res := &SendResult{
-		ID: msg.ID(),
-	}
-	if status != nil {
-		res.Status = *status
-	}
-	res.ProviderMessageID.ProviderName = s.name
-	res.ProviderMessageID.ExternalID = externalID
-
-	return res, err
+	return &SendResult{
+		ID:       msg.ID(),
+		SrcValue: sent.SrcValue,
+		Status: Status{
+			State:   sent.State,
+			Details: sent.StateDetails,
+		},
+		ProviderMessageID: ProviderMessageID{
+			ProviderName: s.name,
+			ExternalID:   sent.ExternalID,
+		},
+	}, nil
 }

--- a/notification/sender.go
+++ b/notification/sender.go
@@ -6,13 +6,22 @@ import (
 	"github.com/pkg/errors"
 )
 
+// SentMessage contains information about a message that was sent to a remote
+// system.
+type SentMessage struct {
+	ExternalID   string
+	State        State
+	StateDetails string
+	SrcValue     string
+}
+
 // A Sender can send notifications.
 type Sender interface {
 	// Send should return nil error if the notification was sent successfully. It should be expected
 	// that a returned error means that the notification should be attempted again.
 	//
 	// If the sent message can have its status tracked, a unique externalID should be returned.
-	Send(context.Context, Message) (externalID string, status *Status, err error)
+	Send(context.Context, Message) (*SentMessage, error)
 }
 
 // A StatusChecker is an optional interface a Sender can implement that allows checking the status

--- a/notification/status.go
+++ b/notification/status.go
@@ -25,6 +25,8 @@ type SendResult struct {
 	ProviderMessageID ProviderMessageID
 
 	Status
+
+	SrcValue string
 }
 
 // State represents the current state of an outgoing message.
@@ -34,9 +36,12 @@ type State int
 func (s State) IsOK() bool { return s == StateSending || s == StateSent || s == StateDelivered }
 
 const (
+	// StateUnknown is returned when the message has not yet been sent.
+	StateUnknown State = iota
+
 	// StateSending should be specified when a message is sending but has not been sent.
 	// This includes things like remotely queued, ringing, or in-progress calls.
-	StateSending State = iota
+	StateSending
 
 	// StatePending idicates a message waiting to be sent.
 	StatePending

--- a/notification/stubsender.go
+++ b/notification/stubsender.go
@@ -8,6 +8,6 @@ type stubSender struct{}
 
 var _ Sender = stubSender{}
 
-func (stubSender) Send(ctx context.Context, msg Message) (string, *Status, error) {
-	return "", &Status{State: StateDelivered}, nil
+func (stubSender) Send(ctx context.Context, msg Message) (*SentMessage, error) {
+	return &SentMessage{State: StateDelivered}, nil
 }

--- a/notification/twilio/call.go
+++ b/notification/twilio/call.go
@@ -57,6 +57,16 @@ type Call struct {
 	ErrorCode      *CallErrorCode
 }
 
+func (call *Call) sentMessage() *notification.SentMessage {
+	stat := call.messageStatus()
+
+	return &notification.SentMessage{
+		ExternalID:   call.SID,
+		State:        stat.State,
+		StateDetails: stat.Details,
+		SrcValue:     call.From,
+	}
+}
 func (call *Call) messageStatus() *notification.Status {
 	if call == nil {
 		return nil

--- a/notification/twilio/message.go
+++ b/notification/twilio/message.go
@@ -69,31 +69,36 @@ type Message struct {
 	ErrorMessage *string
 }
 
-func (msg *Message) messageStatus() *notification.Status {
+func (msg *Message) messageStatus() *notification.SentMessage {
 	if msg == nil {
 		return nil
 	}
 
-	var status notification.Status
+	sent := notification.SentMessage{
+		ExternalID: msg.SID,
+		SrcValue:   msg.From,
+	}
+
 	if msg.ErrorMessage != nil && msg.ErrorCode != nil {
-		status.Details = fmt.Sprintf("%s: [%d] %s", msg.Status, *msg.ErrorCode, *msg.ErrorMessage)
+		sent.StateDetails = fmt.Sprintf("%s: [%d] %s", msg.Status, *msg.ErrorCode, *msg.ErrorMessage)
 	} else {
-		status.Details = string(msg.Status)
+		sent.StateDetails = string(msg.Status)
 	}
 	switch msg.Status {
 	case MessageStatusFailed:
 		if msg.ErrorCode != nil &&
 			(*msg.ErrorCode == 30008 || *msg.ErrorCode == 30001) {
 
-			status.State = notification.StateFailedTemp
+			sent.State = notification.StateFailedTemp
 		}
-		status.State = notification.StateFailedPerm
+		sent.State = notification.StateFailedPerm
 	case MessageStatusDelivered:
-		status.State = notification.StateDelivered
+		sent.State = notification.StateDelivered
 	case MessageStatusSent, MessageStatusUndelivered:
-		status.State = notification.StateSent
+		sent.State = notification.StateSent
 	default:
-		status.State = notification.StateSending
+		sent.State = notification.StateSending
 	}
-	return &status
+
+	return &sent
 }

--- a/notification/twilio/sms.go
+++ b/notification/twilio/sms.go
@@ -69,9 +69,8 @@ func (s *SMS) Status(ctx context.Context, externalID string) (*notification.Stat
 	if err != nil {
 		return nil, err
 	}
-	sent := msg.messageStatus()
 
-	return &notification.Status{State: sent.State, Details: sent.StateDetails}, nil
+	return msg.messageStatus(), nil
 }
 
 // Send implements the notification.Sender interface.
@@ -162,7 +161,7 @@ func (s *SMS) Send(ctx context.Context, msg notification.Message) (*notification
 	// If the message was sent successfully, reset reply limits.
 	s.limit.Reset(destNumber)
 
-	return resp.messageStatus(), nil
+	return resp.sentMessage(), nil
 }
 
 func (s *SMS) ServeStatusCallback(w http.ResponseWriter, req *http.Request) {
@@ -188,9 +187,7 @@ func (s *SMS) ServeStatusCallback(w http.ResponseWriter, req *http.Request) {
 
 	log.Debugf(ctx, "Got Twilio SMS status callback.")
 
-	sent := msg.messageStatus()
-
-	err := s.r.SetMessageStatus(ctx, sid, &notification.Status{State: sent.State, Details: sent.StateDetails})
+	err := s.r.SetMessageStatus(ctx, sid, msg.messageStatus())
 	if err != nil {
 		// log and continue
 		log.Log(ctx, err)

--- a/notification/twilio/voice.go
+++ b/notification/twilio/voice.go
@@ -192,15 +192,15 @@ func spellNumber(n int) string {
 }
 
 // Send implements the notification.Sender interface.
-func (v *Voice) Send(ctx context.Context, msg notification.Message) (string, *notification.Status, error) {
+func (v *Voice) Send(ctx context.Context, msg notification.Message) (*notification.SentMessage, error) {
 	cfg := config.FromContext(ctx)
 	if !cfg.Twilio.Enable {
-		return "", nil, errors.New("Twilio provider is disabled")
+		return nil, errors.New("Twilio provider is disabled")
 	}
 	toNumber := msg.Destination().Value
 
 	if toNumber == cfg.Twilio.FromNumber {
-		return "", nil, errors.New("refusing to make outgoing call to FromNumber")
+		return nil, errors.New("refusing to make outgoing call to FromNumber")
 	}
 	ctx = log.WithFields(ctx, log.Fields{
 		"Number": toNumber,
@@ -234,7 +234,7 @@ func (v *Voice) Send(ctx context.Context, msg notification.Message) (string, *no
 		message = "This is a message from GoAlert to verify your voice contact method. Your verification code is: " + spellNumber(t.Code) + ". Again, your verification code is: " + spellNumber(t.Code)
 		opts.CallType = CallTypeVerify
 	default:
-		return "", nil, errors.Errorf("unhandled message type: %T", t)
+		return nil, errors.Errorf("unhandled message type: %T", t)
 	}
 
 	if message == "" {
@@ -250,10 +250,10 @@ func (v *Voice) Send(ctx context.Context, msg notification.Message) (string, *no
 	voiceResponse, err := v.c.StartVoice(ctx, toNumber, opts)
 	if err != nil {
 		log.Log(ctx, errors.Wrap(err, "call user"))
-		return "", nil, err
+		return nil, err
 	}
 
-	return voiceResponse.SID, voiceResponse.messageStatus(), nil
+	return voiceResponse.sentMessage(), nil
 }
 
 func disabled(w http.ResponseWriter, req *http.Request) bool {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adds a new column `src_value` to the `outgoing_messages` table in order to track the real-world source of sent messages.

The message module's version has been increased (8 -> 9) accordingly. 