### PR TITLE
ui/schedules: introduce schedule calendar actions menu

### DIFF
--- a/web/src/app/schedules/CalendarEventWrapper.js
+++ b/web/src/app/schedules/CalendarEventWrapper.js
@@ -6,6 +6,7 @@ import Popover from '@material-ui/core/Popover'
 import Typography from '@material-ui/core/Typography'
 import { makeStyles } from '@material-ui/core'
 import { DateTime } from 'luxon'
+import { ScheduleCalendarContext } from './ScheduleDetails'
 
 const useStyles = makeStyles({
   button: {
@@ -26,17 +27,12 @@ const useStyles = makeStyles({
   },
 })
 
-export const EventHandlerContext = React.createContext({
-  onOverrideClick: () => {},
-  onEditTempSched: () => {},
-  onDeleteTempSched: () => {},
-})
-
 export default function CalendarEventWrapper({ children, event }) {
   const classes = useStyles()
   const [anchorEl, setAnchorEl] = useState(null)
-  const { onOverrideClick, onEditTempSched, onDeleteTempSched } =
-    useContext(EventHandlerContext)
+  const { setOverrideDialog, onEditTempSched, onDeleteTempSched } = useContext(
+    ScheduleCalendarContext,
+  )
   const open = Boolean(anchorEl)
   const id = open ? 'shift-popover' : undefined
 
@@ -58,7 +54,7 @@ export default function CalendarEventWrapper({ children, event }) {
   function handleShowOverrideForm(type) {
     handleCloseShiftInfo()
 
-    onOverrideClick({
+    setOverrideDialog({
       variant: type,
       defaultValue: {
         start: event.start.toISOString(),

--- a/web/src/app/schedules/CalendarToolbar.tsx
+++ b/web/src/app/schedules/CalendarToolbar.tsx
@@ -21,6 +21,12 @@ const useStyles = makeStyles((theme) => ({
   container: {
     paddingBottom: theme.spacing(2),
   },
+  filterBtn: {
+    marginRight: theme.spacing(1.75),
+  },
+  endAdornment: {
+    marginLeft: theme.spacing(1.75),
+  },
 }))
 
 type ViewType = 'month' | 'week'
@@ -158,7 +164,9 @@ function CalendarToolbar(props: CalendarToolbarProps): JSX.Element {
 
       <Grid item>
         <Grid container alignItems='center' justifyContent='flex-end'>
-          {props.filter}
+          {props.filter && (
+            <div className={classes.filterBtn}>{props.filter}</div>
+          )}
           <ButtonGroup
             color='primary'
             aria-label='Toggle between Monthly and Weekly views'
@@ -180,7 +188,9 @@ function CalendarToolbar(props: CalendarToolbarProps): JSX.Element {
               Week
             </Button>
           </ButtonGroup>
-          {props.endAdornment}
+          {props.endAdornment && (
+            <div className={classes.endAdornment}>{props.endAdornment}</div>
+          )}
         </Grid>
       </Grid>
     </Grid>

--- a/web/src/app/schedules/ScheduleCalendarActionsMenu.tsx
+++ b/web/src/app/schedules/ScheduleCalendarActionsMenu.tsx
@@ -1,0 +1,61 @@
+import React, { useContext, useState } from 'react'
+import GroupAdd from '@material-ui/icons/GroupAdd'
+import { Button, Menu, MenuItem } from '@material-ui/core'
+import { ScheduleCalendarContext } from './ScheduleDetails'
+
+function ScheduleCalendarActionsSelect(): JSX.Element {
+  const { onNewTempSched, setOverrideDialog } = useContext(
+    ScheduleCalendarContext,
+  )
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+
+  const handleClick = (variant: string): void => {
+    if (variant === 'temp') {
+      onNewTempSched()
+    } else {
+      setOverrideDialog({ variant })
+    }
+    setAnchorEl(null)
+  }
+
+  return (
+    <React.Fragment>
+      <Button
+        aria-controls='calendar-override-menu'
+        aria-haspopup='true'
+        onClick={(e) => setAnchorEl(e.currentTarget)}
+        size='medium'
+        variant='contained'
+        color='primary'
+        startIcon={<GroupAdd />}
+      >
+        Override
+      </Button>
+      <Menu
+        id='calendar-override-menu'
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        transformOrigin={{
+          vertical: -8,
+          horizontal: 'right',
+        }}
+        getContentAnchorEl={null} // unset in order to tranform origin
+      >
+        <MenuItem onClick={() => handleClick('add')}>Add User</MenuItem>
+        <MenuItem onClick={() => handleClick('remove')}>Remove User</MenuItem>
+        <MenuItem onClick={() => handleClick('replace')}>Replace User</MenuItem>
+        <MenuItem onClick={() => handleClick('temp')}>
+          Create Temporary Schedule
+        </MenuItem>
+      </Menu>
+    </React.Fragment>
+  )
+}
+
+export default ScheduleCalendarActionsSelect

--- a/web/src/app/schedules/ScheduleCalendarQuery.tsx
+++ b/web/src/app/schedules/ScheduleCalendarQuery.tsx
@@ -48,14 +48,10 @@ const query = gql`
 
 interface ScheduleCalendarQueryProps {
   scheduleID: string
-  onNewTempSched: () => void
-  onEditTempSched: () => void
-  onDeleteTempSched: () => void
 }
 
 function ScheduleCalendarQuery({
   scheduleID,
-  ...other
 }: ScheduleCalendarQueryProps): JSX.Element | null {
   const width = useWidth()
   const isMobile = isWidthDown('sm', width)
@@ -86,11 +82,9 @@ function ScheduleCalendarQuery({
 
   return (
     <ScheduleCalendar
-      scheduleID={scheduleID}
       loading={loading && !data}
       shifts={data?.schedule?.shifts ?? []}
       temporarySchedules={data?.schedule?.temporarySchedules ?? []}
-      {...other}
     />
   )
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR replaces the Temp Sched button in the calendar toolbar with an Override button that opens a menu to allow users to create an Add, Remove, or Replace override from the calendar view

**Screenshots:**
<img width="406" alt="override" src="https://user-images.githubusercontent.com/17692467/129048256-285c197a-ffb4-4260-8ff0-eb384e562e1b.png">

**Describe any introduced user-facing changes:**
Temp Sched button -> Override Button

**Additional Info:**
To achieve this, the override dialog is now rendered at the `ScheduleDetails` level of the component heirarchy, and the `EventwrapperContext` has been lifted and renamed `ScheduleCalendarContext` accordingly
