### PR TITLE
engine/statusmanager: fix performance and behavior issues

### DIFF
--- a/engine/statusupdatemanager/db.go
+++ b/engine/statusupdatemanager/db.go
@@ -65,7 +65,7 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 		`),
 
 		latestLogEntry: p.P(`
-			select id from alert_logs
+			select id, sub_user_id from alert_logs
 			where alert_id = $1 and event = $2
 			order by id desc
 			limit 1

--- a/engine/statusupdatemanager/db.go
+++ b/engine/statusupdatemanager/db.go
@@ -45,9 +45,9 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 		`),
 
 		needsUpdate: p.P(`
-			select sub.id, channel_id, contact_method_id, alert_id, a.status
+			select sub.id, channel_id, contact_method_id, alert_id, (select status from alerts a where a.id = sub.alert_id)
 			from alert_status_subscriptions sub
-			join alerts a on a.id = sub.alert_id and a.status != sub.last_alert_status
+			where sub.last_alert_status != (select status from alerts a where a.id = sub.alert_id)
 			limit 1
 			for update skip locked
 		`),

--- a/engine/statusupdatemanager/db.go
+++ b/engine/statusupdatemanager/db.go
@@ -66,7 +66,7 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 
 		latestLogEntry: p.P(`
 			select id, sub_user_id from alert_logs
-			where alert_id = $1 and event = $2
+			where alert_id = $1 and event = $2 and timestamp > now() - '1 hour'::interval
 			order by id desc
 			limit 1
 		`),

--- a/engine/statusupdatemanager/db.go
+++ b/engine/statusupdatemanager/db.go
@@ -38,9 +38,9 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 		lock: lock,
 
 		cmWantsUpdates: p.P(`
-			select coalesce(u.alert_status_log_contact_method_id = $1, false), u.id
+			select u.id
 			from user_contact_methods cm
-			join users u on u.id = cm.user_id
+			join users u on u.id = cm.user_id and u.alert_status_log_contact_method_id = $1
 			where cm.id = $1 and not cm.disabled
 		`),
 

--- a/engine/statusupdatemanager/db.go
+++ b/engine/statusupdatemanager/db.go
@@ -16,7 +16,7 @@ type DB struct {
 	needsUpdate    *sql.Stmt
 	insertMessage  *sql.Stmt
 	updateStatus   *sql.Stmt
-	cleanupClosed  *sql.Stmt
+	deleteSub      *sql.Stmt
 	cmWantsUpdates *sql.Stmt
 }
 
@@ -71,7 +71,7 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 			limit 1
 		`),
 
-		updateStatus:  p.P(`update alert_status_subscriptions set last_alert_status = $2 where id = $1`),
-		cleanupClosed: p.P(`delete from alert_status_subscriptions where id = $1`),
+		updateStatus: p.P(`update alert_status_subscriptions set last_alert_status = $2 where id = $1`),
+		deleteSub:    p.P(`delete from alert_status_subscriptions where id = $1`),
 	}, p.Err
 }

--- a/engine/statusupdatemanager/update.go
+++ b/engine/statusupdatemanager/update.go
@@ -21,6 +21,19 @@ func (db *DB) UpdateAll(ctx context.Context) error {
 	}
 
 	log.Debugf(ctx, "Processing status updates.")
+
+	_, err = db.lock.Exec(ctx, db.cmUnsub)
+	if err != nil {
+		// okay to proceed
+		log.Log(ctx, fmt.Errorf("delete status subscriptions for disabled contact methods: %w", err))
+	}
+
+	_, err = db.lock.Exec(ctx, db.usrUnsub)
+	if err != nil {
+		// okay to proceed
+		log.Log(ctx, fmt.Errorf("delete status subscriptions for disabled users: %w", err))
+	}
+
 	// process up to 100
 	for i := 0; i < 100; i++ {
 		err = db.update(ctx)

--- a/engine/statusupdatemanager/update.go
+++ b/engine/statusupdatemanager/update.go
@@ -59,7 +59,8 @@ func (db *DB) update(ctx context.Context) error {
 	isSubscribed := chanID.Valid
 	var userID sql.NullString
 	if cmID.Valid {
-		err = tx.StmtContext(ctx, db.cmWantsUpdates).QueryRowContext(ctx, cmID).Scan(&isSubscribed, &userID)
+		isSubscribed = true
+		err = tx.StmtContext(ctx, db.cmWantsUpdates).QueryRowContext(ctx, cmID).Scan(&userID)
 		if errors.Is(err, sql.ErrNoRows) {
 			isSubscribed = false
 			err = nil

--- a/engine/statusupdatemanager/update.go
+++ b/engine/statusupdatemanager/update.go
@@ -94,10 +94,10 @@ func (db *DB) update(ctx context.Context) error {
 		}
 	}
 
-	if newStatus == alert.StatusClosed {
-		_, err = tx.StmtContext(ctx, db.cleanupClosed).ExecContext(ctx, id)
+	if newStatus == alert.StatusClosed || !isSubscribed {
+		_, err = tx.StmtContext(ctx, db.deleteSub).ExecContext(ctx, id)
 		if err != nil {
-			return fmt.Errorf("delete subscription for closed alert #%d (id=%d): %w", alertID, id, err)
+			return fmt.Errorf("delete subscription for alert #%d (id=%d): %w", alertID, id, err)
 		}
 	} else {
 		_, err = tx.StmtContext(ctx, db.updateStatus).ExecContext(ctx, id, newStatus)

--- a/migrate/migrations/20210811110849-valid-status-updates-indexes.sql
+++ b/migrate/migrations/20210811110849-valid-status-updates-indexes.sql
@@ -1,0 +1,8 @@
+-- +migrate Up
+CREATE INDEX idx_valid_contact_methods ON user_contact_methods (id) WHERE NOT disabled;
+CREATE INDEX idx_user_status_updates ON users (alert_status_log_contact_method_id) WHERE alert_status_log_contact_method_id IS NOT NULL;
+
+-- +migrate Down
+
+DROP INDEX idx_valid_contact_methods;
+DROP INDEX idx_user_status_updates;

--- a/smoketest/statusupdates_test.go
+++ b/smoketest/statusupdates_test.go
@@ -84,4 +84,8 @@ func TestStatusUpdates(t *testing.T) {
 
 	doClose("second alert")
 	d1.ExpectSMS("closed")
+
+	// Ensure status updates are not sent to the user that caused them.
+	h.CreateAlert(h.UUID("sid"), "third alert")
+	d1.ExpectSMS("third alert").ThenReply("c").ThenExpect("closed")
 }

--- a/smoketest/statusupdatescancel_test.go
+++ b/smoketest/statusupdatescancel_test.go
@@ -1,0 +1,96 @@
+package smoketest
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/target/goalert/smoketest/harness"
+)
+
+// TestStatusUpdatesCancel checks that status updates are unsubscribed when updates, or the contact method, are disabled.
+func TestStatusUpdatesCancel(t *testing.T) {
+	t.Parallel()
+
+	sql := `
+	insert into users (id, name, email, role) 
+	values 
+		({{uuid "user"}}, 'bob', 'joe@test.com', 'admin');
+	insert into user_contact_methods (id, user_id, name, type, value) 
+	values
+		({{uuid "cm1"}}, {{uuid "user"}}, 'personal', 'SMS', {{phone "1"}}),
+		({{uuid "cm2"}}, {{uuid "user"}}, 'personal2', 'SMS', {{phone "2"}});
+
+	update users set alert_status_log_contact_method_id = {{uuid "cm1"}}
+	where id = {{uuid "user"}};
+
+	insert into user_notification_rules (user_id, contact_method_id, delay_minutes) 
+	values
+		({{uuid "user"}}, {{uuid "cm1"}}, 0),
+		({{uuid "user"}}, {{uuid "cm2"}}, 0);
+
+	insert into escalation_policies (id, name) 
+	values
+		({{uuid "eid"}}, 'esc policy');
+	insert into escalation_policy_steps (id, escalation_policy_id) 
+	values
+		({{uuid "esid"}}, {{uuid "eid"}});
+	insert into escalation_policy_actions (escalation_policy_step_id, user_id) 
+	values 
+		({{uuid "esid"}}, {{uuid "user"}});
+
+	insert into services (id, escalation_policy_id, name) 
+	values
+		({{uuid "sid"}}, {{uuid "eid"}}, 'service');
+
+	insert into integration_keys (id, service_id, type, name)
+	values
+		({{uuid "int1"}}, {{uuid "sid"}}, 'generic', 'test');
+`
+	h := harness.NewHarness(t, sql, "alert-status-updates")
+	defer h.Close()
+
+	doClose := func(summary string) {
+		u := h.URL() + "/v1/api/alerts?key=" + h.UUID("int1")
+		v := make(url.Values)
+		v.Set("summary", summary)
+		v.Set("action", "close")
+		resp, err := http.Post(u, "application/x-www-form-urlencoded", bytes.NewBufferString(v.Encode()))
+		if err != nil {
+			t.Fatal("post to generic endpoint failed:", err)
+		} else if resp.StatusCode/100 != 2 {
+			t.Error("non-2xx response:", resp.Status)
+		}
+		resp.Body.Close()
+	}
+
+	tw := h.Twilio(t)
+	d1 := tw.Device(h.Phone("1"))
+	d2 := tw.Device(h.Phone("2"))
+
+	h.CreateAlert(h.UUID("sid"), "first")
+	d1.ExpectSMS("first")
+	d2.ExpectSMS("first")
+	h.Trigger() // cleanup subscription to cm2, since only cm1 is configured
+
+	h.GraphQLQueryUserT(t, h.UUID("user"), fmt.Sprintf(`mutation{updateUser(input:{id:"%s",statusUpdateContactMethodID:"%s"})}`, h.UUID("user"), h.UUID("cm2")))
+
+	h.Trigger() // cleanup subscription to cm1, now that cm2 is the only one configured
+	doClose("first")
+	// no status update as only cm1 was subscribed, and the setting change
+	// should have canceled the subscription.
+
+	h.CreateAlert(h.UUID("sid"), "second")
+	d1.ExpectSMS("second")
+	d2.ExpectSMS("second")
+
+	d2.SendSMS("stop")
+	h.Trigger() // cleanup subscription to cm2
+	d2.SendSMS("start")
+
+	doClose("second")
+	// contact method was canceled, so no status updates should not be sent.
+
+}

--- a/smoketest/statusupdatescancel_test.go
+++ b/smoketest/statusupdatescancel_test.go
@@ -91,6 +91,6 @@ func TestStatusUpdatesCancel(t *testing.T) {
 	d2.SendSMS("start")
 
 	doClose("second")
-	// contact method was canceled, so no status updates should not be sent.
+	// contact method was canceled, so no status updates should be sent.
 
 }

--- a/smoketest/statusupdatescancel_test.go
+++ b/smoketest/statusupdatescancel_test.go
@@ -18,10 +18,10 @@ func TestStatusUpdatesCancel(t *testing.T) {
 	insert into users (id, name, email, role) 
 	values 
 		({{uuid "user"}}, 'bob', 'joe@test.com', 'admin');
-	insert into user_contact_methods (id, user_id, name, type, value) 
+	insert into user_contact_methods (id, user_id, name, type, value, disabled) 
 	values
-		({{uuid "cm1"}}, {{uuid "user"}}, 'personal', 'SMS', {{phone "1"}}),
-		({{uuid "cm2"}}, {{uuid "user"}}, 'personal2', 'SMS', {{phone "2"}});
+		({{uuid "cm1"}}, {{uuid "user"}}, 'personal', 'SMS', {{phone "1"}}, false),
+		({{uuid "cm2"}}, {{uuid "user"}}, 'personal2', 'SMS', {{phone "2"}}, false);
 
 	update users set alert_status_log_contact_method_id = {{uuid "cm1"}}
 	where id = {{uuid "user"}};


### PR DESCRIPTION

**Description:**
This PR fixes a number of issues/regressions with the status update code:
1. performance issue when querying for updates
2. sending messages after CM disabled, or status updates turned off
3. sending updates for events that are very old
4. updates went to users who initiated the action

The existing smoketest was updated to validate 4. A new smoketest was added to validate 2 & 3.
For the first issue, it's harder to reproduce but the query was rewritten to use subqueries to avoid scanning
the alerts table during the join resulting in 100x performance improvement in certain workloads.

