### PR TITLE
ui: use real from number in dialogs

### DIFF
--- a/dataloader/alertlogstateloader.go
+++ b/dataloader/alertlogstateloader.go
@@ -25,7 +25,7 @@ func NewNotificationMessageStatusLoader(ctx context.Context, store notification.
 	return p
 }
 
-func (l *NotificationMessageStatusLoader) FetchOne(ctx context.Context, id string) (*notification.Status, error) {
+func (l *NotificationMessageStatusLoader) FetchOne(ctx context.Context, id string) (*notification.SendResult, error) {
 	ls, err := l.loader.FetchOne(ctx, id)
 	if err != nil {
 		return nil, err
@@ -33,7 +33,7 @@ func (l *NotificationMessageStatusLoader) FetchOne(ctx context.Context, id strin
 	if ls == nil {
 		return nil, err
 	}
-	return &ls.(*notification.SendResult).Status, nil
+	return ls.(*notification.SendResult), nil
 }
 
 func (l *NotificationMessageStatusLoader) fetch(ctx context.Context, ids []string) ([]interface{}, error) {

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -263,8 +263,9 @@ type ComplexityRoot struct {
 	}
 
 	NotificationState struct {
-		Details func(childComplexity int) int
-		Status  func(childComplexity int) int
+		Details           func(childComplexity int) int
+		FormattedSrcValue func(childComplexity int) int
+		Status            func(childComplexity int) int
 	}
 
 	OnCallNotificationRule struct {
@@ -1764,6 +1765,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.NotificationState.Details(childComplexity), true
+
+	case "NotificationState.formattedSrcValue":
+		if e.complexity.NotificationState.FormattedSrcValue == nil {
+			break
+		}
+
+		return e.complexity.NotificationState.FormattedSrcValue(childComplexity), true
 
 	case "NotificationState.status":
 		if e.complexity.NotificationState.Status == nil {
@@ -4025,6 +4033,7 @@ type AlertLogEntry {
 type NotificationState {
   details: String!
   status: NotificationStatus
+  formattedSrcValue: String!
 }
 
 enum NotificationStatus {
@@ -9906,6 +9915,41 @@ func (ec *executionContext) _NotificationState_status(ctx context.Context, field
 	res := resTmp.(*NotificationStatus)
 	fc.Result = res
 	return ec.marshalONotificationStatus2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐNotificationStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _NotificationState_formattedSrcValue(ctx context.Context, field graphql.CollectedField, obj *NotificationState) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "NotificationState",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FormattedSrcValue, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _OnCallNotificationRule_id(ctx context.Context, field graphql.CollectedField, obj *schedule.OnCallNotificationRule) (ret graphql.Marshaler) {
@@ -20820,6 +20864,11 @@ func (ec *executionContext) _NotificationState(ctx context.Context, sel ast.Sele
 			}
 		case "status":
 			out.Values[i] = ec._NotificationState_status(ctx, field, obj)
+		case "formattedSrcValue":
+			out.Values[i] = ec._NotificationState_formattedSrcValue(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -154,6 +154,7 @@ type ComplexityRoot struct {
 	}
 
 	DebugSendSMSInfo struct {
+		FromNumber  func(childComplexity int) int
 		ID          func(childComplexity int) int
 		ProviderURL func(childComplexity int) int
 	}
@@ -995,6 +996,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.DebugCarrierInfo.Type(childComplexity), true
+
+	case "DebugSendSMSInfo.fromNumber":
+		if e.complexity.DebugSendSMSInfo.FromNumber == nil {
+			break
+		}
+
+		return e.complexity.DebugSendSMSInfo.FromNumber(childComplexity), true
 
 	case "DebugSendSMSInfo.id":
 		if e.complexity.DebugSendSMSInfo.ID == nil {
@@ -3429,6 +3437,7 @@ input DebugSendSMSInput {
 type DebugSendSMSInfo {
   id: ID!
   providerURL: String!
+  fromNumber: String!
 }
 
 type TemporarySchedule {
@@ -6896,6 +6905,41 @@ func (ec *executionContext) _DebugSendSMSInfo_providerURL(ctx context.Context, f
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return obj.ProviderURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _DebugSendSMSInfo_fromNumber(ctx context.Context, field graphql.CollectedField, obj *DebugSendSMSInfo) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "DebugSendSMSInfo",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FromNumber, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -20206,6 +20250,11 @@ func (ec *executionContext) _DebugSendSMSInfo(ctx context.Context, sel ast.Selec
 			}
 		case "providerURL":
 			out.Values[i] = ec._DebugSendSMSInfo_providerURL(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "fromNumber":
+			out.Values[i] = ec._DebugSendSMSInfo_fromNumber(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}

--- a/graphql2/graphqlapp/alert.go
+++ b/graphql2/graphqlapp/alert.go
@@ -42,7 +42,7 @@ func (a *AlertLogEntry) Message(ctx context.Context, obj *alertlog.Entry) (strin
 	return e.String(), nil
 }
 
-func notificationStateFromStatus(s notification.Status) *graphql2.NotificationState {
+func notificationStateFromSendResult(s notification.Status, formattedSrc string) *graphql2.NotificationState {
 	var status graphql2.NotificationStatus
 	switch s.State {
 	case notification.StateFailedTemp, notification.StateFailedPerm:
@@ -75,13 +75,15 @@ func notificationStateFromStatus(s notification.Status) *graphql2.NotificationSt
 	}
 
 	return &graphql2.NotificationState{
-		Details: details,
-		Status:  &status,
+		Details:           details,
+		Status:            &status,
+		FormattedSrcValue: formattedSrc,
 	}
 }
 
 func (a *AlertLogEntry) escalationState(ctx context.Context, obj *alertlog.Entry) (*graphql2.NotificationState, error) {
 	e := *obj
+
 	meta, ok := e.Meta().(*alertlog.EscalationMetaData)
 	if !ok || meta == nil || !meta.NoOneOnCall {
 		return nil, nil
@@ -109,7 +111,7 @@ func (a *AlertLogEntry) notificationSentState(ctx context.Context, obj *alertlog
 		return nil, nil
 	}
 
-	return notificationStateFromStatus(*s), nil
+	return notificationStateFromSendResult(s.Status, a.FormatDestFunc(ctx, s.DestType, s.SrcValue)), nil
 }
 
 func (a *AlertLogEntry) createdState(ctx context.Context, obj *alertlog.Entry) (*graphql2.NotificationState, error) {

--- a/graphql2/graphqlapp/contactmethod.go
+++ b/graphql2/graphqlapp/contactmethod.go
@@ -33,7 +33,7 @@ func (a *ContactMethod) Value(ctx context.Context, obj *contactmethod.ContactMet
 }
 
 func (a *ContactMethod) FormattedValue(ctx context.Context, obj *contactmethod.ContactMethod) (string, error) {
-	return a.FormatDestFunc(ctx, obj.Type.DestType(), obj.Value), nil
+	return a.FormatDestFunc(ctx, notification.ScannableDestType{CM: obj.Type}.DestType(), obj.Value), nil
 }
 
 func (a *ContactMethod) LastTestMessageState(ctx context.Context, obj *contactmethod.ContactMethod) (*graphql2.NotificationState, error) {
@@ -50,7 +50,7 @@ func (a *ContactMethod) LastTestMessageState(ctx context.Context, obj *contactme
 		return nil, nil
 	}
 
-	return notificationStateFromStatus(status.Status), nil
+	return notificationStateFromSendResult(status.Status, a.FormatDestFunc(ctx, status.DestType, status.SrcValue)), nil
 }
 func (a *ContactMethod) LastVerifyMessageState(ctx context.Context, obj *contactmethod.ContactMethod) (*graphql2.NotificationState, error) {
 	t := obj.LastTestVerifyAt()
@@ -66,7 +66,7 @@ func (a *ContactMethod) LastVerifyMessageState(ctx context.Context, obj *contact
 		return nil, nil
 	}
 
-	return notificationStateFromStatus(status.Status), nil
+	return notificationStateFromSendResult(status.Status, a.FormatDestFunc(ctx, status.DestType, status.SrcValue)), nil
 }
 
 func (q *Query) UserContactMethod(ctx context.Context, id string) (*contactmethod.ContactMethod, error) {

--- a/graphql2/graphqlapp/dataloaders.go
+++ b/graphql2/graphqlapp/dataloaders.go
@@ -58,14 +58,14 @@ func (a *App) closeLoaders(ctx context.Context) {
 	}
 }
 
-func (app *App) FindOneNotificationMessageStatus(ctx context.Context, id string) (*notification.Status, error) {
+func (app *App) FindOneNotificationMessageStatus(ctx context.Context, id string) (*notification.SendResult, error) {
 	loader, ok := ctx.Value(dataLoaderKeyNotificationMessageStatus).(*dataloader.NotificationMessageStatusLoader)
 	if !ok {
 		ms, err := app.NotificationStore.FindManyMessageStatuses(ctx, id)
 		if err != nil {
 			return nil, err
 		}
-		return &ms[0].Status, nil
+		return &ms[0], nil
 	}
 
 	return loader.FetchOne(ctx, id)

--- a/graphql2/graphqlapp/toolbox.go
+++ b/graphql2/graphqlapp/toolbox.go
@@ -41,6 +41,7 @@ func (a *Mutation) DebugSendSms(ctx context.Context, input graphql2.DebugSendSMS
 	return &graphql2.DebugSendSMSInfo{
 		ID:          msg.SID,
 		ProviderURL: "https://www.twilio.com/console/sms/logs/" + url.PathEscape(msg.SID),
+		FromNumber:  msg.From,
 	}, nil
 }
 

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -252,8 +252,9 @@ type LabelValueSearchOptions struct {
 }
 
 type NotificationState struct {
-	Details string              `json:"details"`
-	Status  *NotificationStatus `json:"status"`
+	Details           string              `json:"details"`
+	Status            *NotificationStatus `json:"status"`
+	FormattedSrcValue string              `json:"formattedSrcValue"`
 }
 
 type PageInfo struct {

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -201,6 +201,7 @@ type DebugCarrierInfoInput struct {
 type DebugSendSMSInfo struct {
 	ID          string `json:"id"`
 	ProviderURL string `json:"providerURL"`
+	FromNumber  string `json:"fromNumber"`
 }
 
 type DebugSendSMSInput struct {

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -863,6 +863,7 @@ type AlertLogEntry {
 type NotificationState {
   details: String!
   status: NotificationStatus
+  formattedSrcValue: String!
 }
 
 enum NotificationStatus {

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -259,6 +259,7 @@ input DebugSendSMSInput {
 type DebugSendSMSInfo {
   id: ID!
   providerURL: String!
+  fromNumber: String!
 }
 
 type TemporarySchedule {

--- a/notification/manager.go
+++ b/notification/manager.go
@@ -43,6 +43,9 @@ func (mgr *Manager) SetStubNotifiers() {
 // FormatDestValue will format the destination value if an available FriendlyValuer exists
 // for the destType or return the original.
 func (mgr *Manager) FormatDestValue(ctx context.Context, destType DestType, value string) string {
+	if value == "" {
+		return ""
+	}
 	mgr.mx.RLock()
 	defer mgr.mx.RUnlock()
 

--- a/notification/status.go
+++ b/notification/status.go
@@ -26,6 +26,7 @@ type SendResult struct {
 
 	Status
 
+	DestType DestType
 	SrcValue string
 }
 

--- a/web/src/app/admin/AdminSMSSend.tsx
+++ b/web/src/app/admin/AdminSMSSend.tsx
@@ -27,6 +27,7 @@ const sendSMSMutation = gql`
     debugSendSMS(input: $input) {
       id
       providerURL
+      fromNumber
     }
   }
 `
@@ -109,7 +110,10 @@ export default function AdminSMSSend(): JSX.Element {
             {sendStatus.data?.debugSendSMS && (
               <AppLink to={sendStatus.data.debugSendSMS.providerURL} newTab>
                 <div className={classes.twilioLink}>
-                  <Typography>Open in Twilio&nbsp;</Typography>
+                  <Typography>
+                    Sent from {sendStatus.data.debugSendSMS.fromNumber}. Open in
+                    Twilio&nbsp;
+                  </Typography>
                   <OpenInNewIcon fontSize='small' />
                 </div>
               </AppLink>

--- a/web/src/app/users/UserContactMethodVerificationDialog.js
+++ b/web/src/app/users/UserContactMethodVerificationDialog.js
@@ -4,7 +4,6 @@ import p from 'prop-types'
 import FormDialog from '../dialogs/FormDialog'
 import { fieldErrors, nonFieldErrors } from '../util/errutil'
 import UserContactMethodVerificationForm from './UserContactMethodVerificationForm'
-import { useConfigValue } from '../util/RequireConfig'
 
 /*
  * Reactivates a cm if disabled and the verification code matches

--- a/web/src/app/users/UserContactMethodVerificationDialog.js
+++ b/web/src/app/users/UserContactMethodVerificationDialog.js
@@ -1,8 +1,7 @@
 import React, { useState } from 'react'
-import { useMutation, gql } from '@apollo/client'
+import { useMutation, useQuery, gql } from '@apollo/client'
 import p from 'prop-types'
 import FormDialog from '../dialogs/FormDialog'
-import Query from '../util/Query'
 import { fieldErrors, nonFieldErrors } from '../util/errutil'
 import UserContactMethodVerificationForm from './UserContactMethodVerificationForm'
 import { useConfigValue } from '../util/RequireConfig'
@@ -25,6 +24,11 @@ const contactMethodQuery = gql`
       id
       type
       formattedValue
+      lastVerifyMessageState {
+        status
+        details
+        formattedSrcValue
+      }
     }
   }
 `
@@ -44,57 +48,51 @@ export default function UserContactMethodVerificationDialog(props) {
     },
     onCompleted: props.onClose,
   })
-  const [fromNumber] = useConfigValue('Twilio.FromNumber')
 
-  // dialog rendered that handles rendering the verification form
-  function renderDialog(cm) {
-    const { loading, error } = status
-    const fieldErrs = fieldErrors(error)
+  const { data } = useQuery(contactMethodQuery, {
+    variables: { id: props.contactMethodID },
+  })
 
-    let caption = null
-    if (fromNumber && cm.type === 'SMS') {
-      caption = `If you do not receive a code, try sending START to ${fromNumber} before resending.`
-    }
-    return (
-      <FormDialog
-        title='Verify Contact Method'
-        subTitle={`A verification code has been sent to ${cm.formattedValue} (${cm.type})`}
-        caption={caption}
-        loading={loading}
-        errors={
-          sendError
-            ? [{ message: sendError, nonSubmit: true }].concat(
-                nonFieldErrors(error),
-              )
-            : nonFieldErrors(error)
-        }
-        data-cy='verify-form'
-        onClose={props.onClose}
-        onSubmit={() => {
-          setSendError('')
-          return submitVerify()
-        }}
-        form={
-          <UserContactMethodVerificationForm
-            contactMethodID={cm.id}
-            errors={fieldErrs}
-            setSendError={setSendError}
-            disabled={loading}
-            value={value}
-            onChange={(value) => setValue(value)}
-          />
-        }
-      />
-    )
+  const fromNumber =
+    data?.userContactMethod?.lastVerifyMessageState?.formattedSrcValue ?? '...'
+  const cm = data?.userContactMethod ?? {}
+
+  const { loading, error } = status
+  const fieldErrs = fieldErrors(error)
+
+  let caption = null
+  if (fromNumber && cm.type === 'SMS') {
+    caption = `If you do not receive a code, try sending START to ${fromNumber} before resending.`
   }
-
-  // queries for cm data for the dialog subtitle
   return (
-    <Query
-      query={contactMethodQuery}
-      variables={{ id: props.contactMethodID }}
-      render={({ data }) => renderDialog(data.userContactMethod)}
-      noPoll
+    <FormDialog
+      title='Verify Contact Method'
+      subTitle={`A verification code has been sent to ${cm.formattedValue} (${cm.type})`}
+      caption={caption}
+      loading={loading || !cm.type}
+      errors={
+        sendError
+          ? [{ message: sendError, nonSubmit: true }].concat(
+              nonFieldErrors(error),
+            )
+          : nonFieldErrors(error)
+      }
+      data-cy='verify-form'
+      onClose={props.onClose}
+      onSubmit={() => {
+        setSendError('')
+        return submitVerify()
+      }}
+      form={
+        <UserContactMethodVerificationForm
+          contactMethodID={props.contactMethodID}
+          errors={fieldErrs}
+          setSendError={setSendError}
+          disabled={loading}
+          value={value}
+          onChange={(value) => setValue(value)}
+        />
+      }
     />
   )
 }

--- a/web/src/cypress/support/dialog.ts
+++ b/web/src/cypress/support/dialog.ts
@@ -31,9 +31,9 @@ function dialogClick(s: string): Cypress.Chainable {
 }
 
 function dialogFinish(s: string): Cypress.Chainable {
-  return dialogClick(s)
-    .get(`[role=dialog]`)
-    .should('not.exist', { timeout: 15000 })
+  const open = dialog()
+  dialogClick(s)
+  return open.should('not.exist', { timeout: 15000 })
 }
 
 Cypress.Commands.add('dialogFinish', dialogFinish)

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -671,6 +671,7 @@ export interface AlertLogEntry {
 export interface NotificationState {
   details: string
   status?: NotificationStatus
+  formattedSrcValue: string
 }
 
 export type NotificationStatus = 'OK' | 'WARN' | 'ERROR'

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -182,6 +182,7 @@ export interface DebugSendSMSInput {
 export interface DebugSendSMSInfo {
   id: string
   providerURL: string
+  fromNumber: string
 }
 
 export interface TemporarySchedule {


### PR DESCRIPTION
**Description:**
This PR updates the Test and Verify dialogs, as well as the admin Send-SMS tool, to use the From value returned by Twilio when sending messages.

This is in preparation for SID support when the FromNumber config value may be a SID and multiple numbers could be used when delivering messages.

A new field, `formattedSrcValue` was added to the `NotificationState` type in the GraphQL schema.