### PR TITLE
oncall: index for schedule on-call query

### DIFF
--- a/migrate/migrations/20210813131213-sched-query-index.sql
+++ b/migrate/migrations/20210813131213-sched-query-index.sql
@@ -1,0 +1,7 @@
+-- +migrate Up notransaction
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sched_oncall_times ON schedule_on_call_users
+USING spgist (tstzrange(start_time, end_time));
+
+-- +migrate Down
+
+DROP INDEX IF EXISTS idx_sched_oncall_times;

--- a/oncall/store.go
+++ b/oncall/store.go
@@ -111,7 +111,7 @@ func NewDB(ctx context.Context, db *sql.DB, ruleStore rule.Store, schedStore *sc
 			from schedule_on_call_users
 			where
 				schedule_id = $1 and
-				($2, $3) OVERLAPS (start_time, coalesce(end_time, 'infinity')) and
+				tstzrange($2, $3) && tstzrange(start_time, end_time) and
 				(end_time isnull or (end_time - start_time) > '1 minute'::interval)
 		`),
 		schedTZ: p.P(`select time_zone, now() from schedules where id = $1`),

--- a/web/src/cypress/integration/favorites.ts
+++ b/web/src/cypress/integration/favorites.ts
@@ -31,8 +31,8 @@ function check(
     })
     it('should list favorites at the top', () => {
       const prefix = c.word({ length: 12 })
-      const name1 = prefix + 'A'
-      const name2 = prefix + 'Z'
+      const name1 = prefix + ' A'
+      const name2 = prefix + ' Z'
       createFunc(name1, false)
       createFunc(name2, true)
       cy.visit(`/${urlPrefix}?search=${encodeURIComponent(prefix)}`)
@@ -49,8 +49,8 @@ function check(
     if (getSearchSelectFunc) {
       it('should sort favorites-first in a search-select', () => {
         const prefix = c.word({ length: 20 })
-        const name1 = prefix + 'A'
-        const name2 = prefix + 'Z'
+        const name1 = prefix + ' A'
+        const name2 = prefix + ' Z'
         createFunc(name1, false)
         createFunc(name2, true)
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adds an index to `schedule_on_call_users` and updates the shift query to use `tstzrange()`. It is functionally identical to the prior query but makes use of the index to greatly reduce DB load.