### PR TITLE
engine/statusmanager: fix status updates for notification channels

### DIFF
--- a/engine/statusupdatemanager/db.go
+++ b/engine/statusupdatemanager/db.go
@@ -43,7 +43,9 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 		cmUnsub: p.P(`
 			delete from alert_status_subscriptions where id in (
 				select stat.id from alert_status_subscriptions stat
-				where not exists (select true from user_contact_methods cm where cm.id = stat.contact_method_id and cm.disabled = false)
+				where stat.contact_method_id notnull and exists (
+					select true from user_contact_methods cm where cm.id = stat.contact_method_id and cm.disabled
+				)
 				limit 100
 				for update skip locked
 			)
@@ -52,7 +54,9 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 		usrUnsub: p.P(`
 			delete from alert_status_subscriptions where id in (
 				select stat.id from alert_status_subscriptions stat
-				where not exists (select true from users u where u.alert_status_log_contact_method_id = stat.contact_method_id)
+				where stat.contact_method_id notnull and not exists (
+					select true from users u where u.alert_status_log_contact_method_id = stat.contact_method_id
+				)
 				limit 100
 				for update skip locked
 			)

--- a/smoketest/harness/harness.go
+++ b/smoketest/harness/harness.go
@@ -409,6 +409,34 @@ func (h *Harness) execQuery(sql string, data interface{}) {
 	}
 }
 
+func (h *Harness) CloseAlert(serviceID, summary string) {
+	permission.SudoContext(context.Background(), func(ctx context.Context) {
+		h.t.Helper()
+		tx, err := h.backend.DB().BeginTx(ctx, nil)
+		if err != nil {
+			h.t.Fatalf("failed to start tx: %v", err)
+		}
+		defer tx.Rollback()
+
+		a := &alert.Alert{
+			ServiceID: serviceID,
+			Summary:   summary,
+			Status:    alert.StatusClosed,
+		}
+
+		h.t.Logf("close alert: %v", a)
+		_, _, err = h.backend.AlertStore.CreateOrUpdateTx(ctx, tx, a)
+		if err != nil {
+			h.t.Fatalf("failed to close alert: %v", err)
+		}
+
+		err = tx.Commit()
+		if err != nil {
+			h.t.Fatalf("failed to commit tx: %v", err)
+		}
+	})
+}
+
 // CreateAlert will create one or more unacknowledged alerts for a service.
 func (h *Harness) CreateAlert(serviceID string, summary ...string) {
 	h.t.Helper()

--- a/smoketest/statusupdateschannel_test.go
+++ b/smoketest/statusupdateschannel_test.go
@@ -1,0 +1,40 @@
+package smoketest
+
+import (
+	"testing"
+
+	"github.com/target/goalert/smoketest/harness"
+)
+
+// TestStatusUpdatesChannel tests status updates to notification channels.
+func TestStatusUpdatesChannel(t *testing.T) {
+	t.Parallel()
+
+	sql := `
+	insert into escalation_policies (id, name) 
+	values
+		({{uuid "eid"}}, 'esc policy');
+	insert into escalation_policy_steps (id, escalation_policy_id) 
+	values
+		({{uuid "esid"}}, {{uuid "eid"}});
+
+	insert into notification_channels (id, type, name, value)
+	values
+		({{uuid "chan"}}, 'SLACK', '#test', {{slackChannelID "test"}});
+
+	insert into escalation_policy_actions (escalation_policy_step_id, channel_id) 
+	values 
+		({{uuid "esid"}}, {{uuid "chan"}});
+
+	insert into services (id, escalation_policy_id, name) 
+	values
+		({{uuid "sid"}}, {{uuid "eid"}}, 'service');
+`
+	h := harness.NewHarness(t, sql, "slack-user-link")
+	defer h.Close()
+
+	h.CreateAlert(h.UUID("sid"), "testing")
+	h.Slack().Channel("test").ExpectMessage("testing")
+	h.CloseAlert(h.UUID("sid"), "testing")
+	h.Slack().Channel("test").ExpectMessage("Closed")
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Fixes a bug that prevented status updates for notification channels (e.g., Slack) from working and adds a smoketest to check for this.