### PR TITLE
ui/rotations: preserve on-call user when deleting

### DIFF
--- a/web/src/app/rotations/RotationUserDeleteDialog.js
+++ b/web/src/app/rotations/RotationUserDeleteDialog.js
@@ -32,12 +32,14 @@ const RotationUserDeleteDialog = (props) => {
       id: rotationID,
     },
   })
-  const { userIDs, users } = data.rotation
+  const { userIDs, users, activeUserIndex } = data.rotation
   const [deleteUserMutation] = useMutation(mutation, {
     onCompleted: onClose,
     variables: {
       input: {
         id: rotationID,
+        activeUserIndex:
+          activeUserIndex > userIndex ? activeUserIndex - 1 : activeUserIndex,
         userIDs: userIDs.filter((_, index) => index !== userIndex),
       },
     },


### PR DESCRIPTION
**Description:**
Fixes an issue where deleting a rotation user listed before the currently active user from the UI would result in the rotation advancing.
