### PR TITLE
engine/schedulemanager: fix sending messages to multiple Slack channels at the same time

### DIFF
--- a/smoketest/oncallnotify_test.go
+++ b/smoketest/oncallnotify_test.go
@@ -44,7 +44,8 @@ func TestOnCallNotify(t *testing.T) {
 	h := harness.NewHarness(t, sql, "outgoing-messages-schedule-id")
 	defer h.Close()
 
-	h.Slack().Channel("test").ExpectMessage("on-call", "testschedule", "bob")
+	h.Slack().Channel("test1").ExpectMessage("on-call", "testschedule", "bob")
+	h.Slack().Channel("test2").ExpectMessage("on-call", "testschedule", "bob")
 
 	h.FastForward(time.Hour)
 

--- a/smoketest/oncallnotify_test.go
+++ b/smoketest/oncallnotify_test.go
@@ -34,11 +34,12 @@ func TestOnCallNotify(t *testing.T) {
 
 	insert into notification_channels (id, type, name, value)
 	values
-		({{uuid "chan"}}, 'SLACK', '#test', {{slackChannelID "test"}});
-	
+		({{uuid "chan1"}}, 'SLACK', '#test1', {{slackChannelID "test1"}}),
+		({{uuid "chan2"}}, 'SLACK', '#test2', {{slackChannelID "test2"}});
+
 	insert into schedule_data (schedule_id, data)
 	values
-		({{uuid "sid"}}, '{"V1":{"OnCallNotificationRules": [{"ChannelID": {{uuidJSON "chan"}} }]}}');
+		({{uuid "sid"}}, '{"V1":{"OnCallNotificationRules": [{"ChannelID": {{uuidJSON "chan1"}} }, {"ChannelID": {{uuidJSON "chan2"}} }]}}');
 `
 	h := harness.NewHarness(t, sql, "outgoing-messages-schedule-id")
 	defer h.Close()
@@ -56,5 +57,6 @@ func TestOnCallNotify(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	h.Slack().Channel("test").ExpectMessage("on-call", "testschedule", "bob", "joe")
+	h.Slack().Channel("test1").ExpectMessage("on-call", "testschedule", "bob", "joe")
+	h.Slack().Channel("test2").ExpectMessage("on-call", "testschedule", "bob", "joe")
 }

--- a/smoketest/oncallnotifytod_test.go
+++ b/smoketest/oncallnotifytod_test.go
@@ -26,11 +26,12 @@ func TestOnCallNotifyTOD(t *testing.T) {
 
 	insert into notification_channels (id, type, name, value)
 	values
-		({{uuid "chan"}}, 'SLACK', '#test', {{slackChannelID "test"}});
+		({{uuid "chan1"}}, 'SLACK', '#test1', {{slackChannelID "test1"}}),
+		({{uuid "chan2"}}, 'SLACK', '#test2', {{slackChannelID "test2"}});
 	
 	insert into schedule_data (schedule_id, data)
 	values
-		({{uuid "sid"}}, '{"V1":{"OnCallNotificationRules": [{"ChannelID": {{uuidJSON "chan"}}, "Time": "00:00" }]}}');
+		({{uuid "sid"}}, '{"V1":{"OnCallNotificationRules": [{"ChannelID": {{uuidJSON "chan1"}}, "Time": "00:00" },{"ChannelID": {{uuidJSON "chan2"}}, "Time": "00:00" }]}}');
 `
 	h := harness.NewHarness(t, sql, "outgoing-messages-schedule-id")
 	defer h.Close()
@@ -39,6 +40,6 @@ func TestOnCallNotifyTOD(t *testing.T) {
 
 	h.FastForward(24 * time.Hour)
 
-	h.Slack().Channel("test").ExpectMessage("on-call", "testschedule", "bob")
-
+	h.Slack().Channel("test1").ExpectMessage("on-call", "testschedule", "bob")
+	h.Slack().Channel("test2").ExpectMessage("on-call", "testschedule", "bob")
 }

--- a/smoketest/oncallnotifytod_test.go
+++ b/smoketest/oncallnotifytod_test.go
@@ -31,7 +31,7 @@ func TestOnCallNotifyTOD(t *testing.T) {
 	
 	insert into schedule_data (schedule_id, data)
 	values
-		({{uuid "sid"}}, '{"V1":{"OnCallNotificationRules": [{"ChannelID": {{uuidJSON "chan1"}}, "Time": "00:00" },{"ChannelID": {{uuidJSON "chan2"}}, "Time": "00:00" }]}}');
+		({{uuid "sid"}}, '{"V1":{"OnCallNotificationRules": [{"ChannelID": {{uuidJSON "chan1"}}, "Time": "00:00" },{"ChannelID": {{uuidJSON "chan1"}}, "Time": "01:00" },{"ChannelID": {{uuidJSON "chan2"}}, "Time": "00:00" }]}}');
 `
 	h := harness.NewHarness(t, sql, "outgoing-messages-schedule-id")
 	defer h.Close()
@@ -40,6 +40,7 @@ func TestOnCallNotifyTOD(t *testing.T) {
 
 	h.FastForward(24 * time.Hour)
 
+	// should only send 1 message to each channel
 	h.Slack().Channel("test1").ExpectMessage("on-call", "testschedule", "bob")
 	h.Slack().Channel("test2").ExpectMessage("on-call", "testschedule", "bob")
 }


### PR DESCRIPTION
**Description:**
Fixes an issue where multiple on-call notifications would fail to send at the same time (for separate channels).

**Additional Info:**
When collecting the messages to be sent we were tracking them so that a schedule ID mapped to a single channel ID. Now they are stored as a slice of channel IDs -- with care taken to ensure we don't send duplicate messages to the same channel.
