### PR TITLE
ui: ignore dependabot updates for luxon deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,13 @@ updates:
       # ignore all patch updates
       - dependency-name: '*'
         update-types: ['version-update:semver-patch']
+
+      # while using @material-ui/pickers@3:
+      # https://github.com/mui-org/material-ui-pickers/issues/1440
+      # @material-ui/pickers@3 requires @date-io/luxon@1
       - dependency-name: '@date-io/luxon'
-        versions:
-          - '<=3.0.0'
       - dependency-name: '@date-io/core'
-        versions:
-          - 2.10.7
+      # @date-io/luxon@1 requires luxon@1
+      - dependency-name: 'luxon'
+      # luxon@1 requires @types/luxon@1
+      - dependency-name: '@types/luxon'


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR ignores luxon dependencies due to https://github.com/mui-org/material-ui-pickers/issues/1440

It seems we must wait for Material UI version 5, which will ship with newer pickers