### PR TITLE
ui/schedules: fix grammar affect -> effect

### DIFF
--- a/web/src/app/schedules/useOverrideNotices.ts
+++ b/web/src/app/schedules/useOverrideNotices.ts
@@ -42,7 +42,7 @@ export default function useOverrideNotices(
     {
       type: 'WARNING',
       message: 'This override overlaps with one or more temporary schedules',
-      details: 'Overrides do not take affect during temporary schedules',
+      details: 'Overrides do not take effect during temporary schedules',
     },
   ]
 }


### PR DESCRIPTION
Effect is the noun and the direct cause, so you would “take effect”. You cannot take a descriptive word.

<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes a grammar typo
