### PR TITLE
ui/schedules: display override events on schedule calendar

### DIFF
--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -17,6 +17,7 @@ import LuxonLocalizer from '../../util/LuxonLocalizer'
 import { parseInterval, trimSpans } from '../../util/shifts'
 import _ from 'lodash'
 import GroupAdd from '@material-ui/icons/GroupAdd'
+import { PersonAdd as PersonAddIcon } from '@material-ui/icons'
 import FilterContainer from '../../util/FilterContainer'
 import { UserSelect } from '../../selection'
 import SpinContainer from '../../loading/components/SpinContainer'
@@ -35,6 +36,10 @@ const useStyles = makeStyles((theme) => ({
   },
   tempSchedBtn: {
     marginLeft: theme.spacing(1.75),
+  },
+  overrideTitle: {
+    display: 'inline',
+    verticalAlign: 'middle',
   },
 }))
 
@@ -84,7 +89,7 @@ function ScheduleCalendar(props) {
     }))
 
     const overrides = userOverrides.map((o) => ({
-      user: { name: 'foobar replaces abc' },
+      user: { name: 'foobar'},
       start: o.start,
       end: o.end,
       fixed: false,
@@ -136,7 +141,7 @@ function ScheduleCalendar(props) {
 
     return filteredShifts.map((shift) => {
       return {
-        title: shift.user.name,
+        title: <div><PersonAddIcon className={classes.overrideTitle} ></PersonAddIcon> {shift.user.name}</div>,
         userID: shift.user.id,
         start: new Date(shift.start),
         end: new Date(shift.end),

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -103,7 +103,7 @@ function ScheduleCalendar(props) {
             className={classes.overrideTitle}
             aria-label='Add Override'
           />{' '}
-            Override
+          Override
            </div>
      }
     else {

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -96,7 +96,8 @@ function ScheduleCalendar(props) {
         </div>
       )
     } else if (o.addUser) {
-    return <div>
+      return (
+        <div>
            <AccountPlus fontSize='small' className={classes.overrideTitle} aria-label='Add Override'/>{' '}
             Override
            </div>

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -84,13 +84,14 @@ function ScheduleCalendar(props) {
     }))
 
     const overrides = userOverrides.map((o) => ({
-      user: { name: 'Override', id: o.id },
+      user: { name: 'Override' },
       start: o.start,
       end: o.end,
       fixed: false,
       isTempSchedShift: false,
       tempSched: false,
       isOverride: true,
+      override: o,
     }))
 
     // flat list of all fixed shifts, with `fixed` set to true
@@ -145,6 +146,7 @@ function ScheduleCalendar(props) {
         isTempSchedShift: shift.isTempSchedShift,
         tempSched: shift.tempSched,
         isOverride: shift.isOverride,
+        override: shift.override,
       }
     })
   }

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -110,7 +110,8 @@ function ScheduleCalendar(props) {
             aria-label='Remove Override'
           />{' '}
           Override
-           </div>
+        </div>
+      )
     }
   }
 

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react'
 import { PropTypes as p } from 'prop-types'
 import { Card, Button, makeStyles } from '@material-ui/core'
+import { darken } from '@material-ui/core/styles'
 import Grid from '@material-ui/core/Grid'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import Switch from '@material-ui/core/Switch'
@@ -52,20 +53,22 @@ function ScheduleCalendar(props) {
 
   const { shifts, temporarySchedules } = props
 
-  const eventStyleGetter = (event, start, end, isSelected,) => {
+  const eventStyleGetter = (event, start, end, isSelected) => {
+    const green = '#0C6618'
     if (event.fixed) {
       return {
         style: {
-          backgroundColor: isSelected ? '#094F13' : '#0C6618',
-          borderColor: '#094F13',
+          backgroundColor: isSelected ? darken(green, 0.3) : green,
+          borderColor: darken(green, 0.3),
         },
       }
     }
     if (event.isOverride) {
+      const lavender = '#BB7E8C'
       return {
         style: {
-          backgroundColor: '#FF0000',
-          borderColor: '#FF0000',
+          backgroundColor: isSelected ? darken(lavender, 0.3) : lavender,
+          borderColor: darken(lavender, 0.3),
         },
       }
     }
@@ -80,16 +83,15 @@ function ScheduleCalendar(props) {
       fixed: true,
     }))
 
-    const overrides = userOverrides.map((o) => ({    
-      user: { name:"Override"},
+    const overrides = userOverrides.map((o) => ({
+      user: { name: 'Override' },
       start: o.start,
-      end:o.end,
+      end: o.end,
       fixed: false,
       isTempSchedShift: false,
       tempSched: false,
       isOverride: true,
-    })
-    )
+    }))
 
     // flat list of all fixed shifts, with `fixed` set to true
     const fixedShifts = _.flatten(

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -95,7 +95,7 @@ function ScheduleCalendar(props) {
           Override
         </div>
       )
-    else if (o.addUser) {
+    } else if (o.addUser) {
     return <div>
            <AccountPlus fontSize='small' className={classes.overrideTitle} aria-label='Add Override'/>{' '}
             Override

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -103,7 +103,8 @@ function ScheduleCalendar(props) {
            </div>
      }
     else {
-    return <div>
+      return (
+        <div>
           <AccountMinus
             fontSize='small'
             className={classes.overrideTitle}

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -64,6 +64,8 @@ function ScheduleCalendar(props) {
 
   const eventStyleGetter = (event, start, end, isSelected) => {
     const green = '#0C6618'
+    const lavender = '#BB7E8C'
+
     if (event.fixed) {
       return {
         style: {
@@ -73,7 +75,6 @@ function ScheduleCalendar(props) {
       }
     }
     if (event.isOverride) {
-      const lavender = '#BB7E8C'
       return {
         style: {
           backgroundColor: isSelected ? darken(lavender, 0.3) : lavender,
@@ -83,8 +84,9 @@ function ScheduleCalendar(props) {
     }
   }
 
-  const getIcon = (o) => {
+  const getOverrideTitle = (o) => {
     if (o.addUser && o.removeUser) {
+      // replace override
       return (
         <div>
           <AccountSwitch
@@ -97,6 +99,7 @@ function ScheduleCalendar(props) {
       )
     }
     if (o.addUser) {
+      // add override
       return (
         <div>
           <AccountPlus
@@ -109,6 +112,7 @@ function ScheduleCalendar(props) {
       )
     }
     return (
+      // remove override
       <div>
         <AccountMinus
           fontSize='small'
@@ -131,7 +135,7 @@ function ScheduleCalendar(props) {
 
     const overrides = userOverrides.map((o) => ({
       user: {
-        name: getIcon(o),
+        name: getOverrideTitle(o),
       },
       start: o.start,
       end: o.end,

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -37,13 +37,14 @@ const useStyles = makeStyles((theme) => ({
   tempSchedBtn: {
     marginLeft: theme.spacing(1.75),
   },
-  overrideTitle: {
+  overrideTitleIcon: {
     verticalAlign: 'middle',
     borderRadius: '50%',
     background: theme.palette.secondary.main,
     padding: '3px',
     height: '100%',
     width: '18px',
+    marginRight: '0.25rem',
   },
 }))
 
@@ -91,9 +92,9 @@ function ScheduleCalendar(props) {
         <div>
           <AccountSwitch
             fontSize='small'
-            className={classes.overrideTitle}
+            className={classes.overrideTitleIcon}
             aria-label='Replace Override'
-          />{' '}
+          />
           Override
         </div>
       )
@@ -104,9 +105,9 @@ function ScheduleCalendar(props) {
         <div>
           <AccountPlus
             fontSize='small'
-            className={classes.overrideTitle}
+            className={classes.overrideTitleIcon}
             aria-label='Add Override'
-          />{' '}
+          />
           Override
         </div>
       )
@@ -116,9 +117,9 @@ function ScheduleCalendar(props) {
       <div>
         <AccountMinus
           fontSize='small'
-          className={classes.overrideTitle}
+          className={classes.overrideTitleIcon}
           aria-label='Remove Override'
-        />{' '}
+        />
         Override
       </div>
     )

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -104,7 +104,7 @@ function ScheduleCalendar(props) {
             aria-label='Add Override'
           />{' '}
           Override
-           </div>
+        </div>
      }
     else {
       return (

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -52,7 +52,7 @@ function ScheduleCalendar(props) {
 
   const { shifts, temporarySchedules } = props
 
-  const eventStyleGetter = (event, start, end, isSelected) => {
+  const eventStyleGetter = (event, start, end, isSelected,) => {
     if (event.fixed) {
       return {
         style: {
@@ -61,9 +61,17 @@ function ScheduleCalendar(props) {
         },
       }
     }
+    if (event.isOverride) {
+      return {
+        style: {
+          backgroundColor: '#FF0000',
+          borderColor: '#FF0000',
+        },
+      }
+    }
   }
 
-  const getCalEvents = (shifts, _tempScheds) => {
+  const getCalEvents = (shifts, _tempScheds, userOverrides) => {
     const tempSchedules = _tempScheds.map((sched) => ({
       start: sched.start,
       end: sched.end,
@@ -71,6 +79,17 @@ function ScheduleCalendar(props) {
       tempSched: sched,
       fixed: true,
     }))
+
+    const overrides = userOverrides.map((o) => ({    
+      user: { name:"Override"},
+      start: o.start,
+      end:o.end,
+      fixed: false,
+      isTempSchedShift: false,
+      tempSched: false,
+      isOverride: true,
+    })
+    )
 
     // flat list of all fixed shifts, with `fixed` set to true
     const fixedShifts = _.flatten(
@@ -88,10 +107,13 @@ function ScheduleCalendar(props) {
     let filteredShifts = [
       ...tempSchedules,
       ...fixedShifts,
+      ...overrides,
 
       // Remove shifts within a temporary schedule, and trim any that overlap
       ...trimSpans(shifts, ...fixedIntervals),
     ]
+
+    console.log('Overrides =', props.overrides)
 
     // if any users in users array, only show the ids present
     if (userFilter.length > 0) {
@@ -120,6 +142,7 @@ function ScheduleCalendar(props) {
         fixed: shift.fixed,
         isTempSchedShift: shift.isTempSchedShift,
         tempSched: shift.tempSched,
+        isOverride: shift.isOverride,
       }
     })
   }
@@ -186,7 +209,7 @@ function ScheduleCalendar(props) {
           <Calendar
             date={DateTime.fromISO(start).toJSDate()}
             localizer={localizer}
-            events={getCalEvents(shifts, temporarySchedules)}
+            events={getCalEvents(shifts, temporarySchedules, props.overrides)}
             style={{
               height: weekly ? '100%' : '45rem',
               fontFamily: theme.typography.body2.fontFamily,
@@ -222,6 +245,7 @@ function ScheduleCalendar(props) {
 ScheduleCalendar.propTypes = {
   scheduleID: p.string.isRequired,
   shifts: p.array.isRequired,
+  overrides: p.array.isRequired,
   temporarySchedules: p.array,
   loading: p.bool,
 }

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -104,7 +104,11 @@ function ScheduleCalendar(props) {
      }
     else {
     return <div>
-           <AccountMinus fontSize='small' className={classes.overrideTitle} aria-label='Remove Override'/>{' '}
+          <AccountMinus
+            fontSize='small'
+            className={classes.overrideTitle}
+            aria-label='Remove Override'
+          />{' '}
             Override
            </div>
     }

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -126,9 +126,7 @@ function ScheduleCalendar(props) {
 
     const overrides = userOverrides.map((o) => ({
       user: {
-        name: (
-         getIcon(o)
-        ),
+        name: getIcon(o),
       },
       start: o.start,
       end: o.end,

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -105,7 +105,7 @@ function ScheduleCalendar(props) {
           />{' '}
           Override
         </div>
-     }
+      )
     else {
       return (
         <div>

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -98,7 +98,11 @@ function ScheduleCalendar(props) {
     } else if (o.addUser) {
       return (
         <div>
-           <AccountPlus fontSize='small' className={classes.overrideTitle} aria-label='Add Override'/>{' '}
+          <AccountPlus
+            fontSize='small'
+            className={classes.overrideTitle}
+            aria-label='Add Override'
+          />{' '}
             Override
            </div>
      }

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -17,7 +17,7 @@ import LuxonLocalizer from '../../util/LuxonLocalizer'
 import { parseInterval, trimSpans } from '../../util/shifts'
 import _ from 'lodash'
 import GroupAdd from '@material-ui/icons/GroupAdd'
-import { PersonAdd as PersonAddIcon } from '@material-ui/icons'
+import { AccountSwitch, AccountMinus, AccountPlus } from 'mdi-material-ui'
 import FilterContainer from '../../util/FilterContainer'
 import { UserSelect } from '../../selection'
 import SpinContainer from '../../loading/components/SpinContainer'
@@ -40,7 +40,7 @@ const useStyles = makeStyles((theme) => ({
   overrideTitle: {
     verticalAlign: 'middle',
     borderRadius: '50%',
-    background: '#222222',
+    background: theme.palette.secondary.main,
     padding: '3px',
     height: '100%',
     width: '18px',
@@ -83,6 +83,27 @@ function ScheduleCalendar(props) {
     }
   }
 
+  const getIcon = (o) => {
+    if (o.addUser && o.removeUser) {
+    return <div>
+           <AccountSwitch fontSize='small' className={classes.overrideTitle} aria-label='Replace Override'/>{' '}
+            Override
+           </div>
+    }
+    else if (o.addUser) {
+    return <div>
+           <AccountPlus fontSize='small' className={classes.overrideTitle} aria-label='Add Override'/>{' '}
+            Override
+           </div>
+     }
+    else {
+    return <div>
+           <AccountMinus fontSize='small' className={classes.overrideTitle} aria-label='Remove Override'/>{' '}
+            Override
+           </div>
+    }
+  }
+
   const getCalEvents = (shifts, _tempScheds, userOverrides) => {
     const tempSchedules = _tempScheds.map((sched) => ({
       start: sched.start,
@@ -95,17 +116,7 @@ function ScheduleCalendar(props) {
     const overrides = userOverrides.map((o) => ({
       user: {
         name: (
-          <div>
-            <PersonAddIcon fontSize='small' className={classes.overrideTitle} />{' '}
-            {/* {o.addUser && o.removeUser
-              ? `${o.removeUser.name} replaces ${o.addUser.name}.`
-              : o.addUser
-              ? `Add ${o.addUser.name}`
-              : o.removeUser
-              ? `Remove ${o.removeUser.name}`
-              : null} */}
-            Override
-          </div>
+         getIcon(o)
         ),
       },
       start: o.start,

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -109,7 +109,7 @@ function ScheduleCalendar(props) {
             className={classes.overrideTitle}
             aria-label='Remove Override'
           />{' '}
-            Override
+          Override
            </div>
     }
   }

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -84,7 +84,7 @@ function ScheduleCalendar(props) {
     }))
 
     const overrides = userOverrides.map((o) => ({
-      user: { name: 'Override' },
+      user: { name: 'Override', id: o.id },
       start: o.start,
       end: o.end,
       fixed: false,
@@ -115,7 +115,7 @@ function ScheduleCalendar(props) {
       ...trimSpans(shifts, ...fixedIntervals),
     ]
 
-    console.log('Overrides =', props.overrides)
+    console.log('Overrides =', overrides)
 
     // if any users in users array, only show the ids present
     if (userFilter.length > 0) {

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -84,7 +84,7 @@ function ScheduleCalendar(props) {
     }))
 
     const overrides = userOverrides.map((o) => ({
-      user: { name: 'Override' },
+      user: { name: 'foobar replaces abc' },
       start: o.start,
       end: o.end,
       fixed: false,
@@ -115,8 +115,6 @@ function ScheduleCalendar(props) {
       // Remove shifts within a temporary schedule, and trim any that overlap
       ...trimSpans(shifts, ...fixedIntervals),
     ]
-
-    console.log('Overrides =', overrides)
 
     // if any users in users array, only show the ids present
     if (userFilter.length > 0) {

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -93,7 +93,7 @@ function ScheduleCalendar(props) {
             aria-label='Replace Override'
           />{' '}
           Override
-           </div>
+        </div>
     }
     else if (o.addUser) {
     return <div>

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -38,8 +38,12 @@ const useStyles = makeStyles((theme) => ({
     marginLeft: theme.spacing(1.75),
   },
   overrideTitle: {
-    display: 'inline',
     verticalAlign: 'middle',
+    borderRadius: '50%',
+    background: '#222222',
+    padding: '3px',
+    height: '100%',
+    width: '18px',
   },
 }))
 
@@ -89,7 +93,21 @@ function ScheduleCalendar(props) {
     }))
 
     const overrides = userOverrides.map((o) => ({
-      user: { name: 'foobar'},
+      user: {
+        name: (
+          <div>
+            <PersonAddIcon fontSize='small' className={classes.overrideTitle} />{' '}
+            {/* {o.addUser && o.removeUser
+              ? `${o.removeUser.name} replaces ${o.addUser.name}.`
+              : o.addUser
+              ? `Add ${o.addUser.name}`
+              : o.removeUser
+              ? `Remove ${o.removeUser.name}`
+              : null} */}
+            Override
+          </div>
+        ),
+      },
       start: o.start,
       end: o.end,
       fixed: false,
@@ -141,7 +159,7 @@ function ScheduleCalendar(props) {
 
     return filteredShifts.map((shift) => {
       return {
-        title: <div><PersonAddIcon className={classes.overrideTitle} ></PersonAddIcon> {shift.user.name}</div>,
+        title: shift.user.name,
         userID: shift.user.id,
         start: new Date(shift.start),
         end: new Date(shift.end),

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -85,7 +85,8 @@ function ScheduleCalendar(props) {
 
   const getIcon = (o) => {
     if (o.addUser && o.removeUser) {
-    return <div>
+      return (
+        <div>
            <AccountSwitch fontSize='small' className={classes.overrideTitle} aria-label='Replace Override'/>{' '}
             Override
            </div>

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -87,7 +87,11 @@ function ScheduleCalendar(props) {
     if (o.addUser && o.removeUser) {
       return (
         <div>
-           <AccountSwitch fontSize='small' className={classes.overrideTitle} aria-label='Replace Override'/>{' '}
+          <AccountSwitch
+            fontSize='small'
+            className={classes.overrideTitle}
+            aria-label='Replace Override'
+          />{' '}
             Override
            </div>
     }

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -92,7 +92,7 @@ function ScheduleCalendar(props) {
             className={classes.overrideTitle}
             aria-label='Replace Override'
           />{' '}
-            Override
+          Override
            </div>
     }
     else if (o.addUser) {

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -95,7 +95,8 @@ function ScheduleCalendar(props) {
           Override
         </div>
       )
-    } else if (o.addUser) {
+    }
+    if (o.addUser) {
       return (
         <div>
           <AccountPlus
@@ -106,18 +107,17 @@ function ScheduleCalendar(props) {
           Override
         </div>
       )
-    else {
-      return (
-        <div>
-          <AccountMinus
-            fontSize='small'
-            className={classes.overrideTitle}
-            aria-label='Remove Override'
-          />{' '}
-          Override
-        </div>
-      )
     }
+    return (
+      <div>
+        <AccountMinus
+          fontSize='small'
+          className={classes.overrideTitle}
+          aria-label='Remove Override'
+        />{' '}
+        Override
+      </div>
+    )
   }
 
   const getCalEvents = (shifts, _tempScheds, userOverrides) => {

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -94,7 +94,7 @@ function ScheduleCalendar(props) {
           />{' '}
           Override
         </div>
-    }
+      )
     else if (o.addUser) {
     return <div>
            <AccountPlus fontSize='small' className={classes.overrideTitle} aria-label='Add Override'/>{' '}

--- a/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.js
@@ -169,35 +169,44 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
     if (DateTime.fromJSDate(event.end) <= DateTime.utc()) return null
     if (event.tempSched) return renderTempSchedButtons()
     if (event.fixed) return null
-    if (event.isOverride) return renderOverrideButtons(event)
+    if (event.isOverride) return renderOverrideButtons()
 
     return renderShiftButtons()
   }
 
-  function renderText() {
-    if (event.isOverride) {
-      if (event.override.addUser && event.override.removeUser) {
+  function renderOverrideText() {
+    function getText(addUser, removeUser) {
+      if (addUser && removeUser)
         return (
-          <Grid item xs={12}>
-            <Typography variant='body2'>{`${event.override.removeUser.name} replaces ${event.override.addUser.name}.`}</Typography>
-          </Grid>
+          <React.Fragment>
+            <b>{removeUser.name}</b> replaces <b>{addUser.name}</b>.
+          </React.Fragment>
         )
-      }
-      if (event.override.addUser) {
+      if (addUser)
         return (
-          <Grid item xs={12}>
-            <Typography variant='body2'>{`Adds ${event.override.addUser.name}.`}</Typography>
-          </Grid>
+          <React.Fragment>
+            Adds <b>{addUser.name}</b>.
+          </React.Fragment>
         )
-      }
-      if (event.override.removeUser) {
+      if (removeUser)
         return (
-          <Grid item xs={12}>
-            <Typography variant='body2'>{`Removes ${event.override.removeUser.name}.`}</Typography>
-          </Grid>
+          <React.Fragment>
+            Removes <b>{removeUser.name}</b>.
+          </React.Fragment>
         )
-      }
     }
+
+    return (
+      <Grid item xs={12}>
+        <Typography variant='body2'>
+          {getText(event.override.addUser, event.override.removeUser)}
+        </Typography>
+      </Grid>
+    )
+  }
+
+  function renderText() {
+    if (event.isOverride) return renderOverrideText()
 
     return null
   }

--- a/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.js
@@ -115,7 +115,7 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
     )
   }
 
-  function renderOverrideButtons(event) {
+  function renderOverrideButtons() {
     return (
       <React.Fragment>
         <CardActions
@@ -131,22 +131,13 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
             {
               icon: <DeleteIcon />,
               label: 'Delete',
-              handleOnClick: () => setShowDeleteDialog(true),
+              handleOnClick: () => {
+                handleCloseShiftInfo()
+                setShowDeleteDialog(true)
+              },
             },
           ]}
         />
-        {showEditDialog && (
-          <ScheduleOverrideEditDialog
-            overrideID={event.userID}
-            onClose={() => setShowEditDialog(false)}
-          />
-        )}
-        {showDeleteDialog && (
-          <ScheduleOverrideDeleteDialog
-            overrideID={event.userID}
-            onClose={() => setShowDeleteDialog(false)}
-          />
-        )}
       </React.Fragment>
     )
   }
@@ -235,6 +226,18 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
         'aria-pressed': open,
         'aria-describedby': id,
       })}
+      {showEditDialog && (
+        <ScheduleOverrideEditDialog
+          overrideID={event.override.id}
+          onClose={() => setShowEditDialog(false)}
+        />
+      )}
+      {showDeleteDialog && (
+        <ScheduleOverrideDeleteDialog
+          overrideID={event.override.id}
+          onClose={() => setShowDeleteDialog(false)}
+        />
+      )}
     </React.Fragment>
   )
 }

--- a/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.js
@@ -9,6 +9,8 @@ import { DateTime } from 'luxon'
 import { ScheduleCalendarContext } from '../ScheduleDetails'
 import CardActions from '../../details/CardActions'
 import { Edit as EditIcon, Delete as DeleteIcon } from '@material-ui/icons'
+import ScheduleOverrideEditDialog from '../ScheduleOverrideEditDialog'
+import ScheduleOverrideDeleteDialog from '../ScheduleOverrideDeleteDialog'
 
 const useStyles = makeStyles({
   button: {
@@ -35,6 +37,9 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
   // toDo setState for edit and delete
   // user setOverrideDialog() to open the edit
   // delete to be done manually
+  const [showEditDialog, setShowEditDialog] = useState(false)
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+
   const { setOverrideDialog, onEditTempSched, onDeleteTempSched } = useContext(
     ScheduleCalendarContext,
   )
@@ -110,22 +115,39 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
     )
   }
 
-  function renderOverrideButtons() {
+  function renderOverrideButtons(event) {
     return (
-      <CardActions
-        secondaryActions={[
-          {
-            icon: <EditIcon />,
-            label: 'Edit',
-            //  handleOnClick: () => close(),
-          },
-          {
-            icon: <DeleteIcon />,
-            label: 'Delete',
-            // handleOnClick: () => escalate(),
-          },
-        ]}
-      />
+      <React.Fragment>
+        <CardActions
+          secondaryActions={[
+            {
+              icon: <EditIcon />,
+              label: 'Edit',
+              handleOnClick: () => {
+                handleCloseShiftInfo()
+                setShowEditDialog(true)
+              },
+            },
+            {
+              icon: <DeleteIcon />,
+              label: 'Delete',
+              handleOnClick: () => setShowDeleteDialog(true),
+            },
+          ]}
+        />
+        {showEditDialog && (
+          <ScheduleOverrideEditDialog
+            overrideID={event.userID}
+            onClose={() => setShowEditDialog(false)}
+          />
+        )}
+        {showDeleteDialog && (
+          <ScheduleOverrideDeleteDialog
+            overrideID={event.userID}
+            onClose={() => setShowDeleteDialog(false)}
+          />
+        )}
+      </React.Fragment>
     )
   }
 
@@ -153,7 +175,7 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
     if (DateTime.fromJSDate(event.end) <= DateTime.utc()) return null
     if (event.tempSched) return renderTempSchedButtons()
     if (event.fixed) return null
-    if (event.isOverride) return renderOverrideButtons()
+    if (event.isOverride) return renderOverrideButtons(event)
 
     return renderShiftButtons()
   }

--- a/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.js
@@ -13,6 +13,9 @@ import ScheduleOverrideEditDialog from '../ScheduleOverrideEditDialog'
 import ScheduleOverrideDeleteDialog from '../ScheduleOverrideDeleteDialog'
 
 const useStyles = makeStyles({
+  cardActionContainer: {
+    width: '100%',
+  },
   button: {
     padding: '4px',
     minHeight: 0,
@@ -37,8 +40,8 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
   // toDo setState for edit and delete
   // user setOverrideDialog() to open the edit
   // delete to be done manually
-  const [showEditDialog, setShowEditDialog] = useState(false)
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+  const [showEditDialog, setShowEditDialog] = useState(null)
+  const [showDeleteDialog, setShowDeleteDialog] = useState(null)
 
   const { setOverrideDialog, onEditTempSched, onDeleteTempSched } = useContext(
     ScheduleCalendarContext,
@@ -117,7 +120,7 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
 
   function renderOverrideButtons() {
     return (
-      <React.Fragment>
+      <div className={classes.cardActionContainer}>
         <CardActions
           secondaryActions={[
             {
@@ -125,7 +128,7 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
               label: 'Edit',
               handleOnClick: () => {
                 handleCloseShiftInfo()
-                setShowEditDialog(true)
+                setShowEditDialog(event?.override?.id)
               },
             },
             {
@@ -133,12 +136,12 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
               label: 'Delete',
               handleOnClick: () => {
                 handleCloseShiftInfo()
-                setShowDeleteDialog(true)
+                setShowDeleteDialog(event?.override?.id)
               },
             },
           ]}
         />
-      </React.Fragment>
+      </div>
     )
   }
 
@@ -171,6 +174,34 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
     return renderShiftButtons()
   }
 
+  function renderText() {
+    if (event.isOverride) {
+      if (event.override.addUser && event.override.removeUser) {
+        return (
+          <Grid item xs={12}>
+            <Typography variant='body2'>{`${event.override.removeUser.name} replaces ${event.override.addUser.name}.`}</Typography>
+          </Grid>
+        )
+      }
+      if (event.override.addUser) {
+        return (
+          <Grid item xs={12}>
+            <Typography variant='body2'>{`Adds ${event.override.addUser.name}.`}</Typography>
+          </Grid>
+        )
+      }
+      if (event.override.removeUser) {
+        return (
+          <Grid item xs={12}>
+            <Typography variant='body2'>{`Removes ${event.override.removeUser.name}.`}</Typography>
+          </Grid>
+        )
+      }
+    }
+
+    return null
+  }
+
   /*
    * Renders an interactive tooltip when selecting
    * an event in the calendar that will show
@@ -188,6 +219,7 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
             {`${fmt(event.start)}  –  ${fmt(event.end)}`}
           </Typography>
         </Grid>
+        {renderText()}
         {renderButtons()}
       </Grid>
     )
@@ -228,14 +260,14 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
       })}
       {showEditDialog && (
         <ScheduleOverrideEditDialog
-          overrideID={event.override.id}
-          onClose={() => setShowEditDialog(false)}
+          overrideID={showEditDialog}
+          onClose={() => setShowEditDialog(null)}
         />
       )}
       {showDeleteDialog && (
         <ScheduleOverrideDeleteDialog
-          overrideID={event.override.id}
-          onClose={() => setShowDeleteDialog(false)}
+          overrideID={showDeleteDialog}
+          onClose={() => setShowDeleteDialog(null)}
         />
       )}
     </React.Fragment>

--- a/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.js
@@ -122,7 +122,7 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
         <CardActions
           secondaryActions={[
             {
-              icon: <EditIcon />,
+              icon: <EditIcon fontSize='small' />,
               label: 'Edit',
               handleOnClick: () => {
                 handleCloseShiftInfo()
@@ -130,7 +130,7 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
               },
             },
             {
-              icon: <DeleteIcon />,
+              icon: <DeleteIcon fontSize='small' />,
               label: 'Delete',
               handleOnClick: () => {
                 handleCloseShiftInfo()
@@ -174,7 +174,8 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
 
   function renderOverrideDescription() {
     if (!event.isOverride) return null
-    function getDesc(addUser, removeUser) {
+
+    const getDesc = (addUser, removeUser) => {
       if (addUser && removeUser)
         return (
           <React.Fragment>
@@ -216,12 +217,12 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
 
     return (
       <Grid container spacing={1}>
+        {renderOverrideDescription()}
         <Grid item xs={12}>
           <Typography variant='body2'>
             {`${fmt(event.start)}  –  ${fmt(event.end)}`}
           </Typography>
         </Grid>
-        {renderOverrideDescription()}
         {renderButtons()}
       </Grid>
     )

--- a/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.js
@@ -37,9 +37,7 @@ const useStyles = makeStyles({
 export default function ScheduleCalendarEventWrapper({ children, event }) {
   const classes = useStyles()
   const [anchorEl, setAnchorEl] = useState(null)
-  // toDo setState for edit and delete
-  // user setOverrideDialog() to open the edit
-  // delete to be done manually
+
   const [showEditDialog, setShowEditDialog] = useState(null)
   const [showDeleteDialog, setShowDeleteDialog] = useState(null)
 
@@ -174,8 +172,8 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
     return renderShiftButtons()
   }
 
-  function renderOverrideText() {
-    function getText(addUser, removeUser) {
+  function renderOverrideDescription() {
+    function getDesc(addUser, removeUser) {
       if (addUser && removeUser)
         return (
           <React.Fragment>
@@ -199,14 +197,14 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
     return (
       <Grid item xs={12}>
         <Typography variant='body2'>
-          {getText(event.override.addUser, event.override.removeUser)}
+          {getDesc(event.override.addUser, event.override.removeUser)}
         </Typography>
       </Grid>
     )
   }
 
-  function renderText() {
-    if (event.isOverride) return renderOverrideText()
+  function renderDescription() {
+    if (event.isOverride) return renderOverrideDescription()
 
     return null
   }
@@ -228,7 +226,7 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
             {`${fmt(event.start)}  –  ${fmt(event.end)}`}
           </Typography>
         </Grid>
-        {renderText()}
+        {renderDescription()}
         {renderButtons()}
       </Grid>
     )

--- a/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.js
@@ -7,6 +7,8 @@ import Typography from '@material-ui/core/Typography'
 import { makeStyles } from '@material-ui/core'
 import { DateTime } from 'luxon'
 import { ScheduleCalendarContext } from '../ScheduleDetails'
+import CardActions from '../../details/CardActions'
+import { Edit as EditIcon, Delete as DeleteIcon } from '@material-ui/icons'
 
 const useStyles = makeStyles({
   button: {
@@ -30,6 +32,9 @@ const useStyles = makeStyles({
 export default function ScheduleCalendarEventWrapper({ children, event }) {
   const classes = useStyles()
   const [anchorEl, setAnchorEl] = useState(null)
+  // toDo setState for edit and delete
+  // user setOverrideDialog() to open the edit
+  // delete to be done manually
   const { setOverrideDialog, onEditTempSched, onDeleteTempSched } = useContext(
     ScheduleCalendarContext,
   )
@@ -107,6 +112,25 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
 
   function renderOverrideButtons() {
     return (
+      <CardActions
+        secondaryActions={[
+          {
+            icon: <EditIcon />,
+            label: 'Edit',
+            //  handleOnClick: () => close(),
+          },
+          {
+            icon: <DeleteIcon />,
+            label: 'Delete',
+            // handleOnClick: () => escalate(),
+          },
+        ]}
+      />
+    )
+  }
+
+  function renderShiftButtons() {
+    return (
       <React.Fragment>
         <Grid item className={classes.flexGrow} />
         <Grid item>
@@ -129,8 +153,9 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
     if (DateTime.fromJSDate(event.end) <= DateTime.utc()) return null
     if (event.tempSched) return renderTempSchedButtons()
     if (event.fixed) return null
+    if (event.isOverride) return renderOverrideButtons()
 
-    return renderOverrideButtons()
+    return renderShiftButtons()
   }
 
   /*

--- a/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.js
@@ -173,6 +173,7 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
   }
 
   function renderOverrideDescription() {
+    if (!event.isOverride) return null
     function getDesc(addUser, removeUser) {
       if (addUser && removeUser)
         return (
@@ -203,12 +204,6 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
     )
   }
 
-  function renderDescription() {
-    if (event.isOverride) return renderOverrideDescription()
-
-    return null
-  }
-
   /*
    * Renders an interactive tooltip when selecting
    * an event in the calendar that will show
@@ -226,7 +221,7 @@ export default function ScheduleCalendarEventWrapper({ children, event }) {
             {`${fmt(event.start)}  –  ${fmt(event.end)}`}
           </Typography>
         </Grid>
-        {renderDescription()}
+        {renderOverrideDescription()}
         {renderButtons()}
       </Grid>
     )

--- a/web/src/app/schedules/calendar/ScheduleCalendarQuery.tsx
+++ b/web/src/app/schedules/calendar/ScheduleCalendarQuery.tsx
@@ -15,6 +15,27 @@ const query = gql`
     $start: ISOTimestamp!
     $end: ISOTimestamp!
   ) {
+      userOverrides(input: {scheduleID: $id, start: $start, end: $end}) {
+      nodes {
+        id
+        start
+        end
+        addUser {
+          id
+          name
+        }
+        removeUser {
+          id
+          name
+        }
+      }
+
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+
     schedule(id: $id) {
       id
       shifts(start: $start, end: $end) {
@@ -87,6 +108,7 @@ function ScheduleCalendarQuery({
       loading={loading && !data}
       shifts={data?.schedule?.shifts ?? []}
       temporarySchedules={data?.schedule?.temporarySchedules ?? []}
+      overrides = {data?.userOverrides?.nodes ?? []}
       {...other}
     />
   )

--- a/web/src/app/schedules/calendar/ScheduleCalendarQuery.tsx
+++ b/web/src/app/schedules/calendar/ScheduleCalendarQuery.tsx
@@ -15,7 +15,7 @@ const query = gql`
     $start: ISOTimestamp!
     $end: ISOTimestamp!
   ) {
-      userOverrides(input: {scheduleID: $id, start: $start, end: $end}) {
+    userOverrides(input: { scheduleID: $id, start: $start, end: $end }) {
       nodes {
         id
         start
@@ -108,7 +108,7 @@ function ScheduleCalendarQuery({
       loading={loading && !data}
       shifts={data?.schedule?.shifts ?? []}
       temporarySchedules={data?.schedule?.temporarySchedules ?? []}
-      overrides = {data?.userOverrides?.nodes ?? []}
+      overrides={data?.userOverrides?.nodes ?? []}
       {...other}
     />
   )

--- a/web/src/cypress/integration/scheduleCalendar.ts
+++ b/web/src/cypress/integration/scheduleCalendar.ts
@@ -203,6 +203,70 @@ function testCalendar(screen: ScreenFormat): void {
     cy.dialogTitle('Remove')
     cy.dialogFinish('Submit')
   })
+
+  it('should show overrides on calendar and open edit dialog from tooltip', () => {
+    cy.get('[data-cy-spin-loading=false]').should('exist')
+    const name = rot.users[0].name
+
+    cy.fixture('users').then((users) => {
+      let addUserName = users[0].name
+      if (rot.users[0].id === users[0].id) addUserName = users[1].name
+      cy.get('[data-cy=calendar]')
+        .should('contain', name)
+        .contains('div', name)
+        .click()
+      cy.get('div[data-cy="shift-tooltip"]').should('be.visible')
+      cy.get('button[data-cy="override"]').click()
+      cy.dialogTitle('Choose')
+      cy.dialogForm({ variant: 'replace' })
+      cy.dialogClick('Next')
+
+      cy.dialogTitle('Replace')
+      cy.dialogForm({ addUserID: addUserName })
+      cy.dialogFinish('Submit')
+
+      cy.get('[aria-label="Replace Override"]').should('be.visible').click()
+
+      cy.get('div[data-cy="shift-tooltip"]')
+        .find('[data-cy="card-actions"]')
+        .find('button[title="Edit"]')
+        .click()
+      cy.dialogTitle('Edit Schedule Override')
+      cy.dialogFinish('Cancel')
+    })
+  })
+
+  it('should show overrides on calendar and open delete dialog from tooltip', () => {
+    cy.get('[data-cy-spin-loading=false]').should('exist')
+    const name = rot.users[0].name
+
+    cy.fixture('users').then((users) => {
+      let addUserName = users[0].name
+      if (rot.users[0].id === users[0].id) addUserName = users[1].name
+      cy.get('[data-cy=calendar]')
+        .should('contain', name)
+        .contains('div', name)
+        .click()
+      cy.get('div[data-cy="shift-tooltip"]').should('be.visible')
+      cy.get('button[data-cy="override"]').click()
+      cy.dialogTitle('Choose')
+      cy.dialogForm({ variant: 'replace' })
+      cy.dialogClick('Next')
+
+      cy.dialogTitle('Replace')
+      cy.dialogForm({ addUserID: addUserName })
+      cy.dialogFinish('Submit')
+
+      cy.get('[aria-label="Replace Override"]').should('be.visible').click()
+
+      cy.get('div[data-cy="shift-tooltip"]')
+        .find('[data-cy="card-actions"]')
+        .find('button[title="Delete"]')
+        .click()
+      cy.dialogTitle('Are you sure?')
+      cy.dialogFinish('Cancel')
+    })
+  })
 }
 
 testScreen('Calendar', testCalendar)


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Currently, the calendar only shows the resulting shifts from an override. This PR adds an override item to the calendar that shows the details of the override as-well. This lets you edit these details straight from the calendar. You can change the details of the override such as who is affected & for what duration. You can also remove overrides straight from the calendar.

**Screenshots:**

Image of new override event on calendar.
<img width="758" alt="Screen Shot 2021-09-27 at 3 44 13 PM" src="https://user-images.githubusercontent.com/28174559/134982416-6d11fe36-7397-4815-b810-a5a6ff29eca6.png">

Tooltip when calendar item is selected:
<img width="570" alt="Screen Shot 2021-09-27 at 3 43 56 PM" src="https://user-images.githubusercontent.com/28174559/134982366-bc3e75de-bd6c-49e0-9d31-11a4fb3e4293.png">

- The pencil icon takes you to the edit override dialog
- The trash can takes you to the delete override dialog

**Describe any introduced user-facing changes:**
Users will now be able to see overrides on the schedule calendar, and perform edit and delete operations for current/future overrides via the tooltip.

