### PR TITLE
ui/schedules: use explicit time zone when parsing intervals

### DIFF
--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -84,7 +84,7 @@ function ScheduleCalendar(props) {
       }),
     )
 
-    const fixedIntervals = tempSchedules.map(parseInterval)
+    const fixedIntervals = tempSchedules.map((t) => parseInterval(t, 'local'))
     let filteredShifts = [
       ...tempSchedules,
       ...fixedShifts,

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -90,7 +90,7 @@ function ScheduleCalendar(props) {
       ...fixedShifts,
 
       // Remove shifts within a temporary schedule, and trim any that overlap
-      ...trimSpans(shifts, ...fixedIntervals),
+      ...trimSpans(shifts, ...fixedIntervals, 'local'),
     ]
 
     // if any users in users array, only show the ids present

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -90,7 +90,7 @@ function ScheduleCalendar(props) {
       ...fixedShifts,
 
       // Remove shifts within a temporary schedule, and trim any that overlap
-      ...trimSpans(shifts, ...fixedIntervals, 'local'),
+      ...trimSpans(shifts, fixedIntervals, 'local'),
     ]
 
     // if any users in users array, only show the ids present

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -57,10 +57,13 @@ export default function TempSchedDialog({
     }
   }, [q.loading, zone])
 
-  const schedInterval = parseInterval(value)
-  const hasInvalidShift = value.shifts.some(
-    (s) => !schedInterval.engulfs(parseInterval(s)),
-  )
+  const hasInvalidShift = (() => {
+    if (q.loading) return false
+    const schedInterval = parseInterval(value, zone)
+    return value.shifts.some(
+      (s) => !schedInterval.engulfs(parseInterval(s, zone)),
+    )
+  })()
 
   const shiftErrors = hasInvalidShift
     ? [

--- a/web/src/app/schedules/temp-sched/sharedUtils.tsx
+++ b/web/src/app/schedules/temp-sched/sharedUtils.tsx
@@ -1,4 +1,4 @@
-import { DateTime, Interval } from 'luxon'
+import { DateTime } from 'luxon'
 import React, { ReactNode } from 'react'
 
 export type Value = {
@@ -16,27 +16,6 @@ export type Shift = {
     id: string
     name: string
   }
-}
-
-const parseInterval = (start: string, end: string): Interval =>
-  Interval.fromDateTimes(DateTime.fromISO(start), DateTime.fromISO(end))
-
-export function validateShift(
-  schedStart: string,
-  schedEnd: string,
-  shift: Shift,
-): Error | null {
-  const schedSpan = parseInterval(schedStart, schedEnd)
-  const shiftSpan = parseInterval(shift.start, shift.end)
-
-  // these two just for completeness but should never happen
-  if (!shiftSpan.isValid) return new Error('invalid shift times')
-  if (!schedSpan.isValid) return new Error('invalid schedule times')
-
-  if (!schedSpan.engulfs(shiftSpan))
-    return new Error('shift extends beyond temporary schedule')
-
-  return null
 }
 
 // removes bottom margin from content text so form fields

--- a/web/src/app/schedules/useOverrideNotices.ts
+++ b/web/src/app/schedules/useOverrideNotices.ts
@@ -1,7 +1,6 @@
-import { Notice } from '../../schema'
+import { Notice, TemporarySchedule } from '../../schema'
 import { parseInterval, SpanISO } from '../util/shifts'
 import { useQuery, gql } from '@apollo/client'
-import _ from 'lodash'
 import { Interval } from 'luxon'
 
 const scheduleQuery = gql`
@@ -9,6 +8,7 @@ const scheduleQuery = gql`
     schedule(id: $id) {
       id
       name
+      timeZone
       temporarySchedules {
         start
         end
@@ -29,10 +29,11 @@ export default function useOverrideNotices(
   if (loading) {
     return []
   }
-  const tempSchedules = _.get(data, 'schedule.temporarySchedules')
-  const valueInterval = parseInterval(value)
+  const tempSchedules = data?.schedule?.temporarySchedules
+  const zone = data?.schedule?.timeZone
+  const valueInterval = parseInterval(value, zone)
   const doesOverlap = tempSchedules
-    .map(parseInterval)
+    .map((t: TemporarySchedule) => parseInterval(t, zone))
     .some((invl: Interval) => invl.overlaps(valueInterval))
 
   if (!doesOverlap) {

--- a/web/src/app/schedules/useOverrideNotices.ts
+++ b/web/src/app/schedules/useOverrideNotices.ts
@@ -1,7 +1,6 @@
 import { Notice, TemporarySchedule } from '../../schema'
 import { parseInterval, SpanISO } from '../util/shifts'
 import { useQuery, gql } from '@apollo/client'
-import { Interval } from 'luxon'
 
 const scheduleQuery = gql`
   query ($id: ID!) {
@@ -32,9 +31,9 @@ export default function useOverrideNotices(
   const tempSchedules = data?.schedule?.temporarySchedules
   const zone = data?.schedule?.timeZone
   const valueInterval = parseInterval(value, zone)
-  const doesOverlap = tempSchedules
-    .map((t: TemporarySchedule) => parseInterval(t, zone))
-    .some((invl: Interval) => invl.overlaps(valueInterval))
+  const doesOverlap = tempSchedules.some((t: TemporarySchedule) =>
+    parseInterval(t, zone).overlaps(valueInterval),
+  )
 
   if (!doesOverlap) {
     return []

--- a/web/src/app/util/shifts.ts
+++ b/web/src/app/util/shifts.ts
@@ -1,4 +1,4 @@
-import { DateTime, Interval } from 'luxon'
+import { DateTime, DateTimeOptions, Interval } from 'luxon'
 import _ from 'lodash'
 
 export interface SpanISO {
@@ -6,7 +6,9 @@ export interface SpanISO {
   end: string
 }
 
-export function parseInterval(s: SpanISO, zone = 'local'): Interval {
+type ExplicitZone = NonNullable<DateTimeOptions['zone']>
+
+export function parseInterval(s: SpanISO, zone: ExplicitZone): Interval {
   return Interval.fromDateTimes(
     DateTime.fromISO(s.start, { zone }),
     DateTime.fromISO(s.end, { zone }),
@@ -15,13 +17,14 @@ export function parseInterval(s: SpanISO, zone = 'local'): Interval {
 
 export function trimSpans<T extends SpanISO>(
   spans: T[],
-  ...intervals: Interval[]
+  intervals: Interval[],
+  zone: ExplicitZone,
 ): T[] {
   intervals = Interval.merge(intervals)
 
   return _.flatten(
     spans.map((s) => {
-      const ivl = parseInterval(s)
+      const ivl = parseInterval(s, zone)
 
       return ivl.difference(...intervals).map((ivl) => ({
         ...s,


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR changes `parseInterval` and `trimSpans` to require an explicit timezone as the second parameter. Previously, these defaulted to `'local'` i.e. system zone. Without setting a zone, the interval's endpoints (start/end) will be in the system zone. Sometimes this doesn't matter e.g. simply checking if two intervals overlap, but the more I work with luxon, the more I wish they enforced explicit zones in their function signatures. Time without a location isn't a concept, and bugs will crop up if we aren't being deliberate about pairing time with location.

Summary of changes:
- use `'local'` for `ScheduleCalendar`
- use schedule zone for `TempSchedDialog`
- remove redundant `parseInterval` function
- remove unused `validateShift` function
- use schedule zone for `useOverrideNotices` (also remove unnecessary `map`) 