### PR TITLE
github-actions: don't run on draft PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ jobs:
   node-checks:
     name: Node checks
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
This PR disables @github-actions from running on draft PRs. We had a case where a draft PR wasn't fully linted yet and got bombarded with comments.

---

An alternative could be to continue running everything as we do now, but instead have the bot comment just once with something like
```
Linting failed for the following files:
web/src/someFile.ts
web/src/someOtherFile.ts
```
for drafts, instead of line by line.