### PR TITLE
Twilio: allow configuring messaging service SID as FromNumber

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -402,7 +402,7 @@ func (cfg Config) Validate() error {
 		err = validate.Many(err, validate.AbsoluteURL("GitHub.EnterpriseURL", cfg.GitHub.EnterpriseURL))
 	}
 	if cfg.Twilio.FromNumber != "" {
-		err = validate.Many(err, validate.Phone("Twilio.FromNumber", cfg.Twilio.FromNumber))
+		err = validate.Many(err, validate.TwilioFromValue("Twilio.FromNumber", cfg.Twilio.FromNumber))
 	}
 	if cfg.Mailgun.EmailDomain != "" {
 		err = validate.Many(err, validate.Email("Mailgun.EmailDomain", "example@"+cfg.Mailgun.EmailDomain))

--- a/devtools/mocktwilio/server.go
+++ b/devtools/mocktwilio/server.go
@@ -234,6 +234,7 @@ func (s *Server) NewMessagingService(smsURL, voiceURL string, numbers ...string)
 		s.callbacks["SMS:"+num] = smsURL
 		s.callbacks["VOICE:"+num] = voiceURL
 	}
+	s.msgSvc[svcID] = numbers
 
 	return svcID, nil
 }

--- a/smoketest/harness/harness.go
+++ b/smoketest/harness/harness.go
@@ -652,7 +652,7 @@ func (h *Harness) TwilioMessagingService() string {
 	}
 	defer h.mx.Unlock()
 
-	nums := []string{h.phoneCCG.Get(""), h.phoneCCG.Get(""), h.phoneCCG.Get("")}
+	nums := []string{h.phoneCCG.Get("twilio_sid_1"), h.phoneCCG.Get("twilio_sid_2"), h.phoneCCG.Get("twilio_sid_3")}
 	newID, err := h.tw.NewMessagingService(h.URL()+"/v1/twilio/sms/messages", h.URL()+"/v1/twilio/voice/call", nums...)
 	if err != nil {
 		panic(err)

--- a/smoketest/twiliosid_test.go
+++ b/smoketest/twiliosid_test.go
@@ -1,0 +1,64 @@
+package smoketest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/target/goalert/smoketest/harness"
+)
+
+// TestTwilioSID checks that messages to SMS and Voice numbers work when using a Messaging Service SID for Twilio.FromNumber.
+func TestTwilioSID(t *testing.T) {
+	t.Parallel()
+
+	sql := `
+	insert into users (id, name, email, role) 
+	values 
+		({{uuid "user"}}, 'bob', 'joe', 'user');
+	insert into user_contact_methods (id, user_id, name, type, value) 
+	values
+		({{uuid "cm1"}}, {{uuid "user"}}, 'personal', 'SMS', {{phone "1"}}),
+		({{uuid "cm2"}}, {{uuid "user"}}, 'personal', 'VOICE', {{phone "1"}});
+
+	insert into user_notification_rules (user_id, contact_method_id, delay_minutes) 
+	values
+		({{uuid "user"}}, {{uuid "cm1"}}, 0),
+		({{uuid "user"}}, {{uuid "cm2"}}, 0),
+		({{uuid "user"}}, {{uuid "cm1"}}, 30),
+		({{uuid "user"}}, {{uuid "cm2"}}, 30);
+
+	insert into escalation_policies (id, name) 
+	values
+		({{uuid "eid"}}, 'esc policy');
+	insert into escalation_policy_steps (id, escalation_policy_id) 
+	values
+		({{uuid "esid"}}, {{uuid "eid"}});
+	insert into escalation_policy_actions (escalation_policy_step_id, user_id) 
+	values 
+		({{uuid "esid"}}, {{uuid "user"}});
+
+	insert into services (id, escalation_policy_id, name) 
+	values
+		({{uuid "sid"}}, {{uuid "eid"}}, 'service');
+`
+	h := harness.NewHarness(t, sql, "ids-to-uuids")
+	defer h.Close()
+
+	h.SetConfigValue("Twilio.FromNumber", h.TwilioMessagingService())
+
+	h.CreateAlert(h.UUID("sid"), "testing")
+
+	tw := h.Twilio(t)
+	d1 := tw.Device(h.Phone("1"))
+
+	d1.ExpectSMS("testing").
+		ThenReply("ack 1").
+		ThenExpect("acknowledged")
+
+	d1.ExpectVoice("testing").
+		ThenPress("6").
+		ThenExpect("closed")
+
+	h.FastForward(time.Hour)
+	// no more messages
+}

--- a/web/src/app/admin/AdminFieldComponents.tsx
+++ b/web/src/app/admin/AdminFieldComponents.tsx
@@ -6,7 +6,7 @@ import InputAdornment from '@material-ui/core/InputAdornment'
 import Switch from '@material-ui/core/Switch'
 import Visibility from '@material-ui/icons/Visibility'
 import VisibilityOff from '@material-ui/icons/VisibilityOff'
-import TelTextField from '../util/TelTextField'
+import FromValueField from '../util/FromValueField'
 
 interface InputProps {
   type?: string
@@ -37,7 +37,9 @@ export function StringInput(props: InputProps): JSX.Element {
   }
 
   if (props.name === 'Twilio.FromNumber') {
-    return <TelTextField onChange={(e) => onChange(e.target.value)} {...rest} />
+    return (
+      <FromValueField onChange={(e) => onChange(e.target.value)} {...rest} />
+    )
   }
   return (
     <Input

--- a/web/src/app/util/FromValueField.tsx
+++ b/web/src/app/util/FromValueField.tsx
@@ -18,6 +18,7 @@ export default function FromValueField(
   if (!phoneMode) {
     return (
       <TextField
+        fullWidth
         {...props}
         label='Messaging Service SID'
         InputLabelProps={{


### PR DESCRIPTION
**Description:**
Turns on the ability to configure a Messaging Service SID as the Twilio FromNumber in the admin config.
