### PR TITLE
ui/docs: hide webhook docs when webhooks not enabled

### DIFF
--- a/web/src/app/documentation/Documentation.tsx
+++ b/web/src/app/documentation/Documentation.tsx
@@ -16,11 +16,17 @@ const useStyles = makeStyles({
 })
 
 export default function IntegrationKeyAPI(): JSX.Element {
-  const [publicURL] = useConfigValue('General.PublicURL')
+  const [publicURL, webhookEnabled] = useConfigValue(
+    'General.PublicURL',
+    'Webhook.Enable',
+  )
   const classes = useStyles()
 
   // NOTE list markdown documents here
-  let markdownDocs = [integrationKeys, webhooks]
+  let markdownDocs = [integrationKeys]
+  if (webhookEnabled) {
+    markdownDocs.push(webhooks)
+  }
 
   markdownDocs = markdownDocs.map((md) =>
     md.replaceAll(


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR prevents rendering the webhook in-app documentation when webhooks are not enabled by an admin
