### PR TITLE
ui/services: remove end adornment on integration key type select

### DIFF
--- a/web/src/app/services/IntegrationKeyForm.tsx
+++ b/web/src/app/services/IntegrationKeyForm.tsx
@@ -2,20 +2,9 @@ import React from 'react'
 import Grid from '@material-ui/core/Grid'
 import TextField from '@material-ui/core/TextField'
 import MenuItem from '@material-ui/core/MenuItem'
-import { Help } from '@material-ui/icons'
-import { makeStyles } from '@material-ui/core/styles'
-import Tooltip from '@material-ui/core/Tooltip'
-import InputAdornment from '@material-ui/core/InputAdornment'
 import { FormContainer, FormField } from '../forms'
 import { Config } from '../util/RequireConfig'
-import AppLink from '../util/AppLink'
 import { IntegrationKeyType } from '../../schema'
-
-const useStyles = makeStyles((theme) => ({
-  infoIcon: {
-    color: theme.palette.primary.main,
-  },
-}))
 
 interface Value {
   name: string
@@ -36,7 +25,6 @@ interface IntegrationKeyFormProps {
 export default function IntegrationKeyForm(
   props: IntegrationKeyFormProps,
 ): JSX.Element {
-  const classes = useStyles()
   const { ...formProps } = props
   return (
     <FormContainer {...formProps} optionalLabels>
@@ -60,17 +48,6 @@ export default function IntegrationKeyForm(
                 required
                 label='Type'
                 name='type'
-                InputProps={{
-                  endAdornment: (
-                    <InputAdornment position='end'>
-                      <Tooltip title='API Documentation' placement='right'>
-                        <AppLink to='/docs' newTab>
-                          <Help className={classes.infoIcon} />
-                        </AppLink>
-                      </Tooltip>
-                    </InputAdornment>
-                  ),
-                }}
               >
                 {cfg['Mailgun.Enable'] && (
                   <MenuItem value='email'>Email</MenuItem>


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes an issue in which an end adornment conflicts with a select expand icon (see screenshot below). This adornment was a link to the integration docs, but there is already a link to those on the integration keys page.

**Screenshots:**
<img width="763" alt="Screen Shot 2021-09-28 at 2 56 32 PM" src="https://user-images.githubusercontent.com/17692467/135156809-4df932b4-acf8-4d43-abb7-1b20b54b441b.png">

**Describe any introduced user-facing changes:**
Link to docs not available from end adornment of input field
