### PR TITLE
ui/admin: use outlined input for admin fields

### DIFF
--- a/web/src/app/admin/AdminFieldComponents.tsx
+++ b/web/src/app/admin/AdminFieldComponents.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import Grid from '@material-ui/core/Grid'
 import IconButton from '@material-ui/core/IconButton'
-import Input from '@material-ui/core/Input'
+import Input from '@material-ui/core/OutlinedInput'
 import InputAdornment from '@material-ui/core/InputAdornment'
 import Switch from '@material-ui/core/Switch'
 import Visibility from '@material-ui/icons/Visibility'


### PR DESCRIPTION
**Description:**
This PR misses an oversight from introducing the new outlined default variant for TextFields coming with MUI v5. The admin page uses `Input` instead of `TextField`, so the import has been adjusted to use the proper Input (`OutlinedInput`) component.
