### PR TITLE
ui/schedules: persist render state of schedule calendar override dialog on screen resize

### DIFF
--- a/web/src/app/schedules/ScheduleDetails.js
+++ b/web/src/app/schedules/ScheduleDetails.js
@@ -4,6 +4,7 @@ import { gql, useQuery } from '@apollo/client'
 import { Redirect } from 'react-router-dom'
 import _ from 'lodash'
 import { Edit, Delete } from '@material-ui/icons'
+import { isWidthDown } from '@material-ui/core/withWidth/index'
 
 import DetailsPage from '../details/DetailsPage'
 import ScheduleEditDialog from './ScheduleEditDialog'
@@ -17,6 +18,8 @@ import TempSchedDialog from './temp-sched/TempSchedDialog'
 import TempSchedDeleteConfirmation from './temp-sched/TempSchedDeleteConfirmation'
 import { ScheduleAvatar } from '../util/avatars'
 import { useConfigValue } from '../util/RequireConfig'
+import ScheduleCalendarOverrideDialog from './calendar/ScheduleCalendarOverrideDialog'
+import useWidth from '../util/useWidth'
 
 const query = gql`
   fragment ScheduleTitleQuery on Schedule {
@@ -39,7 +42,6 @@ export const ScheduleCalendarContext = React.createContext({
   // ts files infer function signature, need parameter list
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setOverrideDialog: (overrideVal) => {},
-  overrideDialog: null,
 })
 
 export default function ScheduleDetails({ scheduleID }) {
@@ -47,6 +49,8 @@ export default function ScheduleDetails({ scheduleID }) {
   const [showDelete, setShowDelete] = useState(false)
   const [configTempSchedule, setConfigTempSchedule] = useState(null)
   const [deleteTempSchedule, setDeleteTempSchedule] = useState(null)
+  const width = useWidth()
+  const isMobile = isWidthDown('sm', width)
 
   const [slackEnabled] = useConfigValue('Slack.Enable')
 
@@ -113,10 +117,18 @@ export default function ScheduleDetails({ scheduleID }) {
               onEditTempSched,
               onDeleteTempSched,
               setOverrideDialog,
-              overrideDialog,
             }}
           >
-            <ScheduleCalendarQuery scheduleID={scheduleID} />
+            {!isMobile && <ScheduleCalendarQuery scheduleID={scheduleID} />}
+            {Boolean(overrideDialog) && (
+              <ScheduleCalendarOverrideDialog
+                defaultValue={overrideDialog.defaultValue}
+                variantOptions={overrideDialog.variantOptions}
+                scheduleID={scheduleID}
+                onClose={() => setOverrideDialog(null)}
+                removeUserReadOnly={overrideDialog.removeUserReadOnly}
+              />
+            )}
           </ScheduleCalendarContext.Provider>
         }
         primaryActions={[

--- a/web/src/app/schedules/calendar/ScheduleCalendar.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.js
@@ -23,7 +23,6 @@ import { UserSelect } from '../../selection'
 import SpinContainer from '../../loading/components/SpinContainer'
 import { useCalendarNavigation } from './hooks'
 import { ScheduleCalendarContext } from '../ScheduleDetails'
-import ScheduleCalendarOverrideDialog from '../calendar/ScheduleCalendarOverrideDialog'
 
 const localizer = LuxonLocalizer(DateTime, { firstDayOfWeek: 0 })
 
@@ -51,9 +50,7 @@ const useStyles = makeStyles((theme) => ({
 function ScheduleCalendar(props) {
   const classes = useStyles()
 
-  const { overrideDialog, setOverrideDialog } = useContext(
-    ScheduleCalendarContext,
-  )
+  const { setOverrideDialog } = useContext(ScheduleCalendarContext)
 
   const { weekly, start } = useCalendarNavigation()
 
@@ -284,15 +281,6 @@ function ScheduleCalendar(props) {
           />
         </SpinContainer>
       </Card>
-      {Boolean(overrideDialog) && (
-        <ScheduleCalendarOverrideDialog
-          defaultValue={overrideDialog.defaultValue}
-          variantOptions={overrideDialog.variantOptions}
-          scheduleID={props.scheduleID}
-          onClose={() => setOverrideDialog(null)}
-          removeUserReadOnly={overrideDialog.removeUserReadOnly}
-        />
-      )}
     </React.Fragment>
   )
 }

--- a/web/src/app/schedules/calendar/ScheduleCalendarQuery.tsx
+++ b/web/src/app/schedules/calendar/ScheduleCalendarQuery.tsx
@@ -1,10 +1,8 @@
 import React from 'react'
 import { gql, useQuery } from '@apollo/client'
 import ScheduleCalendar from './ScheduleCalendar'
-import { isWidthDown } from '@material-ui/core/withWidth/index'
 import { getStartOfWeek, getEndOfWeek } from '../../util/luxon-helpers'
 import { DateTime } from 'luxon'
-import useWidth from '../../util/useWidth'
 import { Query } from '../../../schema'
 import { GenericError, ObjectNotFound } from '../../error-pages'
 import { useCalendarNavigation } from './hooks'
@@ -73,10 +71,7 @@ interface ScheduleCalendarQueryProps {
 
 function ScheduleCalendarQuery({
   scheduleID,
-  ...other
 }: ScheduleCalendarQueryProps): JSX.Element | null {
-  const width = useWidth()
-  const isMobile = isWidthDown('sm', width)
   const { weekly, start } = useCalendarNavigation()
 
   const [queryStart, queryEnd] = weekly
@@ -95,10 +90,8 @@ function ScheduleCalendarQuery({
       start: queryStart,
       end: queryEnd,
     },
-    skip: isMobile,
   })
 
-  if (isMobile) return null
   if (error) return <GenericError error={error.message} />
   if (!loading && !data?.schedule?.id) return <ObjectNotFound type='schedule' />
 
@@ -109,7 +102,6 @@ function ScheduleCalendarQuery({
       shifts={data?.schedule?.shifts ?? []}
       temporarySchedules={data?.schedule?.temporarySchedules ?? []}
       overrides={data?.userOverrides?.nodes ?? []}
-      {...other}
     />
   )
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes an issue wherein resizing a schedule calendar override dialog would result in it disappearing. The fix involves lifting the dialog component a couple of levels in the component hierarchy such that it can be managed independent of the calendar component.

**Describe any introduced user-facing changes:**
Users may now continue using override dialogs having resized their viewports
