### PR TITLE
ui/schedules: refine temporary schedule dialog css

### DIFF
--- a/web/src/app/dialogs/FormDialog.js
+++ b/web/src/app/dialogs/FormDialog.js
@@ -40,16 +40,13 @@ const useStyles = makeStyles((theme) => {
       flexGrow: 0,
       overflowY: 'visible',
     },
+    fullHeight: {
+      height: '100%',
+    },
   }
 })
 
 function FormDialog(props) {
-  const classes = useStyles()
-  const width = useWidth()
-  const isWideScreen = isWidthUp('md', width)
-  const [open, setOpen] = useState(true)
-  const [attemptCount, setAttemptCount] = useState(0)
-
   const {
     alert,
     confirm,
@@ -66,8 +63,21 @@ function FormDialog(props) {
     title,
     onNext,
     onBack,
+    fullHeight,
     ...dialogProps
   } = props
+
+  const classes = useStyles()
+  const width = useWidth()
+  const isWideScreen = isWidthUp('md', width)
+  const [open, setOpen] = useState(true)
+  const [attemptCount, setAttemptCount] = useState(0)
+
+  const classesProp = fullHeight
+    ? {
+        paper: classes.fullHeight,
+      }
+    : {}
 
   const handleOnClose = () => {
     setOpen(false)
@@ -154,6 +164,7 @@ function FormDialog(props) {
   const fs = fullScreen || (!isWideScreen && !confirm)
   return (
     <Dialog
+      classes={classesProp}
       fullScreen={fs}
       maxWidth={maxWidth}
       fullWidth
@@ -243,6 +254,9 @@ FormDialog.propTypes = {
 
   // notices to render; see details/Notices.tsx
   notices: p.arrayOf(p.object),
+
+  // make dialog fill vertical space
+  fullHeight: p.bool,
 }
 
 FormDialog.defaultProps = {

--- a/web/src/app/schedules/calendar/ScheduleCalendarOverrideDialog.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendarOverrideDialog.js
@@ -69,6 +69,8 @@ export default function ScheduleCalendarOverrideDialog(props) {
     setFieldErrors(getFieldErrors(error))
   }, [error])
 
+  onNewTempSched()
+
   const onNext = () => {
     if (activeVariant === 'temp') {
       onNewTempSched()

--- a/web/src/app/schedules/calendar/ScheduleCalendarOverrideDialog.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendarOverrideDialog.js
@@ -69,8 +69,6 @@ export default function ScheduleCalendarOverrideDialog(props) {
     setFieldErrors(getFieldErrors(error))
   }, [error])
 
-  onNewTempSched()
-
   const onNext = () => {
     if (activeVariant === 'temp') {
       onNewTempSched()

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -50,6 +50,7 @@ const useStyles = makeStyles((theme) => ({
     [theme.breakpoints.down('md')]: {
       marginTop: '1rem',
     },
+    overflow: 'hidden',
   },
   sticky: {
     position: 'sticky',

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -46,6 +46,11 @@ const useStyles = makeStyles((theme) => ({
     marginTop: '.5rem',
     marginBottom: '.5rem',
   },
+  rightPane: {
+    [theme.breakpoints.down('md')]: {
+      marginTop: '1rem',
+    },
+  },
   sticky: {
     position: 'sticky',
     top: 0,
@@ -256,7 +261,14 @@ export default function TempSchedDialog({
             </Grid>
 
             {/* right pane */}
-            <Grid item xs={12} md={6} container spacing={2}>
+            <Grid
+              item
+              xs={12}
+              md={6}
+              container
+              spacing={2}
+              className={classes.rightPane}
+            >
               <Grid item xs={12}>
                 <Typography variant='subtitle1' component='h3'>
                   Shifts

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -41,7 +41,6 @@ const useStyles = makeStyles((theme) => ({
   },
   formContainer: {
     height: '100%',
-    padding: '0.5rem',
   },
   noCoverageError: {
     marginTop: '.5rem',
@@ -183,7 +182,12 @@ export default function TempSchedDialog({
           value={value}
           onChange={(newValue: Value) => setValue(newValue)}
         >
-          <Grid container className={classes.formContainer}>
+          <Grid
+            container
+            className={classes.formContainer}
+            justifyContent='space-between'
+          >
+            {/* left pane */}
             <Grid
               item
               xs={12}
@@ -191,7 +195,6 @@ export default function TempSchedDialog({
               container
               alignContent='flex-start'
               spacing={2}
-              style={{ paddingRight: '1rem' }}
             >
               <Grid item xs={12}>
                 <DialogContentText className={classes.contentText}>
@@ -247,13 +250,12 @@ export default function TempSchedDialog({
               </Grid>
             </Grid>
 
-            {/* shifts list container */}
+            {/* right pane */}
             <Grid item xs={12} md={6}>
               <Typography variant='subtitle1' component='h3'>
                 Shifts
               </Typography>
 
-              {/* coverage warning */}
               {hasSubmitted && hasCoverageGaps && (
                 <Alert severity='error' className={classes.noCoverageError}>
                   <AlertTitle>Gaps in coverage</AlertTitle>

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -252,47 +252,51 @@ export default function TempSchedDialog({
             </Grid>
 
             {/* right pane */}
-            <Grid item xs={12} md={6}>
-              <Typography variant='subtitle1' component='h3'>
-                Shifts
-              </Typography>
+            <Grid item xs={12} md={6} container spacing={2}>
+              <Grid item xs={12}>
+                <Typography variant='subtitle1' component='h3'>
+                  Shifts
+                </Typography>
 
-              {hasSubmitted && hasCoverageGaps && (
-                <Alert severity='error' className={classes.noCoverageError}>
-                  <AlertTitle>Gaps in coverage</AlertTitle>
-                  <FormHelperText>
-                    There are gaps in coverage. During these gaps, nobody on the
-                    schedule will receive alerts. If you still want to proceed,
-                    check the box below and retry.
-                  </FormHelperText>
-                  <FormControlLabel
-                    label='Allow gaps in coverage'
-                    labelPlacement='end'
-                    control={
-                      <Checkbox
-                        data-cy='no-coverage-checkbox'
-                        checked={allowNoCoverage}
-                        onChange={(e) => setAllowNoCoverage(e.target.checked)}
-                        name='allowCoverageGaps'
-                      />
-                    }
-                  />
-                </Alert>
-              )}
+                {hasSubmitted && hasCoverageGaps && (
+                  <Alert severity='error' className={classes.noCoverageError}>
+                    <AlertTitle>Gaps in coverage</AlertTitle>
+                    <FormHelperText>
+                      There are gaps in coverage. During these gaps, nobody on
+                      the schedule will receive alerts. If you still want to
+                      proceed, check the box below and retry.
+                    </FormHelperText>
+                    <FormControlLabel
+                      label='Allow gaps in coverage'
+                      labelPlacement='end'
+                      control={
+                        <Checkbox
+                          data-cy='no-coverage-checkbox'
+                          checked={allowNoCoverage}
+                          onChange={(e) => setAllowNoCoverage(e.target.checked)}
+                          name='allowCoverageGaps'
+                        />
+                      }
+                    />
+                  </Alert>
+                )}
 
-              <TempSchedShiftsList
-                scheduleID={scheduleID}
-                value={value.shifts}
-                start={value.start}
-                end={value.end}
-                onRemove={(shift: Shift) => {
-                  setValue({
-                    ...value,
-                    shifts: value.shifts.filter((s) => !shiftEquals(shift, s)),
-                  })
-                }}
-                edit={edit}
-              />
+                <TempSchedShiftsList
+                  scheduleID={scheduleID}
+                  value={value.shifts}
+                  start={value.start}
+                  end={value.end}
+                  onRemove={(shift: Shift) => {
+                    setValue({
+                      ...value,
+                      shifts: value.shifts.filter(
+                        (s) => !shiftEquals(shift, s),
+                      ),
+                    })
+                  }}
+                  edit={edit}
+                />
+              </Grid>
             </Grid>
           </Grid>
         </FormContainer>

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -46,6 +46,10 @@ const useStyles = makeStyles((theme) => ({
     marginTop: '.5rem',
     marginBottom: '.5rem',
   },
+  sticky: {
+    position: 'sticky',
+    top: 0,
+  },
   tzNote: {
     fontStyle: 'italic',
   },
@@ -241,7 +245,7 @@ export default function TempSchedDialog({
                 />
               </Grid>
 
-              <Grid item xs={12}>
+              <Grid item xs={12} className={classes.sticky}>
                 <TempSchedAddNewShift
                   value={value}
                   onChange={(shifts: Shift[]) => setValue({ ...value, shifts })}

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -156,6 +156,7 @@ export default function TempSchedDialog({
 
   return (
     <FormDialog
+      fullHeight
       maxWidth='lg'
       title='Define a Temporary Schedule'
       onClose={onClose}

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -16,7 +16,6 @@ import FlatList, {
 } from '../../lists/FlatList'
 import { UserAvatar } from '../../util/avatars'
 import { useUserInfo } from '../../util/useUserInfo'
-import { styles } from '../../styles/materialStyles'
 import { parseInterval } from '../../util/shifts'
 import { useScheduleTZ } from './hooks'
 import { CircularProgress } from '@material-ui/core'
@@ -30,22 +29,17 @@ import {
   sortItems,
 } from './shiftsListUtil'
 
-const useStyles = makeStyles((theme) => {
-  return {
-    secondaryActionWrapper: {
-      display: 'flex',
-      alignItems: 'center',
-    },
-    secondaryActionError: {
-      color: styles(theme).error.color,
-    },
-    spinContainer: {
-      display: 'flex',
-      alignItems: 'center',
-      flexDirection: 'column',
-      marginTop: '15rem',
-    },
-  }
+const useStyles = makeStyles({
+  secondaryActionWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  spinContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    flexDirection: 'column',
+    marginTop: '15rem',
+  },
 })
 
 type TempSchedShiftsListProps = {

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -19,7 +19,7 @@ import { useUserInfo } from '../../util/useUserInfo'
 import { styles } from '../../styles/materialStyles'
 import { parseInterval } from '../../util/shifts'
 import { useScheduleTZ } from './hooks'
-import Spinner from '../../loading/components/Spinner'
+import { CircularProgress } from '@material-ui/core'
 import { splitAtMidnight } from '../../util/luxon-helpers'
 import {
   fmtTime,
@@ -39,8 +39,11 @@ const useStyles = makeStyles((theme) => {
     secondaryActionError: {
       color: styles(theme).error.color,
     },
-    listSpinner: {
-      marginTop: '20rem',
+    spinContainer: {
+      display: 'flex',
+      alignItems: 'center',
+      flexDirection: 'column',
+      marginTop: '15rem',
     },
   }
 })
@@ -196,8 +199,8 @@ export default function TempSchedShiftsList({
   }
 
   return q.loading ? (
-    <div className={classes.listSpinner}>
-      <Spinner />
+    <div className={classes.spinContainer}>
+      <CircularProgress />
     </div>
   ) : (
     <FlatList


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR has some finishing touches for the Temp Schedules redesign:

- Fixes shift list loading spinner placement
- Fixes right hand pane placement (wrap in Grid container)
- Fixes subheader overflow issue, but subheaders are no longer sticky
- Keeps height of dialog 100%
- Add Shift form is now "sticky" and will follow a user's vertical scroll
- Adds vertical spacing between left and right pane on mobile

**Screenshots:**
Sticky Add Shift form:
<img width="1012" alt="Screen Shot 2021-09-30 at 12 50 56 PM" src="https://user-images.githubusercontent.com/17692467/135505888-edbc5709-c592-48e2-97f5-2c3e2d454687.png">

**Describe any introduced user-facing changes:**
A smoother experience :)

**Describe any introduced API changes:**
React:
`FormDialog` has a new `fullHeight` boolean prop that, when set, will make the dialog have a height of 100%.
