### PR TITLE
ui/temp-schedules: Add check for valid schedule interval before running operations on it

### DIFF
--- a/web/src/app/schedules/temp-sched/shiftsListUtil.ts
+++ b/web/src/app/schedules/temp-sched/shiftsListUtil.ts
@@ -97,6 +97,9 @@ export function getCoverageGapItems(
   shifts: Shift[],
   zone: string,
 ): Sortable<FlatListNotice>[] {
+  if (!schedInterval.isValid) {
+    return []
+  }
   const shiftIntervals = shifts.map((s) => parseInterval(s, zone))
   const gapIntervals = _.flatMap(
     schedInterval.difference(...shiftIntervals),


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Will check if schedule interval is valid (end date is later than start date) and if not it won't try to render the no coverage shifts. Before this was throwing an error.


**Which issue(s) this PR fixes:**
Fixes #1943 - This PR includes steps for recreating issue.

**Screenshots:**
Before it crashed and showed console error. Now shows this:
<img width="934" alt="Screen Shot 2021-10-04 at 3 36 24 PM" src="https://user-images.githubusercontent.com/28174559/135921228-8792a273-910d-4005-bd13-2510b524fbfd.png">

**Describe any introduced user-facing changes:**

**Describe any introduced API changes:**

**Additional Info:**
