### PR TITLE
ui/temp-sched: Enforce date bounds

### DIFF
--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -216,6 +216,7 @@ export default function TempSchedDialog({
                   name='start'
                   label='Schedule Start'
                   min={now}
+                  max={DateTime.fromISO(now).plus({ year: 1 }).toISO()}
                   validate={() => validate()}
                   timeZone={zone}
                   disabled={q.loading || edit}
@@ -230,6 +231,7 @@ export default function TempSchedDialog({
                   name='end'
                   label='Schedule End'
                   min={value.start}
+                  max={DateTime.fromISO(value.start).plus({ month: 1 }).toISO()}
                   validate={() => validate()}
                   timeZone={zone}
                   disabled={q.loading || edit}

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -231,7 +231,7 @@ export default function TempSchedDialog({
                   name='end'
                   label='Schedule End'
                   min={value.start}
-                  max={DateTime.fromISO(value.start).plus({ month: 1 }).toISO()}
+                  max={DateTime.fromISO(value.start).plus({ month: 3 }).toISO()}
                   validate={() => validate()}
                   timeZone={zone}
                   disabled={q.loading || edit}

--- a/web/src/app/util/ISOPickers.js
+++ b/web/src/app/util/ISOPickers.js
@@ -62,10 +62,18 @@ function useISOPicker(
     setInputValue(value && dtValue ? dtValue.toFormat(format) : '')
   }, [value, zone])
 
+  // sets min and max if set
+  const inputProps = otherProps?.inputProps ?? {}
+  if (min) inputProps.min = DateTime.fromISO(min).toFormat(format)
+  if (max) inputProps.max = DateTime.fromISO(max).toFormat(format)
+
   const handleChange = (e) => {
     setInputValue(e.target.value)
 
     const newVal = inputToISO(e.target.value)
+    if (min && DateTime.fromISO(newVal) < DateTime.fromISO(min)) return
+    if (max && DateTime.fromISO(newVal) > DateTime.fromISO(max)) return
+
     // Only fire the parent's `onChange` handler when we have a new valid value,
     // taking care to ensure we ignore any zonal differences.
     if (!dtValue || (newVal && newVal !== dtValue.toUTC().toISO())) {
@@ -73,14 +81,18 @@ function useISOPicker(
     }
   }
 
+  const inputDT = DateTime.fromISO(inputToISO(inputValue))
+  let isValid = inputDT.isValid
+  if (min && isValid) {
+    isValid = inputDT >= DateTime.fromISO(min)
+  }
+  if (max && isValid) {
+    isValid = inputDT <= DateTime.fromISO(max)
+  }
+
   // shrink: true sets the label above the textfield so the placeholder can be properly seen
   const inputLabelProps = otherProps?.InputLabelProps ?? {}
   inputLabelProps.shrink = true
-
-  // sets min and max if set
-  const inputProps = otherProps?.inputProps ?? {}
-  if (min) inputProps.min = DateTime.fromISO(min).toFormat(format)
-  if (max) inputProps.max = DateTime.fromISO(max).toFormat(format)
 
   if (native) {
     return (
@@ -91,6 +103,8 @@ function useISOPicker(
         {...otherProps}
         InputLabelProps={inputLabelProps}
         inputProps={inputProps}
+        error={otherProps.error || !isValid}
+        onBlur={() => setInputValue(dtValue.toFormat(format))}
       />
     )
   }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Enforces the start/end time bounds for temporary schedules to help prevent slow downs in the ui from having bounds too far apart.
