### PR TITLE
ui/temp-sched: change end notice format

### DIFF
--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -172,15 +172,22 @@ export default function TempSchedShiftsList({
       } as Sortable<FlatListNotice>
     })()
 
-    const endItem: Sortable<FlatListNotice> = {
-      id: 'sched-end_' + end,
-      type: 'OK',
-      icon: <ScheduleIcon />,
-      message: '',
-      details: `Ends at ${fmtTime(DateTime.fromISO(end, { zone }))}`,
-      at: DateTime.fromISO(end, { zone }),
-      itemType: 'end',
-    }
+    const endItem = (() => {
+      const at = DateTime.fromISO(end, { zone })
+      const details = at.equals(at.startOf('day'))
+        ? 'Ends at midnight'
+        : 'Ends at ' + fmtTime(at)
+
+      return {
+        id: 'sched-end_' + end,
+        type: 'OK',
+        icon: <ScheduleIcon />,
+        message: '',
+        details,
+        at,
+        itemType: 'end',
+      } as Sortable<FlatListNotice>
+    })()
 
     return sortItems([
       ...shiftItems,


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR changes the end notices in the shifts list to use "Ends at midnight" instead of "12:00 AM". This is misleading since it refers to the start of the _next_ day even though we don't have a subsection for the next day.

**Screenshots:**
Before: 
<img width="614" alt="Screen Shot 2021-10-06 at 5 16 36 PM" src="https://user-images.githubusercontent.com/17692467/136291231-4f8333e9-a295-4885-981a-a1e60c2505bb.png">
After:
<img width="620" alt="Screen Shot 2021-10-06 at 5 11 24 PM" src="https://user-images.githubusercontent.com/17692467/136291244-06c60de4-b704-464a-b7f4-45f8f0820299.png">

