### PR TITLE
temp schedules: no coverage notice interaction

### DIFF
--- a/web/src/app/lists/FlatList.tsx
+++ b/web/src/app/lists/FlatList.tsx
@@ -81,6 +81,7 @@ export interface FlatListNotice extends Notice {
   icon?: JSX.Element
   transition?: boolean
   handleOnClick?: (event: MouseEvent) => void
+  'data-cy'?: string
 }
 export interface FlatListItem {
   title?: string
@@ -91,6 +92,7 @@ export interface FlatListItem {
   url?: string
   id?: string
   scrollIntoView?: boolean
+  'data-cy'?: string
 }
 
 export type FlatListListItem = FlatListSub | FlatListItem | FlatListNotice
@@ -174,6 +176,7 @@ export default function FlatList({
         <ButtonBase
           className={classnames(classes.buttonBase, classes.alert)}
           onClick={item.handleOnClick}
+          data-cy={item['data-cy']}
         >
           <Alert
             className={classes.alertAsButton}

--- a/web/src/app/lists/FlatList.tsx
+++ b/web/src/app/lists/FlatList.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from 'react'
+import React, { useLayoutEffect, MouseEvent } from 'react'
 import List, { ListProps } from '@material-ui/core/List'
 import ListItem, { ListItemProps } from '@material-ui/core/ListItem'
 import ListItemIcon from '@material-ui/core/ListItemIcon'
@@ -16,9 +16,10 @@ import {
 } from 'react-beautiful-dnd'
 import ListSubheader from '@material-ui/core/ListSubheader'
 import AppLink from '../util/AppLink'
-import { makeStyles } from '@material-ui/core'
+import { ButtonBase, makeStyles } from '@material-ui/core'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import { Alert, AlertTitle, Color } from '@material-ui/lab'
+import classnames from 'classnames'
 import { Notice, NoticeType } from '../details/Notices'
 
 const lime = '#93ed94'
@@ -28,6 +29,16 @@ const lightGrey = '#ebebeb'
 const useStyles = makeStyles({
   alert: {
     margin: '0.5rem 0 0.5rem 0',
+    width: '100%',
+  },
+  alertAsButton: {
+    width: '100%',
+    '&:hover, &.Mui-focusVisible': {
+      filter: 'brightness(90%)',
+    },
+  },
+  buttonBase: {
+    borderRadius: 4,
   },
   background: { backgroundColor: 'white' },
   highlightedItem: {
@@ -69,6 +80,7 @@ export interface FlatListNotice extends Notice {
   id?: string
   icon?: JSX.Element
   transition?: boolean
+  handleOnClick?: (event: MouseEvent) => void
 }
 export interface FlatListItem {
   title?: string
@@ -157,6 +169,26 @@ export default function FlatList({
   }
 
   function renderNoticeItem(item: FlatListNotice, idx: number): JSX.Element {
+    if (item.handleOnClick) {
+      return (
+        <ButtonBase
+          className={classnames(classes.buttonBase, classes.alert)}
+          onClick={item.handleOnClick}
+        >
+          <Alert
+            className={classes.alertAsButton}
+            key={idx}
+            component='li'
+            severity={severityMap[item.type]}
+            icon={item.icon}
+          >
+            {item.message && <AlertTitle>{item.message}</AlertTitle>}
+            {item.details}
+          </Alert>
+        </ButtonBase>
+      )
+    }
+
     return (
       <Alert
         key={idx}

--- a/web/src/app/schedules/ScheduleDetails.js
+++ b/web/src/app/schedules/ScheduleDetails.js
@@ -91,7 +91,7 @@ export default function ScheduleDetails({ scheduleID }) {
           onClose={() => setShowDelete(false)}
         />
       )}
-      {configTempSchedule && (
+      {true && (
         <TempSchedDialog
           value={configTempSchedule === true ? null : configTempSchedule}
           onClose={() => setConfigTempSchedule(null)}

--- a/web/src/app/schedules/ScheduleDetails.js
+++ b/web/src/app/schedules/ScheduleDetails.js
@@ -91,7 +91,7 @@ export default function ScheduleDetails({ scheduleID }) {
           onClose={() => setShowDelete(false)}
         />
       )}
-      {true && (
+      {configTempSchedule && (
         <TempSchedDialog
           value={configTempSchedule === true ? null : configTempSchedule}
           onClose={() => setConfigTempSchedule(null)}

--- a/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
@@ -27,10 +27,8 @@ type AddShiftsStepProps = {
   edit?: boolean
   showForm: boolean
   setShowForm: (showForm: boolean) => void
-  // rename to handleCoverageGap everywhere
-  handleShowForm: (gapCoverage: Interval) => void
-  shift: Shift|null,
-  setShift: (shift: Shift)=> void
+  shift: Shift | null
+  setShift: (shift: Shift) => void
 }
 
 type DTShift = {
@@ -82,10 +80,9 @@ export default function TempSchedAddNewShift({
   value,
   edit,
   showForm,
-  handleShowForm,
   setShowForm,
   shift,
-  setShift
+  setShift,
 }: AddShiftsStepProps): JSX.Element {
   const [submitted, setSubmitted] = useState(false)
 
@@ -154,7 +151,11 @@ export default function TempSchedAddNewShift({
       value={shift}
       onChange={(val: Shift) => setShift(val)}
     >
-      <Accordion variant='outlined' onChange={()=>setShowForm(!showForm)} expanded={showForm}>
+      <Accordion
+        variant='outlined'
+        onChange={() => setShowForm(!showForm)}
+        expanded={showForm}
+      >
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
           data-cy='add-shift-expander'

--- a/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
@@ -25,6 +25,8 @@ type AddShiftsStepProps = {
 
   scheduleID: string
   edit?: boolean
+  showForm: boolean
+  handleShowForm: () => void
 }
 
 type DTShift = {
@@ -75,12 +77,15 @@ export default function TempSchedAddNewShift({
   onChange,
   value,
   edit,
+  showForm,
+  handleShowForm
 }: AddShiftsStepProps): JSX.Element {
   const [shift, setShift] = useState(null as Shift | null)
   const [submitted, setSubmitted] = useState(false)
 
   const [manualEntry, setManualEntry] = useState(false)
   const [now] = useState(DateTime.utc().startOf('minute').toISO())
+  const [showAddShift, setShowAddShift] = useState(false)
   const { q, zone, isLocalZone } = useScheduleTZ(scheduleID)
 
   // set start equal to the temporary schedule's start
@@ -144,7 +149,7 @@ export default function TempSchedAddNewShift({
       value={shift}
       onChange={(val: Shift) => setShift(val)}
     >
-      <Accordion variant='outlined'>
+      <Accordion variant='outlined' onChange={handleShowForm} expanded={showForm}>
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
           data-cy='add-shift-expander'

--- a/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
@@ -239,7 +239,7 @@ export default function TempSchedAddNewShift({
                   // value held in form input
                   mapValue={(nextVal: string, formValue: Value) => {
                     const nextValDT = DateTime.fromISO(nextVal, { zone })
-                    const formValDT = DateTime.fromISO(formValue?.start, {
+                    const formValDT = DateTime.fromISO(formValue?.start ?? '', {
                       zone,
                     })
                     const duration = dtToDuration(formValDT, nextValDT)

--- a/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
@@ -78,7 +78,6 @@ export default function TempSchedAddNewShift({
   scheduleID,
   onChange,
   value,
-  edit,
   showForm,
   setShowForm,
   shift,

--- a/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
@@ -8,7 +8,7 @@ import Typography from '@material-ui/core/Typography'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import ToggleIcon from '@material-ui/icons/CompareArrows'
 import _ from 'lodash'
-import { fmtLocal, Shift, Value } from './sharedUtils'
+import { dtToDuration, fmtLocal, Shift, Value } from './sharedUtils'
 import { FormContainer, FormField } from '../../forms'
 import { DateTime, Interval } from 'luxon'
 import { FieldError } from '../../util/errutil'
@@ -239,13 +239,11 @@ export default function TempSchedAddNewShift({
                   // value held in form input
                   mapValue={(nextVal: string, formValue: Value) => {
                     const nextValDT = DateTime.fromISO(nextVal, { zone })
-                    if (!formValue || !nextValDT.isValid) return ''
-                    return nextValDT
-                      .diff(
-                        DateTime.fromISO(formValue.start, { zone }),
-                        'hours',
-                      )
-                      .hours.toString()
+                    const formValDT = DateTime.fromISO(formValue?.start, {
+                      zone,
+                    })
+                    const duration = dtToDuration(formValDT, nextValDT)
+                    return duration === -1 ? '' : duration.toString()
                   }}
                   // value held in state
                   mapOnChangeValue={(nextVal: string, formValue: Value) => {

--- a/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
@@ -26,7 +26,11 @@ type AddShiftsStepProps = {
   scheduleID: string
   edit?: boolean
   showForm: boolean
-  handleShowForm: () => void
+  setShowForm: (showForm: boolean) => void
+  // rename to handleCoverageGap everywhere
+  handleShowForm: (gapCoverage: Interval) => void
+  shift: Shift|null,
+  setShift: (shift: Shift)=> void
 }
 
 type DTShift = {
@@ -78,14 +82,15 @@ export default function TempSchedAddNewShift({
   value,
   edit,
   showForm,
-  handleShowForm
+  handleShowForm,
+  setShowForm,
+  shift,
+  setShift
 }: AddShiftsStepProps): JSX.Element {
-  const [shift, setShift] = useState(null as Shift | null)
   const [submitted, setSubmitted] = useState(false)
 
   const [manualEntry, setManualEntry] = useState(false)
   const [now] = useState(DateTime.utc().startOf('minute').toISO())
-  const [showAddShift, setShowAddShift] = useState(false)
   const { q, zone, isLocalZone } = useScheduleTZ(scheduleID)
 
   // set start equal to the temporary schedule's start
@@ -149,7 +154,7 @@ export default function TempSchedAddNewShift({
       value={shift}
       onChange={(val: Shift) => setShift(val)}
     >
-      <Accordion variant='outlined' onChange={handleShowForm} expanded={showForm}>
+      <Accordion variant='outlined' onChange={()=>setShowForm(!showForm)} expanded={showForm}>
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
           data-cy='add-shift-expander'

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -14,7 +14,13 @@ import { DateTime, Interval } from 'luxon'
 
 import { fieldErrors, nonFieldErrors } from '../../util/errutil'
 import FormDialog from '../../dialogs/FormDialog'
-import { contentText, fmtLocal, Shift, Value } from './sharedUtils'
+import {
+  contentText,
+  dtToDuration,
+  fmtLocal,
+  Shift,
+  Value,
+} from './sharedUtils'
 import { FormContainer, FormField } from '../../forms'
 import TempSchedAddNewShift from './TempSchedAddNewShift'
 import { isISOAfter, parseInterval } from '../../util/shifts'
@@ -127,10 +133,18 @@ export default function TempSchedDialog({
 
   function handleCoverageGapClick(coverageGap: Interval): void {
     if (!showForm) setShowForm(true)
+
+    // make sure duration remains the same (evaluated off of the end timestamp)
+    const startDT = DateTime.fromISO(shift?.start ?? '', { zone })
+    const endDT = DateTime.fromISO(shift?.end ?? '', { zone })
+    const duration = dtToDuration(startDT, endDT)
+    const nextStart = coverageGap?.start
+    const nextEnd = nextStart.plus({ hours: duration })
+
     setShift({
       userID: shift?.userID ?? '',
-      start: coverageGap?.start.toISO(),
-      end: coverageGap?.end.toISO(),
+      start: nextStart.toISO(),
+      end: nextEnd.toISO(),
     })
   }
 

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -10,7 +10,7 @@ import { makeStyles } from '@material-ui/core'
 import Alert from '@material-ui/lab/Alert'
 import AlertTitle from '@material-ui/lab/AlertTitle'
 import _ from 'lodash'
-import { DateTime } from 'luxon'
+import { DateTime, Interval } from 'luxon'
 
 import { fieldErrors, nonFieldErrors } from '../../util/errutil'
 import FormDialog from '../../dialogs/FormDialog'
@@ -84,6 +84,7 @@ export default function TempSchedDialog({
       _.pick(s, 'start', 'end', 'userID'),
     ),
   })
+  const [shift, setShift] = useState(null as Shift | null)
   const [allowNoCoverage, setAllowNoCoverage] = useState(false)
   const [hasSubmitted, setHasSubmitted] = useState(false)
 
@@ -150,8 +151,15 @@ export default function TempSchedDialog({
     submit()
   }
 
-    function handleShowForm(): void {
-    setShowForm(!showForm)
+  function handleShowForm(gapCoverage: Interval): void {
+    if (!showForm) {
+      setShowForm(true)
+    }
+    setShift({
+      userID: shift?.userID??'',
+      start: gapCoverage?.start.toISO(),
+      end: gapCoverage?.end.toISO(),
+    })
   }
 
   const nonFieldErrs = nonFieldErrors(error).map((e) => ({
@@ -264,6 +272,9 @@ export default function TempSchedDialog({
                   edit={edit}
                   showForm={showForm}
                   handleShowForm={handleShowForm}
+                  setShowForm={setShowForm}
+                  shift={shift}
+                  setShift={setShift}
                 />
               </Grid>
             </Grid>

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -128,7 +128,10 @@ export default function TempSchedDialog({
   const hasCoverageGaps = (() => {
     if (q.loading) return false
     const schedInterval = parseInterval(value, zone)
-    return getCoverageGapItems(schedInterval, value.shifts, zone, handleShowForm).length > 0
+    return (
+      getCoverageGapItems(schedInterval, value.shifts, zone, handleShowForm)
+        .length > 0
+    )
   })()
 
   const [submit, { loading, error }] = useMutation(mutation, {
@@ -156,7 +159,7 @@ export default function TempSchedDialog({
       setShowForm(true)
     }
     setShift({
-      userID: shift?.userID??'',
+      userID: shift?.userID ?? '',
       start: gapCoverage?.start.toISO(),
       end: gapCoverage?.end.toISO(),
     })

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -76,6 +76,7 @@ export default function TempSchedDialog({
   const edit = Boolean(_value)
   const { q, zone, isLocalZone } = useScheduleTZ(scheduleID)
   const [now] = useState(DateTime.utc().startOf('minute').toISO())
+  const [showForm, setShowForm] = useState(false)
   const [value, setValue] = useState({
     start: _value?.start ?? '',
     end: _value?.end ?? '',
@@ -126,7 +127,7 @@ export default function TempSchedDialog({
   const hasCoverageGaps = (() => {
     if (q.loading) return false
     const schedInterval = parseInterval(value, zone)
-    return getCoverageGapItems(schedInterval, value.shifts, zone).length > 0
+    return getCoverageGapItems(schedInterval, value.shifts, zone, handleShowForm).length > 0
   })()
 
   const [submit, { loading, error }] = useMutation(mutation, {
@@ -147,6 +148,10 @@ export default function TempSchedDialog({
     }
 
     submit()
+  }
+
+    function handleShowForm(): void {
+    setShowForm(!showForm)
   }
 
   const nonFieldErrs = nonFieldErrors(error).map((e) => ({
@@ -257,6 +262,8 @@ export default function TempSchedDialog({
                   onChange={(shifts: Shift[]) => setValue({ ...value, shifts })}
                   scheduleID={scheduleID}
                   edit={edit}
+                  showForm={showForm}
+                  handleShowForm={handleShowForm}
                 />
               </Grid>
             </Grid>
@@ -312,6 +319,8 @@ export default function TempSchedDialog({
                     })
                   }}
                   edit={edit}
+                  handleShowForm={handleShowForm}
+                  showForm={showForm}
                 />
               </Grid>
             </Grid>

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -125,12 +125,25 @@ export default function TempSchedDialog({
       ]
     : []
 
+  function handleCoverageGapClick(coverageGap: Interval): void {
+    if (!showForm) setShowForm(true)
+    setShift({
+      userID: shift?.userID ?? '',
+      start: coverageGap?.start.toISO(),
+      end: coverageGap?.end.toISO(),
+    })
+  }
+
   const hasCoverageGaps = (() => {
     if (q.loading) return false
     const schedInterval = parseInterval(value, zone)
     return (
-      getCoverageGapItems(schedInterval, value.shifts, zone, handleShowForm)
-        .length > 0
+      getCoverageGapItems(
+        schedInterval,
+        value.shifts,
+        zone,
+        handleCoverageGapClick,
+      ).length > 0
     )
   })()
 
@@ -152,17 +165,6 @@ export default function TempSchedDialog({
     }
 
     submit()
-  }
-
-  function handleShowForm(gapCoverage: Interval): void {
-    if (!showForm) {
-      setShowForm(true)
-    }
-    setShift({
-      userID: shift?.userID ?? '',
-      start: gapCoverage?.start.toISO(),
-      end: gapCoverage?.end.toISO(),
-    })
   }
 
   const nonFieldErrs = nonFieldErrors(error).map((e) => ({
@@ -274,7 +276,6 @@ export default function TempSchedDialog({
                   scheduleID={scheduleID}
                   edit={edit}
                   showForm={showForm}
-                  handleShowForm={handleShowForm}
                   setShowForm={setShowForm}
                   shift={shift}
                   setShift={setShift}
@@ -333,8 +334,7 @@ export default function TempSchedDialog({
                     })
                   }}
                   edit={edit}
-                  handleShowForm={handleShowForm}
-                  showForm={showForm}
+                  handleCoverageGapClick={handleCoverageGapClick}
                 />
               </Grid>
             </Grid>

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -111,7 +111,7 @@ export default function TempSchedDialog({
         return true
       }),
   })
-  const [shift, setShift] = useState(null as Shift | null)
+  const [shift, setShift] = useState<Shift | null>(null)
   const [allowNoCoverage, setAllowNoCoverage] = useState(false)
   const [hasSubmitted, setHasSubmitted] = useState(false)
 

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -6,7 +6,7 @@ import ScheduleIcon from '@material-ui/icons/Schedule'
 import Delete from '@material-ui/icons/Delete'
 import Error from '@material-ui/icons/Error'
 import _ from 'lodash'
-import { DateTime } from 'luxon'
+import { DateTime, Interval } from 'luxon'
 
 import { Shift } from './sharedUtils'
 import FlatList, {
@@ -76,10 +76,11 @@ export default function TempSchedShiftsList({
 
   const schedInterval = parseInterval({ start, end }, zone)
 
-  function handleCoverageClick(): void {
+  function handleCoverageClick(coverageGap: Interval): void {
     if (!showForm) {
-      console.log(showForm)
       handleShowForm()
+      
+     // setValue(newValue)
     } 
   }
 

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -49,6 +49,8 @@ type TempSchedShiftsListProps = {
   end: string
   edit?: boolean
   scheduleID: string
+  showForm: boolean
+  handleShowForm: () => void
 }
 
 export default function TempSchedShiftsList({
@@ -58,6 +60,8 @@ export default function TempSchedShiftsList({
   value,
   onRemove,
   scheduleID,
+  showForm,
+  handleShowForm
 }: TempSchedShiftsListProps): JSX.Element {
   const classes = useStyles()
   const { q, zone } = useScheduleTZ(scheduleID)
@@ -71,6 +75,13 @@ export default function TempSchedShiftsList({
   }
 
   const schedInterval = parseInterval({ start, end }, zone)
+
+  function handleCoverageClick(): void {
+    if (!showForm) {
+      console.log(showForm)
+      handleShowForm()
+    } 
+  }
 
   function items(): FlatListListItem[] {
     // render helpful message if interval is invalid
@@ -89,7 +100,7 @@ export default function TempSchedShiftsList({
     }
 
     const subheaderItems = getSubheaderItems(schedInterval, shifts, zone)
-    const coverageGapItems = getCoverageGapItems(schedInterval, shifts, zone)
+    const coverageGapItems = getCoverageGapItems(schedInterval, shifts, zone, handleCoverageClick)
     const outOfBoundsItems = getOutOfBoundsItems(schedInterval, shifts, zone)
 
     const shiftItems = (() => {

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -61,7 +61,7 @@ export default function TempSchedShiftsList({
   onRemove,
   scheduleID,
   showForm,
-  handleShowForm
+  handleShowForm,
 }: TempSchedShiftsListProps): JSX.Element {
   const classes = useStyles()
   const { q, zone } = useScheduleTZ(scheduleID)
@@ -75,7 +75,6 @@ export default function TempSchedShiftsList({
   }
 
   const schedInterval = parseInterval({ start, end }, zone)
-
 
   function items(): FlatListListItem[] {
     // render helpful message if interval is invalid
@@ -94,7 +93,12 @@ export default function TempSchedShiftsList({
     }
 
     const subheaderItems = getSubheaderItems(schedInterval, shifts, zone)
-    const coverageGapItems = getCoverageGapItems(schedInterval, shifts, zone, handleShowForm)
+    const coverageGapItems = getCoverageGapItems(
+      schedInterval,
+      shifts,
+      zone,
+      handleShowForm,
+    )
     const outOfBoundsItems = getOutOfBoundsItems(schedInterval, shifts, zone)
 
     const shiftItems = (() => {

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -50,7 +50,7 @@ type TempSchedShiftsListProps = {
   edit?: boolean
   scheduleID: string
   showForm: boolean
-  handleShowForm: () => void
+  handleShowForm: (gapCoverage: Interval) => void
 }
 
 export default function TempSchedShiftsList({
@@ -76,13 +76,6 @@ export default function TempSchedShiftsList({
 
   const schedInterval = parseInterval({ start, end }, zone)
 
-  function handleCoverageClick(coverageGap: Interval): void {
-    if (!showForm) {
-      handleShowForm()
-      
-     // setValue(newValue)
-    } 
-  }
 
   function items(): FlatListListItem[] {
     // render helpful message if interval is invalid
@@ -101,7 +94,7 @@ export default function TempSchedShiftsList({
     }
 
     const subheaderItems = getSubheaderItems(schedInterval, shifts, zone)
-    const coverageGapItems = getCoverageGapItems(schedInterval, shifts, zone, handleCoverageClick)
+    const coverageGapItems = getCoverageGapItems(schedInterval, shifts, zone, handleShowForm)
     const outOfBoundsItems = getOutOfBoundsItems(schedInterval, shifts, zone)
 
     const shiftItems = (() => {

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -49,8 +49,7 @@ type TempSchedShiftsListProps = {
   end: string
   edit?: boolean
   scheduleID: string
-  showForm: boolean
-  handleShowForm: (gapCoverage: Interval) => void
+  handleCoverageGapClick: (coverageGap: Interval) => void
 }
 
 export default function TempSchedShiftsList({
@@ -60,8 +59,7 @@ export default function TempSchedShiftsList({
   value,
   onRemove,
   scheduleID,
-  showForm,
-  handleShowForm,
+  handleCoverageGapClick,
 }: TempSchedShiftsListProps): JSX.Element {
   const classes = useStyles()
   const { q, zone } = useScheduleTZ(scheduleID)
@@ -97,7 +95,7 @@ export default function TempSchedShiftsList({
       schedInterval,
       shifts,
       zone,
-      handleShowForm,
+      handleCoverageGapClick,
     )
     const outOfBoundsItems = getOutOfBoundsItems(schedInterval, shifts, zone)
 

--- a/web/src/app/schedules/temp-sched/sharedUtils.tsx
+++ b/web/src/app/schedules/temp-sched/sharedUtils.tsx
@@ -65,3 +65,9 @@ export function fmtLocal(iso?: string): string {
   const dt = DateTime.fromISO(iso, { zone: 'local' })
   return `${dt.toLocaleString(DateTime.TIME_SIMPLE)} ${dt.toFormat('ZZZZ')}`
 }
+
+// dtToDuration takes two date times and returns the duration between the two
+export function dtToDuration(a: DateTime, b: DateTime): number {
+  if (!a.isValid || !b.isValid) return -1
+  return b.diff(a, 'hours').hours
+}

--- a/web/src/app/schedules/temp-sched/shiftsListUtil.test.ts
+++ b/web/src/app/schedules/temp-sched/shiftsListUtil.test.ts
@@ -166,7 +166,12 @@ describe('getCoverageGapItems', () => {
       const schedInterval = Interval.fromISO(tc.schedIntervalISO, {
         zone: tc.zone,
       })
-      const result = getCoverageGapItems(schedInterval, tc.shifts, tc.zone)
+      const result = getCoverageGapItems(
+        schedInterval,
+        tc.shifts,
+        tc.zone,
+        () => {},
+      )
 
       expect(result).toHaveLength(tc.expected.length)
       expect(_.uniq(result.map((r) => r.id))).toHaveLength(tc.expected.length)

--- a/web/src/app/schedules/temp-sched/shiftsListUtil.ts
+++ b/web/src/app/schedules/temp-sched/shiftsListUtil.ts
@@ -96,6 +96,7 @@ export function getCoverageGapItems(
   schedInterval: Interval,
   shifts: Shift[],
   zone: string,
+  handleCoverageClick: ()=>void
 ): Sortable<FlatListNotice>[] {
   if (!schedInterval.isValid) {
     return []
@@ -127,6 +128,7 @@ export function getCoverageGapItems(
       itemType: 'gap',
       handleOnClick: () => {
         console.log('notice clicked')
+        handleCoverageClick()
       },
     }
   })

--- a/web/src/app/schedules/temp-sched/shiftsListUtil.ts
+++ b/web/src/app/schedules/temp-sched/shiftsListUtil.ts
@@ -96,7 +96,7 @@ export function getCoverageGapItems(
   schedInterval: Interval,
   shifts: Shift[],
   zone: string,
-  handleCoverageClick: ()=>void
+  handleCoverageClick: (coverageGap: Interval)=>void
 ): Sortable<FlatListNotice>[] {
   if (!schedInterval.isValid) {
     return []
@@ -127,8 +127,7 @@ export function getCoverageGapItems(
       ends: gap.end,
       itemType: 'gap',
       handleOnClick: () => {
-        console.log('notice clicked')
-        handleCoverageClick()
+        handleCoverageClick(gap)
       },
     }
   })

--- a/web/src/app/schedules/temp-sched/shiftsListUtil.ts
+++ b/web/src/app/schedules/temp-sched/shiftsListUtil.ts
@@ -96,7 +96,7 @@ export function getCoverageGapItems(
   schedInterval: Interval,
   shifts: Shift[],
   zone: string,
-  handleCoverageClick: (coverageGap: Interval)=>void
+  handleCoverageClick: (coverageGap: Interval) => void,
 ): Sortable<FlatListNotice>[] {
   if (!schedInterval.isValid) {
     return []
@@ -119,6 +119,7 @@ export function getCoverageGapItems(
     }
 
     return {
+      'data-cy': 'day-no-coverage',
       id: 'day-no-coverage_' + gap.start.toISO(),
       type: 'WARNING',
       message: '',

--- a/web/src/app/schedules/temp-sched/shiftsListUtil.ts
+++ b/web/src/app/schedules/temp-sched/shiftsListUtil.ts
@@ -123,7 +123,11 @@ export function getCoverageGapItems(
       message: '',
       details,
       at: gap.start,
+      ends: gap.end,
       itemType: 'gap',
+      handleOnClick: () => {
+        console.log('notice clicked')
+      },
     }
   })
 }

--- a/web/src/cypress/integration/temporarySchedule.ts
+++ b/web/src/cypress/integration/temporarySchedule.ts
@@ -185,6 +185,45 @@ function testTemporarySchedule(screen: string): void {
     cy.get('[data-cy="shifts-list"]').should('contain', graphQLAddUser.name)
     cy.get('[data-cy="shifts-list"]').should('contain', manualAddUser.name)
   })
+
+  it.only('should be able to click no coverage to update times', () => {
+    const start = DateTime.utc()
+      .setZone(schedule.timeZone)
+      .plus({ day: 1 })
+      .startOf('day')
+
+    const end = start.plus({ days: 2 })
+
+    cy.createTemporarySchedule({
+      scheduleID: schedule.id,
+      start: start.toFormat(dtFmt),
+      end: end.toFormat(dtFmt),
+      shifts: [],
+    }).then(() => {
+      cy.reload()
+      cy.get('div').contains('Temporary Schedule').click()
+      cy.get('div[data-cy="shift-tooltip"]').should('be.visible')
+      cy.get('button[data-cy="edit-temp-sched"]').click()
+      // click on first button element no coverage
+      cy.get('[data-cy="day-no-coverage"]').eq(0).click()
+      cy.get('input[name="shift-start"]').should(
+        'have.value',
+        start.toFormat(dtFmt),
+      )
+      cy.get('input[name="shift-end"]').should(
+        'have.value',
+        start.plus({ hours: 24 }).toFormat(dtFmt),
+      )
+    })
+    // click on no coverage opens form
+    // click on no coverage leaves form open
+    // check value of shift.start & shift.end
+
+    // add shift for random day
+    // click on no coverage on new random day
+    // click on no coverage leaves form open
+    // check value of shift.start & shift.end
+  })
 }
 
 testScreen('temporary Schedule', testTemporarySchedule)

--- a/web/src/cypress/integration/temporarySchedule.ts
+++ b/web/src/cypress/integration/temporarySchedule.ts
@@ -208,21 +208,20 @@ function testTemporarySchedule(screen: string): void {
       'have.value',
       start.toFormat(dtFmt),
     )
-    cy.get('input[name="shift-end"]').should('have.value', 24)
 
-    // add shift for random day
+    // add shift to split up coverage for a given day
     const shiftStart = start.plus({ day: 1 }).toFormat(dtFmt)
-    const duration = 8
+    const duration = 2
     cy.dialogForm({
       userID: manualAddUser.name,
       'shift-start': shiftStart,
-      'shift-end': duration,
+      'shift-end': duration, // this value should not change
     })
     cy.get('button[data-cy="add-shift"]').click()
 
-    // give random time before clicking no coverage
+    // reset shift start field to a random value
     const randDate = randDTWithinInterval(Interval.fromDateTimes(start, end))
-    cy.dialogForm({ 'shift-start': randDate, 'shift-end': 44 })
+    cy.dialogForm({ 'shift-start': randDate })
 
     // click on second no coverage notice in list (partial day)
     cy.get('[data-cy="day-no-coverage"]').eq(1).click()
@@ -230,7 +229,7 @@ function testTemporarySchedule(screen: string): void {
 
     const shiftEnd = start.plus({ day: 1, hours: duration }).toFormat(dtFmt)
     cy.get('input[name="shift-start"]').should('have.value', shiftEnd)
-    cy.get('input[name="shift-end"]').should('have.value', 16)
+    cy.get('input[name="shift-end"]').should('have.value', duration) // ensure duration remains the same
   })
 }
 


### PR DESCRIPTION
**Description:**
This PR adds the ability to click on a "No Coverage" notice within the Temporary Schedules Dialog to set the shift's start and end times in the form.

e.g.
1. 24hr No Coverage on Oct 14th
2. Clicking this would set the start to `October 14th, 12:00 AM`, and the duration to `24 hours`

**Describe any introduced user-facing changes:**
- Coverage Notices within the Temporary Schedule Dialog are now clickable buttons
- Clicking a coverage notice will also cause the shift form to expand open, if closed