### PR TITLE
ui/temp-sched: Scroll to show coverage gap notice on submit

### DIFF
--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, createRef, useRef } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { useMutation, gql } from '@apollo/client'
 import Checkbox from '@material-ui/core/Checkbox'
 import DialogContentText from '@material-ui/core/DialogContentText'


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
1. Open the dialog to create a new temp schedule
2. Make the temp sched end far into the future so the shift list is scrollable
3. Scroll down on the shift list
4. Submit

Before: No coverage error would pop up but you won't be able to find it because you're scrolled down in the shift list
After: It will scroll up to show the no coverage checkbox on the page

**Which issue(s) this PR fixes:**

**Out of Scope:**

**Screenshots:**

**Describe any introduced user-facing changes:**

**Describe any introduced API changes:**

**Additional Info:**
