### PR TITLE
ui/schedules: Fix console error from malformed props

### DIFF
--- a/web/src/app/schedules/ScheduleDetails.js
+++ b/web/src/app/schedules/ScheduleDetails.js
@@ -172,14 +172,19 @@ export default function ScheduleDetails({ scheduleID }) {
             url: 'shifts',
             subText: 'Review a list of past and future on-call shifts',
           },
+        ].concat(
+          slackEnabled
+            ? [
+                {
+                  // only slack is supported ATM, so hide the link if disabled
 
-          // only slack is supported ATM, so hide the link if disabled
-          slackEnabled && {
-            label: 'On-Call Notifications',
-            url: 'on-call-notifications',
-            subText: 'Set up notifications to know who is on-call',
-          },
-        ]}
+                  label: 'On-Call Notifications',
+                  url: 'on-call-notifications',
+                  subText: 'Set up notifications to know who is on-call',
+                },
+              ]
+            : [],
+        )}
       />
     </React.Fragment>
   )


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Small fix to resolve console error in schedules page when slack is not enabled:
![Screen Shot 2021-11-02 at 10 30 48 AM](https://user-images.githubusercontent.com/28174559/139904682-12a56ac5-719c-443a-9af6-4e555d3cdc43.png)

