### PR TITLE
ui/util: time formatting helpers

### DIFF
--- a/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
@@ -8,7 +8,7 @@ import Typography from '@material-ui/core/Typography'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import ToggleIcon from '@material-ui/icons/CompareArrows'
 import _ from 'lodash'
-import { dtToDuration, fmtLocal, Shift, Value } from './sharedUtils'
+import { dtToDuration, Shift, Value } from './sharedUtils'
 import { FormContainer, FormField } from '../../forms'
 import { DateTime, Interval } from 'luxon'
 import { FieldError } from '../../util/errutil'
@@ -18,6 +18,7 @@ import { ISODateTimePicker } from '../../util/ISOPickers'
 import { UserSelect } from '../../selection'
 import ClickableText from '../../util/ClickableText'
 import NumberField from '../../util/NumberField'
+import { fmtLocal } from '../../util/timeFormat'
 
 type AddShiftsStepProps = {
   value: Value

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -14,13 +14,7 @@ import { DateTime, Interval } from 'luxon'
 
 import { fieldErrors, nonFieldErrors } from '../../util/errutil'
 import FormDialog from '../../dialogs/FormDialog'
-import {
-  contentText,
-  dtToDuration,
-  fmtLocal,
-  Shift,
-  Value,
-} from './sharedUtils'
+import { contentText, dtToDuration, Shift, Value } from './sharedUtils'
 import { FormContainer, FormField } from '../../forms'
 import TempSchedAddNewShift from './TempSchedAddNewShift'
 import { isISOAfter, parseInterval } from '../../util/shifts'
@@ -29,6 +23,7 @@ import { useScheduleTZ } from './hooks'
 import TempSchedShiftsList from './TempSchedShiftsList'
 import { ISODateTimePicker } from '../../util/ISOPickers'
 import { getCoverageGapItems } from './shiftsListUtil'
+import { fmtLocal } from '../../util/timeFormat'
 
 const mutation = gql`
   mutation ($input: SetTemporaryScheduleInput!) {

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import IconButton from '@material-ui/core/IconButton'
 import makeStyles from '@material-ui/core/styles/makeStyles'
 import Tooltip from '@material-ui/core/Tooltip/Tooltip'
-import { fmtLocal, Shift } from './sharedUtils'
+import { Shift } from './sharedUtils'
 import ScheduleIcon from '@material-ui/icons/Schedule'
 import Delete from '@material-ui/icons/Delete'
 import Error from '@material-ui/icons/Error'
@@ -21,13 +21,13 @@ import { useScheduleTZ } from './hooks'
 import { CircularProgress } from '@material-ui/core'
 import { splitAtMidnight } from '../../util/luxon-helpers'
 import {
-  fmtTime,
   getCoverageGapItems,
   getSubheaderItems,
   getOutOfBoundsItems,
   Sortable,
   sortItems,
 } from './shiftsListUtil'
+import { fmtLocal, fmtTime } from '../../util/timeFormat'
 
 const useStyles = makeStyles({
   secondaryActionWrapper: {
@@ -113,8 +113,8 @@ export default function TempSchedShiftsList({
         const dayInvs = splitAtMidnight(shiftInv)
 
         return dayInvs.map((inv, index) => {
-          const startTime = fmtTime(inv.start)
-          const endTime = fmtTime(inv.end)
+          const startTime = fmtTime(inv.start, zone, false)
+          const endTime = fmtTime(inv.end, zone, false)
 
           let subText = ''
           let titleText = ''
@@ -174,7 +174,7 @@ export default function TempSchedShiftsList({
     })()
 
     const startItem = (() => {
-      let details = `Starts at ${fmtTime(DateTime.fromISO(start, { zone }))}`
+      let details = `Starts at ${fmtTime(start, zone, false)}`
       const detailsTooltip = `Starts at ${fmtLocal(start)}`
       let message = ''
 
@@ -205,7 +205,7 @@ export default function TempSchedShiftsList({
       const at = DateTime.fromISO(end, { zone })
       const details = at.equals(at.startOf('day'))
         ? 'Ends at midnight'
-        : 'Ends at ' + fmtTime(at)
+        : 'Ends at ' + fmtTime(at, zone, false)
       const detailsTooltip = `Ends at ${fmtLocal(end)}`
 
       return {

--- a/web/src/app/schedules/temp-sched/sharedUtils.tsx
+++ b/web/src/app/schedules/temp-sched/sharedUtils.tsx
@@ -57,15 +57,6 @@ export function StepContainer({
   )
 }
 
-// fmtLocal formats iso timestamp in local time; else empty string
-// e.g. '9:30 AM CDT'
-// Only 12-hour if the locale is.
-export function fmtLocal(iso?: string): string {
-  if (!iso) return ''
-  const dt = DateTime.fromISO(iso, { zone: 'local' })
-  return `${dt.toLocaleString(DateTime.TIME_SIMPLE)} ${dt.toFormat('ZZZZ')}`
-}
-
 // dtToDuration takes two date times and returns the duration between the two
 export function dtToDuration(a: DateTime, b: DateTime): number {
   if (!a.isValid || !b.isValid) return -1

--- a/web/src/app/schedules/temp-sched/shiftsListUtil.tsx
+++ b/web/src/app/schedules/temp-sched/shiftsListUtil.tsx
@@ -9,11 +9,9 @@ import {
 } from '../../lists/FlatList'
 import { ExplicitZone, splitAtMidnight } from '../../util/luxon-helpers'
 import { parseInterval } from '../../util/shifts'
-import { fmtLocal, Shift } from './sharedUtils'
+import { Shift } from './sharedUtils'
 import Tooltip from '@material-ui/core/Tooltip/Tooltip'
-
-export const fmtTime = (dt: DateTime): string =>
-  dt.toLocaleString(DateTime.TIME_SIMPLE)
+import { fmtLocal, fmtTime } from '../../util/timeFormat'
 
 export type Sortable<T> = T & {
   // at is the earliest point in time for a list item
@@ -132,16 +130,18 @@ export function getCoverageGapItems(
       // nothing to do
       title = ''
     } else if (gap.start.equals(gap.start.startOf('day'))) {
-      details += ` until ${fmtTime(gap.end)}`
-      title += ` until ${fmtLocal(gap.end.toISO())}`
+      details += ` until ${fmtTime(gap.end, zone, false)}`
+      title += ` until ${fmtLocal(gap.end)}`
     } else if (gap.end.equals(gap.start.plus({ day: 1 }).startOf('day'))) {
-      details += ` after ${fmtTime(gap.start)}`
-      title += ` after ${fmtLocal(gap.start.toISO())}`
+      details += ` after ${fmtTime(gap.start, zone, false)}`
+      title += ` after ${fmtLocal(gap.start)}`
     } else {
-      details += ` from ${fmtTime(gap.start)} to ${fmtTime(gap.end)}`
-      title += ` from ${fmtLocal(gap.start.toISO())} to ${fmtLocal(
-        gap.end.toISO(),
+      details += ` from ${fmtTime(gap.start, zone, false)} to ${fmtTime(
+        gap.end,
+        zone,
+        false,
       )}`
+      title += ` from ${fmtLocal(gap.start)} to ${fmtLocal(gap.end)}`
     }
 
     return {

--- a/web/src/app/util/timeFormat.test.ts
+++ b/web/src/app/util/timeFormat.test.ts
@@ -1,4 +1,4 @@
-import { formatTimeSince, logTimeFormat } from './timeFormat'
+import { formatTimeSince } from './timeFormat'
 import { DateTime, Duration, DurationObject } from 'luxon'
 
 describe('formatTimeSince', () => {
@@ -22,21 +22,4 @@ describe('formatTimeSince', () => {
   check({ months: 3, days: 5 }, '> 3mo ago')
   check({ months: 20, seconds: 1 }, '> 1y ago')
   check({ months: 200, seconds: 1 }, '> 16y ago')
-})
-
-describe('logTimeFormat', () => {
-  const check = (to: string, from: DateTime, exp: string): void => {
-    it(`alert log time format`, () => {
-      expect(logTimeFormat(to, from)).toBe(exp)
-    })
-  }
-  const to = '2019-05-25'
-  let from = DateTime.local(2019, 5, 25)
-  check(to, from, 'Today at 12:00 AM')
-  from = from.plus({ days: 1 })
-  check(to, from, 'Yesterday at 12:00 AM')
-  from = from.plus({ days: 6 })
-  check(to, from, 'Last Saturday at 12:00 AM')
-  from = from.plus({ days: 7 })
-  check(to, from, '05/25/2019')
 })

--- a/web/src/app/util/timeFormat.test.ts
+++ b/web/src/app/util/timeFormat.test.ts
@@ -1,8 +1,8 @@
 import { formatTimeSince, logTimeFormat } from './timeFormat'
-import { DateTime, Duration } from 'luxon'
+import { DateTime, Duration, DurationObject } from 'luxon'
 
 describe('formatTimeSince', () => {
-  const check = (time, exp) => {
+  const check = (time: DurationObject, exp: string): void => {
     const dur = Duration.fromObject(time)
     it(`${dur.toFormat('dDays h:m:s')} === ${exp}`, () => {
       const since = DateTime.utc()
@@ -25,7 +25,7 @@ describe('formatTimeSince', () => {
 })
 
 describe('logTimeFormat', () => {
-  const check = (to, from, exp) => {
+  const check = (to: string, from: DateTime, exp: string): void => {
     it(`alert log time format`, () => {
       expect(logTimeFormat(to, from)).toBe(exp)
     })

--- a/web/src/app/util/timeFormat.ts
+++ b/web/src/app/util/timeFormat.ts
@@ -64,14 +64,3 @@ export function relativeDate(
 
   return build('', { weekday: 'long' })
 }
-
-export function logTimeFormat(_to: string, _from: DateTime): string {
-  const to = DateTime.fromISO(_to)
-  if (Interval.after(_from, { days: 1 }).contains(to))
-    return 'Today at ' + to.toFormat('h:mm a')
-  if (Interval.before(_from, { days: 1 }).contains(to))
-    return 'Yesterday at ' + to.toFormat('h:mm a')
-  if (Interval.before(_from, { weeks: 1 }).contains(to))
-    return 'Last ' + to.weekdayLong + ' at ' + to.toFormat('h:mm a')
-  return to.toFormat('MM/dd/yyyy')
-}

--- a/web/src/app/util/timeFormat.ts
+++ b/web/src/app/util/timeFormat.ts
@@ -1,6 +1,9 @@
-import { Interval, DateTime } from 'luxon'
+import { Interval, DateTime, DateTimeFormatOptions } from 'luxon'
 
-export function formatTimeSince(_since, _now = DateTime.utc()) {
+export function formatTimeSince(
+  _since: DateTime | string,
+  _now = DateTime.utc(),
+): string {
   if (!_since) return ''
   const since = _since instanceof DateTime ? _since : DateTime.fromISO(_since)
   const now = _now instanceof DateTime ? _now : DateTime.fromISO(_now)
@@ -29,17 +32,20 @@ export function formatTimeSince(_since, _now = DateTime.utc()) {
   return `> ${Math.floor(diff.as('years'))}y ago`
 }
 
-export function relativeDate(_to, _from = DateTime.utc()) {
+export function relativeDate(
+  _to: DateTime | string,
+  _from = DateTime.utc(),
+): string {
   const to = _to instanceof DateTime ? _to : DateTime.fromISO(_to)
   const from = (_from instanceof DateTime ? _from : DateTime.fromISO(_from))
     .setZone(to.zoneName)
     .startOf('day')
 
-  const fmt = {
+  const fmt: DateTimeFormatOptions = {
     month: 'long',
     day: 'numeric',
   }
-  const build = (prefix = '', opts = {}) =>
+  const build = (prefix = '', opts = {}): string =>
     `${prefix} ${to.toLocaleString({ ...fmt, ...opts })}`.trim()
 
   if (Interval.after(from, { days: 1 }).contains(to)) return build('Today,')
@@ -59,7 +65,7 @@ export function relativeDate(_to, _from = DateTime.utc()) {
   return build('', { weekday: 'long' })
 }
 
-export function logTimeFormat(_to, _from) {
+export function logTimeFormat(_to: string, _from: DateTime): string {
   const to = DateTime.fromISO(_to)
   if (Interval.after(_from, { days: 1 }).contains(to))
     return 'Today at ' + to.toFormat('h:mm a')

--- a/web/src/app/util/timeFormat.ts
+++ b/web/src/app/util/timeFormat.ts
@@ -1,4 +1,5 @@
 import { Interval, DateTime, DateTimeFormatOptions } from 'luxon'
+import { ExplicitZone } from './luxon-helpers'
 
 export function formatTimeSince(
   _since: DateTime | string,
@@ -63,4 +64,38 @@ export function relativeDate(
     return build('Next', { weekday: 'long' })
 
   return build('', { weekday: 'long' })
+}
+
+// fmtTime returns simple string for ISO string or DateTime object.
+// If `withZoneAbbr` is not specified, zone info will only be provided for non-local times.
+// Only 12-hour if the locale is.
+// e.g. '9:30 AM', '9:30 PM', '9:30 AM CDT'
+export function fmtTime(
+  time: DateTime | string,
+  zone: ExplicitZone,
+  withZoneAbbr: boolean | null = null,
+): string {
+  if (!time) return ''
+  if (typeof time === 'string') {
+    time = DateTime.fromISO(time, { zone })
+  } else {
+    time = time.setZone(zone)
+  }
+
+  const prefix = time.toLocaleString(DateTime.TIME_SIMPLE)
+  const suffix = time.toFormat('ZZZZ')
+
+  if (withZoneAbbr === true) return prefix + ' ' + suffix
+  if (withZoneAbbr === false) return prefix
+
+  if (zone === DateTime.local().zoneName) return prefix
+  return prefix + ' ' + suffix
+}
+
+// fmtLocal is like fmtTime but uses the system zone and displays zone info by default.
+export function fmtLocal(
+  time: DateTime | string,
+  withZoneAbbr: boolean | null = true,
+): string {
+  return fmtTime(time, 'local', withZoneAbbr)
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR converts the time utils to typescript, removes the unused `logTimeFormat`, and adds two new general[purpose utilities: `fmtTime` and `fmtLocal`. 

This is a refactor. No changes in behavior are expected.
