### PR TITLE
notification/slack: add interactivity to alert notifications

### DIFF
--- a/app/inithttp.go
+++ b/app/inithttp.go
@@ -199,6 +199,8 @@ func (app *App) initHTTP(ctx context.Context) error {
 	mux.HandleFunc("/api/v2/twilio/call", app.twilioVoice.ServeCall)
 	mux.HandleFunc("/api/v2/twilio/call/status", app.twilioVoice.ServeStatusCallback)
 
+	mux.HandleFunc("/api/v2/slack/message-action", app.slackChan.ServeMessageAction)
+
 	// Legacy (v1) API mapping
 	mux.HandleFunc("/v1/graphql", app.graphql.ServeHTTP)
 

--- a/config/config.go
+++ b/config/config.go
@@ -87,6 +87,8 @@ type Config struct {
 		// The `xoxb-` prefix is documented by Slack.
 		// https://api.slack.com/docs/token-types#bot
 		AccessToken string `password:"true" info:"Slack app bot user OAuth access token (should start with xoxb-)."`
+
+		InteractiveMessages bool `info:"Enable interactive messages (e.g. buttons)."`
 	}
 
 	Twilio struct {

--- a/config/config.go
+++ b/config/config.go
@@ -88,7 +88,8 @@ type Config struct {
 		// https://api.slack.com/docs/token-types#bot
 		AccessToken string `password:"true" info:"Slack app bot user OAuth access token (should start with xoxb-)."`
 
-		InteractiveMessages bool `info:"Enable interactive messages (e.g. buttons)."`
+		SigningSecret       string `password:"true" info:"Signing secret to verify requests from slack."`
+		InteractiveMessages bool   `info:"Enable interactive messages (e.g. buttons)."`
 	}
 
 	Twilio struct {
@@ -396,6 +397,7 @@ func (cfg Config) Validate() error {
 		validatePath("OIDC.UserInfoEmailPath", cfg.OIDC.UserInfoEmailPath),
 		validatePath("OIDC.UserInfoEmailVerifiedPath", cfg.OIDC.UserInfoEmailVerifiedPath),
 		validatePath("OIDC.UserInfoNamePath", cfg.OIDC.UserInfoNamePath),
+		validateKey("Slack.SigningSecret", cfg.Slack.SigningSecret),
 	)
 
 	if cfg.OIDC.IssuerURL != "" {
@@ -418,6 +420,9 @@ func (cfg Config) Validate() error {
 	}
 	if cfg.SMTP.From != "" {
 		err = validate.Many(err, validate.Email("SMTP.From", cfg.SMTP.From))
+	}
+	if cfg.Slack.InteractiveMessages && cfg.Slack.SigningSecret == "" {
+		err = validate.Many(err, validation.NewFieldError("Slack.SigningSecret", "required to enable Slack interactive messages"))
 	}
 
 	err = validate.Many(

--- a/devtools/mockslack/actions.go
+++ b/devtools/mockslack/actions.go
@@ -1,0 +1,102 @@
+package mockslack
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type actionItem struct {
+	ActionID string `json:"action_id"`
+	BlockID  string `json:"block_id"`
+	Text     struct {
+		Type string
+		Text string
+	}
+	Value string
+	Type  string
+}
+type actionBody struct {
+	Type    string
+	AppID   string `json:"api_app_id"`
+	Channel struct{ ID string }
+	User    struct {
+		ID       string
+		Username string
+		Name     string
+		TeamID   string `json:"team_id"`
+	}
+	ResponseURL string `json:"response_url"`
+	Actions     []actionItem
+}
+
+func (s *Server) ServeActionResponse(w http.ResponseWriter, r *http.Request) {
+	actData := r.URL.Query().Get("action")
+	var p actionBody
+	err := json.Unmarshal([]byte(actData), &p)
+	if respondErr(w, err) {
+		return
+	}
+	r.Form.Set("channel", p.Channel.ID)
+	s.ServeChatPostMessage(w, r)
+}
+
+// PerformActionAs will preform the action as the given user.
+func (s *Server) PerformActionAs(userID string, a Action) error {
+	usr := s.user(userID)
+	if usr == nil {
+		return errors.New("invalid Slack user ID")
+	}
+
+	app := s.app(a.AppID)
+	if app == nil {
+		return errors.New("invalid Slack app ID")
+	}
+
+	actionData, err := json.Marshal(a)
+	if err != nil {
+		return err
+	}
+
+	var p actionBody
+	p.Type = "block_actions"
+	p.User.ID = usr.ID
+	p.User.Username = usr.Name
+	p.User.Name = usr.Name
+	p.User.TeamID = a.TeamID
+	p.Channel.ID = a.ChannelID
+	p.AppID = a.AppID
+	p.ResponseURL = strings.TrimSuffix(s.urlPrefix, "/") + "/actions/response?action=" + url.QueryEscape(string(actionData))
+
+	var action actionItem
+	action.ActionID = a.ActionID
+	action.BlockID = a.BlockID
+	action.Text.Type = "plain_text"
+	action.Text.Text = a.Text
+	action.Value = a.Value
+	action.Type = "button"
+	p.Actions = append(p.Actions, action)
+
+	data, err := json.Marshal(p)
+	if err != nil {
+		return fmt.Errorf("serialize action payload: %w", err)
+	}
+
+	v := make(url.Values)
+	v.Set("payload", string(data))
+
+	resp, err := http.PostForm(app.ActionURL, v)
+	if err != nil {
+		return fmt.Errorf("perform action: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("perform action: %s", resp.Status)
+	}
+
+	return nil
+}

--- a/devtools/mockslack/api.go
+++ b/devtools/mockslack/api.go
@@ -28,5 +28,8 @@ type Message struct {
 	Broadcast bool   `json:"reply_broadcast"`
 	Color     string `json:"color"`
 
+	ChannelID string
+	ToUserID  string
+
 	Actions []Action
 }

--- a/devtools/mockslack/api.go
+++ b/devtools/mockslack/api.go
@@ -27,4 +27,6 @@ type Message struct {
 	User      string `json:"user"`
 	Broadcast bool   `json:"reply_broadcast"`
 	Color     string `json:"color"`
+
+	Actions []Action
 }

--- a/devtools/mockslack/chatpostmessage.go
+++ b/devtools/mockslack/chatpostmessage.go
@@ -126,7 +126,8 @@ type Action struct {
 	Value    string
 }
 
-func attachmentsText(appID, teamID, chanID, value string) (*attachments, error) {
+// parseAttachments parses the attachments from the payload value.
+func parseAttachments(appID, teamID, chanID, value string) (*attachments, error) {
 	if value == "" {
 		return nil, errNoAttachment
 	}
@@ -233,7 +234,7 @@ func (s *Server) serveChatPostMessage(w http.ResponseWriter, req *http.Request, 
 	}
 	s.mx.Unlock()
 
-	attachment, err := attachmentsText(appID, s.teamID, chanID, req.FormValue("attachments"))
+	attachment, err := parseAttachments(appID, s.teamID, chanID, req.FormValue("attachments"))
 	if err == errNoAttachment {
 		err = nil
 		text = req.FormValue("text")

--- a/devtools/mockslack/chatpostmessage.go
+++ b/devtools/mockslack/chatpostmessage.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -142,7 +141,6 @@ func attachmentsText(appID, teamID, chanID, value string) (*attachments, error) 
 			Text     textBlock
 		}
 	}
-	fmt.Println(value)
 	err := json.Unmarshal([]byte(value), &data)
 	if err != nil {
 		return nil, err

--- a/devtools/mockslack/chatpostmessage.go
+++ b/devtools/mockslack/chatpostmessage.go
@@ -21,6 +21,8 @@ type ChatPostMessageOptions struct {
 
 	AsUser bool
 
+	User string
+
 	UpdateTS  string
 	ThreadTS  string
 	Broadcast bool
@@ -91,6 +93,9 @@ func (st *API) ChatPostMessage(ctx context.Context, opts ChatPostMessageOptions)
 		Text:  opts.Text,
 		User:  user,
 		Color: opts.Color,
+
+		ChannelID: opts.ChannelID,
+		ToUserID:  opts.User,
 
 		Actions: opts.Actions,
 
@@ -256,6 +261,8 @@ func (s *Server) serveChatPostMessage(w http.ResponseWriter, req *http.Request, 
 		AsUser:    req.FormValue("as_user") == "true",
 		ThreadTS:  req.FormValue("thread_ts"),
 		UpdateTS:  updateTS,
+
+		User: req.FormValue("user"),
 
 		Broadcast: req.FormValue("reply_broadcast") == "true",
 	})

--- a/devtools/mockslack/chatpostmessage.go
+++ b/devtools/mockslack/chatpostmessage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -15,6 +16,8 @@ type ChatPostMessageOptions struct {
 	ChannelID string
 	Text      string
 	Color     string
+
+	Actions []Action
 
 	AsUser bool
 
@@ -89,6 +92,8 @@ func (st *API) ChatPostMessage(ctx context.Context, opts ChatPostMessageOptions)
 		User:  user,
 		Color: opts.Color,
 
+		Actions: opts.Actions,
+
 		UpdateTS: opts.UpdateTS,
 
 		ThreadTS:  opts.ThreadTS,
@@ -101,24 +106,41 @@ func (st *API) ChatPostMessage(ctx context.Context, opts ChatPostMessageOptions)
 
 var errNoAttachment = errors.New("no attachment")
 
-func attachmentsText(value string) (text, color string, err error) {
-	if value == "" {
-		return "", "", errNoAttachment
-	}
+type attachments struct {
+	Text    string
+	Color   string
+	Actions []Action
+}
+type Action struct {
+	ChannelID string
+	AppID     string
+	TeamID    string
 
+	BlockID  string
+	ActionID string
+	Text     string
+	Value    string
+}
+
+func attachmentsText(appID, teamID, chanID, value string) (*attachments, error) {
+	if value == "" {
+		return nil, errNoAttachment
+	}
 	type textBlock struct{ Text string }
 
 	var data [1]struct {
 		Color  string
 		Blocks []struct {
-			Elements []textBlock
+			Type     string
+			BlockID  string `json:"block_id"`
+			Elements json.RawMessage
 			Text     textBlock
 		}
 	}
-
-	err = json.Unmarshal([]byte(value), &data)
+	fmt.Println(value)
+	err := json.Unmarshal([]byte(value), &data)
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
 
 	var payload strings.Builder
@@ -129,14 +151,53 @@ func attachmentsText(value string) (text, color string, err error) {
 		payload.WriteString(b.Text + "\n")
 	}
 
+	var actions []Action
 	for _, b := range data[0].Blocks {
 		appendText(b.Text)
-		for _, e := range b.Elements {
-			appendText(e)
+		switch b.Type {
+		case "context":
+			var txtEl []textBlock
+			err = json.Unmarshal(b.Elements, &txtEl)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, e := range txtEl {
+				appendText(e)
+			}
+		case "actions":
+			var acts []struct {
+				Text     textBlock
+				ActionID string `json:"action_id"`
+				Value    string
+			}
+			err = json.Unmarshal(b.Elements, &acts)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, a := range acts {
+				actions = append(actions, Action{
+					ChannelID: chanID,
+					TeamID:    teamID,
+					AppID:     appID,
+					BlockID:   b.BlockID,
+					ActionID:  a.ActionID,
+					Text:      a.Text.Text,
+					Value:     a.Value,
+				})
+			}
+		default:
+			continue
 		}
+
 	}
 
-	return payload.String(), data[0].Color, nil
+	return &attachments{
+		Text:    payload.String(),
+		Color:   data[0].Color,
+		Actions: actions,
+	}, nil
 }
 
 // ServeChatPostMessage serves a request to the `chat.postMessage` API call.
@@ -156,10 +217,27 @@ func (s *Server) ServeChatUpdate(w http.ResponseWriter, req *http.Request) {
 func (s *Server) serveChatPostMessage(w http.ResponseWriter, req *http.Request, isUpdate bool) {
 	chanID := req.FormValue("channel")
 
-	text, color, err := attachmentsText(req.FormValue("attachments"))
+	var text, color string
+	var actions []Action
+
+	var appID string
+	s.mx.Lock()
+	for id := range s.apps {
+		if appID != "" {
+			panic("multiple apps not supported")
+		}
+		appID = id
+	}
+	s.mx.Unlock()
+
+	attachment, err := attachmentsText(appID, s.teamID, chanID, req.FormValue("attachments"))
 	if err == errNoAttachment {
 		err = nil
 		text = req.FormValue("text")
+	} else {
+		text = attachment.Text
+		color = attachment.Color
+		actions = attachment.Actions
 	}
 	if respondErr(w, err) {
 		return
@@ -174,6 +252,7 @@ func (s *Server) serveChatPostMessage(w http.ResponseWriter, req *http.Request, 
 		ChannelID: chanID,
 		Text:      text,
 		Color:     color,
+		Actions:   actions,
 		AsUser:    req.FormValue("as_user") == "true",
 		ThreadTS:  req.FormValue("thread_ts"),
 		UpdateTS:  updateTS,

--- a/devtools/mockslack/chatpostmessage_test.go
+++ b/devtools/mockslack/chatpostmessage_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAttachmentsText(t *testing.T) {
+func TestParseAttachments(t *testing.T) {
 	const data = `[{"color":"#862421","blocks":[{"type":"section","text":{"type":"mrkdwn","text":"\u003chttp://127.0.0.1:39999/alerts/1|Alert #1: testing\u003e"}},{"type":"section","text":{"type":"mrkdwn","text":"\u003e "}},{"type":"context","elements":[{"type":"plain_text","text":"Unacknowledged"}]}]}]`
 
-	att, err := attachmentsText("", "", "", data)
+	att, err := parseAttachments("", "", "", data)
 	assert.NoError(t, err)
 	assert.Equal(t, "#862421", att.Color)
 	assert.Equal(t, "<http://127.0.0.1:39999/alerts/1|Alert #1: testing>\n> \nUnacknowledged\n", att.Text)

--- a/devtools/mockslack/chatpostmessage_test.go
+++ b/devtools/mockslack/chatpostmessage_test.go
@@ -9,9 +9,9 @@ import (
 func TestAttachmentsText(t *testing.T) {
 	const data = `[{"color":"#862421","blocks":[{"type":"section","text":{"type":"mrkdwn","text":"\u003chttp://127.0.0.1:39999/alerts/1|Alert #1: testing\u003e"}},{"type":"section","text":{"type":"mrkdwn","text":"\u003e "}},{"type":"context","elements":[{"type":"plain_text","text":"Unacknowledged"}]}]}]`
 
-	text, color, err := attachmentsText(data)
+	att, err := attachmentsText("", "", "", data)
 	assert.NoError(t, err)
-	assert.Equal(t, "#862421", color)
-	assert.Equal(t, "<http://127.0.0.1:39999/alerts/1|Alert #1: testing>\n> \nUnacknowledged\n", text)
+	assert.Equal(t, "#862421", att.Color)
+	assert.Equal(t, "<http://127.0.0.1:39999/alerts/1|Alert #1: testing>\n> \nUnacknowledged\n", att.Text)
 
 }

--- a/devtools/mockslack/server.go
+++ b/devtools/mockslack/server.go
@@ -29,6 +29,7 @@ func NewServer() *Server {
 
 	srv.mux.HandleFunc("/actions/response", srv.ServeActionResponse)
 	srv.mux.HandleFunc("/api/chat.postMessage", srv.ServeChatPostMessage)
+	srv.mux.HandleFunc("/api/chat.postEphemeral", srv.ServeChatPostMessage)
 	srv.mux.HandleFunc("/api/chat.update", srv.ServeChatUpdate)
 	srv.mux.HandleFunc("/api/conversations.info", srv.ServeConversationsInfo)
 	srv.mux.HandleFunc("/api/conversations.list", srv.ServeConversationsList)
@@ -83,6 +84,7 @@ type AppInfo struct {
 	ClientID     string
 	ClientSecret string
 	AccessToken  string
+	TeamID       string
 
 	ActionURL string
 }
@@ -107,6 +109,7 @@ func (st *state) InstallStaticApp(app AppInfo, scopes ...string) (*AppInfo, erro
 	if app.AccessToken == "" {
 		app.AccessToken = st.gen.UserAccessToken()
 	}
+	app.TeamID = st.teamID
 
 	if !clientIDRx.MatchString(app.ClientID) {
 		return nil, errors.Errorf("invalid client ID format: %s", app.ClientID)

--- a/devtools/mockslack/server.go
+++ b/devtools/mockslack/server.go
@@ -86,6 +86,8 @@ type AppInfo struct {
 	AccessToken  string
 	TeamID       string
 
+	SigningSecret string
+
 	ActionURL string
 }
 
@@ -141,6 +143,8 @@ func (st *state) InstallStaticApp(app AppInfo, scopes ...string) (*AppInfo, erro
 			Secret:    app.ClientSecret,
 			AuthToken: tok,
 			ActionURL: app.ActionURL,
+
+			SigningSecret: app.SigningSecret,
 		},
 	}
 

--- a/devtools/mockslack/server.go
+++ b/devtools/mockslack/server.go
@@ -16,6 +16,8 @@ type Server struct {
 	mux *http.ServeMux
 
 	handler http.Handler
+
+	urlPrefix string
 }
 
 // NewServer creates a new blank Server.
@@ -25,6 +27,7 @@ func NewServer() *Server {
 		state: newState(),
 	}
 
+	srv.mux.HandleFunc("/actions/response", srv.ServeActionResponse)
 	srv.mux.HandleFunc("/api/chat.postMessage", srv.ServeChatPostMessage)
 	srv.mux.HandleFunc("/api/chat.update", srv.ServeChatUpdate)
 	srv.mux.HandleFunc("/api/conversations.info", srv.ServeConversationsInfo)
@@ -66,6 +69,11 @@ func NewServer() *Server {
 	return srv
 }
 
+// SetURLPrefix will update the URL prefix for this server.
+func (s *Server) SetURLPrefix(prefix string) {
+	s.urlPrefix = prefix
+}
+
 // TokenCookieName is the name of a cookie containing a token for a user session.
 const TokenCookieName = "slack_token"
 
@@ -75,6 +83,14 @@ type AppInfo struct {
 	ClientID     string
 	ClientSecret string
 	AccessToken  string
+
+	ActionURL string
+}
+
+func (s *Server) SetActionURL(appID string, actionURL string) {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+	s.apps[appID].App.ActionURL = actionURL
 }
 
 // InstallApp will "install" a new app to this Slack server using pre-configured AppInfo.
@@ -121,6 +137,7 @@ func (st *state) InstallStaticApp(app AppInfo, scopes ...string) (*AppInfo, erro
 			Name:      app.Name,
 			Secret:    app.ClientSecret,
 			AuthToken: tok,
+			ActionURL: app.ActionURL,
 		},
 	}
 

--- a/devtools/mockslack/state.go
+++ b/devtools/mockslack/state.go
@@ -48,6 +48,8 @@ type App struct {
 	Secret    string
 	AuthToken *AuthToken
 	ActionURL string
+
+	SigningSecret string
 }
 
 type channelState struct {

--- a/devtools/mockslack/state.go
+++ b/devtools/mockslack/state.go
@@ -47,6 +47,7 @@ type App struct {
 	Name      string
 	Secret    string
 	AuthToken *AuthToken
+	ActionURL string
 }
 
 type channelState struct {

--- a/engine/backend.go
+++ b/engine/backend.go
@@ -59,11 +59,13 @@ func (b *backend) FindOne(ctx context.Context, id string) (*callback, error) {
 	var c callback
 	var alertID sql.NullInt64
 	var serviceID sql.NullString
-	err = b.findOne.QueryRowContext(ctx, id).Scan(&c.ID, &alertID, &serviceID, &c.ContactMethodID)
+	var cmID sql.NullString
+	err = b.findOne.QueryRowContext(ctx, id).Scan(&c.ID, &alertID, &serviceID, &cmID)
 	if err != nil {
 		return nil, err
 	}
 	c.AlertID = int(alertID.Int64)
 	c.ServiceID = serviceID.String
+	c.ContactMethodID = cmID.String
 	return &c, nil
 }

--- a/engine/sendmessage.go
+++ b/engine/sendmessage.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"github.com/target/goalert/alert"
 	alertlog "github.com/target/goalert/alert/log"
 	"github.com/target/goalert/engine/message"
 	"github.com/target/goalert/notification"
@@ -104,14 +103,14 @@ func (p *Engine) sendMessage(ctx context.Context, msg *message.Message) (*notifi
 			return nil, fmt.Errorf("could not find original notification for alert %d to %s", msg.AlertID, msg.Dest.String())
 		}
 
-		var status alert.Status
+		var status notification.AlertState
 		switch e.Type() {
 		case alertlog.TypeAcknowledged:
-			status = alert.StatusActive
+			status = notification.AlertStateAcknowledged
 		case alertlog.TypeEscalated:
-			status = alert.StatusTriggered
+			status = notification.AlertStateUnacknowledged
 		case alertlog.TypeClosed:
-			status = alert.StatusClosed
+			status = notification.AlertStateClosed
 		}
 
 		notifMsg = notification.AlertStatus{
@@ -121,7 +120,7 @@ func (p *Engine) sendMessage(ctx context.Context, msg *message.Message) (*notifi
 			LogEntry:       e.String(),
 			Summary:        a.Summary,
 			Details:        a.Details,
-			NewAlertStatus: status,
+			NewAlertState:  status,
 			OriginalStatus: *stat,
 		}
 	case notification.MessageTypeTest:

--- a/graphql2/mapconfig.go
+++ b/graphql2/mapconfig.go
@@ -62,6 +62,7 @@ func MapConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "Slack.ClientID", Type: ConfigTypeString, Description: "", Value: cfg.Slack.ClientID},
 		{ID: "Slack.ClientSecret", Type: ConfigTypeString, Description: "", Value: cfg.Slack.ClientSecret, Password: true},
 		{ID: "Slack.AccessToken", Type: ConfigTypeString, Description: "Slack app bot user OAuth access token (should start with xoxb-).", Value: cfg.Slack.AccessToken, Password: true},
+		{ID: "Slack.InteractiveMessages", Type: ConfigTypeBoolean, Description: "Enable interactive messages (e.g. buttons).", Value: fmt.Sprintf("%t", cfg.Slack.InteractiveMessages)},
 		{ID: "Twilio.Enable", Type: ConfigTypeBoolean, Description: "Enables sending and processing of Voice and SMS messages through the Twilio notification provider.", Value: fmt.Sprintf("%t", cfg.Twilio.Enable)},
 		{ID: "Twilio.AccountSID", Type: ConfigTypeString, Description: "", Value: cfg.Twilio.AccountSID},
 		{ID: "Twilio.AuthToken", Type: ConfigTypeString, Description: "The primary Auth Token for Twilio. Must be primary (not secondary) for request valiation.", Value: cfg.Twilio.AuthToken, Password: true},
@@ -277,6 +278,12 @@ func ApplyConfigValues(cfg config.Config, vals []ConfigValueInput) (config.Confi
 			cfg.Slack.ClientSecret = v.Value
 		case "Slack.AccessToken":
 			cfg.Slack.AccessToken = v.Value
+		case "Slack.InteractiveMessages":
+			val, err := parseBool(v.ID, v.Value)
+			if err != nil {
+				return cfg, err
+			}
+			cfg.Slack.InteractiveMessages = val
 		case "Twilio.Enable":
 			val, err := parseBool(v.ID, v.Value)
 			if err != nil {

--- a/graphql2/mapconfig.go
+++ b/graphql2/mapconfig.go
@@ -62,6 +62,7 @@ func MapConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "Slack.ClientID", Type: ConfigTypeString, Description: "", Value: cfg.Slack.ClientID},
 		{ID: "Slack.ClientSecret", Type: ConfigTypeString, Description: "", Value: cfg.Slack.ClientSecret, Password: true},
 		{ID: "Slack.AccessToken", Type: ConfigTypeString, Description: "Slack app bot user OAuth access token (should start with xoxb-).", Value: cfg.Slack.AccessToken, Password: true},
+		{ID: "Slack.SigningSecret", Type: ConfigTypeString, Description: "Signing secret to verify requests from slack.", Value: cfg.Slack.SigningSecret, Password: true},
 		{ID: "Slack.InteractiveMessages", Type: ConfigTypeBoolean, Description: "Enable interactive messages (e.g. buttons).", Value: fmt.Sprintf("%t", cfg.Slack.InteractiveMessages)},
 		{ID: "Twilio.Enable", Type: ConfigTypeBoolean, Description: "Enables sending and processing of Voice and SMS messages through the Twilio notification provider.", Value: fmt.Sprintf("%t", cfg.Twilio.Enable)},
 		{ID: "Twilio.AccountSID", Type: ConfigTypeString, Description: "", Value: cfg.Twilio.AccountSID},
@@ -278,6 +279,8 @@ func ApplyConfigValues(cfg config.Config, vals []ConfigValueInput) (config.Confi
 			cfg.Slack.ClientSecret = v.Value
 		case "Slack.AccessToken":
 			cfg.Slack.AccessToken = v.Value
+		case "Slack.SigningSecret":
+			cfg.Slack.SigningSecret = v.Value
 		case "Slack.InteractiveMessages":
 			val, err := parseBool(v.ID, v.Value)
 			if err != nil {

--- a/notification/alertstatus.go
+++ b/notification/alertstatus.go
@@ -1,6 +1,15 @@
 package notification
 
-import "github.com/target/goalert/alert"
+// AlertState is the current state of an Alert.
+type AlertState int
+
+// All alert states
+const (
+	AlertStateUnknown AlertState = iota
+	AlertStateUnacknowledged
+	AlertStateAcknowledged
+	AlertStateClosed
+)
 
 type AlertStatus struct {
 	Dest       Dest
@@ -16,8 +25,8 @@ type AlertStatus struct {
 	// OriginalStatus is the status of the first Alert notification to this Dest for this AlertID.
 	OriginalStatus SendResult
 
-	// NewAlertStatus contains the most recent status for the alert.
-	NewAlertStatus alert.Status
+	// NewAlertState contains the most recent state of the alert.
+	NewAlertState AlertState
 }
 
 var _ Message = &AlertStatus{}

--- a/notification/namedreceiver.go
+++ b/notification/namedreceiver.go
@@ -40,3 +40,9 @@ func (nr *namedReceiver) Receive(ctx context.Context, callbackID string, result 
 	metricRecvTotal.WithLabelValues(nr.ns.destType.String(), result.String())
 	return nr.r.Receive(ctx, callbackID, result)
 }
+
+// Receive implements the Receiver interface by calling the underlying Receiver.ReceiveSubject method.
+func (nr *namedReceiver) ReceiveSubject(ctx context.Context, providerID, subjectID, callbackID string, result Result) error {
+	metricRecvTotal.WithLabelValues(nr.ns.destType.String(), result.String())
+	return nr.r.ReceiveSubject(ctx, providerID, subjectID, callbackID, result)
+}

--- a/notification/receiver.go
+++ b/notification/receiver.go
@@ -1,6 +1,9 @@
 package notification
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 // A Receiver processes incoming messages and responses.
 type Receiver interface {
@@ -9,6 +12,9 @@ type Receiver interface {
 
 	// Receive records a response to a previously sent message.
 	Receive(ctx context.Context, callbackID string, result Result) error
+
+	// ReceiveSubject records a response to a previously sent message from a provider/subject (e.g. Slack user).
+	ReceiveSubject(ctx context.Context, providerID, subjectID, callbackID string, result Result) error
 
 	// Start indicates a user has opted-in for notifications to this contact method.
 	Start(context.Context, Dest) error
@@ -19,3 +25,6 @@ type Receiver interface {
 	// IsKnownDest checks if the given destination is known/not disabled.
 	IsKnownDest(ctx context.Context, value string) (bool, error)
 }
+
+// ErrUnknownSubject is returend from ReceiveSubject when the subject is unknown.
+var ErrUnknownSubject = errors.New("unknown subject for that provider")

--- a/notification/resultreceiver.go
+++ b/notification/resultreceiver.go
@@ -9,6 +9,7 @@ type ResultReceiver interface {
 	SetSendResult(ctx context.Context, res *SendResult) error
 
 	Receive(ctx context.Context, callbackID string, result Result) error
+	ReceiveSubject(ctx context.Context, providerID, subjectID, callbackID string, result Result) error
 	Start(context.Context, Dest) error
 	Stop(context.Context, Dest) error
 

--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -285,7 +285,8 @@ func alertMsgOption(ctx context.Context, callbackID string, id int, summary, det
 	blocks = append(blocks,
 		slack.NewContextBlock("", slack.NewTextBlockObject("plain_text", logEntry, false, false)),
 	)
-	if len(actions) > 0 {
+	cfg := config.FromContext(ctx)
+	if len(actions) > 0 && cfg.Slack.InteractiveMessages {
 		blocks = append(blocks, actions...)
 	}
 

--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -246,6 +246,7 @@ const (
 	alertAckActionID     = "action_alert_ack"
 )
 
+// alertMsgOption will return the slack.MsgOption for an alert-type message (e.g., notification or status update).
 func alertMsgOption(ctx context.Context, callbackID string, id int, summary, details, logEntry string, state notification.AlertState) slack.MsgOption {
 	blocks := []slack.Block{
 		slack.NewSectionBlock(

--- a/notification/slack/servemessageaction.go
+++ b/notification/slack/servemessageaction.go
@@ -1,0 +1,58 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/target/goalert/notification"
+	"github.com/target/goalert/util/errutil"
+	"github.com/target/goalert/validation"
+)
+
+func (s *ChannelSender) ServeMessageAction(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+
+	var payload struct {
+		Type string
+		User struct {
+			ID     string `json:"id"`
+			TeamID string `json:"team_id"`
+		}
+		Actions []struct {
+			ActionID string `json:"action_id"`
+			BlockID  string `json:"block_id"`
+			Value    string `json:"value"`
+		}
+	}
+	err := json.Unmarshal([]byte(req.FormValue("payload")), &payload)
+	if errutil.HTTPError(ctx, w, err) {
+		return
+	}
+
+	if len(payload.Actions) != 1 {
+		errutil.HTTPError(ctx, w, validation.NewFieldError("payload", "invalid payload"))
+		return
+	}
+
+	act := payload.Actions[0]
+	if act.BlockID != alertResponseBlockID {
+		errutil.HTTPError(ctx, w, validation.NewFieldErrorf("block_id", "unknown block ID '%s'", act.BlockID))
+		return
+	}
+
+	var res notification.Result
+	switch act.ActionID {
+	case alertAckActionID:
+		res = notification.ResultAcknowledge
+	case alertCloseActionID:
+		res = notification.ResultResolve
+	default:
+		errutil.HTTPError(ctx, w, validation.NewFieldErrorf("action_id", "unknown action ID '%s'", act.ActionID))
+		return
+	}
+
+	err = s.recv.ReceiveSubject(ctx, "slack:"+payload.User.TeamID, payload.User.ID, act.Value, res)
+	if errutil.HTTPError(ctx, w, err) {
+		return
+	}
+}

--- a/notification/slack/servemessageaction.go
+++ b/notification/slack/servemessageaction.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/slack-go/slack"
+	"github.com/target/goalert/alert"
 	"github.com/target/goalert/config"
 	"github.com/target/goalert/notification"
 	"github.com/target/goalert/util/errutil"
@@ -123,6 +124,10 @@ func (s *ChannelSender) ServeMessageAction(w http.ResponseWriter, req *http.Requ
 			)
 			return err
 		})
+	}
+	if alert.IsAlreadyAcknowledged(err) || alert.IsAlreadyClosed(err) {
+		// ignore errors from duplicate requests
+		return
 	}
 	if errutil.HTTPError(ctx, w, err) {
 		return

--- a/smoketest/harness/harness.go
+++ b/smoketest/harness/harness.go
@@ -317,6 +317,7 @@ func (h *Harness) Start() {
 		h.t.Fatalf("failed to start backend: %v", err)
 	}
 	h.TwilioNumber("") // register default number
+	h.slack.SetActionURL(h.slackApp.ClientID, h.backend.URL()+"/api/v2/slack/message-action")
 
 	go h.backend.Run(context.Background())
 	err = h.backend.WaitForStartup(ctx)

--- a/smoketest/harness/harness.go
+++ b/smoketest/harness/harness.go
@@ -244,6 +244,7 @@ func (h *Harness) Start() {
 	cfg.Slack.AccessToken = h.slackApp.AccessToken
 	cfg.Slack.ClientID = h.slackApp.ClientID
 	cfg.Slack.ClientSecret = h.slackApp.ClientSecret
+	cfg.Slack.SigningSecret = SlackTestSigningSecret
 	cfg.Twilio.Enable = true
 	cfg.Twilio.AccountSID = twilioAccountSID
 	cfg.Twilio.AuthToken = twilioAuthToken

--- a/smoketest/harness/slack.go
+++ b/smoketest/harness/slack.go
@@ -12,6 +12,10 @@ import (
 	"github.com/target/goalert/devtools/mockslack"
 )
 
+const (
+	SlackTestSigningSecret = "secret"
+)
+
 type SlackServer interface {
 	Channel(string) SlackChannel
 
@@ -292,7 +296,9 @@ func (h *Harness) initSlack() {
 	}
 	h.slackS = httptest.NewServer(h.slack)
 
-	h.slackApp = h.slack.InstallApp("GoAlert Smoketest", "bot")
+	app, err := h.slack.InstallStaticApp(mockslack.AppInfo{Name: "GoAlert Smoketest", SigningSecret: SlackTestSigningSecret}, "bot")
+	require.NoError(h.t, err)
+	h.slackApp = *app
 	h.slackUser = h.slack.NewUser("GoAlert Smoketest User")
 
 	h.slack.SetURLPrefix(h.slackS.URL)

--- a/smoketest/slackinteraction_test.go
+++ b/smoketest/slackinteraction_test.go
@@ -1,0 +1,73 @@
+package smoketest
+
+import (
+	"testing"
+
+	"github.com/target/goalert/smoketest/harness"
+)
+
+// TestSlackInteraction checks that interactive slack messages work properly.
+func TestSlackInteraction(t *testing.T) {
+	t.Parallel()
+
+	sql := `
+	insert into escalation_policies (id, name) 
+	values
+		({{uuid "eid"}}, 'esc policy');
+	insert into escalation_policy_steps (id, escalation_policy_id) 
+	values
+		({{uuid "esid"}}, {{uuid "eid"}});
+
+	insert into notification_channels (id, type, name, value)
+	values
+		({{uuid "chan"}}, 'SLACK', '#test', {{slackChannelID "test"}});
+
+	insert into escalation_policy_actions (escalation_policy_step_id, channel_id) 
+	values 
+		({{uuid "esid"}}, {{uuid "chan"}});
+
+	insert into services (id, escalation_policy_id, name) 
+	values
+		({{uuid "sid"}}, {{uuid "eid"}}, 'service');
+`
+	h := harness.NewHarness(t, sql, "slack-user-link")
+	defer h.Close()
+
+	h.SetConfigValue("Slack.InteractiveMessages", "true")
+
+	a := h.CreateAlertWithDetails(h.UUID("sid"), "testing", "details")
+
+	ch := h.Slack().Channel("test")
+	msg := ch.ExpectMessage("testing", "details")
+	msg.AssertColor("#862421")
+	msg.AssertActions("Acknowledge", "Close")
+
+	h.IgnoreErrorsWith("unknown provider/subject")
+	msg.Action("Acknowledge").Click() // expect ephemeral
+	ch.ExpectEphemeralMessage("GoAlert", "admin")
+
+	h.LinkSlackUser()
+	msg.Action("Acknowledge").Click()
+
+	updated := msg.ExpectUpdate()
+	updated.AssertText("Ack", "testing", "details")
+	updated.AssertColor("#867321")
+	updated.AssertActions("Close")
+
+	a.Escalate()
+
+	updated = msg.ExpectUpdate()
+	updated.AssertText("Escalated", "testing", "details")
+	updated.AssertColor("#862421")
+	updated.AssertActions("Acknowledge", "Close")
+	msg.ExpectBroadcastReply("testing")
+
+	msg.Action("Close").Click()
+
+	updated = msg.ExpectUpdate()
+	updated.AssertText("Closed", "testing")
+	updated.AssertNotText("details")
+	updated.AssertColor("#218626")
+
+	updated.AssertActions() // no actions
+}

--- a/smoketest/statusupdateschannel_test.go
+++ b/smoketest/statusupdateschannel_test.go
@@ -37,8 +37,7 @@ func TestStatusUpdatesChannel(t *testing.T) {
 	msg := h.Slack().Channel("test").ExpectMessage("testing", "details")
 	msg.AssertColor("#862421")
 	msg.AssertActions("Acknowledge", "Close")
-	msg.Action("Acknowledge").Click()
-	t.FailNow()
+	a.Ack()
 
 	updated := msg.ExpectUpdate()
 	updated.AssertText("Ack", "testing", "details")
@@ -53,7 +52,7 @@ func TestStatusUpdatesChannel(t *testing.T) {
 	updated.AssertActions("Acknowledge", "Close")
 	msg.ExpectBroadcastReply("testing")
 
-	updated.Action("Close").Click()
+	a.Close()
 
 	updated = msg.ExpectUpdate()
 	updated.AssertText("Closed", "testing")
@@ -62,5 +61,4 @@ func TestStatusUpdatesChannel(t *testing.T) {
 
 	updated.AssertActions() // no actions
 
-	t.Fail()
 }

--- a/smoketest/statusupdateschannel_test.go
+++ b/smoketest/statusupdateschannel_test.go
@@ -36,20 +36,20 @@ func TestStatusUpdatesChannel(t *testing.T) {
 	a := h.CreateAlertWithDetails(h.UUID("sid"), "testing", "details")
 	msg := h.Slack().Channel("test").ExpectMessage("testing", "details")
 	msg.AssertColor("#862421")
-	msg.AssertActions("Acknowledge", "Close")
+	msg.AssertActions()
 	a.Ack()
 
 	updated := msg.ExpectUpdate()
 	updated.AssertText("Ack", "testing", "details")
 	updated.AssertColor("#867321")
-	updated.AssertActions("Close")
+	updated.AssertActions()
 
 	a.Escalate()
 
 	updated = msg.ExpectUpdate()
 	updated.AssertText("Escalated", "testing", "details")
 	updated.AssertColor("#862421")
-	updated.AssertActions("Acknowledge", "Close")
+	updated.AssertActions()
 	msg.ExpectBroadcastReply("testing")
 
 	a.Close()

--- a/smoketest/statusupdateschannel_test.go
+++ b/smoketest/statusupdateschannel_test.go
@@ -36,25 +36,31 @@ func TestStatusUpdatesChannel(t *testing.T) {
 	a := h.CreateAlertWithDetails(h.UUID("sid"), "testing", "details")
 	msg := h.Slack().Channel("test").ExpectMessage("testing", "details")
 	msg.AssertColor("#862421")
-
-	a.Ack()
+	msg.AssertActions("Acknowledge", "Close")
+	msg.Action("Acknowledge").Click()
+	t.FailNow()
 
 	updated := msg.ExpectUpdate()
 	updated.AssertText("Ack", "testing", "details")
 	updated.AssertColor("#867321")
+	updated.AssertActions("Close")
 
 	a.Escalate()
 
 	updated = msg.ExpectUpdate()
 	updated.AssertText("Escalated", "testing", "details")
 	updated.AssertColor("#862421")
-
+	updated.AssertActions("Acknowledge", "Close")
 	msg.ExpectBroadcastReply("testing")
 
-	a.Close()
+	updated.Action("Close").Click()
 
 	updated = msg.ExpectUpdate()
 	updated.AssertText("Closed", "testing")
 	updated.AssertNotText("details")
 	updated.AssertColor("#218626")
+
+	updated.AssertActions() // no actions
+
+	t.Fail()
 }

--- a/validation/fieldvalidationerror.go
+++ b/validation/fieldvalidationerror.go
@@ -102,6 +102,11 @@ func NewFieldError(fieldName string, reason string) FieldError {
 	return &fieldError{reason: reason, fieldName: fieldName, stack: errors.New("").(stackTracer).StackTrace()}
 }
 
+// NewFieldError will create a new FieldError for the given field and reason
+func NewFieldErrorf(fieldName string, reason string, args ...interface{}) FieldError {
+	return &fieldError{reason: fmt.Sprintf(reason, args...), fieldName: fieldName, stack: errors.New("").(stackTracer).StackTrace()}
+}
+
 // IsValidationError will determine if an error's cause is a field validation error.
 func IsValidationError(err error) bool {
 	var e validation

--- a/validation/fieldvalidationerror.go
+++ b/validation/fieldvalidationerror.go
@@ -103,8 +103,8 @@ func NewFieldError(fieldName string, reason string) FieldError {
 }
 
 // NewFieldError will create a new FieldError for the given field and reason
-func NewFieldErrorf(fieldName string, reason string, args ...interface{}) FieldError {
-	return &fieldError{reason: fmt.Sprintf(reason, args...), fieldName: fieldName, stack: errors.New("").(stackTracer).StackTrace()}
+func NewFieldErrorf(fieldName string, reasonFormat string, args ...interface{}) FieldError {
+	return NewFieldError(fieldName, fmt.Sprintf(reasonFormat, args...))
 }
 
 // IsValidationError will determine if an error's cause is a field validation error.

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -977,6 +977,7 @@ type ConfigID =
   | 'Slack.ClientID'
   | 'Slack.ClientSecret'
   | 'Slack.AccessToken'
+  | 'Slack.SigningSecret'
   | 'Slack.InteractiveMessages'
   | 'Twilio.Enable'
   | 'Twilio.AccountSID'

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -977,6 +977,7 @@ type ConfigID =
   | 'Slack.ClientID'
   | 'Slack.ClientSecret'
   | 'Slack.AccessToken'
+  | 'Slack.InteractiveMessages'
   | 'Twilio.Enable'
   | 'Twilio.AccountSID'
   | 'Twilio.AuthToken'


### PR DESCRIPTION
**Description:**
Adds two-way interactivity as an option for Slack notifications.

**Additional Info:**
Summary of changes:
- make alert log store support both contact methods and notification channels for ack/close actions
- new http route `/api/v2/slack/message-action` added
- new config option `Slack.InteractiveMessages` to opt-in
- action support in the mockslack server
- new `ReceiveSubject` method that can map a provider/subject ID to a GoAlert user for notification channel responses
- remove `alert` as a dependency for the `notification` package by using a new AlertState type instead of alert.Status
- updated Send() method in Slack ChannelSender to add action blocks
- added support for Ephemeral messages and actions and assertions in test harness/mockslack
- added slack interaction smoketest
- added FindOneBySubject to user.Store
- added FieldErrorf to validation package to support formatting error messages cleaner
