### PR TITLE
dev: spelling fixes

### DIFF
--- a/app/contextlocker.go
+++ b/app/contextlocker.go
@@ -116,7 +116,7 @@ func (c *contextLocker) RLockCount() int {
 	return int(atomic.LoadInt64(&c.readCount))
 }
 
-// ErrLockerShutdown is returned when attempting to aquire a lock after being shutdown.
+// ErrLockerShutdown is returned when attempting to acquire a lock after being shutdown.
 var ErrLockerShutdown = errors.New("context locker is already shutdown")
 
 func (c *contextLocker) Lock(ctx context.Context) error {

--- a/devtools/sendit/client.go
+++ b/devtools/sendit/client.go
@@ -139,7 +139,7 @@ func ConnectAndServe(urlStr, dstURLStr, token string, ttl time.Duration) error {
 		defer t.Stop()
 		defer srv.Close()
 		for {
-			// check cancelled first
+			// check canceled first
 			select {
 			case <-ctx.Done():
 				return

--- a/devtools/sendit/session.go
+++ b/devtools/sendit/session.go
@@ -102,7 +102,7 @@ func (sess *session) OpenContext(ctx context.Context) (net.Conn, error) {
 	sess.mx.Lock()
 	defer sess.mx.Unlock()
 
-	// check done/cancelled first
+	// check done/canceled first
 	select {
 	case <-sess.doneCh:
 		return nil, io.ErrClosedPipe

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -4,7 +4,7 @@ This guide assumes you have the commands `docker`, `go` (>= 1.16), `node`, `yarn
 
 ## Database (PostgreSQL)
 
-GoAlert is built and tested against Postgres 11. Version 9.6 should still work as of this writing, but is not recomended as future versions may begin using newer features.
+GoAlert is built and tested against Postgres 11. Version 9.6 should still work as of this writing, but is not recommended as future versions may begin using newer features.
 
 The easiest way to setup Postgres for development is to run `make postgres`.
 This will start a docker container with the correct configuration for the dev environment.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,7 +57,7 @@ You should see migrations applied followed by a `Listening.` message and an engi
 
 When running multiple instances of GoAlert (e.g. in a kubernetes cluster) it is recommended to run a single instance in the default mode, and the rest with the `--api-only` flag set.
 
-While it is safe to run multiple "engine" instances simultaneously, it is generally unecessary and can cause unwanted contention. It is useful, however, to run an "engine" instance
+While it is safe to run multiple "engine" instances simultaneously, it is generally unnecessary and can cause unwanted contention. It is useful, however, to run an "engine" instance
 in separate geographic regions or availability zones. If messages fail to send from one (e.g. network outage), they may be retried in the other this way.
 
 ## First Time Login

--- a/notification/receiver.go
+++ b/notification/receiver.go
@@ -26,5 +26,5 @@ type Receiver interface {
 	IsKnownDest(ctx context.Context, value string) (bool, error)
 }
 
-// ErrUnknownSubject is returend from ReceiveSubject when the subject is unknown.
+// ErrUnknownSubject is returned from ReceiveSubject when the subject is unknown.
 var ErrUnknownSubject = errors.New("unknown subject for that provider")

--- a/notification/status.go
+++ b/notification/status.go
@@ -35,7 +35,7 @@ type SendResult struct {
 // State represents the current state of an outgoing message.
 type State int
 
-// IsOK returns true if the message has passed sucessfuly to a remote system (StateSending, StateSent, or StateDelivered).
+// IsOK returns true if the message has passed successfully to a remote system (StateSending, StateSent, or StateDelivered).
 func (s State) IsOK() bool { return s == StateSending || s == StateSent || s == StateDelivered }
 
 const (

--- a/permission/context.go
+++ b/permission/context.go
@@ -170,7 +170,7 @@ func WithoutAuth(ctx context.Context) context.Context {
 	return ctx
 }
 
-// SudoContext elevates an existing context to system level. The elevated context is automatically cancelled
+// SudoContext elevates an existing context to system level. The elevated context is automatically canceled
 // as soon as the callback returns.
 func SudoContext(ctx context.Context, f func(context.Context)) {
 	name := "Sudo"

--- a/permission/context_test.go
+++ b/permission/context_test.go
@@ -12,7 +12,7 @@ func ExampleSudoContext() {
 	SudoContext(ctx, func(ctx context.Context) {
 		// within this function scope, ctx now has System privileges
 	})
-	// once the function returns, the elevated context is cancelled, but the original ctx is still valid
+	// once the function returns, the elevated context is canceled, but the original ctx is still valid
 }
 
 func TestSudoContext(t *testing.T) {

--- a/retry/do.go
+++ b/retry/do.go
@@ -80,7 +80,7 @@ func FibBackoff(d time.Duration) Option {
 	}
 }
 
-// Context will allow retry to continue until the context is cancelled.
+// Context will allow retry to continue until the context is canceled.
 func Context(ctx context.Context) Option {
 	return func(a int, _ error) bool {
 		return ctx.Err() == nil

--- a/schedule/storetemporaryschedules.go
+++ b/schedule/storetemporaryschedules.go
@@ -32,7 +32,7 @@ func (store *Store) TemporarySchedules(ctx context.Context, tx *sql.Tx, schedule
 		return nil, err
 	}
 
-	// omit shifts for non-existant users
+	// omit shifts for non-existent users
 	for i, tmp := range data.V1.TemporarySchedules {
 		shifts := tmp.Shifts[:0]
 		for _, shift := range tmp.Shifts {

--- a/switchover/README.md
+++ b/switchover/README.md
@@ -44,7 +44,7 @@ Viewed from logs or with the `status` command from the `switchover-shell`.
 | -------------- | ---------------------------------------------------------------------------------------- |
 | starting       | Node has reset or is still starting up.                                                  |
 | ready          | Node is idle and ready for instructions.                                                 |
-| armed          | Node has recieved switchover timetable and is waiting for confirmation from other nodes. |
+| armed          | Node has received switchover timetable and is waiting for confirmation from other nodes. |
 | armed-waiting  | Node is waiting for the pause phase (all known nodes confirmed)                          |
 | pausing        | Node is waiting for the engine to finish pausing.                                        |
 | paused-waiting | Node is paused. Engine will not run, and idle connections are disabled.                  |
@@ -73,11 +73,11 @@ The `execute` command will ask for confirmation of the proposed timetable:
 Switch-Over Details
   Pause API Requests: no       # Pause API requests for the full duration, instead of just the final sync
   Consensus Timeout : 3s       # Deadline for all nodes to confirm they got the timetable and are ready
-  Pause Starts After: 5s       # How long to wait before begining the pause
+  Pause Starts After: 5s       # How long to wait before beginning the pause
   Pause Timeout     : 10s      # Max time to wait for all nodes to pause before aborting
   Absolute Max Pause: 13s      # The maximum possible pause time of the engine (and API requests if set above)
   Avail. Sync Time  : 1s - 11s # Indicates the possible final sync time alloted with this configuration
-  Max Alloted Time  : 18s      # Max time from begining to end of the switchover process
+  Max Alloted Time  : 18s      # Max time from beginning to end of the switchover process
 
 Ready?
 

--- a/web/src/app/alerts/CreateAlertDialog/useCreateAlerts.js
+++ b/web/src/app/alerts/CreateAlertDialog/useCreateAlerts.js
@@ -17,7 +17,7 @@ const getAliasedMutation = (mutation, index) =>
   })
 
 // useCreateAlerts will return mutation, status and a function for mapping
-// field/paths from the response to the respecitve service ID.
+// field/paths from the response to the respective service ID.
 export const useCreateAlerts = (value) => {
   // 1. build mutation
   let m = getAliasedMutation(baseMutation, 0)

--- a/web/src/app/details/Notices.tsx
+++ b/web/src/app/details/Notices.tsx
@@ -67,8 +67,8 @@ export default function Notices({
   }
 
   /*
-   * Spacing set manually on grid items to accomadate manual
-   * accordian transitions for multiple notices
+   * Spacing set manually on grid items to accommodate manual
+   * accordion transitions for multiple notices
    */
   function getGridClassName(index: number): string {
     switch (index) {

--- a/web/src/app/forms/README.md
+++ b/web/src/app/forms/README.md
@@ -4,7 +4,7 @@ Form components handle passing validation and value information to separate 3 ma
 
 1. Errors and value data/state -- `FormContainer`
 2. Individual field layout and validation -- `FormField`
-3. Overall form validation & submittion -- `Form`
+3. Overall form validation & submitting -- `Form`
 
 ### FormContainer
 
@@ -17,7 +17,7 @@ map to descendant `FormField` components. Rather than value, error, onChange, et
 ### FormField
 
 The `FormField` component will receive `value` and `error` data from a `FormContainer`. It also registers a `validate`
-function, if provided. The field name (used for error checking and the container's value prop) defaults to `name` but can be overriden with the `fieldName` prop.
+function, if provided. The field name (used for error checking and the container's value prop) defaults to `name` but can be overridden with the `fieldName` prop.
 
 ### Form
 

--- a/web/src/app/schedules/ScheduleOverrideCreateDialog.js
+++ b/web/src/app/schedules/ScheduleOverrideCreateDialog.js
@@ -76,7 +76,7 @@ export default function ScheduleOverrideCreateDialog(props) {
       title={variantDetails[props.variant].title}
       subTitle={variantDetails[props.variant].desc}
       errors={nonFieldErrors(error)}
-      notices={notices} // create and edit dialogue
+      notices={notices} // create and edit dialog
       onSubmit={() => mutate()}
       form={
         <ScheduleOverrideForm

--- a/web/src/app/schedules/calendar/ScheduleCalendarOverrideDialog.js
+++ b/web/src/app/schedules/calendar/ScheduleCalendarOverrideDialog.js
@@ -94,7 +94,7 @@ export default function ScheduleCalendarOverrideDialog(props) {
           : variantDetails[activeVariant].desc
       }
       errors={nonFieldErrors(error)}
-      notices={step === 0 ? [] : notices} // create and edit dialogue
+      notices={step === 0 ? [] : notices} // create and edit dialog
       loading={loading}
       form={
         <React.Fragment>

--- a/web/src/app/util/safeURL.ts
+++ b/web/src/app/util/safeURL.ts
@@ -15,7 +15,7 @@ export function safeURL(url: string, label: string): boolean {
   // handle http protocols
   if (!/https?:\/\//.test(url)) return false // require absolute URLs
   if (!/[./]/.test(label)) return true // don't consider it a path/url without slashes or periods
-  if (url.startsWith(label)) return true // if it matches the begining, then it's fine
+  if (url.startsWith(label)) return true // if it matches the beginning, then it's fine
   if (url.replace(/^https?:\/\//, '').startsWith(label)) return true // same prefix without protocol
   if (url.replace(/^https?:\/\//, '').startsWith('www.' + label)) return true // same prefix without protocol
 

--- a/web/src/cypress/support/form.ts
+++ b/web/src/cypress/support/form.ts
@@ -43,7 +43,7 @@ const finishPicker = (): void => {
   cy.get('[role=dialog][data-cy=picker-fallback]')
     .contains('button', 'OK')
     .click()
-  // wait for dialog to dissapear
+  // wait for dialog to disappear
   cy.get('[role=dialog][data-cy=picker-fallback]').should('not.exist')
 }
 


### PR DESCRIPTION
Ran `go run github.com/client9/misspell/cmd/misspell -locale US`  to correct some spelling mistakes.