### PR TITLE
slack: add hints and update manifest

### DIFF
--- a/config/hints.go
+++ b/config/hints.go
@@ -15,6 +15,9 @@ type Hints struct {
 		MessageWebhookURL string
 		VoiceWebhookURL   string
 	}
+	Slack struct {
+		InteractivityResponseURL string
+	}
 }
 
 // Hints returns available hints for the current configuration.
@@ -26,6 +29,7 @@ func (cfg Config) Hints() Hints {
 	h.Mailgun.ForwardURL = cfg.CallbackURL("/api/v2/mailgun/incoming")
 	h.Twilio.MessageWebhookURL = cfg.CallbackURL("/api/v2/twilio/message")
 	h.Twilio.VoiceWebhookURL = cfg.CallbackURL("/api/v2/twilio/call")
+	h.Slack.InteractivityResponseURL = cfg.CallbackURL("/api/v2/slack/message-action")
 
 	return h
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -188,27 +188,21 @@ For the time being you will need to create your own Slack app in your workspace 
 
 To configure Slack, first [create a workspace](https://slack.com/create#email) or log in to an existing one.
 
-1. From https://api.slack.com/apps click **Create New App**
-1. Enter a name for your app (e.g. `GoAlert`)
-1. Select your workspace
-1. Click **Create App**
-1. In the list under Features, click **OAuth & Permissions**
-1. Click on **Add New Redirect URL** and enter your `<General.Public URL>` and click **Add**
-1. Under **Scopes** find **Bot Token Scopes**, click on **Add an OAuth Scope**
-1. Add the following scopes:  
-   `channels:read`  
-   `groups:read`  
-   `chat:write`
-1. At the top of the page, click **Install App to Workspace** and **Allow**
+1. Open the **Slack** section of the GoAlert Admin page
+2. Click `App Manifest`
+3. Click `Create New App`
+4. Follow the prompts to install the app in your workspace
 
 You may now configure the **Slack** section of the GoAlert Admin page.
 
 - You may find your **Access Token** under **OAuth & Permissions** -- it is the **Bot User OAuth Access Token**
-- **Client ID** and **Client Secret** are found under **Basic Information** in the **App Credentials** section.
+- **Client ID**, **Client Secret**, and **Signing Secret** are found under **Basic Information** in the **App Credentials** section.
 
 Be sure to **Enable** Slack using the toggle.
 
 You must invite the new app (e.g. GoAlert) by typing `/invite @GoAlert` in the desired Slack channel(s).
+
+To have `Interactive Messages` work, you will need to link Slack and GoAlert users using a tool like `goalert-slack-email-sync` in this repo. This will be made easier (e.g., user-initiated) in the future.
 
 ### Twilio
 

--- a/graphql2/graphqlapp/slack.manifest.yaml
+++ b/graphql2/graphqlapp/slack.manifest.yaml
@@ -22,5 +22,6 @@ oauth_config:
       - im:read
       - im:write
       - users:read
+      - users:read.email
   redirect_urls:
     - '{{.CallbackURL "/api/v2/identity/providers/oidc/callback"}}'

--- a/graphql2/mapconfig.go
+++ b/graphql2/mapconfig.go
@@ -18,6 +18,7 @@ func MapConfigHints(cfg config.Hints) []ConfigHint {
 		{ID: "Mailgun.ForwardURL", Value: cfg.Mailgun.ForwardURL},
 		{ID: "Twilio.MessageWebhookURL", Value: cfg.Twilio.MessageWebhookURL},
 		{ID: "Twilio.VoiceWebhookURL", Value: cfg.Twilio.VoiceWebhookURL},
+		{ID: "Slack.InteractivityResponseURL", Value: cfg.Slack.InteractivityResponseURL},
 	}
 }
 

--- a/web/src/app/admin/SlackActions.tsx
+++ b/web/src/app/admin/SlackActions.tsx
@@ -61,7 +61,7 @@ export default function SlackActions(): JSX.Element {
       <CardActions
         primaryActions={[
           {
-            label: 'Create New Slack App',
+            label: 'App Manifest',
             handleOnClick: () => {
               getManifest()
               setShowManifest(true)
@@ -77,7 +77,7 @@ export default function SlackActions(): JSX.Element {
         onClose={() => setShowManifest(false)}
         fullWidth
       >
-        <DialogTitle data-cy='dialog-title'>Create New Slack App</DialogTitle>
+        <DialogTitle data-cy='dialog-title'>Slack App Manifest</DialogTitle>
         <DialogContent>
           <DialogContentText>
             Copy the manifest generated below to configure a new GoAlert app

--- a/web/src/app/admin/SlackActions.tsx
+++ b/web/src/app/admin/SlackActions.tsx
@@ -80,8 +80,8 @@ export default function SlackActions(): JSX.Element {
         <DialogTitle data-cy='dialog-title'>Slack App Manifest</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            Copy the manifest generated below to configure a new GoAlert app
-            within Slack.
+            Copy the manifest generated below to a new Slack app or to update an
+            existing one.
           </DialogContentText>
           {renderContent()}
           <DialogContentText>

--- a/web/src/app/admin/SlackActions.tsx
+++ b/web/src/app/admin/SlackActions.tsx
@@ -39,12 +39,12 @@ export default function SlackActions(): JSX.Element {
   const [getManifest, { called, loading, error, data }] = useLazyQuery(query, {
     pollInterval: 0,
   })
+  const manifest = data?.generateSlackAppManifest ?? ''
 
   function renderContent(): JSX.Element {
     if (called && loading) return <Spinner />
     if (error) return <GenericError error={error.message} />
 
-    const manifest = data?.generateSlackAppManifest ?? ''
     return (
       <div>
         <div className={classes.copyButton}>
@@ -101,11 +101,14 @@ export default function SlackActions(): JSX.Element {
             color='primary'
             endIcon={<OpenInNewIcon />}
             component={AppLink}
-            to='https://api.slack.com/apps'
+            to={
+              'https://api.slack.com/apps?new_app=1&manifest_yaml=' +
+              encodeURIComponent(manifest)
+            }
             newTab
             data-cy='configure-in-slack'
           >
-            Configure in Slack
+            Create New App
           </Button>
         </DialogActions>
       </Dialog>

--- a/web/src/cypress/integration/admin.ts
+++ b/web/src/cypress/integration/admin.ts
@@ -171,8 +171,8 @@ function testAdmin(): void {
     it('should generate a slack manifest', () => {
       const publicURL = cfg.General.PublicURL
       cy.get('[id="accordion-Slack"]').click()
-      cy.get('button').contains('Create New Slack App').click()
-      cy.dialogTitle('Create New Slack App')
+      cy.get('button').contains('App Manifest').click()
+      cy.dialogTitle('App Manifest')
 
       // verify data integrity from pulled values
       cy.dialogContains("name: 'GoAlert'")
@@ -188,11 +188,9 @@ function testAdmin(): void {
       cy.dialogContains("display_name: 'GoAlert'")
 
       // verify button routing to slack config page
-      cy.get('[data-cy="configure-in-slack"]').should(
-        'have.attr',
-        'href',
-        'https://api.slack.com/apps',
-      )
+      cy.get('[data-cy="configure-in-slack"]')
+        .should('have.attr', 'href')
+        .and('contain', 'https://api.slack.com/apps?new_app=1&manifest_yaml=')
     })
   })
 }


### PR DESCRIPTION
**Description:**
Adds a callback URL hint in Slack config, adds missing scope to the app manifest, and renames button to "App Manifest" rather than "Create New App" now that Slack allows editing/updating the manifest for existing apps.
