### PR TITLE
ui/schedules/calendar: Increase override query page size for calendar

### DIFF
--- a/web/src/app/schedules/calendar/ScheduleCalendarQuery.tsx
+++ b/web/src/app/schedules/calendar/ScheduleCalendarQuery.tsx
@@ -13,7 +13,10 @@ const query = gql`
     $start: ISOTimestamp!
     $end: ISOTimestamp!
   ) {
-    userOverrides(input: { scheduleID: $id, start: $start, end: $end }) {
+    userOverrides(
+      input: { scheduleID: $id, start: $start, end: $end, first: 149 }
+    ) {
+      # todo - make query expandable to handle >149 overrides
       nodes {
         id
         start


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Work-around for #1987 by raising overrides fetched per-page from 15 (default) to 149. 

**Out of scope:**
If there are more than 149 overrides for a schedule (unlikely, but still a limit to keep in mind), they won't all be queried. Would need a more permanent fix like #2028 to handle that.