### PR TITLE
dev: require given node version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,12 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v2
+      - name: Set Node version
+        run: |
+          echo "NODE_VERSION=$(grep '"node":' package.json -m1 | cut -d'"' -f4)" >> $GITHUB_ENV
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: ${{ env.NODE_VERSION }}
       - run: yarn install
       - uses: reviewdog/action-eslint@v1
         with:

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -1,6 +1,10 @@
 # Development Setup
 
-This guide assumes you have the commands `docker`, `go` (>= 1.16), `node`, `yarn`, and `make` installed/available.
+This guide assumes you have the commands `docker`, `go`, `node`, `yarn`, and `make` installed/available.
+
+The required Go version is specified in `go.mod`.
+
+The required Node version is specified in `package.json`.
 
 ## Database (PostgreSQL)
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "fmt": "prettier -l --write '**/*.{js,jsx,yml,yaml,json,css,ts,tsx,html}'"
   },
   "engines": {
-    "node": "16"
+    "node": "12"
   },
   "standard": {
     "parser": "babel-eslint",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "lint": "eslint --ext .js,.jsx,.ts,.tsx --fix . && stylelint --fix ./**/*.css",
     "fmt": "prettier -l --write '**/*.{js,jsx,yml,yaml,json,css,ts,tsx,html}'"
   },
+  "engines": {
+    "node": "16"
+  },
   "standard": {
     "parser": "babel-eslint",
     "env": [


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR specifies which major version of Node to use for building locally and CI in github. This avoids discrepancies that occasionally crop up between developers running the own node configurations.

**Additional Info:**
Note: some testing will likely be done on this branch re CI.