### PR TITLE
ui/temp-sched: omit displayStart from shift object on submit

### DIFF
--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -185,15 +185,17 @@ export default function TempSchedDialog({
         end: value.end,
         clearStart: value.clearStart,
         clearEnd: value.clearEnd,
-        shifts: value.shifts.filter((s) => {
-          // clamp/filter out shifts that are in the past
-          if (DateTime.fromISO(s.end) <= DateTime.fromISO(now)) {
-            return false
-          }
+        shifts: value.shifts
+          .map((s) => _.pick(s, 'start', 'end', 'userID'))
+          .filter((s) => {
+            // clamp/filter out shifts that are in the past
+            if (DateTime.fromISO(s.end) <= DateTime.fromISO(now)) {
+              return false
+            }
 
-          s.start = clampForward(now, s.start)
-          return true
-        }),
+            s.start = clampForward(now, s.start)
+            return true
+          }),
         scheduleID,
       },
     },

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -160,7 +160,8 @@ export default function TempSchedShiftsList({
                 )}
                 {!isHistoricShift && (
                   <IconButton
-                    aria-label={'delete shift index: ' + idx}
+                    data-cy={'delete shift index: ' + idx}
+                    aria-label='delete shift'
                     onClick={() => onRemove(s)}
                   >
                     <Delete />

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -102,7 +102,7 @@ export default function TempSchedShiftsList({
     const outOfBoundsItems = getOutOfBoundsItems(schedInterval, shifts, zone)
 
     const shiftItems = (() => {
-      return _.flatMap(shifts, (s) => {
+      return _.flatMap(shifts, (s, idx) => {
         const shiftInv = parseInterval(s, zone)
         const isValid = schedInterval.engulfs(shiftInv)
         const dayInvs = splitAtMidnight(shiftInv)
@@ -160,7 +160,7 @@ export default function TempSchedShiftsList({
                 )}
                 {!isHistoricShift && (
                   <IconButton
-                    aria-label='delete shift'
+                    aria-label={'delete shift index: ' + idx}
                     onClick={() => onRemove(s)}
                   >
                     <Delete />

--- a/web/src/cypress/integration/temporarySchedule.ts
+++ b/web/src/cypress/integration/temporarySchedule.ts
@@ -115,7 +115,7 @@ function testTemporarySchedule(screen: string): void {
       cy.get('button[data-cy="edit-temp-sched"]').click()
       cy.get('[data-cy="shifts-list"]').should('contain', graphQLAddUser.name)
       cy.get(
-        '[data-cy="shifts-list"] li [aria-label="delete shift index: 0"]',
+        '[data-cy="shifts-list"] li [data-cy="delete shift index: 0"]',
       ).click({
         force: true,
       }) // delete
@@ -164,7 +164,7 @@ function testTemporarySchedule(screen: string): void {
       cy.get('button[data-cy="edit-temp-sched"]').click()
       cy.get('[data-cy="shifts-list"]').should('contain', graphQLAddUser.name)
       cy.get(
-        '[data-cy="shifts-list"] li [aria-label="delete shift index: 0"]',
+        '[data-cy="shifts-list"] li [data-cy="delete shift index: 0"]',
       ).click({
         force: true,
       }) // delete
@@ -180,7 +180,7 @@ function testTemporarySchedule(screen: string): void {
         .check()
       cy.dialogFinish('Retry')
       cy.reload() // ensure calendar update
-      cy.get('div').contains(manualAddUser.name).click()
+      cy.get('div').contains(graphQLAddSecondUser.name).click()
       cy.get('div[data-cy="shift-tooltip"]').should('be.visible')
     })
   })

--- a/web/src/cypress/integration/temporarySchedule.ts
+++ b/web/src/cypress/integration/temporarySchedule.ts
@@ -11,10 +11,12 @@ function testTemporarySchedule(screen: string): void {
   let schedule: Schedule
   let manualAddUser: User
   let graphQLAddUser: User
+  let graphQLAddSecondUser: User
   beforeEach(() => {
     cy.fixture('users').then((u) => {
       manualAddUser = u[0]
       graphQLAddUser = u[1]
+      graphQLAddSecondUser = u[2]
 
       cy.createSchedule({ timeZone: 'Europe/Berlin' }).then((s: Schedule) => {
         schedule = s
@@ -99,7 +101,7 @@ function testTemporarySchedule(screen: string): void {
   })
 
   // seems buggy when shift list has overflow
-  it('should edit a temporary schedule', () => {
+  it('should edit and remove and add to a temporary schedule', () => {
     const now = DateTime.utc()
 
     cy.createTemporarySchedule({
@@ -112,13 +114,90 @@ function testTemporarySchedule(screen: string): void {
       cy.get('div[data-cy="shift-tooltip"]').should('be.visible')
       cy.get('button[data-cy="edit-temp-sched"]').click()
       cy.get('[data-cy="shifts-list"]').should('contain', graphQLAddUser.name)
-      cy.get('[data-cy="shifts-list"] li [aria-label="delete shift"]').click({
+      cy.get(
+        '[data-cy="shifts-list"] li [aria-label="delete shift index: 0"]',
+      ).click({
         force: true,
       }) // delete
       cy.get('[data-cy="shifts-list"]').should(
         'not.contain',
         graphQLAddUser.name,
       )
+
+      cy.get('[data-cy="add-shift-expander"]').click()
+      cy.dialogForm({
+        userID: manualAddUser.name,
+        'shift-start': schedTZ(now.plus({ hour: 1 })),
+      })
+      cy.get('[data-cy="shifts-list"]').should(
+        'not.contain',
+        manualAddUser.name,
+      )
+      cy.get('button[data-cy="add-shift"]').click()
+      cy.get('[data-cy="shifts-list"]').should('contain', manualAddUser.name)
+      cy.dialogClick('Submit')
+      cy.get('[data-cy="no-coverage-checkbox"]')
+        .should('be.visible')
+        .find('input[name="allowCoverageGaps"]')
+        .check()
+      cy.dialogFinish('Retry')
+      cy.reload() // ensure calendar update
+      cy.get('div').contains(manualAddUser.name).click()
+      cy.get('div[data-cy="shift-tooltip"]').should('be.visible')
+    })
+  })
+
+  it('should edit and remove from a temporary schedule', () => {
+    const now = DateTime.utc()
+
+    cy.createTemporarySchedule({
+      scheduleID: schedule.id,
+      start: now.toISO(),
+      shifts: [
+        { userID: graphQLAddUser.id },
+        { userID: graphQLAddSecondUser.id },
+      ],
+    }).then(() => {
+      cy.reload()
+      cy.get('div').contains('Temporary Schedule').click()
+      cy.get('div[data-cy="shift-tooltip"]').should('be.visible')
+      cy.get('button[data-cy="edit-temp-sched"]').click()
+      cy.get('[data-cy="shifts-list"]').should('contain', graphQLAddUser.name)
+      cy.get(
+        '[data-cy="shifts-list"] li [aria-label="delete shift index: 0"]',
+      ).click({
+        force: true,
+      }) // delete
+      cy.get('[data-cy="shifts-list"]').should(
+        'not.contain',
+        graphQLAddUser.name,
+      )
+
+      cy.dialogClick('Submit')
+      cy.get('[data-cy="no-coverage-checkbox"]')
+        .should('be.visible')
+        .find('input[name="allowCoverageGaps"]')
+        .check()
+      cy.dialogFinish('Retry')
+      cy.reload() // ensure calendar update
+      cy.get('div').contains(manualAddUser.name).click()
+      cy.get('div[data-cy="shift-tooltip"]').should('be.visible')
+    })
+  })
+
+  it('should edit and add to a temporary schedule', () => {
+    const now = DateTime.utc()
+
+    cy.createTemporarySchedule({
+      scheduleID: schedule.id,
+      start: now.toISO(),
+      shifts: [{ userID: graphQLAddUser.id }],
+    }).then(() => {
+      cy.reload()
+      cy.get('div').contains('Temporary Schedule').click()
+      cy.get('div[data-cy="shift-tooltip"]').should('be.visible')
+      cy.get('button[data-cy="edit-temp-sched"]').click()
+      cy.get('[data-cy="shifts-list"]').should('contain', graphQLAddUser.name)
 
       cy.get('[data-cy="add-shift-expander"]').click()
       cy.dialogForm({


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR resolves an issue where editing a temporary schedule could result in a 422 error caused by the ``displayStart`` property in the shift object on submit. Fix includes omitting ``displayStart`` from the shift object before submitting and adding additional testing coverage.