### PR TITLE
slack: add missing fallback field for alert notifications

### DIFF
--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -293,8 +293,9 @@ func alertMsgOption(ctx context.Context, callbackID string, id int, summary, det
 
 	return slack.MsgOptionAttachments(
 		slack.Attachment{
-			Color:  color,
-			Blocks: slack.Blocks{BlockSet: blocks},
+			Color:    color,
+			Fallback: fmt.Sprintf("Alert #%d: %s", id, slackutilsx.EscapeMessage(summary)),
+			Blocks:   slack.Blocks{BlockSet: blocks},
 		},
 	)
 }


### PR DESCRIPTION

**Description:**
Adds the link text as the `Fallback` parameter so that notifications appear correctly. (fixes "No preview available" issue)