### PR TITLE
ui/lists: fix list item highlighting

### DIFF
--- a/web/src/app/lists/FlatList.tsx
+++ b/web/src/app/lists/FlatList.tsx
@@ -42,7 +42,6 @@ const useStyles = makeStyles({
   },
   background: { backgroundColor: 'white' },
   highlightedItem: {
-    width: '100%',
     borderLeft: '6px solid ' + lime,
     background: lightLime,
   },
@@ -235,13 +234,6 @@ export default function FlatList({
   }
 
   function renderItem(item: FlatListItem, idx: number): JSX.Element {
-    let itemClass = ''
-    if (!item.highlight) {
-      itemClass = classes.listItem
-    }
-    if (item.disabled) {
-      itemClass = classes.listItemDisabled
-    }
     let itemProps = {}
     if (item.url) {
       itemProps = {
@@ -256,7 +248,11 @@ export default function FlatList({
         scrollIntoView={item.scrollIntoView}
         key={idx}
         {...itemProps}
-        className={itemClass}
+        className={classnames({
+          [classes.listItem]: true,
+          [classes.highlightedItem]: item.highlight,
+          [classes.listItemDisabled]: item.disabled,
+        })}
       >
         {item.icon && <ListItemIcon>{item.icon}</ListItemIcon>}
         <ListItemText


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes a regression in which rotations would not highlight the active on-call user list item.

**Describe any introduced user-facing changes:**
Users will once again see the lime highlight color for active on-call users.

**Additional Info:**
Regression introduced here: https://github.com/target/goalert/commit/a30960f29e1ca7de6c0463517a0c51988f717e35
