### PR TITLE
engine/cleanupmanager: on-call cleanup

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,7 @@ type Config struct {
 	}
 
 	Maintenance struct {
-		DataCleanupDays  int `public:"true" info:"Various data records including alerts and on-call history will be deleted after this many days (0 means disable cleanup)."`
+		AlertCleanupDays int `public:"true" info:"Closed alerts will be deleted after this many days (0 means disable cleanup)."`
 		APIKeyExpireDays int `public:"true" info:"Unused calendar API keys will be disabled after this many days (0 means disable cleanup)."`
 	}
 
@@ -390,7 +390,7 @@ func (cfg Config) Validate() error {
 		validateKey("GitHub.ClientID", cfg.GitHub.ClientID),
 		validateKey("GitHub.ClientSecret", cfg.GitHub.ClientSecret),
 		validateKey("Slack.AccessToken", cfg.Slack.AccessToken),
-		validate.Range("Maintenance.DataCleanupDays", cfg.Maintenance.DataCleanupDays, 0, 9000),
+		validate.Range("Maintenance.AlertCleanupDays", cfg.Maintenance.AlertCleanupDays, 0, 9000),
 		validate.Range("Maintenance.APIKeyExpireDays", cfg.Maintenance.APIKeyExpireDays, 0, 9000),
 		validateScopes("OIDC.Scopes", cfg.OIDC.Scopes),
 		validatePath("OIDC.UserInfoEmailPath", cfg.OIDC.UserInfoEmailPath),

--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,7 @@ type Config struct {
 	}
 
 	Maintenance struct {
-		AlertCleanupDays int `public:"true" info:"Closed alerts will be deleted after this many days (0 means disable cleanup)."`
+		DataCleanupDays  int `public:"true" info:"Various data records including alerts and on-call history will be deleted after this many days (0 means disable cleanup)."`
 		APIKeyExpireDays int `public:"true" info:"Unused calendar API keys will be disabled after this many days (0 means disable cleanup)."`
 	}
 
@@ -390,7 +390,7 @@ func (cfg Config) Validate() error {
 		validateKey("GitHub.ClientID", cfg.GitHub.ClientID),
 		validateKey("GitHub.ClientSecret", cfg.GitHub.ClientSecret),
 		validateKey("Slack.AccessToken", cfg.Slack.AccessToken),
-		validate.Range("Maintenance.AlertCleanupDays", cfg.Maintenance.AlertCleanupDays, 0, 9000),
+		validate.Range("Maintenance.DataCleanupDays", cfg.Maintenance.DataCleanupDays, 0, 9000),
 		validate.Range("Maintenance.APIKeyExpireDays", cfg.Maintenance.APIKeyExpireDays, 0, 9000),
 		validateScopes("OIDC.Scopes", cfg.OIDC.Scopes),
 		validatePath("OIDC.UserInfoEmailPath", cfg.OIDC.UserInfoEmailPath),

--- a/config/config.go
+++ b/config/config.go
@@ -31,8 +31,9 @@ type Config struct {
 	}
 
 	Maintenance struct {
-		AlertCleanupDays int `public:"true" info:"Closed alerts will be deleted after this many days (0 means disable cleanup)."`
-		APIKeyExpireDays int `public:"true" info:"Unused calendar API keys will be disabled after this many days (0 means disable cleanup)."`
+		AlertCleanupDays    int `public:"true" info:"Closed alerts will be deleted after this many days (0 means disable cleanup)."`
+		APIKeyExpireDays    int `public:"true" info:"Unused calendar API keys will be disabled after this many days (0 means disable cleanup)."`
+		ScheduleCleanupDays int `public:"true" info:"Schedule on-call history will be deleted after this many days (0 means disable cleanup)."`
 	}
 
 	Auth struct {
@@ -392,6 +393,7 @@ func (cfg Config) Validate() error {
 		validateKey("Slack.AccessToken", cfg.Slack.AccessToken),
 		validate.Range("Maintenance.AlertCleanupDays", cfg.Maintenance.AlertCleanupDays, 0, 9000),
 		validate.Range("Maintenance.APIKeyExpireDays", cfg.Maintenance.APIKeyExpireDays, 0, 9000),
+		validate.Range("Maintenance.ScheduleCleanupDays", cfg.Maintenance.ScheduleCleanupDays, 0, 9000),
 		validateScopes("OIDC.Scopes", cfg.OIDC.Scopes),
 		validatePath("OIDC.UserInfoEmailPath", cfg.OIDC.UserInfoEmailPath),
 		validatePath("OIDC.UserInfoEmailVerifiedPath", cfg.OIDC.UserInfoEmailVerifiedPath),

--- a/engine/cleanupmanager/db.go
+++ b/engine/cleanupmanager/db.go
@@ -27,6 +27,10 @@ type DB struct {
 
 	cleanupAlertLogs *sql.Stmt
 
+	cleanupOverrides   *sql.Stmt
+	cleanupSchedOnCall *sql.Stmt
+	cleanupEPOnCall    *sql.Stmt
+
 	logIndex int
 }
 
@@ -83,5 +87,9 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 				)
 			select id from scope offset 999
 		`),
+
+		cleanupOverrides:   p.P(`DELETE FROM user_overrides WHERE id = ANY(SELECT id FROM user_overrides WHERE end_time < (now() - $1::interval) LIMIT 100 FOR UPDATE SKIP LOCKED)`),
+		cleanupSchedOnCall: p.P(`DELETE FROM schedule_on_call_users WHERE id = ANY(SELECT id FROM schedule_on_call_users WHERE end_time < (now() - $1::interval) LIMIT 100 FOR UPDATE SKIP LOCKED)`),
+		cleanupEPOnCall:    p.P(`DELETE FROM ep_step_on_call_users WHERE id = ANY(SELECT id FROM ep_step_on_call_users WHERE end_time < (now() - $1::interval) LIMIT 100 FOR UPDATE SKIP LOCKED)`),
 	}, p.Err
 }

--- a/engine/cleanupmanager/update.go
+++ b/engine/cleanupmanager/update.go
@@ -52,9 +52,9 @@ func (db *DB) update(ctx context.Context) error {
 	}
 
 	cfg := config.FromContext(ctx)
-	if cfg.Maintenance.DataCleanupDays > 0 {
+	if cfg.Maintenance.AlertCleanupDays > 0 {
 		var dur pgtype.Interval
-		dur.Days = int32(cfg.Maintenance.DataCleanupDays)
+		dur.Days = int32(cfg.Maintenance.AlertCleanupDays)
 		dur.Status = pgtype.Present
 		_, err = tx.StmtContext(ctx, db.cleanupAlerts).ExecContext(ctx, &dur)
 		if err != nil {

--- a/engine/cleanupmanager/update.go
+++ b/engine/cleanupmanager/update.go
@@ -52,9 +52,9 @@ func (db *DB) update(ctx context.Context) error {
 	}
 
 	cfg := config.FromContext(ctx)
-	if cfg.Maintenance.AlertCleanupDays > 0 {
+	if cfg.Maintenance.DataCleanupDays > 0 {
 		var dur pgtype.Interval
-		dur.Days = int32(cfg.Maintenance.AlertCleanupDays)
+		dur.Days = int32(cfg.Maintenance.DataCleanupDays)
 		dur.Status = pgtype.Present
 		_, err = tx.StmtContext(ctx, db.cleanupAlerts).ExecContext(ctx, &dur)
 		if err != nil {

--- a/engine/cleanupmanager/update.go
+++ b/engine/cleanupmanager/update.go
@@ -60,6 +60,21 @@ func (db *DB) update(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("cleanup alerts: %w", err)
 		}
+
+		_, err = tx.StmtContext(ctx, db.cleanupOverrides).ExecContext(ctx, &dur)
+		if err != nil {
+			return fmt.Errorf("cleanup overrides: %w", err)
+		}
+
+		_, err = tx.StmtContext(ctx, db.cleanupSchedOnCall).ExecContext(ctx, &dur)
+		if err != nil {
+			return fmt.Errorf("cleanup schedule on-call: %w", err)
+		}
+
+		_, err = tx.StmtContext(ctx, db.cleanupEPOnCall).ExecContext(ctx, &dur)
+		if err != nil {
+			return fmt.Errorf("cleanup escalation policy on-call: %w", err)
+		}
 	}
 	if cfg.Maintenance.APIKeyExpireDays > 0 {
 		var dur pgtype.Interval

--- a/engine/cleanupmanager/update.go
+++ b/engine/cleanupmanager/update.go
@@ -60,7 +60,20 @@ func (db *DB) update(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("cleanup alerts: %w", err)
 		}
-
+	}
+	if cfg.Maintenance.APIKeyExpireDays > 0 {
+		var dur pgtype.Interval
+		dur.Days = int32(cfg.Maintenance.APIKeyExpireDays)
+		dur.Status = pgtype.Present
+		_, err = tx.StmtContext(ctx, db.cleanupAPIKeys).ExecContext(ctx, &dur)
+		if err != nil {
+			return err
+		}
+	}
+	if cfg.Maintenance.ScheduleCleanupDays > 0 {
+		var dur pgtype.Interval
+		dur.Days = int32(cfg.Maintenance.ScheduleCleanupDays)
+		dur.Status = pgtype.Present
 		_, err = tx.StmtContext(ctx, db.cleanupOverrides).ExecContext(ctx, &dur)
 		if err != nil {
 			return fmt.Errorf("cleanup overrides: %w", err)
@@ -74,15 +87,6 @@ func (db *DB) update(ctx context.Context) error {
 		_, err = tx.StmtContext(ctx, db.cleanupEPOnCall).ExecContext(ctx, &dur)
 		if err != nil {
 			return fmt.Errorf("cleanup escalation policy on-call: %w", err)
-		}
-	}
-	if cfg.Maintenance.APIKeyExpireDays > 0 {
-		var dur pgtype.Interval
-		dur.Days = int32(cfg.Maintenance.APIKeyExpireDays)
-		dur.Status = pgtype.Present
-		_, err = tx.StmtContext(ctx, db.cleanupAPIKeys).ExecContext(ctx, &dur)
-		if err != nil {
-			return err
 		}
 	}
 

--- a/graphql2/mapconfig.go
+++ b/graphql2/mapconfig.go
@@ -34,7 +34,7 @@ func MapConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "General.DisableSMSLinks", Type: ConfigTypeBoolean, Description: "If set, SMS messages will not contain a URL pointing to GoAlert.", Value: fmt.Sprintf("%t", cfg.General.DisableSMSLinks)},
 		{ID: "General.DisableLabelCreation", Type: ConfigTypeBoolean, Description: "Disables the ability to create new labels for services.", Value: fmt.Sprintf("%t", cfg.General.DisableLabelCreation)},
 		{ID: "General.DisableCalendarSubscriptions", Type: ConfigTypeBoolean, Description: "If set, disables all active calendar subscriptions as well as the ability to create new calendar subscriptions.", Value: fmt.Sprintf("%t", cfg.General.DisableCalendarSubscriptions)},
-		{ID: "Maintenance.DataCleanupDays", Type: ConfigTypeInteger, Description: "Various data records including alerts and on-call history will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.DataCleanupDays)},
+		{ID: "Maintenance.AlertCleanupDays", Type: ConfigTypeInteger, Description: "Closed alerts will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.AlertCleanupDays)},
 		{ID: "Maintenance.APIKeyExpireDays", Type: ConfigTypeInteger, Description: "Unused calendar API keys will be disabled after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.APIKeyExpireDays)},
 		{ID: "Auth.RefererURLs", Type: ConfigTypeStringList, Description: "Allowed referer URLs for auth and redirects.", Value: strings.Join(cfg.Auth.RefererURLs, "\n")},
 		{ID: "Auth.DisableBasic", Type: ConfigTypeBoolean, Description: "Disallow username/password login.", Value: fmt.Sprintf("%t", cfg.Auth.DisableBasic)},
@@ -98,7 +98,7 @@ func MapPublicConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "General.DisableSMSLinks", Type: ConfigTypeBoolean, Description: "If set, SMS messages will not contain a URL pointing to GoAlert.", Value: fmt.Sprintf("%t", cfg.General.DisableSMSLinks)},
 		{ID: "General.DisableLabelCreation", Type: ConfigTypeBoolean, Description: "Disables the ability to create new labels for services.", Value: fmt.Sprintf("%t", cfg.General.DisableLabelCreation)},
 		{ID: "General.DisableCalendarSubscriptions", Type: ConfigTypeBoolean, Description: "If set, disables all active calendar subscriptions as well as the ability to create new calendar subscriptions.", Value: fmt.Sprintf("%t", cfg.General.DisableCalendarSubscriptions)},
-		{ID: "Maintenance.DataCleanupDays", Type: ConfigTypeInteger, Description: "Various data records including alerts and on-call history will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.DataCleanupDays)},
+		{ID: "Maintenance.AlertCleanupDays", Type: ConfigTypeInteger, Description: "Closed alerts will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.AlertCleanupDays)},
 		{ID: "Maintenance.APIKeyExpireDays", Type: ConfigTypeInteger, Description: "Unused calendar API keys will be disabled after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.APIKeyExpireDays)},
 		{ID: "Auth.DisableBasic", Type: ConfigTypeBoolean, Description: "Disallow username/password login.", Value: fmt.Sprintf("%t", cfg.Auth.DisableBasic)},
 		{ID: "GitHub.Enable", Type: ConfigTypeBoolean, Description: "Enable GitHub authentication.", Value: fmt.Sprintf("%t", cfg.GitHub.Enable)},
@@ -181,12 +181,12 @@ func ApplyConfigValues(cfg config.Config, vals []ConfigValueInput) (config.Confi
 				return cfg, err
 			}
 			cfg.General.DisableCalendarSubscriptions = val
-		case "Maintenance.DataCleanupDays":
+		case "Maintenance.AlertCleanupDays":
 			val, err := parseInt(v.ID, v.Value)
 			if err != nil {
 				return cfg, err
 			}
-			cfg.Maintenance.DataCleanupDays = val
+			cfg.Maintenance.AlertCleanupDays = val
 		case "Maintenance.APIKeyExpireDays":
 			val, err := parseInt(v.ID, v.Value)
 			if err != nil {

--- a/graphql2/mapconfig.go
+++ b/graphql2/mapconfig.go
@@ -34,7 +34,7 @@ func MapConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "General.DisableSMSLinks", Type: ConfigTypeBoolean, Description: "If set, SMS messages will not contain a URL pointing to GoAlert.", Value: fmt.Sprintf("%t", cfg.General.DisableSMSLinks)},
 		{ID: "General.DisableLabelCreation", Type: ConfigTypeBoolean, Description: "Disables the ability to create new labels for services.", Value: fmt.Sprintf("%t", cfg.General.DisableLabelCreation)},
 		{ID: "General.DisableCalendarSubscriptions", Type: ConfigTypeBoolean, Description: "If set, disables all active calendar subscriptions as well as the ability to create new calendar subscriptions.", Value: fmt.Sprintf("%t", cfg.General.DisableCalendarSubscriptions)},
-		{ID: "Maintenance.AlertCleanupDays", Type: ConfigTypeInteger, Description: "Closed alerts will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.AlertCleanupDays)},
+		{ID: "Maintenance.DataCleanupDays", Type: ConfigTypeInteger, Description: "Various data records including alerts and on-call history will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.DataCleanupDays)},
 		{ID: "Maintenance.APIKeyExpireDays", Type: ConfigTypeInteger, Description: "Unused calendar API keys will be disabled after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.APIKeyExpireDays)},
 		{ID: "Auth.RefererURLs", Type: ConfigTypeStringList, Description: "Allowed referer URLs for auth and redirects.", Value: strings.Join(cfg.Auth.RefererURLs, "\n")},
 		{ID: "Auth.DisableBasic", Type: ConfigTypeBoolean, Description: "Disallow username/password login.", Value: fmt.Sprintf("%t", cfg.Auth.DisableBasic)},
@@ -98,7 +98,7 @@ func MapPublicConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "General.DisableSMSLinks", Type: ConfigTypeBoolean, Description: "If set, SMS messages will not contain a URL pointing to GoAlert.", Value: fmt.Sprintf("%t", cfg.General.DisableSMSLinks)},
 		{ID: "General.DisableLabelCreation", Type: ConfigTypeBoolean, Description: "Disables the ability to create new labels for services.", Value: fmt.Sprintf("%t", cfg.General.DisableLabelCreation)},
 		{ID: "General.DisableCalendarSubscriptions", Type: ConfigTypeBoolean, Description: "If set, disables all active calendar subscriptions as well as the ability to create new calendar subscriptions.", Value: fmt.Sprintf("%t", cfg.General.DisableCalendarSubscriptions)},
-		{ID: "Maintenance.AlertCleanupDays", Type: ConfigTypeInteger, Description: "Closed alerts will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.AlertCleanupDays)},
+		{ID: "Maintenance.DataCleanupDays", Type: ConfigTypeInteger, Description: "Various data records including alerts and on-call history will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.DataCleanupDays)},
 		{ID: "Maintenance.APIKeyExpireDays", Type: ConfigTypeInteger, Description: "Unused calendar API keys will be disabled after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.APIKeyExpireDays)},
 		{ID: "Auth.DisableBasic", Type: ConfigTypeBoolean, Description: "Disallow username/password login.", Value: fmt.Sprintf("%t", cfg.Auth.DisableBasic)},
 		{ID: "GitHub.Enable", Type: ConfigTypeBoolean, Description: "Enable GitHub authentication.", Value: fmt.Sprintf("%t", cfg.GitHub.Enable)},
@@ -181,12 +181,12 @@ func ApplyConfigValues(cfg config.Config, vals []ConfigValueInput) (config.Confi
 				return cfg, err
 			}
 			cfg.General.DisableCalendarSubscriptions = val
-		case "Maintenance.AlertCleanupDays":
+		case "Maintenance.DataCleanupDays":
 			val, err := parseInt(v.ID, v.Value)
 			if err != nil {
 				return cfg, err
 			}
-			cfg.Maintenance.AlertCleanupDays = val
+			cfg.Maintenance.DataCleanupDays = val
 		case "Maintenance.APIKeyExpireDays":
 			val, err := parseInt(v.ID, v.Value)
 			if err != nil {

--- a/graphql2/mapconfig.go
+++ b/graphql2/mapconfig.go
@@ -36,6 +36,7 @@ func MapConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "General.DisableCalendarSubscriptions", Type: ConfigTypeBoolean, Description: "If set, disables all active calendar subscriptions as well as the ability to create new calendar subscriptions.", Value: fmt.Sprintf("%t", cfg.General.DisableCalendarSubscriptions)},
 		{ID: "Maintenance.AlertCleanupDays", Type: ConfigTypeInteger, Description: "Closed alerts will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.AlertCleanupDays)},
 		{ID: "Maintenance.APIKeyExpireDays", Type: ConfigTypeInteger, Description: "Unused calendar API keys will be disabled after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.APIKeyExpireDays)},
+		{ID: "Maintenance.ScheduleCleanupDays", Type: ConfigTypeInteger, Description: "Schedule on-call history will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.ScheduleCleanupDays)},
 		{ID: "Auth.RefererURLs", Type: ConfigTypeStringList, Description: "Allowed referer URLs for auth and redirects.", Value: strings.Join(cfg.Auth.RefererURLs, "\n")},
 		{ID: "Auth.DisableBasic", Type: ConfigTypeBoolean, Description: "Disallow username/password login.", Value: fmt.Sprintf("%t", cfg.Auth.DisableBasic)},
 		{ID: "GitHub.Enable", Type: ConfigTypeBoolean, Description: "Enable GitHub authentication.", Value: fmt.Sprintf("%t", cfg.GitHub.Enable)},
@@ -100,6 +101,7 @@ func MapPublicConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "General.DisableCalendarSubscriptions", Type: ConfigTypeBoolean, Description: "If set, disables all active calendar subscriptions as well as the ability to create new calendar subscriptions.", Value: fmt.Sprintf("%t", cfg.General.DisableCalendarSubscriptions)},
 		{ID: "Maintenance.AlertCleanupDays", Type: ConfigTypeInteger, Description: "Closed alerts will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.AlertCleanupDays)},
 		{ID: "Maintenance.APIKeyExpireDays", Type: ConfigTypeInteger, Description: "Unused calendar API keys will be disabled after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.APIKeyExpireDays)},
+		{ID: "Maintenance.ScheduleCleanupDays", Type: ConfigTypeInteger, Description: "Schedule on-call history will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.ScheduleCleanupDays)},
 		{ID: "Auth.DisableBasic", Type: ConfigTypeBoolean, Description: "Disallow username/password login.", Value: fmt.Sprintf("%t", cfg.Auth.DisableBasic)},
 		{ID: "GitHub.Enable", Type: ConfigTypeBoolean, Description: "Enable GitHub authentication.", Value: fmt.Sprintf("%t", cfg.GitHub.Enable)},
 		{ID: "OIDC.Enable", Type: ConfigTypeBoolean, Description: "Enable OpenID Connect authentication.", Value: fmt.Sprintf("%t", cfg.OIDC.Enable)},
@@ -193,6 +195,12 @@ func ApplyConfigValues(cfg config.Config, vals []ConfigValueInput) (config.Confi
 				return cfg, err
 			}
 			cfg.Maintenance.APIKeyExpireDays = val
+		case "Maintenance.ScheduleCleanupDays":
+			val, err := parseInt(v.ID, v.Value)
+			if err != nil {
+				return cfg, err
+			}
+			cfg.Maintenance.ScheduleCleanupDays = val
 		case "Auth.RefererURLs":
 			cfg.Auth.RefererURLs = parseStringList(v.Value)
 		case "Auth.DisableBasic":

--- a/smoketest/alertcleanup_test.go
+++ b/smoketest/alertcleanup_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 // TestAlertCleanup verifies that old alerts are purged from the DB
-// when `Maintenance.DataCleanupDays` is set.
-func TestDataCleanup(t *testing.T) {
+// when `Maintenance.AlertCleanupDays` is set.
+func TestAlertCleanup(t *testing.T) {
 	t.Parallel()
 
 	sql := `
@@ -43,7 +43,7 @@ func TestDataCleanup(t *testing.T) {
 	assert.Equal(t, "1", data.A.ID)
 	assert.Equal(t, "2", data.B.ID)
 
-	h.SetConfigValue("Maintenance.DataCleanupDays", "1")
+	h.SetConfigValue("Maintenance.AlertCleanupDays", "1")
 
 	h.Trigger()
 

--- a/smoketest/alertcleanup_test.go
+++ b/smoketest/alertcleanup_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 // TestAlertCleanup verifies that old alerts are purged from the DB
-// when `Maintenance.AlertCleanupDays` is set.
-func TestAlertCleanup(t *testing.T) {
+// when `Maintenance.DataCleanupDays` is set.
+func TestDataCleanup(t *testing.T) {
 	t.Parallel()
 
 	sql := `
@@ -43,7 +43,7 @@ func TestAlertCleanup(t *testing.T) {
 	assert.Equal(t, "1", data.A.ID)
 	assert.Equal(t, "2", data.B.ID)
 
-	h.SetConfigValue("Maintenance.AlertCleanupDays", "1")
+	h.SetConfigValue("Maintenance.DataCleanupDays", "1")
 
 	h.Trigger()
 

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -950,6 +950,7 @@ type ConfigID =
   | 'General.DisableCalendarSubscriptions'
   | 'Maintenance.AlertCleanupDays'
   | 'Maintenance.APIKeyExpireDays'
+  | 'Maintenance.ScheduleCleanupDays'
   | 'Auth.RefererURLs'
   | 'Auth.DisableBasic'
   | 'GitHub.Enable'

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -948,7 +948,7 @@ type ConfigID =
   | 'General.DisableSMSLinks'
   | 'General.DisableLabelCreation'
   | 'General.DisableCalendarSubscriptions'
-  | 'Maintenance.AlertCleanupDays'
+  | 'Maintenance.DataCleanupDays'
   | 'Maintenance.APIKeyExpireDays'
   | 'Auth.RefererURLs'
   | 'Auth.DisableBasic'

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -948,7 +948,7 @@ type ConfigID =
   | 'General.DisableSMSLinks'
   | 'General.DisableLabelCreation'
   | 'General.DisableCalendarSubscriptions'
-  | 'Maintenance.DataCleanupDays'
+  | 'Maintenance.AlertCleanupDays'
   | 'Maintenance.APIKeyExpireDays'
   | 'Auth.RefererURLs'
   | 'Auth.DisableBasic'


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
The PR introduces cleanup for 3 additional tables: `user_overrides` `schedule_on_call_users` and `ep_step_on_call_users`

**Which issue(s) this PR fixes:**
Fixes #916 

**Describe any introduced user-facing changes:**
In admin config panel, "Alert Cleanup days" has been renamed to "Data cleanup days", and the associated description has been updated appropriately.

**Describe any introduced API changes:**
Deprecated `'Maintenance.AlertCleanupDays'` in favor of `'Maintenance.DataCleanupDays'`
