### PR TITLE
ui: refactor URL query parameter interactions

### DIFF
--- a/web/src/app/alerts/AlertsList.js
+++ b/web/src/app/alerts/AlertsList.js
@@ -8,7 +8,6 @@ import {
   Check as AcknowledgeIcon,
   Close as CloseIcon,
 } from '@mui/icons-material'
-import { useSelector } from 'react-redux'
 import { DateTime } from 'luxon'
 
 import AlertsListFilter from './components/AlertsListFilter'
@@ -16,11 +15,11 @@ import AlertsListControls from './components/AlertsListControls'
 import UpdateAlertsSnackbar from './components/UpdateAlertsSnackbar'
 
 import { formatTimeSince } from '../util/timeFormat'
-import { urlParamSelector } from '../selectors'
 import QueryList from '../lists/QueryList'
 import { useIsWidthDown } from '../util/useWidth'
 import CreateFAB from '../lists/CreateFAB'
 import CreateAlertDialog from './CreateAlertDialog/CreateAlertDialog'
+import { useURLParam } from '../actions'
 
 export const alertsListQuery = gql`
   query alertsList($input: AlertSearchOptions) {
@@ -98,10 +97,9 @@ export default function AlertsList(props) {
   const [actionCompleteDismissed, setActionCompleteDismissed] = useState(true)
 
   // get redux url vars
-  const params = useSelector(urlParamSelector)
-  const allServices = params('allServices')
-  const fullTime = params('fullTime')
-  const filter = params('filter', 'active')
+  const [allServices] = useURLParam('allServices')
+  const [fullTime] = useURLParam('fullTime')
+  const [filter] = useURLParam('filter', 'active')
 
   // query for current service name if props.serviceID is provided
   const serviceNameQuery = useQuery(

--- a/web/src/app/lists/QueryList.tsx
+++ b/web/src/app/lists/QueryList.tsx
@@ -10,12 +10,13 @@ import { Grid } from '@mui/material'
 import { once } from 'lodash'
 import { PaginatedList, PaginatedListItemProps } from './PaginatedList'
 import { ITEMS_PER_PAGE, POLL_INTERVAL } from '../config'
-import { searchSelector, urlKeySelector } from '../selectors'
+import { urlKeySelector } from '../selectors'
 import { fieldAlias } from '../util/graphql'
 import { GraphQLClientWithErrors } from '../apollo'
 import ControlledPaginatedList, {
   ControlledPaginatedListProps,
 } from './ControlledPaginatedList'
+import { useURLParam } from '../actions'
 
 // any && object type map
 // used for objects with unknown key/values from parent
@@ -102,7 +103,7 @@ export default function QueryList(props: QueryListProps): JSX.Element {
   } = props
   const { input, ...vars } = variables
 
-  const searchParam = useSelector(searchSelector)
+  const [searchParam] = useURLParam('search', '')
   const urlKey = useSelector(urlKeySelector)
   const aliasedQuery = useMemo(() => fieldAlias(query, 'data'), [query])
 

--- a/web/src/app/main/components/NewUserSetup.js
+++ b/web/src/app/main/components/NewUserSetup.js
@@ -1,16 +1,12 @@
 import React, { useState } from 'react'
 import UserContactMethodCreateDialog from '../../users/UserContactMethodCreateDialog'
 import UserContactMethodVerificationDialog from '../../users/UserContactMethodVerificationDialog'
-import { useDispatch, useSelector } from 'react-redux'
-import { urlParamSelector } from '../../selectors'
 import { useSessionInfo, useConfigValue } from '../../util/RequireConfig'
-import { resetURLParams } from '../../actions'
+import { useResetURLParams, useURLParam } from '../../actions'
 
 export default function NewUserSetup() {
-  const urlParams = useSelector(urlParamSelector)
-  const isFirstLogin = urlParams('isFirstLogin', '')
-  const dispatch = useDispatch()
-  const clearIsFirstLogin = () => dispatch(resetURLParams('isFirstLogin'))
+  const [isFirstLogin] = useURLParam('isFirstLogin', '')
+  const clearIsFirstLogin = useResetURLParams('isFirstLogin')
   const [contactMethodID, setContactMethodID] = useState('')
   const { userID, ready } = useSessionInfo()
   const [disclaimer] = useConfigValue('General.NotificationDisclaimer')

--- a/web/src/app/schedules/ScheduleOverrideForm.js
+++ b/web/src/app/schedules/ScheduleOverrideForm.js
@@ -7,13 +7,12 @@ import { Grid, Typography } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
 
 import { ScheduleTZFilter } from './ScheduleTZFilter'
-import { useSelector } from 'react-redux'
-import { urlParamSelector } from '../selectors'
 import { UserSelect } from '../selection'
 import { mapOverrideUserError } from './util'
 import DialogContentError from '../dialogs/components/DialogContentError'
 import _ from 'lodash'
 import { ISODateTimePicker } from '../util/ISOPickers'
+import { useURLParam } from '../actions'
 
 const query = gql`
   query ($id: ID!) {
@@ -51,8 +50,7 @@ export default function ScheduleOverrideForm(props) {
   } = props
 
   const classes = useStyles()
-  const params = useSelector(urlParamSelector)
-  const zone = params('tz', 'local')
+  const [zone] = useURLParam('tz', 'local')
 
   const conflictingUserFieldError = props.errors.find(
     (e) => e && e.field === 'userID',

--- a/web/src/app/services/ServiceRouter.js
+++ b/web/src/app/services/ServiceRouter.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { gql } from '@apollo/client'
-import { useDispatch, useSelector } from 'react-redux'
 import { Switch, Route } from 'react-router-dom'
 
 import SimpleListPage from '../lists/SimpleListPage'
@@ -11,8 +10,7 @@ import { PageNotFound } from '../error-pages/Errors'
 import ServiceAlerts from './ServiceAlerts'
 import ServiceCreateDialog from './ServiceCreateDialog'
 import HeartbeatMonitorList from './HeartbeatMonitorList'
-import { searchSelector } from '../selectors'
-import { setURLParam } from '../actions'
+import { useURLParam } from '../actions'
 import ServiceLabelFilterContainer from './ServiceLabelFilterContainer'
 import getServiceLabel from '../util/getServiceLabel'
 
@@ -34,10 +32,7 @@ const query = gql`
 `
 
 export default function ServiceRouter() {
-  const searchParam = useSelector(searchSelector) // current total search string on page load
-  const dispatch = useDispatch()
-  const setSearchParam = (value) => dispatch(setURLParam('search', value))
-
+  const [searchParam, setSearchParam] = useURLParam('search', '')
   const { labelKey, labelValue } = getServiceLabel(searchParam)
 
   function renderList() {

--- a/web/src/app/util/ISOPickers.tsx
+++ b/web/src/app/util/ISOPickers.tsx
@@ -1,12 +1,11 @@
 import React, { useState } from 'react'
-import { useSelector } from 'react-redux'
 import { DateTime, DurationObjectUnits } from 'luxon'
 import { TextField, TextFieldProps } from '@mui/material'
 import DatePicker from '@mui/lab/DatePicker'
 import DateTimePicker from '@mui/lab/DateTimePicker'
 import TimePicker from '@mui/lab/TimePicker'
 import { inputtypes } from 'modernizr-esm/feature/inputtypes'
-import { urlParamSelector } from '../selectors'
+import { useURLParam } from '../actions'
 
 interface ISOPickerProps extends ISOTextFieldProps {
   Fallback: typeof TimePicker | typeof DatePicker | typeof DateTimePicker
@@ -51,8 +50,8 @@ function ISOPicker(props: ISOPickerProps): JSX.Element {
   } = props
 
   const native = hasInputSupport(type)
-  const getURLParam = useSelector(urlParamSelector)
-  const zone = timeZone || (getURLParam('tz', 'local') as string)
+  const [_zone] = useURLParam('tz', 'local')
+  const zone = timeZone || _zone
   const valueAsDT = props.value ? DateTime.fromISO(props.value, { zone }) : null
 
   // store input value as DT.format() string. pass to parent onChange as ISO string


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR makes all interactions with URL query parameters use the `useURLParam` and `useResetURLParams` hooks. Using these interfaces consistently isolates the concerns of getting/setting URL params, making it more maintainable e.g. if we need to add any sort of middleware, it can be done in one place.
