### PR TITLE
gRPC/user: fix user ID filter parameters

### DIFF
--- a/notification/slack/oncallnotification.go
+++ b/notification/slack/oncallnotification.go
@@ -32,10 +32,10 @@ func (s *ChannelSender) onCallNotificationText(ctx context.Context, t notificati
 	}
 
 	userSlackIDs := make(map[string]string, len(t.Users))
-	err = s.cfg.UserStore.AuthSubjectsFunc(ctx, "slack:"+teamID, func(sub user.AuthSubject) error {
+	err = s.cfg.UserStore.AuthSubjectsFunc(ctx, "slack:"+teamID, userIDs, func(sub user.AuthSubject) error {
 		userSlackIDs[sub.UserID] = sub.SubjectID
 		return nil
-	}, userIDs...)
+	})
 	if err != nil {
 		log.Log(ctx, fmt.Errorf("lookup auth subjects for slack: %w", err))
 		// handled error by logging, continue on to render message with any included slack IDs

--- a/sysapiserver/server.go
+++ b/sysapiserver/server.go
@@ -33,13 +33,18 @@ func (srv *Server) SetAuthSubject(ctx context.Context, req *sysapi.SetAuthSubjec
 func (srv *Server) AuthSubjects(req *sysapi.AuthSubjectsRequest, rSrv sysapi.SysAPI_AuthSubjectsServer) error {
 	ctx := permission.SystemContext(rSrv.Context(), "SystemAPI")
 
-	return srv.UserStore.AuthSubjectsFunc(ctx, req.ProviderId, func(s user.AuthSubject) error {
+	var filterUsers []string
+	if req.UserId != "" {
+		filterUsers = append(filterUsers, req.UserId)
+	}
+
+	return srv.UserStore.AuthSubjectsFunc(ctx, req.ProviderId, filterUsers, func(s user.AuthSubject) error {
 		return rSrv.Send(&sysapi.AuthSubject{
 			ProviderId: s.ProviderID,
 			SubjectId:  s.SubjectID,
 			UserId:     s.UserID,
 		})
-	}, req.UserId)
+	})
 }
 
 func (srv *Server) DeleteUser(ctx context.Context, req *sysapi.DeleteUserRequest) (*sysapi.DeleteUserResponse, error) {

--- a/user/store.go
+++ b/user/store.go
@@ -248,8 +248,8 @@ func (s *Store) WithoutAuthProviderFunc(ctx context.Context, providerID string, 
 // If an error is returned by forEachFn it will stop reading subjects and be returned.
 //
 // providerID, if not empty, will limit AuthSubjects to those with the same providerID.
-// userID, if not empty, will limit AuthSubjects to those assigned to the given userID.
-func (s *Store) AuthSubjectsFunc(ctx context.Context, providerID string, forEachFn func(AuthSubject) error, userIDs ...string) error {
+// userID, if not empty, will limit AuthSubjects to those assigned to the given userID(s).
+func (s *Store) AuthSubjectsFunc(ctx context.Context, providerID string, userIDs []string, forEachFn func(AuthSubject) error) error {
 	err := permission.LimitCheckAny(ctx, permission.System, permission.Admin)
 	if err != nil {
 		return err
@@ -688,10 +688,10 @@ func (s *Store) FindSomeAuthSubjectsForProvider(ctx context.Context, limit int, 
 // FindAllAuthSubjectsForUser returns all auth subjects associated with a given userID.
 func (s *Store) FindAllAuthSubjectsForUser(ctx context.Context, userID string) ([]AuthSubject, error) {
 	var result []AuthSubject
-	err := s.AuthSubjectsFunc(ctx, "", func(sub AuthSubject) error {
+	err := s.AuthSubjectsFunc(ctx, "", []string{userID}, func(sub AuthSubject) error {
 		result = append(result, sub)
 		return nil
-	}, userID)
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

**Description:**
This PR fixes a regression caused by a subtle change in the way AuthSubjectsFunc works. The `userID` parameter now takes an explicit slice and the sysapiserver package now only includes a slice value if `userID` is not empty.

The regression was caused by the change from calling with an empty userID being interpreted as a slice with a single empty user id (failing validation) when the last parameter was changed from a string to a variadic slice of strings.
