### PR TITLE
ui: refactor `useURLParam` and `useResetURLParams`

### DIFF
--- a/web/src/app/actions/hooks.test.ts
+++ b/web/src/app/actions/hooks.test.ts
@@ -1,0 +1,158 @@
+import { getURLParam, sanitizeURLParam, Value } from './hooks'
+
+interface GetParamTest {
+  desc: string
+  name: string
+  defaultValue: Value
+  expected: Value
+}
+
+describe('getURLParam', () => {
+  const init = 'a=str&b=3&c=1&d=0&e=e&e=e&e=ee'
+  const q = new URLSearchParams(init)
+
+  function check(x: GetParamTest): void {
+    it(x.desc, () => {
+      expect(getURLParam(q, x.name, x.defaultValue)).toEqual(x.expected)
+    })
+  }
+
+  check({
+    desc: 'string value',
+    name: 'a',
+    defaultValue: 'aaa',
+    expected: 'str',
+  })
+
+  check({
+    desc: 'mising string value',
+    name: 'zzz',
+    defaultValue: 'aaa',
+    expected: 'aaa',
+  })
+
+  check({
+    desc: 'string multi-value',
+    name: 'e',
+    defaultValue: ['extra'],
+    expected: ['e', 'e', 'ee'],
+  })
+
+  check({
+    desc: 'missing multi-value',
+    name: 'zzz',
+    defaultValue: ['extra'],
+    expected: ['extra'],
+  })
+
+  check({
+    desc: 'number value 1',
+    name: 'b',
+    defaultValue: 4,
+    expected: 3,
+  })
+
+  check({
+    desc: 'number value 2',
+    name: 'c',
+    defaultValue: 4,
+    expected: 1,
+  })
+
+  check({
+    desc: 'number value 3',
+    name: 'd',
+    defaultValue: 4,
+    expected: 0,
+  })
+
+  check({
+    desc: 'missing number value',
+    name: 'zzz',
+    defaultValue: 4,
+    expected: 4,
+  })
+
+  check({
+    desc: 'bool value (true)',
+    name: 'c',
+    defaultValue: false,
+    expected: true,
+  })
+
+  check({
+    desc: 'bool value (false)',
+    name: 'd',
+    defaultValue: false,
+    expected: false,
+  })
+
+  check({
+    desc: 'missing bool value',
+    name: 'zzz',
+    defaultValue: true,
+    expected: true,
+  })
+})
+
+interface SanitizeTest {
+  desc: string
+  val: Value
+  expected: string | string[]
+}
+
+describe('sanitizeURLParam', () => {
+  function check(x: SanitizeTest): void {
+    it(x.desc, () => {
+      expect(sanitizeURLParam(x.val)).toEqual(x.expected)
+    })
+  }
+
+  check({
+    desc: 'string value',
+    val: 'str',
+    expected: 'str',
+  })
+
+  check({
+    desc: 'empty string',
+    val: '',
+    expected: '',
+  })
+
+  check({
+    desc: 'trim string',
+    val: '  ',
+    expected: '',
+  })
+
+  check({
+    desc: 'multi string',
+    val: [' hello', '', ' world ', '   '],
+    expected: ['hello', 'world'],
+  })
+
+  check({
+    desc: 'bool value true',
+    val: true,
+    expected: '1',
+  })
+
+  check({
+    desc: 'bool value false',
+    val: false,
+    expected: '',
+  })
+
+  check({
+    desc: 'num value 1',
+    val: 1,
+    expected: '1',
+  })
+
+  check({
+    desc: 'num value 2',
+    val: 0,
+    expected: '0',
+  })
+})

--- a/web/src/app/actions/hooks.test.ts
+++ b/web/src/app/actions/hooks.test.ts
@@ -1,13 +1,12 @@
-import { getURLParam, sanitizeURLParam, Value } from './hooks'
+import { getParamValues, sanitizeURLParam, Value } from './hooks'
 
 interface GetParamTest {
   desc: string
-  name: string
-  defaultValue: Value
-  expected: Value
+  params: Record<string, Value>
+  expected: Record<string, Value>
 }
 
-describe('getURLParam', () => {
+describe('getParamValues', () => {
   const mockLocationObject = {
     search: 'a=str&b=3&c=1&d=0&e=e&e=e&e=ee',
     pathname: '',
@@ -17,87 +16,86 @@ describe('getURLParam', () => {
 
   function check(x: GetParamTest): void {
     it(x.desc, () => {
-      expect(getURLParam(mockLocationObject, x.name, x.defaultValue)).toEqual(
-        x.expected,
-      )
+      expect(getParamValues(mockLocationObject, x.params)).toEqual(x.expected)
     })
   }
 
   check({
+    desc: 'empty params',
+    params: {},
+    expected: {},
+  })
+
+  check({
     desc: 'string value',
-    name: 'a',
-    defaultValue: 'aaa',
-    expected: 'str',
+    params: { a: 'aaa' },
+    expected: { a: 'str' },
   })
 
   check({
     desc: 'mising string value',
-    name: 'zzz',
-    defaultValue: 'aaa',
-    expected: 'aaa',
+    params: { zzz: 'aaa' },
+    expected: { zzz: 'aaa' },
   })
 
   check({
     desc: 'string multi-value',
-    name: 'e',
-    defaultValue: ['extra'],
-    expected: ['e', 'e', 'ee'],
+    params: { e: ['extra'] },
+    expected: { e: ['e', 'e', 'ee'] },
   })
 
   check({
     desc: 'missing multi-value',
-    name: 'zzz',
-    defaultValue: ['extra'],
-    expected: ['extra'],
+    params: { zzz: ['extra'] },
+    expected: { zzz: ['extra'] },
   })
 
   check({
     desc: 'number value 1',
-    name: 'b',
-    defaultValue: 4,
-    expected: 3,
+    params: { b: 4 },
+    expected: { b: 3 },
   })
 
   check({
     desc: 'number value 2',
-    name: 'c',
-    defaultValue: 4,
-    expected: 1,
+    params: { c: 4 },
+    expected: { c: 1 },
   })
 
   check({
     desc: 'number value 3',
-    name: 'd',
-    defaultValue: 4,
-    expected: 0,
+    params: { d: 4 },
+    expected: { d: 0 },
   })
 
   check({
     desc: 'missing number value',
-    name: 'zzz',
-    defaultValue: 4,
-    expected: 4,
+    params: { zzz: 4 },
+    expected: { zzz: 4 },
   })
 
   check({
     desc: 'bool value (true)',
-    name: 'c',
-    defaultValue: false,
-    expected: true,
+    params: { c: false },
+    expected: { c: true },
   })
 
   check({
     desc: 'bool value (false)',
-    name: 'd',
-    defaultValue: false,
-    expected: false,
+    params: { d: false },
+    expected: { d: false },
   })
 
   check({
     desc: 'missing bool value',
-    name: 'zzz',
-    defaultValue: true,
-    expected: true,
+    params: { zzz: true },
+    expected: { zzz: true },
+  })
+
+  check({
+    desc: 'multi param',
+    params: { a: '', b: 0, e: [], zzz: false },
+    expected: { a: 'str', b: 3, e: ['e', 'e', 'ee'], zzz: false },
   })
 })
 

--- a/web/src/app/actions/hooks.test.ts
+++ b/web/src/app/actions/hooks.test.ts
@@ -8,12 +8,18 @@ interface GetParamTest {
 }
 
 describe('getURLParam', () => {
-  const init = 'a=str&b=3&c=1&d=0&e=e&e=e&e=ee'
-  const q = new URLSearchParams(init)
+  const mockLocationObject = {
+    search: 'a=str&b=3&c=1&d=0&e=e&e=e&e=ee',
+    pathname: '',
+    state: '',
+    hash: '',
+  }
 
   function check(x: GetParamTest): void {
     it(x.desc, () => {
-      expect(getURLParam(q, x.name, x.defaultValue)).toEqual(x.expected)
+      expect(getURLParam(mockLocationObject, x.name, x.defaultValue)).toEqual(
+        x.expected,
+      )
     })
   }
 

--- a/web/src/app/actions/hooks.test.ts
+++ b/web/src/app/actions/hooks.test.ts
@@ -4,17 +4,19 @@ interface GetParamTest {
   desc: string
   params: Record<string, Value>
   expected: Record<string, Value>
+  search?: string
 }
 
 describe('getParamValues', () => {
-  const mockLocationObject = {
-    search: 'a=str&b=3&c=1&d=0&e=e&e=e&e=ee',
-    pathname: '',
-    state: '',
-    hash: '',
-  }
-
   function check(x: GetParamTest): void {
+    const defaultSearch = 'a=str&b=3&c=1&d=0&e=e&e=e&e=ee&f=ok%2Cgo%21'
+    const mockLocationObject = {
+      search: x.search ? x.search : defaultSearch,
+      pathname: '',
+      state: '',
+      hash: '',
+    }
+
     it(x.desc, () => {
       expect(getParamValues(mockLocationObject, x.params)).toEqual(x.expected)
     })
@@ -97,6 +99,40 @@ describe('getParamValues', () => {
     params: { a: '', b: 0, e: [], zzz: false },
     expected: { a: 'str', b: 3, e: ['e', 'e', 'ee'], zzz: false },
   })
+
+  check({
+    desc: 'char encoding 1',
+    params: { f: '' },
+    expected: { f: 'ok,go!' },
+  })
+
+  check({
+    desc: 'char encoding 2',
+    search: 'search=asdf%26%3D',
+    params: { search: '' },
+    expected: { search: 'asdf&=' },
+  })
+
+  check({
+    desc: 'search foo',
+    search: 'search=foo',
+    params: { search: '' },
+    expected: { search: 'foo' },
+  })
+
+  check({
+    desc: '& prefix',
+    search: '&search=foo',
+    params: { search: '' },
+    expected: { search: 'foo' },
+  })
+
+  check({
+    desc: '&&& suffix',
+    search: 'search=foo&&&',
+    params: { search: '' },
+    expected: { search: 'foo' },
+  })
 })
 
 interface SanitizeTest {
@@ -155,7 +191,7 @@ describe('sanitizeURLParam', () => {
   })
 
   check({
-    desc: 'num value 2',
+    desc: 'num value 0',
     val: 0,
     expected: '0',
   })

--- a/web/src/app/actions/hooks.ts
+++ b/web/src/app/actions/hooks.ts
@@ -25,28 +25,28 @@ export function sanitizeURLParam(value: Value): string | string[] {
   }
 }
 
-// getParamValues converts each value from string|string[]
-// into the desired type based on the respective default value.
+// getParamValues converts each URL search param into the
+// desired type based on its respective default value.
 export function getParamValues<T extends Record<string, Value>>(
   location: Location,
-  params: T,
+  params: T, // <name, default> pairs
 ): T {
   const result = {} as Record<string, Value>
   const q = new URLSearchParams(location.search)
 
-  for (const [k, defaultv] of Object.entries(params)) {
-    if (!q.has(k)) {
-      result[k] = defaultv
-    } else if (Array.isArray(defaultv)) {
-      result[k] = q.getAll(k)
-    } else if (typeof defaultv === 'boolean') {
-      result[k] = q.get(k) === '1'
-    } else if (typeof defaultv === 'string') {
-      result[k] = q.get(k) || ''
-    } else if (typeof defaultv === 'number') {
-      result[k] = +(q.get(k) as string)
+  for (const [name, defaultVal] of Object.entries(params)) {
+    if (!q.has(name)) {
+      result[name] = defaultVal
+    } else if (Array.isArray(defaultVal)) {
+      result[name] = q.getAll(name)
+    } else if (typeof defaultVal === 'boolean') {
+      result[name] = q.get(name) === '1'
+    } else if (typeof defaultVal === 'string') {
+      result[name] = q.get(name) || ''
+    } else if (typeof defaultVal === 'number') {
+      result[name] = +(q.get(name) as string)
     } else {
-      result[k] = defaultv
+      result[name] = defaultVal
     }
   }
   return result as T
@@ -90,15 +90,15 @@ export function useURLParams<T extends Record<string, Value>>(
     }
     called = true
 
-    for (const [k, _v] of Object.entries(newParams)) {
-      const v = k === 'search' ? (_v as string) : sanitizeURLParam(_v)
+    for (const [name, _v] of Object.entries(newParams)) {
+      const value = name === 'search' ? (_v as string) : sanitizeURLParam(_v)
 
-      q.delete(k)
+      q.delete(name)
 
-      if (Array.isArray(v)) {
-        v.forEach((v) => q.append(k, v))
-      } else if (v) {
-        q.set(k, v)
+      if (Array.isArray(value)) {
+        value.forEach((v) => q.append(name, v))
+      } else if (value) {
+        q.set(name, value)
       }
     }
 

--- a/web/src/app/actions/hooks.ts
+++ b/web/src/app/actions/hooks.ts
@@ -79,8 +79,17 @@ export function useURLParams<T extends Record<string, Value>>(
   const location = useLocation()
   const history = useHistory()
   const q = new URLSearchParams(location.search)
+  let called = false
 
   function setParams(newParams: Partial<T>): void {
+    if (called) {
+      console.error(
+        'useURLParams: setParams was called multiple times in one render, aborting',
+      )
+      return
+    }
+    called = true
+
     for (const [k, _v] of Object.entries(newParams)) {
       const v = k === 'search' ? (_v as string) : sanitizeURLParam(_v)
 

--- a/web/src/app/actions/hooks.ts
+++ b/web/src/app/actions/hooks.ts
@@ -45,9 +45,9 @@ export function getURLParam<T extends Value>(
 
 // setURLParams will replace the latest browser history entry with the provided params.
 function setURLParams(
-  params: URLSearchParams,
-  location: Location,
   history: History,
+  location: Location,
+  params: URLSearchParams,
 ): void {
   if (params.sort) params.sort()
   let newSearch = params.toString()
@@ -87,7 +87,7 @@ export function useURLParam<T extends Value>(
       params.set(name, newValue)
     }
 
-    setURLParams(params, location, history)
+    setURLParams(history, location, params)
   }
 
   return [value, setValue]
@@ -110,6 +110,6 @@ export function useResetURLParams(...names: string[]): () => void {
     const params = new URLSearchParams(location.search)
     names.forEach((name) => params.delete(name))
 
-    setURLParams(params, location, history)
+    setURLParams(history, location, params)
   }
 }

--- a/web/src/app/actions/hooks.ts
+++ b/web/src/app/actions/hooks.ts
@@ -131,12 +131,21 @@ export function useURLParam<T extends Value>(
 export function useResetURLParams(...names: string[]): () => void {
   const location = useLocation()
   const history = useHistory()
+  let called = false
 
   return function resetURLParams(): void {
     if (!names.length) {
       // nothing to do
       return
     }
+
+    if (called) {
+      console.error(
+        'useResetURLParams: resetURLParams was called multiple times in one render, aborting',
+      )
+      return
+    }
+    called = true
 
     const params = new URLSearchParams(location.search)
     names.forEach((name) => params.delete(name))

--- a/web/src/app/actions/hooks.ts
+++ b/web/src/app/actions/hooks.ts
@@ -32,23 +32,25 @@ export function getURLParam<T extends Value>(
   name: string,
   defaultValue: T,
 ): T {
-  const url = new URLSearchParams(location.search)
-  if (!url.has(name)) return defaultValue
-  if (Array.isArray(defaultValue)) return url.getAll(name) as T
-  if (typeof defaultValue === 'boolean') return (url.get(name) === '1') as T
-  if (typeof defaultValue === 'string') return (url.get(name) || '') as T
-  if (typeof defaultValue === 'number') return +(url.get(name) as string) as T
+  const params = new URLSearchParams(location.search)
+  if (!params.has(name)) return defaultValue
+  if (Array.isArray(defaultValue)) return params.getAll(name) as T
+  if (typeof defaultValue === 'boolean') return (params.get(name) === '1') as T
+  if (typeof defaultValue === 'string') return (params.get(name) || '') as T
+  if (typeof defaultValue === 'number') {
+    return +(params.get(name) as string) as T
+  }
   return defaultValue
 }
 
-// setURL will replace the latest browser history entry with the provided config.
-function setURL(
-  config: URLSearchParams,
+// setURLParams will replace the latest browser history entry with the provided params.
+function setURLParams(
+  params: URLSearchParams,
   location: Location,
   history: History,
 ): void {
-  if (config.sort) config.sort()
-  let newSearch = config.toString()
+  if (params.sort) params.sort()
+  let newSearch = params.toString()
   newSearch = newSearch ? '?' + newSearch : ''
 
   if (newSearch === location.search) {
@@ -72,20 +74,20 @@ export function useURLParam<T extends Value>(
   const value = getURLParam<T>(location, name, defaultValue)
 
   function setValue(_newValue: T): void {
-    const url = new URLSearchParams(location.search)
+    const params = new URLSearchParams(location.search)
 
     const newValue =
       name === 'search' ? (_newValue as string) : sanitizeURLParam(_newValue)
 
-    url.delete(name)
+    params.delete(name)
 
     if (Array.isArray(newValue)) {
-      newValue.forEach((v) => url.append(name, v))
+      newValue.forEach((v) => params.append(name, v))
     } else if (newValue) {
-      url.set(name, newValue)
+      params.set(name, newValue)
     }
 
-    setURL(url, location, history)
+    setURLParams(params, location, history)
   }
 
   return [value, setValue]
@@ -105,9 +107,9 @@ export function useResetURLParams(...names: string[]): () => void {
       return
     }
 
-    const url = new URLSearchParams(location.search)
-    names.forEach((name) => url.delete(name))
+    const params = new URLSearchParams(location.search)
+    names.forEach((name) => params.delete(name))
 
-    setURL(url, location, history)
+    setURLParams(params, location, history)
   }
 }

--- a/web/src/app/actions/hooks.ts
+++ b/web/src/app/actions/hooks.ts
@@ -28,10 +28,11 @@ export function sanitizeURLParam(value: Value): string | string[] {
 // getURLParam gets the URL param value and converts it from string|string[]
 // to the desired type based on the provided default value.
 export function getURLParam<T extends Value>(
-  url: URLSearchParams,
+  location: Location,
   name: string,
   defaultValue: T,
 ): T {
+  const url = new URLSearchParams(location.search)
   if (!url.has(name)) return defaultValue
   if (Array.isArray(defaultValue)) return url.getAll(name) as T
   if (typeof defaultValue === 'boolean') return (url.get(name) === '1') as T
@@ -67,11 +68,12 @@ export function useURLParam<T extends Value>(
 ): [T, (newValue: T) => void] {
   const location = useLocation()
   const history = useHistory()
-  const url = new URLSearchParams(location.search)
 
-  const value = getURLParam<T>(url, name, defaultValue)
+  const value = getURLParam<T>(location, name, defaultValue)
 
   function setValue(_newValue: T): void {
+    const url = new URLSearchParams(location.search)
+
     const newValue =
       name === 'search' ? (_newValue as string) : sanitizeURLParam(_newValue)
 

--- a/web/src/app/alerts/AlertsList.js
+++ b/web/src/app/alerts/AlertsList.js
@@ -96,9 +96,8 @@ export default function AlertsList(props) {
   // used if user dismisses snackbar before the auto-close timer finishes
   const [actionCompleteDismissed, setActionCompleteDismissed] = useState(true)
 
-  // get redux url vars
-  const [allServices] = useURLParam('allServices')
-  const [fullTime] = useURLParam('fullTime')
+  const [allServices] = useURLParam('allServices', false)
+  const [fullTime] = useURLParam('fullTime', false)
   const [filter] = useURLParam('filter', 'active')
 
   // query for current service name if props.serviceID is provided

--- a/web/src/app/escalation-policies/PolicyStep.js
+++ b/web/src/app/escalation-policies/PolicyStep.js
@@ -36,7 +36,7 @@ const useStyles = makeStyles(() => ({
 function PolicyStep(props) {
   const classes = useStyles()
 
-  const [editStep, setEditStep] = useURLParam('editStep', null)
+  const [editStep, setEditStep] = useURLParam('editStep', '')
   const resetEditStep = useResetURLParams('editStep')
   const [deleteStep, setDeleteStep] = useState(false)
 

--- a/web/src/app/schedules/calendar/ScheduleCalendarToolbar.tsx
+++ b/web/src/app/schedules/calendar/ScheduleCalendarToolbar.tsx
@@ -34,7 +34,7 @@ function ScheduleCalendarToolbar(
   props: ScheduleCalendarToolbarProps,
 ): JSX.Element {
   const classes = useStyles()
-  const { weekly, setWeekly, start, setStart } = useCalendarNavigation()
+  const { weekly, start, setParams: setNavParams } = useCalendarNavigation()
 
   const getHeader = (): string => {
     if (weekly) {
@@ -73,31 +73,33 @@ function ScheduleCalendarToolbar(
 
     // if viewing the current month, show the current week
     if (nextView === 'week' && prevStartMonth === currMonth) {
-      setWeekly(true)
-      setStart(getStartOfWeek().toISODate())
+      setNavParams({ weekly: true, start: getStartOfWeek().toISODate() })
 
       // if not on the current month, show the first week of the month
     } else if (nextView === 'week' && prevStartMonth !== currMonth) {
-      setWeekly(true)
-      setStart(DateTime.fromISO(start).startOf('month').toISODate())
+      setNavParams({
+        weekly: true,
+        start: DateTime.fromISO(start).startOf('month').toISODate(),
+      })
 
       // go from week to monthly view
       // e.g. if navigating to an overlap of two months such as
       // Jan 27 - Feb 2, show the latter month (February)
     } else {
-      setWeekly(false)
-
-      setStart(
-        getEndOfWeek(DateTime.fromISO(start)).startOf('month').toISODate(),
-      )
+      setNavParams({
+        weekly: false,
+        start: getEndOfWeek(DateTime.fromISO(start))
+          .startOf('month')
+          .toISODate(),
+      })
     }
   }
 
   const onNavigate = (next: DateTime): void => {
     if (weekly) {
-      setStart(getStartOfWeek(next).toISODate())
+      setNavParams({ start: getStartOfWeek(next).toISODate() })
     } else {
-      setStart(next.startOf('month').toISODate())
+      setNavParams({ start: next.startOf('month').toISODate() })
     }
   }
 

--- a/web/src/app/schedules/calendar/hooks.ts
+++ b/web/src/app/schedules/calendar/hooks.ts
@@ -1,27 +1,27 @@
 import { DateTime } from 'luxon'
-import { useURLParam } from '../../actions'
+import { useURLParams } from '../../actions'
 import { getStartOfWeek } from '../../util/luxon-helpers'
 
-interface CalendarNavigation {
+interface CalendarNavParams {
   weekly: boolean
-  setWeekly: (val: boolean) => void
   start: string
-  setStart: (val: string) => void
+}
+interface CalendarNavigation extends CalendarNavParams {
+  setParams: (val: Partial<CalendarNavParams>) => void
 }
 
 export function useCalendarNavigation(): CalendarNavigation {
-  const [weekly, setWeekly] = useURLParam<boolean>('weekly', false)
-  const [start, setStart] = useURLParam(
-    'start',
-    weekly
+  const [_params] = useURLParams({ weekly: false })
+  const [params, setParams] = useURLParams({
+    weekly: false as boolean,
+    start: _params.weekly
       ? getStartOfWeek().toISODate()
       : DateTime.now().startOf('month').toISODate(),
-  )
+  })
 
   return {
-    weekly,
-    setWeekly,
-    start,
-    setStart,
+    weekly: params.weekly,
+    start: params.start,
+    setParams,
   }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR continues our effort to reduce our dependency on redux for client side routing by:
- refactoring `useURLParam` to use the `react-router` API's directly
- writing unit tests for _getting_ a URL param and sanitizing param values pre-_setting_ them
- refactoring `useURLParam` to share logic in `setURL`, and to not clear all params by default if an empty list is passed (too much magic, unrealistic use case)

**API changes:**
- Introduce a new `useURLParams` hook that accepts an object of name-defaultValue pairs, and returns a `[params, setParams]` array. This prevents issues that crop up when invoking `setParams` synchronously in a single render frame. This case is further handled by aborting and logging an error to the console.
- An example of this issue and its solution is provided in this PR in the `schedules/calendar` package.
- `useURLParam` now uses `useURLParams` under the hood.


Bug fixes:
- `sanitizeParam` did not handle numeric values correctly, and it didn't trim string values when given a `string[]`
- a few usages of `useURLParam` were not passing in the required `defaultValue` argument