### PR TITLE
graphql: batch notification channel requests

### DIFF
--- a/dataloader/ncloader.go
+++ b/dataloader/ncloader.go
@@ -35,7 +35,7 @@ func (l *NCLoader) FetchOne(ctx context.Context, id uuid.UUID) (*notificationcha
 		return nil, err
 	}
 	if v == nil {
-		return nil, err
+		return nil, nil
 	}
 	return v.(*notificationchannel.Channel), nil
 }

--- a/dataloader/ncloader.go
+++ b/dataloader/ncloader.go
@@ -1,0 +1,53 @@
+package dataloader
+
+import (
+	"context"
+	"time"
+
+	"github.com/target/goalert/notificationchannel"
+)
+
+// NCLoader will load notification channels from postgres.
+type NCLoader struct {
+	*loader
+	store notificationchannel.Store
+}
+
+// NewNCLoader will create a new CMLoader using the provided store for fetch operations.
+func NewNCLoader(ctx context.Context, store notificationchannel.Store) *NCLoader {
+	p := &NCLoader{
+		store: store,
+	}
+	p.loader = newLoader(ctx, loaderConfig{
+		Max:       100,
+		Delay:     time.Millisecond,
+		IDFunc:    func(v interface{}) string { return v.(*notificationchannel.Channel).ID },
+		FetchFunc: p.fetch,
+	})
+	return p
+}
+
+// FetchOne will fetch a single record from the store, batching requests to the store.
+func (l *NCLoader) FetchOne(ctx context.Context, id string) (*notificationchannel.Channel, error) {
+	v, err := l.loader.FetchOne(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if v == nil {
+		return nil, err
+	}
+	return v.(*notificationchannel.Channel), nil
+}
+
+func (l *NCLoader) fetch(ctx context.Context, ids []string) ([]interface{}, error) {
+	many, err := l.store.FindMany(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]interface{}, len(many))
+	for i := range many {
+		res[i] = &many[i]
+	}
+	return res, nil
+}

--- a/dataloader/ncloader.go
+++ b/dataloader/ncloader.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/target/goalert/notificationchannel"
 )
 
@@ -28,8 +29,8 @@ func NewNCLoader(ctx context.Context, store notificationchannel.Store) *NCLoader
 }
 
 // FetchOne will fetch a single record from the store, batching requests to the store.
-func (l *NCLoader) FetchOne(ctx context.Context, id string) (*notificationchannel.Channel, error) {
-	v, err := l.loader.FetchOne(ctx, id)
+func (l *NCLoader) FetchOne(ctx context.Context, id uuid.UUID) (*notificationchannel.Channel, error) {
+	v, err := l.loader.FetchOne(ctx, id.String())
 	if err != nil {
 		return nil, err
 	}

--- a/dataloader/ncloader.go
+++ b/dataloader/ncloader.go
@@ -14,7 +14,7 @@ type NCLoader struct {
 	store notificationchannel.Store
 }
 
-// NewNCLoader will create a new CMLoader using the provided store for fetch operations.
+// NewNCLoader will create a new NCLoader using the provided store for fetch operations.
 func NewNCLoader(ctx context.Context, store notificationchannel.Store) *NCLoader {
 	p := &NCLoader{
 		store: store,

--- a/graphql2/graphqlapp/dataloaders.go
+++ b/graphql2/graphqlapp/dataloaders.go
@@ -113,14 +113,11 @@ func (app *App) FindOneCM(ctx context.Context, id string) (*contactmethod.Contac
 }
 
 // FindOneNC will return a single notification channel for the given id, using the contexts dataloader if enabled.
-func (app *App) FindOneNC(ctx context.Context, id string) (*notificationchannel.Channel, error) {
+func (app *App) FindOneNC(ctx context.Context, id uuid.UUID) (*notificationchannel.Channel, error) {
 	loader, ok := ctx.Value(dataLoaderKeyNC).(*dataloader.NCLoader)
 	if !ok {
-		u, err := uuid.Parse(id)
-		if err != nil {
-			return nil, err
-		}
-		return app.NCStore.FindOne(ctx, u)
+
+		return app.NCStore.FindOne(ctx, id)
 	}
 
 	return loader.FetchOne(ctx, id)

--- a/graphql2/graphqlapp/query.go
+++ b/graphql2/graphqlapp/query.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/notification"
 	"github.com/target/goalert/notificationchannel"
@@ -21,12 +20,7 @@ type DebugMessage App
 func (a *App) Query() graphql2.QueryResolver { return (*Query)(a) }
 
 func (a *App) formatNC(ctx context.Context, id string) (string, error) {
-	uid, err := uuid.Parse(id)
-	if err != nil {
-		return "", err
-	}
-
-	n, err := a.NCStore.FindOne(ctx, uid)
+	n, err := a.FindOneNC(ctx, id)
 	if err != nil {
 		return "", err
 	}

--- a/graphql2/graphqlapp/query.go
+++ b/graphql2/graphqlapp/query.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/notification"
 	"github.com/target/goalert/notificationchannel"
@@ -20,7 +21,12 @@ type DebugMessage App
 func (a *App) Query() graphql2.QueryResolver { return (*Query)(a) }
 
 func (a *App) formatNC(ctx context.Context, id string) (string, error) {
-	n, err := a.FindOneNC(ctx, id)
+	uid, err := uuid.Parse(id)
+	if err != nil {
+		return "", err
+	}
+
+	n, err := a.FindOneNC(ctx, uid)
 	if err != nil {
 		return "", err
 	}

--- a/graphql2/graphqlapp/schedule.go
+++ b/graphql2/graphqlapp/schedule.go
@@ -33,7 +33,7 @@ func (a *App) OnCallNotificationRule() graphql2.OnCallNotificationRuleResolver {
 }
 
 func (a *OnCallNotificationRule) Target(ctx context.Context, raw *schedule.OnCallNotificationRule) (*assignment.RawTarget, error) {
-	ch, err := a.NCStore.FindOne(ctx, raw.ChannelID)
+	ch, err := (*App)(a).FindOneNC(ctx, raw.ChannelID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Description:**
Causes notification channel lookups to be batched by a new dataloader. Fixes issue in #2061 where too many logs resulted in access denied due to a recursive lookup.
