### PR TITLE
alert: increase max summary length to 1kb

### DIFF
--- a/alert/alert.go
+++ b/alert/alert.go
@@ -11,7 +11,7 @@ import (
 
 // maximum lengths
 const (
-	MaxSummaryLength = 118
+	MaxSummaryLength = 1024     // 1KiB
 	MaxDetailsLength = 6 * 1024 // 6KiB
 )
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR increases the maximum length for a given alert's summary. The current limit set in place is a remnant from when SMS was one of the only alerting options, but this is no longer the case. Each notification module should handle its own truncating of the summary (and description), if necessary.

**Which issue(s) this PR fixes:**
Closes #2053