### PR TITLE
admin/graphql: add alert ID to debugMessage query

### DIFF
--- a/graphql2/graphqlapp/query.go
+++ b/graphql2/graphqlapp/query.go
@@ -147,6 +147,9 @@ func (a *Query) DebugMessages(ctx context.Context, input *graphql2.DebugMessages
 		if m.ServiceName != "" {
 			msg.ServiceName = &m.ServiceName
 		}
+		if m.AlertID != 0 {
+			msg.AlertID = &m.AlertID
+		}
 		if m.ProviderID.ExternalID != "" {
 			msg.ProviderID = &m.ProviderID.ExternalID
 		}


### PR DESCRIPTION
This PR fixes a bug where the alert ID was not returned if present when querying for a DebugMessage.

---

Before:

![Screen Shot 2022-01-12 at 10 02 02 AM](https://user-images.githubusercontent.com/11381794/149196835-f91536ca-c084-4491-a133-d6f92bb8fde8.png)

After:

![Screen Shot 2022-01-12 at 10 02 54 AM](https://user-images.githubusercontent.com/11381794/149196732-21cfb292-f564-4f87-a937-65399bd895f4.png)
