### PR TITLE
Support for `application/json` in incoming webhook

### DIFF
--- a/genericapi/handler.go
+++ b/genericapi/handler.go
@@ -92,11 +92,7 @@ func (h *Handler) ServeCreateAlert(w http.ResponseWriter, r *http.Request) {
 
 	summary := r.FormValue("summary")
 	details := r.FormValue("details")
-
-	status := alert.StatusTriggered
-	if r.FormValue("action") == "close" {
-		status = alert.StatusClosed
-	}
+	action := r.FormValue("action")
 
 	contentType := r.Header.Get("Content-type")
 	if contentType == "application/json" {
@@ -107,10 +103,12 @@ func (h *Handler) ServeCreateAlert(w http.ResponseWriter, r *http.Request) {
 
 		summary = alertMessage.Summary
 		details = alertMessage.Details
-		action := alertMessage.Action
-		if action == "close" {
-			status = alert.StatusClosed
-		}
+		action = alertMessage.Action
+	}
+
+	status := alert.StatusTriggered
+	if action == "close" {
+		status = alert.StatusClosed
 	}
 
 	summary = validate.SanitizeText(summary, alert.MaxSummaryLength)

--- a/package.json
+++ b/package.json
@@ -42,5 +42,6 @@
     "stylelint": "14.2.0",
     "stylelint-config-standard": "23.0.0",
     "typescript": "4.4.3"
-  }
+  },
+  "version": "0.0.0"
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Incoming webhook will now accept `application/json` content type
{"summary":"", "details":"", "action":""}

**Which issue(s) this PR fixes:**
https://github.com/target/goalert/issues/2092

Usage: `Fixes #2092`
