### PR TITLE
timeutil/duration: add `ParseISODuration`

### DIFF
--- a/util/timeutil/duration.go
+++ b/util/timeutil/duration.go
@@ -8,6 +8,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ISODuration contains the components of an ISO duration string.
+// The time components are combined into seconds, and the weeks component
+// is interpreted as a shorthand for 7 days.
 type ISODuration struct {
 	Years, Months, Days, Seconds int
 }

--- a/util/timeutil/duration.go
+++ b/util/timeutil/duration.go
@@ -9,8 +9,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ISODuration contains the components of an ISO duration string.
-// The time components are combined into seconds, and the weeks component
+// ISODuration represents an ISO duration string.
+// The time components are combined, and the weeks component
 // is interpreted as a shorthand for 7 days.
 type ISODuration struct {
 	Years, Months, Days int
@@ -19,10 +19,9 @@ type ISODuration struct {
 
 var re = regexp.MustCompile(`^P\B(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T\B(\d+H)?(\d+M)?(\d+S)?)?$`)
 
-// ParseISODuration parses the components of an ISO Duration string into years, months, days, and seconds.
-// The time components are aggregated into seconds as "the base unit for expressing duration".
-// Nominal date components cannot be aggregated without accounting for daylight savings time, except weeks,
-// which are interpreted as a shorthand for 7 days.
+// ParseISODuration parses the components of an ISO Duration string.
+// The time components are accurate and are aggregated into one TimePart.
+// The nominal date components cannot be aggregated without accounting for daylight savings time.
 // Supported formats are "PnYnMnDTnHnMnS" and "PnW".
 // Negative and decimal units are not supported.
 func ParseISODuration(s string) (d ISODuration, err error) {

--- a/util/timeutil/duration.go
+++ b/util/timeutil/duration.go
@@ -67,7 +67,7 @@ func (dur ISODuration) String() string {
 	return b.String()
 }
 
-var re = regexp.MustCompile(`^P\B(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T\B(\d+H)?(\d+M)?(\d+S)?)?$`)
+var re = regexp.MustCompile(`^P\B(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T\B(\d+H)?(\d+M)?([\d.]+S)?)?$`)
 
 // ParseISODuration parses the components of an ISO Duration string.
 // The time components are accurate and are aggregated into one TimePart.

--- a/util/timeutil/duration.go
+++ b/util/timeutil/duration.go
@@ -9,7 +9,7 @@ import (
 )
 
 type ISODuration struct {
-	years, months, days, seconds int
+	Years, Months, Days, Seconds int
 }
 
 var re = regexp.MustCompile(`^P\B(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T\B(\d+H)?(\d+M)?(\d+S)?)?$`)
@@ -48,22 +48,22 @@ func ParseISODuration(s string) (d ISODuration, err error) {
 
 		switch string(c) {
 		case "Y":
-			d.years += digits
+			d.Years += digits
 		case "M":
 			if isTime {
 				// minutes
-				d.seconds += (digits * 60)
+				d.Seconds += (digits * 60)
 			} else {
-				d.months += digits
+				d.Months += digits
 			}
 		case "D":
-			d.days += digits
+			d.Days += digits
 		case "W":
-			d.days += (digits * 7)
+			d.Days += (digits * 7)
 		case "H":
-			d.seconds += (digits * 60 * 60)
+			d.Seconds += (digits * 60 * 60)
 		case "S":
-			d.seconds += digits
+			d.Seconds += digits
 		default:
 			return d, errors.Errorf("invalid character encountered: %s", string(c))
 		}

--- a/util/timeutil/duration.go
+++ b/util/timeutil/duration.go
@@ -67,7 +67,7 @@ func (dur ISODuration) String() string {
 	return b.String()
 }
 
-var re = regexp.MustCompile(`^P\B(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(\B|[.,])(\d+H)?(\d+M)?([\d.,]+S)?)?$`)
+var re = regexp.MustCompile(`^P\B(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(\B|[.,])(\d+H)?(\d+M)?(\d*[.,]?\d+S)?)?$`)
 
 // ParseISODuration parses the components of an ISO Duration string.
 // The time components are accurate and are aggregated into one TimePart.

--- a/util/timeutil/duration.go
+++ b/util/timeutil/duration.go
@@ -6,9 +6,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
-
-	"github.com/pkg/errors"
 )
 
 // ISODuration represents an ISO duration string.
@@ -67,82 +64,72 @@ func (dur ISODuration) String() string {
 	return b.String()
 }
 
-var re = regexp.MustCompile(`^P\B(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(\B|[.,])(\d+H)?(\d+M)?(\d*[.,]?\d+S)?)?$`)
+var re = regexp.MustCompile(`^P\B((?P<year>\d+)Y)?((?P<month>\d+)M)?((?P<week>\d+)W)?((?P<day>\d+)D)?(T\B((?P<hour>\d+)H)?((?P<minute>\d+)M)?((?P<second>\d*[.,]?\d+)S)?)?$`)
 
 // ParseISODuration parses the components of an ISO Duration string.
 // The time components are accurate and are aggregated into one TimePart.
 // The nominal date components cannot be aggregated without accounting for daylight savings time.
 // Supported formats are "PnYnMnDTnHnMnS" and "PnW".
-// Negative and decimal units are not supported.
+// Negative values are not supported. Fractional values are only supported for seconds.
 func ParseISODuration(s string) (d ISODuration, err error) {
 	if !re.MatchString(s) {
-		return d, errors.Errorf(`invalid format: %s must be an ISO Duration`, s)
+		return zeroDur, fmt.Errorf("invalid ISO Duration format: %s", s)
 	}
 
-	var left, right = 1, 1 // sliding window
-	var isTime, isDecimal bool
+	matches := re.FindStringSubmatch(s)
 
-	for _, c := range s[1:] {
-		if unicode.IsDigit(c) {
-			right++
+	for i, name := range re.SubexpNames() {
+		m := matches[i]
+		if i == 0 || name == "" || m == "" {
 			continue
 		}
 
-		if string(c) == "T" {
-			isTime = true
-			right++
-			left = right
-			continue
-		}
-
-		if string(c) == "." || string(c) == "," {
-			isDecimal = true
-			right++
-			left = right
-			continue
-		}
-
-		digits, err := strconv.Atoi(s[left:right])
-		if err != nil {
-			return d, err
-		}
-
-		switch string(c) {
-		case "Y":
-			d.Years += digits
-		case "M":
-			if isTime {
-				digits *= 60
-			} else {
-				d.Months += digits
-			}
-		case "D":
-			d.Days += digits
-		case "W":
-			d.Days += (digits * 7)
-		case "H":
-			digits *= 3600
-		case "S":
-			// ok
-		default:
-			return d, errors.Errorf("invalid character encountered: %s", string(c))
-		}
-
-		if isTime {
-			durStr := strconv.Itoa(digits) + "s"
-			if isDecimal {
-				durStr = "." + durStr
-			}
-			dur, err := time.ParseDuration(durStr)
+		switch name {
+		case "year":
+			val, err := strconv.Atoi(m)
 			if err != nil {
-				return d, err
+				return zeroDur, err
 			}
-
-			d.TimePart += dur
+			d.Years += val
+		case "month":
+			val, err := strconv.Atoi(m)
+			if err != nil {
+				return zeroDur, err
+			}
+			d.Months += val
+		case "week":
+			val, err := strconv.Atoi(m)
+			if err != nil {
+				return zeroDur, err
+			}
+			d.Days += (val * 7)
+		case "day":
+			val, err := strconv.Atoi(m)
+			if err != nil {
+				return zeroDur, err
+			}
+			d.Days += val
+		case "hour":
+			val, err := time.ParseDuration(m + "h")
+			if err != nil {
+				return zeroDur, err
+			}
+			d.TimePart += val
+		case "minute":
+			val, err := time.ParseDuration(m + "m")
+			if err != nil {
+				return zeroDur, err
+			}
+			d.TimePart += val
+		case "second":
+			val, err := time.ParseDuration(strings.ReplaceAll(m, ",", ".") + "s")
+			if err != nil {
+				return zeroDur, err
+			}
+			d.TimePart += val
+		default:
+			return zeroDur, fmt.Errorf("unknown field %s", name)
 		}
-
-		right++
-		left = right
 	}
 
 	return d, err

--- a/util/timeutil/duration.go
+++ b/util/timeutil/duration.go
@@ -1,0 +1,71 @@
+package timeutil
+
+import (
+	"regexp"
+	"strconv"
+	"unicode"
+
+	"github.com/pkg/errors"
+)
+
+type ISODuration struct {
+	years, months, days, seconds int
+}
+
+// ParseISODuration parses the components of an ISO Duration string into years, months, days, and seconds.
+// The time components are aggregated into seconds as "the base unit for expressing duration".
+// Nominal date components cannot be aggregated without accounting for daylight savings time, except weeks,
+// which are interpreted as a shorthand for 7 days.
+// Supported formats are "PnYnMnDTnHnMnS" and "PnW".
+// Negative and decimal units are not supported.
+func ParseISODuration(s string) (d ISODuration, err error) {
+	var nextDigits []rune
+	var isTime bool
+
+	re := regexp.MustCompile(`^P\B(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T\B(\d+H)?(\d+M)?(\d+S)?)?$`)
+
+	if !re.MatchString(s) {
+		return d, errors.Errorf(`invalid format: %s must be an ISO Duration`, s)
+	}
+
+	for _, c := range s[1:] {
+		if unicode.IsDigit(c) {
+			nextDigits = append(nextDigits, c)
+			continue
+		}
+
+		switch string(c) {
+		case "Y":
+			d.years += runesToInt(nextDigits)
+		case "M":
+			if isTime {
+				// minutes
+				d.seconds += (runesToInt(nextDigits) * 60)
+			} else {
+				d.months += runesToInt(nextDigits)
+			}
+		case "D":
+			d.days += runesToInt(nextDigits)
+		case "W":
+			d.days += (runesToInt(nextDigits) * 7)
+		case "H":
+			d.seconds += (runesToInt(nextDigits) * 60 * 60)
+		case "S":
+			d.seconds += runesToInt(nextDigits)
+		case "T":
+			isTime = true
+		default:
+			return d, errors.Errorf("invalid character encountered: %s", string(c))
+		}
+
+		nextDigits = nextDigits[:0]
+
+	}
+
+	return d, err
+}
+
+func runesToInt(r []rune) int {
+	res, _ := strconv.Atoi(string(r))
+	return res
+}

--- a/util/timeutil/duration.go
+++ b/util/timeutil/duration.go
@@ -12,6 +12,8 @@ type ISODuration struct {
 	years, months, days, seconds int
 }
 
+var re = regexp.MustCompile(`^P\B(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T\B(\d+H)?(\d+M)?(\d+S)?)?$`)
+
 // ParseISODuration parses the components of an ISO Duration string into years, months, days, and seconds.
 // The time components are aggregated into seconds as "the base unit for expressing duration".
 // Nominal date components cannot be aggregated without accounting for daylight savings time, except weeks,
@@ -19,7 +21,6 @@ type ISODuration struct {
 // Supported formats are "PnYnMnDTnHnMnS" and "PnW".
 // Negative and decimal units are not supported.
 func ParseISODuration(s string) (d ISODuration, err error) {
-	re := regexp.MustCompile(`^P\B(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T\B(\d+H)?(\d+M)?(\d+S)?)?$`)
 	if !re.MatchString(s) {
 		return d, errors.Errorf(`invalid format: %s must be an ISO Duration`, s)
 	}

--- a/util/timeutil/duration.go
+++ b/util/timeutil/duration.go
@@ -1,8 +1,10 @@
 package timeutil
 
 import (
+	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 	"unicode"
 
@@ -15,6 +17,54 @@ import (
 type ISODuration struct {
 	Years, Months, Days int
 	TimePart            time.Duration
+}
+
+var zeroDur ISODuration
+
+// String returns an ISO 8601 duration string.
+func (dur ISODuration) String() string {
+	if dur == zeroDur {
+		return "P0D"
+	}
+
+	var b strings.Builder
+	b.WriteRune('P')
+
+	if dur.Years > 0 {
+		fmt.Fprintf(&b, "%dY", dur.Years)
+	}
+	if dur.Months > 0 {
+		fmt.Fprintf(&b, "%dM", dur.Months)
+	}
+	if dur.Days/7 > 0 {
+		fmt.Fprintf(&b, "%dW", dur.Days/7)
+		dur.Days %= 7
+	}
+	if dur.Days > 0 {
+		fmt.Fprintf(&b, "%dD", dur.Days)
+	}
+
+	if dur.TimePart == 0 {
+		return b.String()
+	}
+
+	b.WriteRune('T')
+
+	if dur.TimePart/time.Hour > 0 {
+		fmt.Fprintf(&b, "%dH", dur.TimePart/time.Hour)
+		dur.TimePart %= time.Hour
+	}
+
+	if dur.TimePart/time.Minute > 0 {
+		fmt.Fprintf(&b, "%dM", dur.TimePart/time.Minute)
+		dur.TimePart %= time.Minute
+	}
+
+	if dur.TimePart.Seconds() > 0 {
+		fmt.Fprintf(&b, "%gS", dur.TimePart.Seconds())
+	}
+
+	return b.String()
 }
 
 var re = regexp.MustCompile(`^P\B(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T\B(\d+H)?(\d+M)?(\d+S)?)?$`)

--- a/util/timeutil/duration_test.go
+++ b/util/timeutil/duration_test.go
@@ -115,12 +115,15 @@ func TestParseISODuration(t *testing.T) {
 		TimePart: dur("100ms"),
 	})
 
-	check("fractional seconds without integral", "PT,1S", ISODuration{
-		TimePart: dur("100ms"),
-	})
-
 	check("one and a half seconds", "PT1,5S", ISODuration{
 		TimePart: dur("1.5s"),
+	})
+
+	check("full fractional", "P23Y0M2W012DT1H1M0123.0522S", ISODuration{
+		Years:    23,
+		Months:   0,
+		Days:     2*7 + 12,
+		TimePart: dur("1h1m123.0522s"),
 	})
 }
 
@@ -135,6 +138,7 @@ func TestParseISODurationErrors(t *testing.T) {
 	check("empty", "")
 	check("P only", "P")
 	check("T only", "T")
+	check("no units", "PT")
 	check("Ends with T", "P1Y1M1DT")
 	check("junk", "junk")
 	check("missing T", "P1H")
@@ -144,5 +148,6 @@ func TestParseISODurationErrors(t *testing.T) {
 	check("bad time order", "PT1M1H")
 	check("missing seconds val", "PTS")
 	check("multi decimal", "PT1.2.4S")
-	check("missing decimal", "PT1.S")
+	check("missing fractional", "PT1.S")
+	check("missing integral", "PT,1S")
 }

--- a/util/timeutil/duration_test.go
+++ b/util/timeutil/duration_test.go
@@ -4,7 +4,6 @@
 package timeutil
 
 import (
-	"strconv"
 	"testing"
 	"time"
 
@@ -77,14 +76,14 @@ func TestParseISODuration(t *testing.T) {
 		Years:    3,
 		Months:   6,
 		Days:     14,
-		TimePart: dur(strconv.Itoa(12*3600+30*60+5) + "s"),
+		TimePart: dur("12h30m5s"),
 	})
 
 	check("mixed with week", "P3Y6M2W14DT12H30M5S", ISODuration{
 		Years:    3,
 		Months:   6,
 		Days:     2*7 + 14,
-		TimePart: dur(strconv.Itoa(12*3600+30*60+5) + "s"),
+		TimePart: dur("12h30m5s"),
 	})
 
 	check("time without seconds", "PT1H22M", ISODuration{
@@ -108,9 +107,17 @@ func TestParseISODuration(t *testing.T) {
 	})
 
 	check("fractional seconds", "PT0.1S", ISODuration{
-		TimePart: 100 * time.Millisecond,
+		TimePart: dur("100ms"),
 	})
 
+	check("fractional seconds with comma", "PT0,1S", ISODuration{
+		// comma [,] is preferred over full stop [.]
+		TimePart: dur("100ms"),
+	})
+
+	check("fractional seconds without integral", "PT,1S", ISODuration{
+		TimePart: dur("100ms"),
+	})
 }
 
 func TestParseISODurationErrors(t *testing.T) {
@@ -131,4 +138,7 @@ func TestParseISODurationErrors(t *testing.T) {
 	check("missing T 2", "P3Y6M14D12H30M5S")
 	check("bad date order", "P1M1Y")
 	check("bad time order", "PT1M1H")
+	check("missing seconds val", "PTS")
+	check("multi decimal", "PT1.2.4S")
+	check("missing decimal", "PT1.S")
 }

--- a/util/timeutil/duration_test.go
+++ b/util/timeutil/duration_test.go
@@ -118,6 +118,10 @@ func TestParseISODuration(t *testing.T) {
 	check("fractional seconds without integral", "PT,1S", ISODuration{
 		TimePart: dur("100ms"),
 	})
+
+	check("one and a half seconds", "PT1,5S", ISODuration{
+		TimePart: dur("1.5s"),
+	})
 }
 
 func TestParseISODurationErrors(t *testing.T) {

--- a/util/timeutil/duration_test.go
+++ b/util/timeutil/duration_test.go
@@ -4,7 +4,9 @@
 package timeutil
 
 import (
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,6 +22,11 @@ func TestParseISODuration(t *testing.T) {
 		assert.Equal(t, res, exp, desc)
 	}
 
+	dur := func(s string) time.Duration {
+		res, _ := time.ParseDuration(s)
+		return res
+	}
+
 	check("year only", "P12345Y", ISODuration{
 		Years: 12345,
 	})
@@ -29,12 +36,12 @@ func TestParseISODuration(t *testing.T) {
 	})
 
 	check("one minute", "PT1M", ISODuration{
-		Seconds: 60,
+		TimePart: dur("60s"),
 	})
 
 	check("one month and 1 minute", "P1MT1M", ISODuration{
-		Months:  1,
-		Seconds: 60,
+		Months:   1,
+		TimePart: dur("60s"),
 	})
 
 	check("two days with leading zeros", "P0002D", ISODuration{
@@ -43,26 +50,26 @@ func TestParseISODuration(t *testing.T) {
 	})
 
 	check("mixed", "P3Y6M14DT12H30M5S", ISODuration{
-		Years:   3,
-		Months:  6,
-		Days:    14,
-		Seconds: 12*3600 + 30*60 + 5,
+		Years:    3,
+		Months:   6,
+		Days:     14,
+		TimePart: dur(strconv.Itoa(12*3600+30*60+5) + "s"),
 	})
 
 	check("mixed with week", "P3Y6M2W14DT12H30M5S", ISODuration{
-		Years:   3,
-		Months:  6,
-		Days:    2*7 + 14,
-		Seconds: 12*3600 + 30*60 + 5,
+		Years:    3,
+		Months:   6,
+		Days:     2*7 + 14,
+		TimePart: dur(strconv.Itoa(12*3600+30*60+5) + "s"),
 	})
 
 	check("time without seconds", "PT1H22M", ISODuration{
 		// The lowest order components may be omitted to represent duration with reduced accuracy.
-		Seconds: 3600 + 22*60,
+		TimePart: dur("1h22m"),
 	})
 
 	check("time without minutes", "PT1H22S", ISODuration{
-		Seconds: 3600 + 22,
+		TimePart: dur("1h22s"),
 	})
 
 	check("date only", "P1997Y11M26D", ISODuration{

--- a/util/timeutil/duration_test.go
+++ b/util/timeutil/duration_test.go
@@ -21,59 +21,59 @@ func TestParseISODuration(t *testing.T) {
 	}
 
 	check("year only", "P12345Y", ISODuration{
-		years: 12345,
+		Years: 12345,
 	})
 
 	check("one month", "P1M", ISODuration{
-		months: 1,
+		Months: 1,
 	})
 
 	check("one minute", "PT1M", ISODuration{
-		seconds: 60,
+		Seconds: 60,
 	})
 
 	check("one month and 1 minute", "P1MT1M", ISODuration{
-		months:  1,
-		seconds: 60,
+		Months:  1,
+		Seconds: 60,
 	})
 
 	check("two days with leading zeros", "P0002D", ISODuration{
 		// If a time element in a defined representation has a defined length, then leading zeros shall be used as required
-		days: 2,
+		Days: 2,
 	})
 
 	check("mixed", "P3Y6M14DT12H30M5S", ISODuration{
-		years:   3,
-		months:  6,
-		days:    14,
-		seconds: 12*3600 + 30*60 + 5,
+		Years:   3,
+		Months:  6,
+		Days:    14,
+		Seconds: 12*3600 + 30*60 + 5,
 	})
 
 	check("mixed with week", "P3Y6M2W14DT12H30M5S", ISODuration{
-		years:   3,
-		months:  6,
-		days:    2*7 + 14,
-		seconds: 12*3600 + 30*60 + 5,
+		Years:   3,
+		Months:  6,
+		Days:    2*7 + 14,
+		Seconds: 12*3600 + 30*60 + 5,
 	})
 
 	check("time without seconds", "PT1H22M", ISODuration{
 		// The lowest order components may be omitted to represent duration with reduced accuracy.
-		seconds: 3600 + 22*60,
+		Seconds: 3600 + 22*60,
 	})
 
 	check("time without minutes", "PT1H22S", ISODuration{
-		seconds: 3600 + 22,
+		Seconds: 3600 + 22,
 	})
 
 	check("date only", "P1997Y11M26D", ISODuration{
 		// The designator [T] shall be absent if all of the time components are absent.
-		years:  1997,
-		months: 11,
-		days:   26,
+		Years:  1997,
+		Months: 11,
+		Days:   26,
 	})
 
 	check("week only", "P12W", ISODuration{
-		days: 12 * 7,
+		Days: 12 * 7,
 	})
 
 }

--- a/util/timeutil/duration_test.go
+++ b/util/timeutil/duration_test.go
@@ -1,0 +1,86 @@
+// These tests exercise the requirements specified by ISO:
+// https://www.loc.gov/standards/datetime/iso-tc154-wg5_n0038_iso_wd_8601-1_2016-02-16.pdf
+
+package timeutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseISODuration(t *testing.T) {
+
+	check := func(desc string, iso string, exp ISODuration) {
+		t.Helper()
+
+		res, err := ParseISODuration(iso)
+		require.NoError(t, err, desc)
+		assert.Equal(t, res, exp, desc)
+	}
+
+	check("year only", "P12345Y", ISODuration{
+		years: 12345,
+	})
+
+	check("one month", "P1M", ISODuration{
+		months: 1,
+	})
+
+	check("one minute", "PT1M", ISODuration{
+		seconds: 60,
+	})
+
+	check("two days with leading zeros", "P0002D", ISODuration{
+		// If a time element in a defined representation has a defined length, then leading zeros shall be used as required
+		days: 2,
+	})
+
+	check("mixed", "P3Y6M14DT12H30M5S", ISODuration{
+		years:   3,
+		months:  6,
+		days:    14,
+		seconds: 12*3600 + 30*60 + 5,
+	})
+
+	check("time without seconds", "PT1H22M", ISODuration{
+		// The lowest order components may be omitted to represent duration with reduced accuracy.
+		seconds: 3600 + 22*60,
+	})
+
+	check("time without minutes", "PT1H22S", ISODuration{
+		seconds: 3600 + 22,
+	})
+
+	check("date only", "P1997Y11M26D", ISODuration{
+		// The designator [T] shall be absent if all of the time components are absent.
+		years:  1997,
+		months: 11,
+		days:   26,
+	})
+
+	check("week only", "P12W", ISODuration{
+		days: 12 * 7,
+	})
+
+}
+
+func TestParseISODurationErrors(t *testing.T) {
+	check := func(desc string, iso string) {
+		t.Helper()
+
+		_, err := ParseISODuration(iso)
+		require.Error(t, err, desc)
+	}
+
+	check("empty", "")
+	check("P only", "P")
+	check("T only", "T")
+	check("Ends with T", "P1Y1M1DT")
+	check("junk", "junk")
+	check("missing T", "P1H")
+	check("missing T 2", "P3Y6M14D12H30M5S")
+	check("bad date order", "P1M1Y")
+	check("bad time order", "PT1M1H")
+}

--- a/util/timeutil/duration_test.go
+++ b/util/timeutil/duration_test.go
@@ -107,6 +107,10 @@ func TestParseISODuration(t *testing.T) {
 		Days: 12 * 7,
 	})
 
+	check("fractional seconds", "PT0.1S", ISODuration{
+		TimePart: 100 * time.Millisecond,
+	})
+
 }
 
 func TestParseISODurationErrors(t *testing.T) {

--- a/util/timeutil/duration_test.go
+++ b/util/timeutil/duration_test.go
@@ -32,6 +32,11 @@ func TestParseISODuration(t *testing.T) {
 		seconds: 60,
 	})
 
+	check("one month and 1 minute", "P1MT1M", ISODuration{
+		months:  1,
+		seconds: 60,
+	})
+
 	check("two days with leading zeros", "P0002D", ISODuration{
 		// If a time element in a defined representation has a defined length, then leading zeros shall be used as required
 		days: 2,
@@ -41,6 +46,13 @@ func TestParseISODuration(t *testing.T) {
 		years:   3,
 		months:  6,
 		days:    14,
+		seconds: 12*3600 + 30*60 + 5,
+	})
+
+	check("mixed with week", "P3Y6M2W14DT12H30M5S", ISODuration{
+		years:   3,
+		months:  6,
+		days:    2*7 + 14,
 		seconds: 12*3600 + 30*60 + 5,
 	})
 
@@ -80,6 +92,7 @@ func TestParseISODurationErrors(t *testing.T) {
 	check("Ends with T", "P1Y1M1DT")
 	check("junk", "junk")
 	check("missing T", "P1H")
+	check("mistaken format", "PY3M6D14TH12M30S5")
 	check("missing T 2", "P3Y6M14D12H30M5S")
 	check("bad date order", "P1M1Y")
 	check("bad time order", "PT1M1H")

--- a/util/timeutil/duration_test.go
+++ b/util/timeutil/duration_test.go
@@ -12,6 +12,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestISODuration_String(t *testing.T) {
+	check := func(exp string, dur ISODuration) {
+		t.Helper()
+
+		assert.Equal(t, exp, dur.String())
+	}
+
+	check("P1Y", ISODuration{Years: 1})
+	check("P1Y4M", ISODuration{Years: 1, Months: 4})
+	check("P1D", ISODuration{Days: 1})
+	check("PT1H", ISODuration{TimePart: time.Hour})
+	check("P1YT0.1S", ISODuration{Years: 1, TimePart: time.Millisecond * 100})
+
+	check("P1Y2M3W4DT5H6M7S", ISODuration{
+		Years:  1,
+		Months: 2,
+		Days:   25,
+
+		TimePart: 5*time.Hour + 6*time.Minute + 7*time.Second,
+	})
+	check("P1Y2W1D", ISODuration{Years: 1, Days: 15})
+	check("P0D", ISODuration{}) // must contain at least one element
+}
+
 func TestParseISODuration(t *testing.T) {
 
 	check := func(desc string, iso string, exp ISODuration) {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR introduces a utility for parsing ISO duration strings into an object. The supported formats are `PnYnMnDTnHnMnS` and `PnW`. `P` (for Period) is always first, and `nX` represents `n` units of `X`. `T` is a separator between the nominal date components and the accurate time components.

References include this [ISO working paper](https://www.loc.gov/standards/datetime/iso-tc154-wg5_n0038_iso_wd_8601-1_2016-02-16.pdf) and [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#appendix-A).

Additional context is provided in code comments.