### PR TITLE
ui/a11y: move onClick to form onSubmit functions

### DIFF
--- a/web/src/app/admin/AdminNumberLookup.tsx
+++ b/web/src/app/admin/AdminNumberLookup.tsx
@@ -84,7 +84,13 @@ export default function AdminNumberLookup(): JSX.Element {
 
   return (
     <React.Fragment>
-      <Form>
+      <Form
+        onSubmit={(e) => {
+          e.preventDefault()
+          lookup()
+          setStaleCarrier(false)
+        }}
+      >
         <Card>
           <CardContent>
             <Grid container spacing={2}>
@@ -129,13 +135,8 @@ export default function AdminNumberLookup(): JSX.Element {
                 <Tooltip title='May incur Twilio charges' placement='right'>
                   <LoadingButton
                     buttonText='Lookup Carrier Info'
-                    onClick={() => {
-                      lookup()
-                      setStaleCarrier(false)
-                    }}
                     disabled={!numInfo?.valid}
                     loading={carrLoading}
-                    noSubmit
                   />
                 </Tooltip>
               </CardActions>

--- a/web/src/app/admin/AdminSMSSend.tsx
+++ b/web/src/app/admin/AdminSMSSend.tsx
@@ -93,7 +93,12 @@ export default function AdminSMSSend(): JSX.Element {
 
   return (
     <React.Fragment>
-      <Form>
+      <Form
+        onSubmit={(e) => {
+          e.preventDefault()
+          send()
+        }}
+      >
         <Card>
           <CardContent>
             <Grid container spacing={2}>
@@ -127,14 +132,7 @@ export default function AdminSMSSend(): JSX.Element {
           </CardContent>
 
           <CardActions>
-            <LoadingButton
-              buttonText='Send'
-              onClick={() => {
-                send()
-              }}
-              loading={smsLoading}
-              noSubmit
-            />
+            <LoadingButton buttonText='Send' loading={smsLoading} />
             {smsData?.debugSendSMS && (
               <AppLink to={smsData.debugSendSMS.providerURL} newTab>
                 <div className={classes.twilioLink}>


### PR DESCRIPTION
**Description:**
This PR wraps up some minor tech debt around where we use the `noSubmit` prop for `LoadingButton`, investigating all the places where the onClick function can be instead moved to the parent Form's `onSubmit` instead to remove the use of the `noSubmit` prop, closing #1839.

There were only a few places the prop was being used so there wasn't much to update.

**How to test:**
1. Login as an admin, visit the toolbox on either **Chrome** or **Firefox**
2. Press enter while focused on the **Phone Number** field for the **Twilio Number Lookup** section
3. (Acceptance Criteria) Form should attempt to submit, and the page should not incidentally refresh
4. Repeat test for a TextField in the **Send SMS** section
5. Repeat both tests in the other browser
