### PR TITLE
dev: only rm build and node_modules on `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ resetdb: config.json.bak
 	go run ./devtools/resetdb --no-migrate
 
 clean:
-	rm -rf bin node_modules web/src/node_modules web/src/cypress/videos web/src/cypress/screenshots web/src/build/static
+	rm -rf bin node_modules web/src/node_modules web/src/build/static
 
 build-docker: bin/goalert bin/mockslack
 

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ resetdb: config.json.bak
 	go run ./devtools/resetdb --no-migrate
 
 clean:
-	git clean -xdf
+	rm -rf bin node_modules web/src/node_modules web/src/cypress/videos web/src/cypress/screenshots web/src/build/static
 
 build-docker: bin/goalert bin/mockslack
 


### PR DESCRIPTION
**Description:**
Updates `make clean` target to only cleanup build output and node_modules, leaving things like `Procfile.local` or config backups intact