### PR TITLE
alert/alertlog: convert Store from interface to struct

### DIFF
--- a/alert/alertlog/legacysearch.go
+++ b/alert/alertlog/legacysearch.go
@@ -65,7 +65,7 @@ const (
 )
 
 // LegacySearch will return a list of matching log entries.
-func (db *DB) LegacySearch(ctx context.Context, opts *LegacySearchOptions) ([]Entry, int, error) {
+func (s *Store) LegacySearch(ctx context.Context, opts *LegacySearchOptions) ([]Entry, int, error) {
 	err := permission.LimitCheckAny(ctx, permission.Admin, permission.User, permission.System)
 	if err != nil {
 		return nil, 0, err
@@ -168,7 +168,7 @@ func (db *DB) LegacySearch(ctx context.Context, opts *LegacySearchOptions) ([]En
 		JOIN alerts ON alerts.id = a.alert_id
 	` + whereStr
 
-	tx, err := db.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
 	if err != nil {
 		return nil, 0, err
 	}

--- a/alert/alertlog/search.go
+++ b/alert/alertlog/search.go
@@ -88,7 +88,7 @@ func (opts renderData) QueryArgs() []sql.NamedArg {
 }
 
 // Search will return a list of matching log entries
-func (db *DB) Search(ctx context.Context, opts *SearchOptions) ([]Entry, error) {
+func (s *Store) Search(ctx context.Context, opts *SearchOptions) ([]Entry, error) {
 	if opts == nil {
 		opts = &SearchOptions{}
 	}
@@ -108,7 +108,7 @@ func (db *DB) Search(ctx context.Context, opts *SearchOptions) ([]Entry, error) 
 		return nil, errors.Wrap(err, "render query")
 	}
 
-	rows, err := db.db.QueryContext(ctx, query, args...)
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/alert/logentryfetcher.go
+++ b/alert/logentryfetcher.go
@@ -18,7 +18,7 @@ type logError struct {
 	isAlreadyClosed       bool
 	alertID               int
 	_type                 alertlog.Type
-	logDB                 alertlog.Store
+	logDB                 *alertlog.Store
 }
 
 func (e logError) LogEntry(ctx context.Context) (*alertlog.Entry, error) {

--- a/alert/store.go
+++ b/alert/store.go
@@ -59,7 +59,7 @@ type Manager interface {
 
 type DB struct {
 	db    *sql.DB
-	logDB alertlog.Store
+	logDB *alertlog.Store
 
 	insert          *sql.Stmt
 	update          *sql.Stmt
@@ -95,7 +95,7 @@ type Trigger interface {
 	TriggerAlert(int)
 }
 
-func NewDB(ctx context.Context, db *sql.DB, logDB alertlog.Store) (*DB, error) {
+func NewDB(ctx context.Context, db *sql.DB, logDB *alertlog.Store) (*DB, error) {
 	prep := &util.Prepare{DB: db, Ctx: ctx}
 
 	p := prep.P

--- a/app/app.go
+++ b/app/app.go
@@ -82,7 +82,7 @@ type App struct {
 	ConfigStore *config.Store
 
 	AlertStore    alert.Store
-	AlertLogStore alertlog.Store
+	AlertLogStore *alertlog.Store
 
 	AuthBasicStore        *basic.Store
 	UserStore             *user.Store

--- a/app/initstores.go
+++ b/app/initstores.go
@@ -102,7 +102,7 @@ func (app *App) initStores(ctx context.Context) error {
 	}
 
 	if app.AlertLogStore == nil {
-		app.AlertLogStore, err = alertlog.NewDB(ctx, app.db)
+		app.AlertLogStore, err = alertlog.NewStore(ctx, app.db)
 	}
 	if err != nil {
 		return errors.Wrap(err, "init alertlog store")

--- a/engine/config.go
+++ b/engine/config.go
@@ -15,7 +15,7 @@ import (
 
 // Config contains parameters for controlling how the Engine operates.
 type Config struct {
-	AlertLogStore       alertlog.Store
+	AlertLogStore       *alertlog.Store
 	AlertStore          alert.Store
 	ContactMethodStore  contactmethod.Store
 	NotificationManager *notification.Manager

--- a/engine/escalationmanager/db.go
+++ b/engine/escalationmanager/db.go
@@ -22,14 +22,14 @@ type DB struct {
 	deletedSteps     *sql.Stmt
 	normalEscalation *sql.Stmt
 
-	log alertlog.Store
+	log *alertlog.Store
 }
 
 // Name returns the name of the module.
 func (db *DB) Name() string { return "Engine.EscalationManager" }
 
 // NewDB creates a new DB.
-func NewDB(ctx context.Context, db *sql.DB, log alertlog.Store) (*DB, error) {
+func NewDB(ctx context.Context, db *sql.DB, log *alertlog.Store) (*DB, error) {
 	lock, err := processinglock.NewLock(ctx, db, processinglock.Config{
 		Version: 3,
 		Type:    processinglock.TypeEscalation,

--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -43,7 +43,7 @@ type DB struct {
 	sendDeadlineExpired *sql.Stmt
 
 	failDisabledCM *sql.Stmt
-	alertlogstore  alertlog.Store
+	alertlogstore  *alertlog.Store
 
 	failSMSVoice *sql.Stmt
 
@@ -69,7 +69,7 @@ type DB struct {
 }
 
 // NewDB creates a new DB.
-func NewDB(ctx context.Context, db *sql.DB, a alertlog.Store, pausable lifecycle.Pausable) (*DB, error) {
+func NewDB(ctx context.Context, db *sql.DB, a *alertlog.Store, pausable lifecycle.Pausable) (*DB, error) {
 	lock, err := processinglock.NewLock(ctx, db, processinglock.Config{
 		Type:    processinglock.TypeMessage,
 		Version: 9,

--- a/engine/npcyclemanager/db.go
+++ b/engine/npcyclemanager/db.go
@@ -16,14 +16,14 @@ type DB struct {
 	lock *processinglock.Lock
 
 	queueMessages *sql.Stmt
-	log           alertlog.Store
+	log           *alertlog.Store
 }
 
 // Name returns the name of the module.
 func (db *DB) Name() string { return "Engine.NotificationCycleManager" }
 
 // NewDB creates a new DB.
-func NewDB(ctx context.Context, db *sql.DB, log alertlog.Store) (*DB, error) {
+func NewDB(ctx context.Context, db *sql.DB, log *alertlog.Store) (*DB, error) {
 	lock, err := processinglock.NewLock(ctx, db, processinglock.Config{
 		Type:    processinglock.TypeNPCycle,
 		Version: 2,

--- a/escalation/store.go
+++ b/escalation/store.go
@@ -20,14 +20,14 @@ import (
 
 type Config struct {
 	NCStore         notificationchannel.Store
-	LogStore        alertlog.Store
+	LogStore        *alertlog.Store
 	SlackLookupFunc func(ctx context.Context, channelID string) (*slack.Channel, error)
 }
 
 type Store struct {
 	db *sql.DB
 
-	log     alertlog.Store
+	log     *alertlog.Store
 	ncStore notificationchannel.Store
 	slackFn func(ctx context.Context, channelID string) (*slack.Channel, error)
 

--- a/graphql2/graphqlapp/app.go
+++ b/graphql2/graphqlapp/app.go
@@ -57,7 +57,7 @@ type App struct {
 	NRStore        notificationrule.Store
 	NCStore        notificationchannel.Store
 	AlertStore     alert.Store
-	AlertLogStore  alertlog.Store
+	AlertLogStore  *alertlog.Store
 	ServiceStore   service.Store
 	FavoriteStore  favorite.Store
 	PolicyStore    *escalation.Store


### PR DESCRIPTION
Closes #2127, removing the alertlog interface in favor of using structs