### PR TITLE
regendb: seed the `alert_logs` table

### DIFF
--- a/devtools/resetdb/datagen.go
+++ b/devtools/resetdb/datagen.go
@@ -28,6 +28,13 @@ import (
 var timeZones = []string{"America/Chicago", "Europe/Berlin", "UTC"}
 var rotationTypes = []rotation.Type{rotation.TypeDaily, rotation.TypeHourly, rotation.TypeWeekly}
 
+type AlertLog struct {
+	AlertID   int
+	Timestamp time.Time
+	Event     string
+	Message   string
+}
+
 type datagenConfig struct {
 	UserCount            int
 	CMMax                int
@@ -85,6 +92,7 @@ type datagen struct {
 	IntKeys            []integrationkey.IntegrationKey
 	Monitors           []heartbeat.Monitor
 	Alerts             []alert.Alert
+	AlertLogs          []AlertLog
 	Favorites          []userFavorite
 	Labels             []label.Label
 
@@ -333,12 +341,36 @@ func (d *datagen) NewAlert(status alert.Status) {
 		serviceID = d.Services[rand.Intn(len(d.Services))].ID
 	}
 	d.Alerts = append(d.Alerts, alert.Alert{
+		ID:        len(d.Alerts) + 1,
+		CreatedAt: gofakeit.DateRange(time.Now().Add(-2*time.Hour), time.Now().Add(-1*time.Hour)),
 		Status:    status,
 		ServiceID: serviceID,
 		Summary:   d.ids.Gen(func() string { return gofakeit.Sentence(rand.Intn(10) + 3) }, serviceID),
 		Details:   details,
 		Source:    src,
 	})
+}
+
+// NewAlertLog will generate an alert log with the provided status.
+func (d *datagen) NewAlertLogs(alert alert.Alert) {
+
+	// Add 'created' event log
+	d.AlertLogs = append(d.AlertLogs, AlertLog{
+		AlertID:   alert.ID,
+		Timestamp: alert.CreatedAt,
+		Event:     "created",
+		Message:   "",
+	})
+
+	// Add 'closed' event log
+	if alert.Status == "closed" {
+		d.AlertLogs = append(d.AlertLogs, AlertLog{
+			AlertID:   alert.ID,
+			Timestamp: gofakeit.DateRange(alert.CreatedAt, alert.CreatedAt.Add(30*time.Minute)),
+			Event:     "closed",
+			Message:   "",
+		})
+	}
 }
 
 // NewFavorite will generate a new favorite for the provided user ID.
@@ -483,6 +515,10 @@ func (cfg datagenConfig) Generate() datagen {
 
 	run(cfg.AlertClosedCount, func() { d.NewAlert(alert.StatusClosed) })
 	run(cfg.AlertActiveCount, func() { d.NewAlert(alert.StatusActive) })
+
+	for _, alert := range d.Alerts {
+		d.NewAlertLogs(alert)
+	}
 
 	return d
 }

--- a/devtools/resetdb/datagen.go
+++ b/devtools/resetdb/datagen.go
@@ -351,7 +351,7 @@ func (d *datagen) NewAlert(status alert.Status) {
 	})
 }
 
-// NewAlertLog will generate an alert log with the provided status.
+// NewAlertLog will generate an alert log for the provided alert.
 func (d *datagen) NewAlertLogs(alert alert.Alert) {
 
 	// Add 'created' event log

--- a/devtools/resetdb/main.go
+++ b/devtools/resetdb/main.go
@@ -260,14 +260,19 @@ func fillDB(ctx context.Context, url string) error {
 
 	_, err = pool.Exec(ctx, "alter table alerts disable trigger trg_enforce_alert_limit")
 	must(err)
-	copyFrom("alerts", []string{"status", "summary", "details", "dedup_key", "service_id", "source"}, len(data.Alerts), func(n int) []interface{} {
+	copyFrom("alerts", []string{"id", "created_at", "status", "summary", "details", "dedup_key", "service_id", "source"}, len(data.Alerts), func(n int) []interface{} {
 		a := data.Alerts[n]
 		var dedup *alert.DedupID
 		if a.Status != alert.StatusClosed {
 			dedup = a.DedupKey()
 		}
-		return []interface{}{a.Status, a.Summary, a.Details, dedup, asUUID(a.ServiceID), a.Source}
+		return []interface{}{a.ID, a.CreatedAt, a.Status, a.Summary, a.Details, dedup, asUUID(a.ServiceID), a.Source}
 	}, "services")
+
+	copyFrom("alert_logs", []string{"alert_id", "timestamp", "event", "message"}, len(data.AlertLogs), func(n int) []interface{} {
+		a := data.AlertLogs[n]
+		return []interface{}{a.AlertID, a.Timestamp, a.Event, a.Message}
+	}, "alerts")
 
 	dt.Wait()
 	_, err = pool.Exec(ctx, "alter table alerts enable trigger all")


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adds records to `alert_logs` when running `make regendb`.

**Which issue(s) this PR fixes:**
Fixes #2138

**How to test:**
1. Run `make regendb`
2. Verify that `alert_logs` contains a "created" event for every alert, and that closed alerts have a corresponding "closed" event. Closed events are timestamped after the relevant created event.