### PR TITLE
ui/main: fix breadcrumb navigation

### DIFF
--- a/web/src/app/main/components/ToolbarTitle.js
+++ b/web/src/app/main/components/ToolbarTitle.js
@@ -138,7 +138,6 @@ function ToolbarTitle() {
           noWrap
           variant='h6'
           to='..'
-          replace
         >
           {query ? (
             <NameLoader


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR makes the breadcrumb links push to the native navigation stack (instead of replacing the latest entry). This prevents several strange scenarios that a user may experience when navigating with mixed use of the breadcrumbs and the native browser navigation.

**Which issue(s) this PR fixes:**
Fixes #2048 

