### PR TITLE
dev: adjust prometheus log level

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -4,7 +4,7 @@ build: while true; do make -qs bin/goalert || make bin/goalert; sleep 0.1; done
 goalert: ./bin/goalert -l=localhost:3030 --ui-url=http://localhost:3035 --db-url=postgres://goalert@localhost:5432/goalert?sslmode=disable --listen-sysapi=localhost:1234 --listen-prometheus=localhost:2112
 
 smtp: go run github.com/mailhog/MailHog -ui-bind-addr=localhost:8025 -api-bind-addr=localhost:8025 -smtp-bind-addr=localhost:1025
-prom: bin/tools/prometheus --config.file=devtools/prometheus/prometheus.yml --storage.tsdb.path=bin/prom-data/ --web.listen-address=localhost:9090
+prom: bin/tools/prometheus --config.file=devtools/prometheus/prometheus.yml --storage.tsdb.path=bin/prom-data/ --web.listen-address=localhost:9090 --log.level=warn
 
 @watch-file=./web/src/webpack.config.js
 ui: yarn workspace goalert-web webpack serve --config ./webpack.config.js


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR sets the Prometheus log severity threshold to "warn"

**Which issue(s) this PR fixes:**
Suggested in #2156

**Additional Info:**
For some reason, this flag can only be set on the CLI (not config file).
Options were debug, info, warn, and error.

I decided to keep prod using the default (info) since the main motivation for this change is DX.
