### PR TITLE
dev: Fix make start output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,9 @@ cy-wide-prod: web/src/build/static/app.js cypress
 cy-mobile-prod: web/src/build/static/app.js cypress
 	CONTAINER_TOOL=$(CONTAINER_TOOL) CYPRESS_viewportWidth=375 CYPRESS_viewportHeight=667 CY_ACTION=$(CY_ACTION) go run ./devtools/runproc -f Procfile.cypress.prod
 cy-wide-prod-run: web/src/build/static/app.js cypress
-	make cy-wide-prod CY_ACTION=run CONTAINER_TOOL=$(CONTAINER_TOOL)
+	$(MAKE) $(MFLAGS) cy-wide-prod CY_ACTION=run CONTAINER_TOOL=$(CONTAINER_TOOL) BUNDLE=1
 cy-mobile-prod-run: web/src/build/static/app.js cypress
-	make cy-mobile-prod CY_ACTION=run CONTAINER_TOOL=$(CONTAINER_TOOL)
+	$(MAKE) $(MFLAGS) cy-mobile-prod CY_ACTION=run CONTAINER_TOOL=$(CONTAINER_TOOL) BUNDLE=1
 
 web/src/schema.d.ts: graphql2/schema.graphql node_modules web/src/genschema.go devtools/gqlgen/*
 	go generate ./web/src
@@ -92,7 +92,7 @@ start: bin/goalert node_modules web/src/schema.d.ts $(BIN_DIR)/tools/prometheus
 start-prod: web/src/build/static/app.js $(BIN_DIR)/tools/prometheus
 	# force rebuild to ensure build-flags are set
 	touch cmd/goalert/main.go
-	make bin/goalert BUNDLE=1
+	$(MAKE) $(MFLAGS) bin/goalert BUNDLE=1
 	go run ./devtools/runproc -f Procfile.prod -l Procfile.local
 
 jest: node_modules 

--- a/Procfile
+++ b/Procfile
@@ -3,7 +3,7 @@ build: while true; do make -qs bin/goalert || make bin/goalert || (echo '\033[0;
 @watch-file=./bin/goalert
 goalert: ./bin/goalert -l=localhost:3030 --ui-url=http://localhost:3035 --db-url=postgres://goalert@localhost:5432/goalert?sslmode=disable --listen-sysapi=localhost:1234 --listen-prometheus=localhost:2112
 
-smtp: go run github.com/mailhog/MailHog -ui-bind-addr=localhost:8025 -api-bind-addr=localhost:8025 -smtp-bind-addr=localhost:1025
+smtp: go run github.com/mailhog/MailHog -ui-bind-addr=localhost:8025 -api-bind-addr=localhost:8025 -smtp-bind-addr=localhost:1025 | grep -v KEEPALIVE
 prom: bin/tools/prometheus --log.level=warn --config.file=devtools/prometheus/prometheus.yml --storage.tsdb.path=bin/prom-data/ --web.listen-address=localhost:9090
 
 @watch-file=./web/src/webpack.config.js

--- a/Procfile
+++ b/Procfile
@@ -4,7 +4,7 @@ build: while true; do make -qs bin/goalert || make bin/goalert || (echo '\033[0;
 goalert: ./bin/goalert -l=localhost:3030 --ui-url=http://localhost:3035 --db-url=postgres://goalert@localhost:5432/goalert?sslmode=disable --listen-sysapi=localhost:1234 --listen-prometheus=localhost:2112
 
 smtp: go run github.com/mailhog/MailHog -ui-bind-addr=localhost:8025 -api-bind-addr=localhost:8025 -smtp-bind-addr=localhost:1025
-prom: bin/tools/prometheus --config.file=devtools/prometheus/prometheus.yml --storage.tsdb.path=bin/prom-data/ --web.listen-address=localhost:9090
+prom: bin/tools/prometheus --log.level=warn --config.file=devtools/prometheus/prometheus.yml --storage.tsdb.path=bin/prom-data/ --web.listen-address=localhost:9090
 
 @watch-file=./web/src/webpack.config.js
 ui: yarn workspace goalert-web webpack serve --config ./webpack.config.js

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-build: while true; do make -qs bin/goalert || make bin/goalert; sleep 0.1; done
+build: while true; do make -qs bin/goalert || make bin/goalert || (echo '\033[0;31mBuild Failure'; sleep 3); sleep 0.1; done
 
 @watch-file=./bin/goalert
 goalert: ./bin/goalert -l=localhost:3030 --ui-url=http://localhost:3035 --db-url=postgres://goalert@localhost:5432/goalert?sslmode=disable --listen-sysapi=localhost:1234 --listen-prometheus=localhost:2112

--- a/Procfile.cypress
+++ b/Procfile.cypress
@@ -1,4 +1,4 @@
-build: while true; do make -qs bin/goalert || make bin/goalert; sleep 0.1; done
+build: while true; do make -qs bin/goalert || make bin/goalert || (echo '\033[0;31mBuild Failure'; sleep 3); sleep 0.1; done
 
 @watch-file=./bin/goalert
 goalert: go run ./devtools/waitfor postgres://postgres@localhost:5433 && go run ./devtools/procwrap -test=localhost:3042 bin/goalert -l=localhost:3042 --ui-url=http://localhost:3045 --db-url=postgres://postgres@localhost:5433 --slack-base-url=http://localhost:3040/slack --log-errors-only

--- a/Procfile.cypress.prod
+++ b/Procfile.cypress.prod
@@ -1,4 +1,4 @@
-build: while true; do make -qs bin/goalert BUNDLE=1 || make bin/goalert BUNDLE=1; sleep 0.1; done
+build: while true; do make -qs bin/goalert BUNDLE=1 || make bin/goalert BUNDLE=1 || (echo '\033[0;31mBuild Failure'; sleep 3); sleep 0.1; done
 
 @watch-file=./bin/goalert
 goalert: go run ./devtools/waitfor postgres://postgres@localhost:5433 && go run ./devtools/procwrap -test=localhost:3042 bin/goalert -l=localhost:3042 --db-url=postgres://postgres@localhost:5433 --slack-base-url=http://localhost:3040/slack --log-errors-only

--- a/Procfile.cypress.prod
+++ b/Procfile.cypress.prod
@@ -1,4 +1,4 @@
-build: while true; do make -qs bin/goalert BUNDLE=1 || make bin/goalert BUNDLE=1 || (echo '\033[0;31mBuild Failure'; sleep 3); sleep 0.1; done
+build: while true; do make -qs bin/goalert BUNDLE=1 >/dev/null || make bin/goalert BUNDLE=1 || (echo '\033[0;31mBuild Failure'; sleep 3); sleep 0.1; done
 
 @watch-file=./bin/goalert
 goalert: go run ./devtools/waitfor postgres://postgres@localhost:5433 && go run ./devtools/procwrap -test=localhost:3042 bin/goalert -l=localhost:3042 --db-url=postgres://postgres@localhost:5433 --slack-base-url=http://localhost:3040/slack --log-errors-only

--- a/Procfile.prod
+++ b/Procfile.prod
@@ -4,4 +4,4 @@ build: while true; do make -qs bin/goalert BUNDLE=1 || make bin/goalert BUNDLE=1
 goalert: ./bin/goalert -l=localhost:3030 --db-url=postgres://goalert@localhost:5432/goalert?sslmode=disable --listen-sysapi=localhost:1234 --listen-prometheus=localhost:2112
 
 smtp: go run github.com/mailhog/MailHog -ui-bind-addr=localhost:8025 -api-bind-addr=localhost:8025 -smtp-bind-addr=localhost:1025
-prom: bin/tools/prometheus --config.file=devtools/prometheus/prometheus.yml --storage.tsdb.path=bin/prom-data/ --web.listen-address=localhost:9090
+prom: bin/tools/prometheus --log.level=warn --config.file=devtools/prometheus/prometheus.yml --storage.tsdb.path=bin/prom-data/ --web.listen-address=localhost:9090

--- a/Procfile.prod
+++ b/Procfile.prod
@@ -1,4 +1,4 @@
-build: while true; do make -qs bin/goalert BUNDLE=1 || make bin/goalert BUNDLE=1; sleep 0.1; done
+build: while true; do make -qs bin/goalert BUNDLE=1 || make bin/goalert BUNDLE=1 || (echo '\033[0;31mBuild Failure'; sleep 3); sleep 0.1; done
 
 @watch-file=./bin/goalert
 goalert: ./bin/goalert -l=localhost:3030 --db-url=postgres://goalert@localhost:5432/goalert?sslmode=disable --listen-sysapi=localhost:1234 --listen-prometheus=localhost:2112

--- a/Procfile.prod
+++ b/Procfile.prod
@@ -3,5 +3,5 @@ build: while true; do make -qs bin/goalert BUNDLE=1 || make bin/goalert BUNDLE=1
 @watch-file=./bin/goalert
 goalert: ./bin/goalert -l=localhost:3030 --db-url=postgres://goalert@localhost:5432/goalert?sslmode=disable --listen-sysapi=localhost:1234 --listen-prometheus=localhost:2112
 
-smtp: go run github.com/mailhog/MailHog -ui-bind-addr=localhost:8025 -api-bind-addr=localhost:8025 -smtp-bind-addr=localhost:1025
+smtp: go run github.com/mailhog/MailHog -ui-bind-addr=localhost:8025 -api-bind-addr=localhost:8025 -smtp-bind-addr=localhost:1025 | grep -v KEEPALIVE
 prom: bin/tools/prometheus --log.level=warn --config.file=devtools/prometheus/prometheus.yml --storage.tsdb.path=bin/prom-data/ --web.listen-address=localhost:9090

--- a/app/cmd.go
+++ b/app/cmd.go
@@ -639,6 +639,7 @@ func getConfig(ctx context.Context) (Config, error) {
 
 		JSON:        viper.GetBool("json"),
 		LogRequests: viper.GetBool("log-requests"),
+		LogEngine:   viper.GetBool("log-engine-cycles"),
 		Verbose:     viper.GetBool("verbose"),
 		APIOnly:     viper.GetBool("api-only"),
 
@@ -768,6 +769,7 @@ func init() {
 
 	RootCmd.PersistentFlags().BoolP("verbose", "v", def.Verbose, "Enable verbose logging.")
 	RootCmd.Flags().Bool("log-requests", def.LogRequests, "Log all HTTP requests. If false, requests will be logged for debug/trace contexts only.")
+	RootCmd.Flags().Bool("log-engine-cycles", def.LogEngine, "Log start and end of each engine cycle.")
 	RootCmd.PersistentFlags().Bool("json", def.JSON, "Log in JSON format.")
 	RootCmd.PersistentFlags().Bool("log-errors-only", false, "Only log errors (superseeds other flags).")
 

--- a/app/config.go
+++ b/app/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	JSON        bool
 	LogRequests bool
 	APIOnly     bool
+	LogEngine   bool
 
 	TLSListenAddr string
 	TLSConfig     *tls.Config

--- a/app/initengine.go
+++ b/app/initengine.go
@@ -48,6 +48,7 @@ func (app *App) initEngine(ctx context.Context) error {
 		MaxMessages: 50,
 
 		DisableCycle: app.cfg.APIOnly,
+		LogCycles:    app.cfg.LogEngine,
 	})
 	if err != nil {
 		return errors.Wrap(err, "init engine")

--- a/engine/config.go
+++ b/engine/config.go
@@ -32,4 +32,5 @@ type Config struct {
 	MaxMessages int
 
 	DisableCycle bool
+	LogCycles    bool
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -479,8 +479,10 @@ passSignals:
 		return
 	}
 
-	log.Logf(ctx, "Engine cycle start.")
-	defer log.Logf(ctx, "Engine cycle end.")
+	if p.cfg.LogCycles {
+		log.Logf(ctx, "Engine cycle start.")
+		defer log.Logf(ctx, "Engine cycle end.")
+	}
 
 	startAll := time.Now()
 	aborted := p.processAll(ctx)


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

**Description:**
This PR fixes some noise issues in the log output.
- Engine cycle is no longer logged by default
- After 5 sec, warnings will be logged with an error at the end of the cycle
- An error will be logged each minute if a cycle is stuck that long
- "Build Failed" will be logged and retried after 3sec on failure with `make start` instead of exiting
- Prometheus is changed to `warn` log level
- Cypress tests should no longer spam make messages

**Which issue(s) this PR fixes:**
Fixes #2156 
Fixes #2157 

**Out of Scope**
Request logging has been left out and can be addressed separately (or with #2106 )