### PR TITLE
slack: limit details to 3000 characters

### DIFF
--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -278,8 +278,16 @@ func alertMsgOption(ctx context.Context, callbackID string, id int, summary, det
 		details = ""
 	}
 	if details != "" {
+		escaped := slackutilsx.EscapeMessage(details)
+		if len(escaped) > 3000 {
+			newDetailsLen := len(details) - (len(escaped) - 3000)
+			if newDetailsLen < 0 {
+				newDetailsLen = 0
+			}
+			escaped = slackutilsx.EscapeMessage(details[:newDetailsLen])
+		}
 		blocks = append(blocks, slack.NewSectionBlock(
-			slack.NewTextBlockObject("mrkdwn", slackutilsx.EscapeMessage(details), false, false), nil, nil),
+			slack.NewTextBlockObject("mrkdwn", escaped, false, false), nil, nil),
 		)
 	}
 

--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -12,6 +12,7 @@ import (
 	"github.com/target/goalert/config"
 	"github.com/target/goalert/notification"
 	"github.com/target/goalert/permission"
+	"github.com/target/goalert/util"
 	"github.com/target/goalert/util/log"
 	"github.com/target/goalert/validation"
 )
@@ -278,13 +279,12 @@ func alertMsgOption(ctx context.Context, callbackID string, id int, summary, det
 		details = ""
 	}
 	if details != "" {
-		escaped := slackutilsx.EscapeMessage(details)
-		if len(escaped) > 3000 {
-			newDetailsLen := len(details) - (len(escaped) - 3000)
-			if newDetailsLen < 0 {
-				newDetailsLen = 0
-			}
-			escaped = slackutilsx.EscapeMessage(details[:newDetailsLen])
+		escaped, err := util.RenderSize(3000, details, func(s string) (string, error) {
+			return slackutilsx.EscapeMessage(s), nil
+		})
+		if err != nil {
+			log.Log(ctx, fmt.Errorf("slack: render alert details: %w", err))
+			escaped = ""
 		}
 		blocks = append(blocks, slack.NewSectionBlock(
 			slack.NewTextBlockObject("mrkdwn", escaped, false, false), nil, nil),

--- a/notification/twilio/alertsms.go
+++ b/notification/twilio/alertsms.go
@@ -106,24 +106,6 @@ func normalizeGSM(str string) (s string) {
 	return s
 }
 
-// trimString will trim the string by the difference between the maxLen and the
-// buffer length. If the string is trimmed, it returns true and the buffer is reset.
-func trimString(str *string, buf *bytes.Buffer, maxLen int) bool {
-	if buf.Len() <= maxLen {
-		return false
-	}
-
-	newLen := len(*str) - (buf.Len() - maxLen)
-	if newLen <= 0 {
-		*str = ""
-	} else {
-		*str = strings.TrimSpace((*str)[:newLen])
-	}
-	buf.Reset()
-
-	return true
-}
-
 // renderAlertMessage will render a single-segment SMS for an Alert.
 //
 // Non-GSM characters will be replaced with '?' and fields will be

--- a/notification/twilio/alertsms.go
+++ b/notification/twilio/alertsms.go
@@ -3,13 +3,13 @@ package twilio
 import (
 	"bytes"
 	"context"
-	"errors"
 	"strings"
 	"text/template"
 	"unicode"
 
 	"github.com/target/goalert/config"
 	"github.com/target/goalert/notification"
+	"github.com/target/goalert/util"
 )
 
 // 160 GSM characters (140 bytes) is the max for a single segment message.
@@ -141,24 +141,20 @@ func renderAlertMessage(maxLen int, a notification.Alert, link string, code int)
 	data.Link = link
 	data.Code = code
 
-	err := alertTempl.Execute(&buf, data)
+	result, err := util.RenderSize(maxLen, data.Alert.Summary, func(summary string) (string, error) {
+		buf.Reset()
+		data.Alert.Summary = strings.TrimSpace(summary)
+		err := alertTempl.Execute(&buf, data)
+		if err != nil {
+			return "", err
+		}
+		return buf.String(), nil
+	})
 	if err != nil {
 		return "", err
 	}
 
-	if trimString(&data.Alert.Summary, &buf, maxLen) {
-		err = alertTempl.Execute(&buf, data)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	// should maybe revisit templates if this starts occurring
-	if buf.Len() > maxLen {
-		return "", errors.New("message too long")
-	}
-
-	return buf.String(), nil
+	return result, nil
 }
 
 // renderAlertStatusMessage will render a single-segment SMS for an Alert Status.
@@ -170,31 +166,21 @@ func renderAlertStatusMessage(maxLen int, a notification.AlertStatus) (string, e
 	a.Summary = normalizeGSM(a.Summary)
 	a.LogEntry = normalizeGSM(a.LogEntry)
 
-	err := statusTempl.Execute(&buf, a)
+	result, err := util.RenderSizeN(maxLen, []string{a.Summary, a.LogEntry}, func(inputs []string) (string, error) {
+		buf.Reset()
+		a.Summary = strings.TrimSpace(inputs[0])
+		a.LogEntry = strings.TrimSpace(inputs[1])
+		err := statusTempl.Execute(&buf, a)
+		if err != nil {
+			return "", err
+		}
+		return buf.String(), nil
+	})
 	if err != nil {
 		return "", err
 	}
 
-	if trimString(&a.Summary, &buf, maxLen) {
-		err = statusTempl.Execute(&buf, a)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	if trimString(&a.LogEntry, &buf, maxLen) {
-		err = statusTempl.Execute(&buf, a)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	// should maybe revisit templates if this starts occurring
-	if buf.Len() > maxLen {
-		return "", errors.New("message too long")
-	}
-
-	return buf.String(), nil
+	return result, nil
 }
 
 // renderAlertBundleMessage will render a single-segment SMS for an Alert Bundle.
@@ -214,22 +200,18 @@ func renderAlertBundleMessage(maxLen int, a notification.AlertBundle, link strin
 	data.Link = link
 	data.Code = code
 
-	err := bundleTempl.Execute(&buf, data)
+	result, err := util.RenderSize(maxLen, data.AlertBundle.ServiceName, func(name string) (string, error) {
+		buf.Reset()
+		data.AlertBundle.ServiceName = strings.TrimSpace(name)
+		err := bundleTempl.Execute(&buf, data)
+		if err != nil {
+			return "", err
+		}
+		return buf.String(), nil
+	})
 	if err != nil {
 		return "", err
 	}
 
-	if trimString(&data.AlertBundle.ServiceName, &buf, maxLen) {
-		err = bundleTempl.Execute(&buf, data)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	// should maybe revisit templates if this starts occurring
-	if buf.Len() > maxLen {
-		return "", errors.New("message too long")
-	}
-
-	return buf.String(), nil
+	return result, nil
 }

--- a/util/rendersize.go
+++ b/util/rendersize.go
@@ -1,21 +1,67 @@
 package util
 
-import "sort"
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// ErrNoSolution is returned by RenderSize when it can't find a solution.
+var ErrNoSolution = fmt.Errorf("no solution")
 
 // RenderSize will return the rendered result as close as possible to the max size.
-func RenderSize(maxSize int, renderFunc func(n int) string) string {
-	result := renderFunc(maxSize)
+func RenderSize(maxSize int, input string, renderFunc func(string) (string, error)) (string, error) {
+	result, err := renderFunc(input)
+	if err != nil {
+		return "", err
+	}
 	if len(result) <= maxSize {
-		return result
+		return result, nil
 	}
 
-	newSize := sort.Search(maxSize, func(max int) bool {
-		return len(renderFunc(max)) > maxSize
+	newSize := sort.Search(len(input), func(n int) bool {
+		if err != nil {
+			return true
+		}
+
+		result, err = renderFunc(input[:n])
+		return len(result) > maxSize
 	})
-	if newSize == maxSize {
-		return ""
+	if err != nil {
+		return "", err
+	}
+	if newSize == 0 {
+		return "", fmt.Errorf("failed to render string to size %d: %w", maxSize, ErrNoSolution)
 	}
 
 	// newSize is the first size that is too large
-	return renderFunc(newSize - 1)
+	return renderFunc(input[:newSize-1])
+}
+
+// RenderSizeN works like RenderSize but accepts multiple inputs.
+//
+// Inputs are trimmed one by one starting with the fist element.
+func RenderSizeN(maxSize int, inputs []string, renderFunc func([]string) (string, error)) (result string, err error) {
+	if len(inputs) == 0 {
+		return RenderSize(maxSize, "", func(string) (string, error) {
+			return renderFunc(nil)
+		})
+	}
+
+	for i := range inputs {
+		result, err = RenderSize(maxSize, inputs[i], func(inputN string) (string, error) {
+			inputs[i] = inputN
+			return renderFunc(inputs)
+		})
+		if errors.Is(err, ErrNoSolution) {
+			inputs[i] = ""
+			continue
+		}
+		if err != nil {
+			return "", err
+		}
+		return result, err
+	}
+
+	return "", ErrNoSolution
 }

--- a/util/rendersize.go
+++ b/util/rendersize.go
@@ -1,0 +1,21 @@
+package util
+
+import "sort"
+
+// RenderSize will return the rendered result as close as possible to the max size.
+func RenderSize(maxSize int, renderFunc func(n int) string) string {
+	result := renderFunc(maxSize)
+	if len(result) <= maxSize {
+		return result
+	}
+
+	newSize := sort.Search(maxSize, func(max int) bool {
+		return len(renderFunc(max)) > maxSize
+	})
+	if newSize == maxSize {
+		return ""
+	}
+
+	// newSize is the first size that is too large
+	return renderFunc(newSize - 1)
+}

--- a/util/rendersize_test.go
+++ b/util/rendersize_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -8,27 +9,43 @@ import (
 )
 
 func TestRenderSize(t *testing.T) {
-	var input string
-	renderFunc := func(n int) string {
-		if n > len(input) {
-			n = len(input)
-		}
-		return strings.ReplaceAll(input[:n], "&", "&amp;")
+	check := func(max int, input, output string) {
+		t.Helper()
+		result, err := RenderSize(max, input, func(n string) (string, error) {
+			return strings.ReplaceAll(n, "&", "&amp;"), nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, output, result)
 	}
 
-	input = "foobarbaz"
-	result := RenderSize(10, renderFunc)
-	assert.Equal(t, "foobarbaz", result)
+	check(10, "foobarbaz", "foobarbaz")
+	check(10, "foobarbazbin", "foobarbazb")
+	check(10, "foo&&rbazbin", "foo&amp;")
+	check(10, "foobarba&&&&", "foobarba")
 
-	input = "foobarbazbin"
-	result = RenderSize(10, renderFunc)
-	assert.Equal(t, "foobarbazb", result)
+	_, err := RenderSize(10, "foo", func(string) (string, error) {
+		return "", fmt.Errorf("failed")
+	})
+	assert.Error(t, err)
 
-	input = "foo&&rbazbin"
-	result = RenderSize(10, renderFunc)
-	assert.Equal(t, "foo&amp;", result)
+	_, err = RenderSize(5, "foo", func(string) (string, error) {
+		return "123456", nil
+	})
+	// can't fulfill the request
+	assert.Error(t, err)
+}
 
-	input = "foobarba&&&&"
-	result = RenderSize(10, renderFunc)
-	assert.Equal(t, "foobarba", result)
+func TestRenderSizeN(t *testing.T) {
+	check := func(max int, inputs []string, output string) {
+		t.Helper()
+		result, err := RenderSizeN(max, inputs, func(inputs []string) (string, error) {
+			return strings.ReplaceAll(strings.Join(inputs, ""), "&", "&amp;"), nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, output, result)
+	}
+
+	check(10, []string{"foobarbaz"}, "foobarbaz")
+	check(10, []string{"foo", "bar", "baz", "bin"}, "fbarbazbin")
+	check(8, []string{"foo", "bar", "baz", "bin"}, "babazbin")
 }

--- a/util/rendersize_test.go
+++ b/util/rendersize_test.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderSize(t *testing.T) {
+	var input string
+	renderFunc := func(n int) string {
+		if n > len(input) {
+			n = len(input)
+		}
+		return strings.ReplaceAll(input[:n], "&", "&amp;")
+	}
+
+	input = "foobarbaz"
+	result := RenderSize(10, renderFunc)
+	assert.Equal(t, "foobarbaz", result)
+
+	input = "foobarbazbin"
+	result = RenderSize(10, renderFunc)
+	assert.Equal(t, "foobarbazb", result)
+
+	input = "foo&&rbazbin"
+	result = RenderSize(10, renderFunc)
+	assert.Equal(t, "foo&amp;", result)
+
+	input = "foobarba&&&&"
+	result = RenderSize(10, renderFunc)
+	assert.Equal(t, "foobarba", result)
+}


### PR DESCRIPTION
**Description:**
Limits the length of details in the original slack message to 3000 characters.

This is done with a new helper `RenderSize` (and `RenderSizeN` for some alert messages) that will use a render function and assert the length is within the limit. If it is not, it performs a binary search to trim the input until it fulfills the requirement.

**Which issue(s) this PR fixes:**
Fixes #2175 
