### PR TITLE
ui/tech debt: OtherActions

### DIFF
--- a/web/src/app/alerts/components/AlertsListFilter.js
+++ b/web/src/app/alerts/components/AlertsListFilter.js
@@ -178,7 +178,6 @@ function AlertsListFilter({ serviceID }) {
     <React.Fragment>
       <IconButton
         aria-label='Filter Alerts'
-        color='inherit'
         onClick={handleOpenFilters}
         size='large'
       >

--- a/web/src/app/lists/ControlledPaginatedList.tsx
+++ b/web/src/app/lists/ControlledPaginatedList.tsx
@@ -168,7 +168,7 @@ export default function ControlledPaginatedList(
           data-cy='checkboxes-menu'
         >
           <OtherActions
-            icon={<ArrowDropDown />}
+            Icon={ArrowDropDown}
             actions={[
               {
                 label: 'All',

--- a/web/src/app/lists/ControlledPaginatedList.tsx
+++ b/web/src/app/lists/ControlledPaginatedList.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react'
-import { Checkbox, Grid, Icon, IconButton, Tooltip } from '@mui/material'
+import { Checkbox, Grid, IconButton, Tooltip } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
 import {
   PaginatedList,
@@ -168,11 +168,7 @@ export default function ControlledPaginatedList(
           data-cy='checkboxes-menu'
         >
           <OtherActions
-            icon={
-              <Icon>
-                <ArrowDropDown />
-              </Icon>
-            }
+            icon={<ArrowDropDown />}
             actions={[
               {
                 label: 'All',

--- a/web/src/app/lists/ControlledPaginatedList.tsx
+++ b/web/src/app/lists/ControlledPaginatedList.tsx
@@ -168,7 +168,7 @@ export default function ControlledPaginatedList(
           data-cy='checkboxes-menu'
         >
           <OtherActions
-            Icon={ArrowDropDown}
+            IconComponent={ArrowDropDown}
             actions={[
               {
                 label: 'All',

--- a/web/src/app/util/OtherActions.js
+++ b/web/src/app/util/OtherActions.js
@@ -15,7 +15,7 @@ const cancelable = (_fn) => {
   return cFn
 }
 
-export default function OtherActions({ color, Icon, actions, placement }) {
+export default function OtherActions({ color, IconComponent, actions, placement }) {
   const [anchorEl, setAnchorEl] = useState(null)
   const onClose = cancelable(() => setAnchorEl(null))
   const ref = useRef(null)
@@ -30,7 +30,7 @@ export default function OtherActions({ color, Icon, actions, placement }) {
         }}
         ref={ref}
       >
-        <Icon
+        <IconComponent
           aria-label='Other Actions'
           data-cy='other-actions'
           aria-expanded={Boolean(anchorEl)}
@@ -65,11 +65,11 @@ OtherActions.propTypes = {
     }),
   ).isRequired,
   color: p.string,
-  Icon: p.elementType,
+  IconComponent: p.elementType,
   placement: p.oneOf(['left', 'right']),
 }
 
 OtherActions.defaultProps = {
-  Icon: OptionsIcon,
+  IconComponent: OptionsIcon,
   placement: 'left',
 }

--- a/web/src/app/util/OtherActions.js
+++ b/web/src/app/util/OtherActions.js
@@ -15,7 +15,12 @@ const cancelable = (_fn) => {
   return cFn
 }
 
-export default function OtherActions({ color, IconComponent, actions, placement }) {
+export default function OtherActions({
+  color,
+  IconComponent,
+  actions,
+  placement,
+}) {
   const [anchorEl, setAnchorEl] = useState(null)
   const onClose = cancelable(() => setAnchorEl(null))
   const ref = useRef(null)

--- a/web/src/app/util/OtherActions.js
+++ b/web/src/app/util/OtherActions.js
@@ -15,7 +15,7 @@ const cancelable = (_fn) => {
   return cFn
 }
 
-export default function OtherActions({ color, icon, actions, placement }) {
+export default function OtherActions({ color, Icon, actions, placement }) {
   const [anchorEl, setAnchorEl] = useState(null)
   const onClose = cancelable(() => setAnchorEl(null))
   const ref = useRef(null)
@@ -30,12 +30,12 @@ export default function OtherActions({ color, icon, actions, placement }) {
         }}
         ref={ref}
       >
-        {React.cloneElement(icon, {
-          'aria-label': 'Other Actions',
-          'data-cy': 'other-actions',
-          color: color || 'inherit',
-          'aria-expanded': Boolean(anchorEl),
-        })}
+        <Icon
+          aria-label='Other Actions'
+          data-cy='other-actions'
+          aria-expanded={Boolean(anchorEl)}
+          style={{ color }}
+        />
       </IconButton>
       <Hidden mdDown>
         <OtherActionsDesktop
@@ -65,11 +65,11 @@ OtherActions.propTypes = {
     }),
   ).isRequired,
   color: p.string,
-  icon: p.element,
+  Icon: p.object,
   placement: p.oneOf(['left', 'right']),
 }
 
 OtherActions.defaultProps = {
-  icon: <OptionsIcon />,
+  Icon: OptionsIcon,
   placement: 'left',
 }

--- a/web/src/app/util/OtherActions.js
+++ b/web/src/app/util/OtherActions.js
@@ -65,7 +65,7 @@ OtherActions.propTypes = {
     }),
   ).isRequired,
   color: p.string,
-  Icon: p.object,
+  Icon: p.elementType,
   placement: p.oneOf(['left', 'right']),
 }
 

--- a/web/src/app/util/OtherActions.js
+++ b/web/src/app/util/OtherActions.js
@@ -28,6 +28,9 @@ export default function OtherActions({
   return (
     <React.Fragment>
       <IconButton
+        aria-label='Other Actions'
+        data-cy='other-actions'
+        aria-expanded={Boolean(anchorEl)}
         size='large'
         onClick={(e) => {
           onClose.cancel()
@@ -35,12 +38,7 @@ export default function OtherActions({
         }}
         ref={ref}
       >
-        <IconComponent
-          aria-label='Other Actions'
-          data-cy='other-actions'
-          aria-expanded={Boolean(anchorEl)}
-          style={{ color }}
-        />
+        <IconComponent style={{ color }} />
       </IconButton>
       <Hidden mdDown>
         <OtherActionsDesktop

--- a/web/src/app/util/OtherActions.js
+++ b/web/src/app/util/OtherActions.js
@@ -22,18 +22,21 @@ export default function OtherActions({ color, icon, actions, placement }) {
 
   return (
     <React.Fragment>
-      <span ref={ref}>
+      <IconButton
+        size='large'
+        onClick={(e) => {
+          onClose.cancel()
+          setAnchorEl(e.currentTarget)
+        }}
+        ref={ref}
+      >
         {React.cloneElement(icon, {
           'aria-label': 'Other Actions',
           'data-cy': 'other-actions',
           color: color || 'inherit',
           'aria-expanded': Boolean(anchorEl),
-          onClick: (e) => {
-            onClose.cancel()
-            setAnchorEl(e.currentTarget)
-          },
         })}
-      </span>
+      </IconButton>
       <Hidden mdDown>
         <OtherActionsDesktop
           isOpen={Boolean(anchorEl)}
@@ -67,10 +70,6 @@ OtherActions.propTypes = {
 }
 
 OtherActions.defaultProps = {
-  icon: (
-    <IconButton size='large'>
-      <OptionsIcon />
-    </IconButton>
-  ),
+  icon: <OptionsIcon />,
   placement: 'left',
 }


### PR DESCRIPTION
Cleans up the implementation of the Icon and IconButton in `OtherActions`. If an icon was provided as a prop, it wouldn't be rendered with an `IconButton` as it was only being added to the JSX from the `defaultProps` section.

Also fixes the color of an IconButton for the `AlertsListFilter` to match the checkbox OtherActions within the page, for consistency.