### PR TITLE
ui/deps: use recommended react-router v5.1 hooks

### DIFF
--- a/web/src/app/alerts/pages/AlertDetailPage.js
+++ b/web/src/app/alerts/pages/AlertDetailPage.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { gql, useQuery } from '@apollo/client'
+import { useParams } from 'react-router-dom'
 import { GenericError, ObjectNotFound } from '../../error-pages'
 import Spinner from '../../loading/components/Spinner'
 import AlertDetails from '../components/AlertDetails'
@@ -41,9 +42,10 @@ const query = gql`
   }
 `
 
-function AlertDetailPage(props) {
+function AlertDetailPage() {
+  const { alertID } = useParams()
   const { loading, error, data } = useQuery(query, {
-    variables: { id: props.match.params.alertID },
+    variables: { id: alertID },
   })
 
   if (!data && loading) return <Spinner />

--- a/web/src/app/escalation-policies/PolicyDetails.js
+++ b/web/src/app/escalation-policies/PolicyDetails.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 import { useQuery, gql } from '@apollo/client'
-import p from 'prop-types'
-import { Redirect } from 'react-router-dom'
+import { Redirect, useParams } from 'react-router-dom'
 import _ from 'lodash'
 import { Edit, Delete } from '@mui/icons-material'
 
@@ -33,7 +32,8 @@ const query = gql`
   }
 `
 
-export default function PolicyDetails(props) {
+export default function PolicyDetails() {
+  const { escalationPolicyID } = useParams()
   const stepNumParam = 'createStep'
   const [createStep, setCreateStep] = useURLParam(stepNumParam, false)
   const resetCreateStep = useResetURLParams(stepNumParam)
@@ -47,7 +47,7 @@ export default function PolicyDetails(props) {
     data: _data,
   } = useQuery(query, {
     variables: {
-      id: props.escalationPolicyID,
+      id: escalationPolicyID,
     },
   })
 
@@ -118,8 +118,4 @@ export default function PolicyDetails(props) {
       )}
     </React.Fragment>
   )
-}
-
-PolicyDetails.propTypes = {
-  escalationPolicyID: p.string.isRequired,
 }

--- a/web/src/app/escalation-policies/PolicyRouter.js
+++ b/web/src/app/escalation-policies/PolicyRouter.js
@@ -42,32 +42,18 @@ export default function PolicyRouter() {
     )
   }
 
-  function renderDetails({ match }) {
-    return (
-      <PolicyDetails escalationPolicyID={match.params.escalationPolicyID} />
-    )
-  }
-
-  function renderServices({ match }) {
-    return (
-      <PolicyServicesQuery
-        escalationPolicyID={match.params.escalationPolicyID}
-      />
-    )
-  }
-
   return (
     <Switch>
       <Route exact path='/escalation-policies' render={renderList} />
       <Route
         exact
         path='/escalation-policies/:escalationPolicyID'
-        render={renderDetails}
+        component={PolicyDetails}
       />
       <Route
         exact
         path='/escalation-policies/:escalationPolicyID/services'
-        render={renderServices}
+        component={PolicyServicesQuery}
       />
       <Route component={PageNotFound} />
     </Switch>

--- a/web/src/app/escalation-policies/PolicyServicesQuery.js
+++ b/web/src/app/escalation-policies/PolicyServicesQuery.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { gql, useQuery } from '@apollo/client'
-import { PropTypes as p } from 'prop-types'
+import { useParams } from 'react-router-dom'
 import PolicyServicesCard from './PolicyServicesCard'
 import Spinner from '../loading/components/Spinner'
 import { GenericError, ObjectNotFound } from '../error-pages'
@@ -17,9 +17,10 @@ const query = gql`
   }
 `
 
-function PolicyServicesQuery(props) {
+function PolicyServicesQuery() {
+  const { escalationPolicyID } = useParams()
   const { data, loading, error } = useQuery(query, {
-    variables: { id: props.escalationPolicyID },
+    variables: { id: escalationPolicyID },
   })
 
   if (!data && loading) {
@@ -37,10 +38,6 @@ function PolicyServicesQuery(props) {
   return (
     <PolicyServicesCard services={data.escalationPolicy.assignedTo || []} />
   )
-}
-
-PolicyServicesQuery.propTypes = {
-  escalationPolicyID: p.string.isRequired,
 }
 
 export default PolicyServicesQuery

--- a/web/src/app/main/components/ToolbarTitle.js
+++ b/web/src/app/main/components/ToolbarTitle.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import p from 'prop-types'
 import Typography from '@mui/material/Typography'
-import { Switch, Route } from 'react-router-dom'
+import { Switch, Route, useParams } from 'react-router-dom'
 import makeStyles from '@mui/styles/makeStyles'
 import { ChevronRight } from '@mui/icons-material'
 import { gql, useQuery } from '@apollo/client'
@@ -112,22 +112,23 @@ function ToolbarTitle() {
     )
   }
 
-  const detailsText = (match) => {
-    const typeName = startCase(match.params.type)
+  const detailsText = (type) => {
+    const typeName = startCase(type)
     return (
       (mapSingular[typeName] || typeName) +
-      (match.params.type !== 'profile' ? ' Details' : '')
+      (type !== 'profile' ? ' Details' : '')
     )
   }
 
-  const renderSubPageTitle = ({ match }) => {
-    const sub = startCase(match.params.sub)
+  function SubPageTitle() {
+    const { sub: _sub, type, id } = useParams()
+    const sub = startCase(_sub)
 
     if (fullScreen) {
       // mobile, only render current title
       return renderTitle(sub)
     }
-    const query = queries[match.params.type]
+    const query = queries[type]
 
     return (
       <div className={classes.div}>
@@ -140,13 +141,9 @@ function ToolbarTitle() {
           to='..'
         >
           {query ? (
-            <NameLoader
-              id={match.params.id}
-              query={query}
-              fallback={detailsText(match)}
-            />
+            <NameLoader id={id} query={query} fallback={detailsText(type)} />
           ) : (
-            detailsText(match)
+              detailsText(type)
           )}
         </Typography>
         <ChevronRight />
@@ -155,43 +152,45 @@ function ToolbarTitle() {
     )
   }
 
-  const renderDetailsPageTitle = ({ match }) => {
-    return renderTitle(detailsText(match))
+  function DetailsPageTitle() {
+    const { type } = useParams()
+    return renderTitle(detailsText(type))
   }
 
-  const renderTopLevelTitle = ({ match }) => {
-    return renderTitle(startCase(match.params.type))
+  function TopLevelTitle() {
+    const { type } = useParams()
+    return renderTitle(startCase(type))
   }
 
   return (
     <Switch>
       <Route
         path='/:type(escalation-policies)/:id/:sub(services)'
-        render={renderSubPageTitle}
+        component={SubPageTitle}
       />
       <Route
         path='/:type(services)/:id/:sub(alerts|integration-keys|heartbeat-monitors|labels|alert-metrics)'
-        render={renderSubPageTitle}
+        component={SubPageTitle}
       />
       <Route
         path='/:type(users)/:id/:sub(on-call-assignments|schedule-calendar-subscriptions|sessions)'
-        render={renderSubPageTitle}
+        component={SubPageTitle}
       />
       <Route
         path='/:type(profile)/:sub(on-call-assignments|schedule-calendar-subscriptions|sessions)'
-        render={renderSubPageTitle}
+        component={SubPageTitle}
       />
       <Route
         path='/:type(schedules)/:id/:sub(assignments|on-call-notifications|escalation-policies|overrides|shifts)'
-        render={renderSubPageTitle}
+        component={SubPageTitle}
       />
       <Route
         path='/:type(alerts|rotations|schedules|escalation-policies|services|users)/:id'
-        render={renderDetailsPageTitle}
+        component={DetailsPageTitle}
       />
       <Route
         path='/:type(alerts|rotations|schedules|escalation-policies|services|users|profile)'
-        render={renderTopLevelTitle}
+        component={TopLevelTitle}
       />
       <Route path='/wizard' render={() => renderTitle('Setup Wizard')} />
       <Route path='/admin' render={() => renderTitle('Admin Page')} />

--- a/web/src/app/main/components/ToolbarTitle.js
+++ b/web/src/app/main/components/ToolbarTitle.js
@@ -143,7 +143,7 @@ function ToolbarTitle() {
           {query ? (
             <NameLoader id={id} query={query} fallback={detailsText(type)} />
           ) : (
-              detailsText(type)
+            detailsText(type)
           )}
         </Typography>
         <ChevronRight />

--- a/web/src/app/rotations/RotationDetails.js
+++ b/web/src/app/rotations/RotationDetails.js
@@ -1,8 +1,7 @@
 import React, { useState } from 'react'
 import { gql, useQuery } from '@apollo/client'
-import p from 'prop-types'
 import _ from 'lodash'
-import { Redirect } from 'react-router-dom'
+import { Redirect, useParams } from 'react-router-dom'
 import { Edit, Delete } from '@mui/icons-material'
 
 import CreateFAB from '../lists/CreateFAB'
@@ -38,7 +37,8 @@ const query = gql`
   }
 `
 
-export default function RotationDetails({ rotationID }) {
+export default function RotationDetails() {
+  const { rotationID } = useParams()
   const [showEdit, setShowEdit] = useState(false)
   const [showDelete, setShowDelete] = useState(false)
   const [showAddUser, setShowAddUser] = useState(false)
@@ -112,8 +112,4 @@ export default function RotationDetails({ rotationID }) {
       />
     </React.Fragment>
   )
-}
-
-RotationDetails.propTypes = {
-  rotationID: p.string.isRequired,
 }

--- a/web/src/app/rotations/RotationRouter.js
+++ b/web/src/app/rotations/RotationRouter.js
@@ -44,13 +44,7 @@ export default function RotationRouter() {
   return (
     <Switch>
       <Route exact path='/rotations' render={renderList} />
-      <Route
-        exact
-        path='/rotations/:rotationID'
-        render={({ match }) => (
-          <RotationDetails rotationID={match.params.rotationID} />
-        )}
-      />
+      <Route exact path='/rotations/:rotationID' component={RotationDetails} />
       <Route component={PageNotFound} />
     </Switch>
   )

--- a/web/src/app/schedules/ScheduleAssignedToList.js
+++ b/web/src/app/schedules/ScheduleAssignedToList.js
@@ -3,7 +3,7 @@ import { gql } from '@apollo/client'
 import Query from '../util/Query'
 import FlatList from '../lists/FlatList'
 import Card from '@mui/material/Card'
-import p from 'prop-types'
+import { useParams } from 'react-router-dom'
 
 const query = gql`
   query ($id: ID!) {
@@ -18,7 +18,8 @@ const query = gql`
   }
 `
 
-export default function ScheduleAssignedToList(props) {
+export default function ScheduleAssignedToList() {
+  const { scheduleID } = useParams()
   function renderList({ data }) {
     return (
       <Card style={{ width: '100%' }}>
@@ -34,14 +35,6 @@ export default function ScheduleAssignedToList(props) {
   }
 
   return (
-    <Query
-      query={query}
-      variables={{ id: props.scheduleID }}
-      render={renderList}
-    />
+    <Query query={query} variables={{ id: scheduleID }} render={renderList} />
   )
-}
-
-ScheduleAssignedToList.propTypes = {
-  scheduleID: p.string.isRequired,
 }

--- a/web/src/app/schedules/ScheduleDetails.tsx
+++ b/web/src/app/schedules/ScheduleDetails.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react'
 import { gql, useQuery } from '@apollo/client'
-import { Redirect } from 'react-router-dom'
+import { Redirect, useParams } from 'react-router-dom'
 import _ from 'lodash'
 import { Edit, Delete } from '@mui/icons-material'
 
@@ -60,13 +60,8 @@ export const ScheduleCalendarContext =
     setOverrideDialog: () => {},
   })
 
-interface ScheduleDetailsProps {
-  scheduleID: string
-}
-
-export default function ScheduleDetails({
-  scheduleID,
-}: ScheduleDetailsProps): JSX.Element {
+export default function ScheduleDetails(): JSX.Element {
+  const { scheduleID } = useParams<{ scheduleID: string }>()
   const [showEdit, setShowEdit] = useState(false)
   const [showDelete, setShowDelete] = useState(false)
   const [configTempSchedule, setConfigTempSchedule] =

--- a/web/src/app/schedules/ScheduleOverrideList.js
+++ b/web/src/app/schedules/ScheduleOverrideList.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
-import p from 'prop-types'
 import { Grid, FormControlLabel, Switch } from '@mui/material'
+import { useParams } from 'react-router-dom'
 import QueryList from '../lists/QueryList'
 import { gql } from '@apollo/client'
 import { UserAvatar } from '../util/avatars'
@@ -41,7 +41,8 @@ const query = gql`
   }
 `
 
-export default function ScheduleOverrideList(props) {
+export default function ScheduleOverrideList() {
+  const { scheduleID } = useParams()
   const [editID, setEditID] = useState(null)
   const [deleteID, setDeleteID] = useState(null)
   const [create, setCreate] = useState(null)
@@ -106,7 +107,7 @@ export default function ScheduleOverrideList(props) {
         })}
         variables={{
           input: {
-            scheduleID: props.scheduleID,
+            scheduleID: scheduleID,
             start: showPast ? null : new Date().toISOString(),
             filterAnyUserID: userFilter,
           },
@@ -126,7 +127,7 @@ export default function ScheduleOverrideList(props) {
               />
             </Grid>
             <Grid item xs={12}>
-              <ScheduleTZFilter scheduleID={props.scheduleID} />
+              <ScheduleTZFilter scheduleID={scheduleID} />
             </Grid>
             <Grid item xs={12}>
               <UserSelect
@@ -141,7 +142,7 @@ export default function ScheduleOverrideList(props) {
       />
       {create && (
         <ScheduleOverrideCreateDialog
-          scheduleID={props.scheduleID}
+          scheduleID={scheduleID}
           variant={create}
           onClose={() => setCreate(null)}
         />
@@ -160,8 +161,4 @@ export default function ScheduleOverrideList(props) {
       )}
     </React.Fragment>
   )
-}
-
-ScheduleOverrideList.propTypes = {
-  scheduleID: p.string.isRequired,
 }

--- a/web/src/app/schedules/ScheduleRouter.js
+++ b/web/src/app/schedules/ScheduleRouter.js
@@ -48,44 +48,26 @@ export default function ScheduleRouter() {
   return (
     <Switch>
       <Route exact path='/schedules' component={ScheduleList} />
-      <Route
-        exact
-        path='/schedules/:scheduleID'
-        render={({ match }) => (
-          <ScheduleDetails scheduleID={match.params.scheduleID} />
-        )}
-      />
+      <Route exact path='/schedules/:scheduleID' component={ScheduleDetails} />
       <Route
         path='/schedules/:scheduleID/assignments'
-        render={({ match }) => (
-          <ScheduleRuleList scheduleID={match.params.scheduleID} />
-        )}
+        component={ScheduleRuleList}
       />
       <Route
         path='/schedules/:scheduleID/on-call-notifications'
-        render={({ match }) => (
-          <ScheduleOnCallNotificationsList
-            scheduleID={match.params.scheduleID}
-          />
-        )}
+        component={ScheduleOnCallNotificationsList}
       />
       <Route
         path='/schedules/:scheduleID/escalation-policies'
-        render={({ match }) => (
-          <ScheduleAssignedToList scheduleID={match.params.scheduleID} />
-        )}
+        component={ScheduleAssignedToList}
       />
       <Route
         path='/schedules/:scheduleID/overrides'
-        render={({ match }) => (
-          <ScheduleOverrideList scheduleID={match.params.scheduleID} />
-        )}
+        component={ScheduleOverrideList}
       />
       <Route
         path='/schedules/:scheduleID/shifts'
-        render={({ match }) => (
-          <ScheduleShiftList scheduleID={match.params.scheduleID} />
-        )}
+        component={ScheduleShiftList}
       />
       <Route component={PageNotFound} />
     </Switch>

--- a/web/src/app/schedules/ScheduleRuleList.js
+++ b/web/src/app/schedules/ScheduleRuleList.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
-import p from 'prop-types'
 import { gql, useQuery } from '@apollo/client'
+import { useParams } from 'react-router-dom'
 import FlatList from '../lists/FlatList'
 import { ScheduleTZFilter } from './ScheduleTZFilter'
 import { Grid, Card } from '@mui/material'
@@ -40,7 +40,8 @@ const query = gql`
   }
 `
 
-export default function ScheduleRuleList(props) {
+export default function ScheduleRuleList() {
+  const { scheduleID } = useParams()
   const [editTarget, setEditTarget] = useState(null)
   const [deleteTarget, setDeleteTarget] = useState(null)
   const [createType, setCreateType] = useState(null)
@@ -49,7 +50,7 @@ export default function ScheduleRuleList(props) {
   const resetFilter = useResetURLParams('tz')
 
   const { data, loading, error } = useQuery(query, {
-    variables: { id: props.scheduleID },
+    variables: { id: scheduleID },
     pollInterval: 0,
   })
 
@@ -122,7 +123,7 @@ export default function ScheduleRuleList(props) {
             headerAction={
               <FilterContainer onReset={() => resetFilter()}>
                 <Grid item xs={12}>
-                  <ScheduleTZFilter scheduleID={props.scheduleID} />
+                  <ScheduleTZFilter scheduleID={scheduleID} />
                 </Grid>
               </FilterContainer>
             }
@@ -133,21 +134,21 @@ export default function ScheduleRuleList(props) {
         {createType && (
           <ScheduleRuleCreateDialog
             targetType={createType}
-            scheduleID={props.scheduleID}
+            scheduleID={scheduleID}
             onClose={() => setCreateType(null)}
           />
         )}
         {editTarget && (
           <ScheduleRuleEditDialog
             target={editTarget}
-            scheduleID={props.scheduleID}
+            scheduleID={scheduleID}
             onClose={() => setEditTarget(null)}
           />
         )}
         {deleteTarget && (
           <ScheduleRuleDeleteDialog
             target={deleteTarget}
-            scheduleID={props.scheduleID}
+            scheduleID={scheduleID}
             onClose={() => setDeleteTarget(null)}
           />
         )}
@@ -156,8 +157,4 @@ export default function ScheduleRuleList(props) {
   }
 
   return renderList(data.schedule.targets, data.schedule.timeZone)
-}
-
-ScheduleRuleList.propTypes = {
-  scheduleID: p.string.isRequired,
 }

--- a/web/src/app/schedules/ScheduleShiftList.js
+++ b/web/src/app/schedules/ScheduleShiftList.js
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react'
 import { DateTime, Duration, Interval } from 'luxon'
-import p from 'prop-types'
+import { useParams } from 'react-router-dom'
 import FlatList from '../lists/FlatList'
 import { gql, useQuery } from '@apollo/client'
 import { relativeDate } from '../util/timeFormat'
@@ -57,7 +57,8 @@ const useStyles = makeStyles({
   },
 })
 
-function ScheduleShiftList({ scheduleID }) {
+function ScheduleShiftList() {
+  const { scheduleID } = useParams()
   const classes = useStyles()
 
   const [create, setCreate] = useState(null)
@@ -304,10 +305,6 @@ function ScheduleShiftList({ scheduleID }) {
       )}
     </React.Fragment>
   )
-}
-
-ScheduleShiftList.propTypes = {
-  scheduleID: p.string.isRequired,
 }
 
 export default ScheduleShiftList

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsList.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsList.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { Grid, Card } from '@mui/material'
 import Avatar from '@mui/material/Avatar'
+import { useParams } from 'react-router-dom'
 
 import FlatList from '../../lists/FlatList'
 import OtherActions from '../../util/OtherActions'
@@ -12,17 +13,12 @@ import ScheduleOnCallNotificationsDeleteDialog from './ScheduleOnCallNotificatio
 import CreateFAB from '../../lists/CreateFAB'
 import ScheduleOnCallNotificationsEditDialog from './ScheduleOnCallNotificationsEditDialog'
 
-interface ScheduleOnCallNotificationsListProps {
-  scheduleID: string
-}
-
-export default function ScheduleOnCallNotificationsList(
-  props: ScheduleOnCallNotificationsListProps,
-): JSX.Element {
+export default function ScheduleOnCallNotificationsList(): JSX.Element {
+  const { scheduleID } = useParams<{ scheduleID: string }>()
   const [createRule, setCreateRule] = useState(false)
   const [editRuleID, setEditRuleID] = useState('')
   const [deleteRuleID, setDeleteRuleID] = useState('')
-  const { q, zone, rules } = useOnCallRulesData(props.scheduleID)
+  const { q, zone, rules } = useOnCallRulesData(scheduleID)
 
   return (
     <React.Fragment>
@@ -68,20 +64,20 @@ export default function ScheduleOnCallNotificationsList(
       </Grid>
       {createRule && (
         <ScheduleOnCallNotificationsCreateDialog
-          scheduleID={props.scheduleID}
+          scheduleID={scheduleID}
           onClose={() => setCreateRule(false)}
         />
       )}
       {editRuleID && (
         <ScheduleOnCallNotificationsEditDialog
-          scheduleID={props.scheduleID}
+          scheduleID={scheduleID}
           ruleID={editRuleID}
           onClose={() => setEditRuleID('')}
         />
       )}
       {deleteRuleID && (
         <ScheduleOnCallNotificationsDeleteDialog
-          scheduleID={props.scheduleID}
+          scheduleID={scheduleID}
           ruleID={deleteRuleID}
           onClose={() => setDeleteRuleID('')}
         />

--- a/web/src/app/services/AlertMetrics/AlertMetrics.tsx
+++ b/web/src/app/services/AlertMetrics/AlertMetrics.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 import { Box, Card, CardContent, CardHeader, Grid } from '@mui/material'
 import { useQuery, gql } from '@apollo/client'
 import { DateTime } from 'luxon'
+import { useParams } from 'react-router-dom'
 import { useURLParams } from '../../actions/hooks'
 import AlertMetricsFilter, {
   DATE_FORMAT,
@@ -44,15 +45,11 @@ const query = gql`
     }
   }
 `
-interface AlertMetricsProps {
-  serviceID: string
-}
 
 const QUERY_LIMIT = 100
 
-export default function AlertMetrics({
-  serviceID,
-}: AlertMetricsProps): JSX.Element {
+export default function AlertMetrics(): JSX.Element {
+  const { serviceID } = useParams<{ serviceID: string }>()
   const now = useMemo(() => DateTime.now(), [])
   const minDate = now.minus({ days: MAX_DAY_COUNT - 1 }).startOf('day')
   const maxDate = now.endOf('day')

--- a/web/src/app/services/HeartbeatMonitorList.js
+++ b/web/src/app/services/HeartbeatMonitorList.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { gql } from '@apollo/client'
-import p from 'prop-types'
+import { useParams } from 'react-router-dom'
 import Grid from '@mui/material/Grid'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
@@ -54,7 +54,8 @@ const sortItems = (a, b) => {
   return 0
 }
 
-export default function HeartbeatMonitorList(props) {
+export default function HeartbeatMonitorList() {
+  const { serviceID } = useParams()
   const classes = useStyles()
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [showEditDialogByID, setShowEditDialogByID] = useState(null)
@@ -114,7 +115,7 @@ export default function HeartbeatMonitorList(props) {
           <CardContent>
             <Query
               query={query}
-              variables={{ serviceID: props.serviceID }}
+              variables={{ serviceID: serviceID }}
               render={({ data }) => renderList(data.service.heartbeatMonitors)}
             />
           </CardContent>
@@ -126,7 +127,7 @@ export default function HeartbeatMonitorList(props) {
       />
       {showCreateDialog && (
         <HeartbeatMonitorCreateDialog
-          serviceID={props.serviceID}
+          serviceID={serviceID}
           onClose={() => setShowCreateDialog(false)}
         />
       )}
@@ -144,7 +145,4 @@ export default function HeartbeatMonitorList(props) {
       )}
     </React.Fragment>
   )
-}
-HeartbeatMonitorList.propTypes = {
-  serviceID: p.string.isRequired,
 }

--- a/web/src/app/services/IntegrationKeyList.js
+++ b/web/src/app/services/IntegrationKeyList.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { gql, useQuery } from '@apollo/client'
 import p from 'prop-types'
+import { useParams } from 'react-router-dom'
 import Grid from '@mui/material/Grid'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
@@ -84,14 +85,15 @@ IntegrationKeyDetails.propTypes = {
   type: p.string.isRequired,
 }
 
-export default function IntegrationKeyList(props) {
+export default function IntegrationKeyList() {
+  const { serviceID } = useParams()
   const classes = useStyles()
 
   const [create, setCreate] = useState(false)
   const [deleteDialog, setDeleteDialog] = useState(null)
 
   const { loading, error, data } = useQuery(query, {
-    variables: { serviceID: props.serviceID },
+    variables: { serviceID: serviceID },
   })
 
   const typeLabels = {
@@ -149,7 +151,7 @@ export default function IntegrationKeyList(props) {
       />
       {create && (
         <IntegrationKeyCreateDialog
-          serviceID={props.serviceID}
+          serviceID={serviceID}
           onClose={() => setCreate(false)}
         />
       )}
@@ -161,8 +163,4 @@ export default function IntegrationKeyList(props) {
       )}
     </React.Fragment>
   )
-}
-
-IntegrationKeyList.propTypes = {
-  serviceID: p.string.isRequired,
 }

--- a/web/src/app/services/ServiceAlerts.js
+++ b/web/src/app/services/ServiceAlerts.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { gql, useMutation } from '@apollo/client'
-import { PropTypes as p } from 'prop-types'
+import { useParams } from 'react-router-dom'
 import Button from '@mui/material/Button'
 import ButtonGroup from '@mui/material/ButtonGroup'
 import Grid from '@mui/material/Grid'
@@ -22,8 +22,8 @@ const useStyles = makeStyles({
   },
 })
 
-export default function ServiceAlerts(props) {
-  const { serviceID } = props
+export default function ServiceAlerts() {
+  const { serviceID } = useParams()
   const classes = useStyles()
 
   const [alertStatus, setAlertStatus] = useState('')
@@ -88,8 +88,4 @@ export default function ServiceAlerts(props) {
       <AlertsList serviceID={serviceID} secondaryActions={secondaryActions} />
     </React.Fragment>
   )
-}
-
-ServiceAlerts.propTypes = {
-  serviceID: p.string.isRequired,
 }

--- a/web/src/app/services/ServiceDetails.js
+++ b/web/src/app/services/ServiceDetails.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
-import p from 'prop-types'
 import { gql, useQuery } from '@apollo/client'
-import { Redirect } from 'react-router-dom'
+import { Redirect, useParams } from 'react-router-dom'
 import _ from 'lodash'
 import { Edit, Delete } from '@mui/icons-material'
 
@@ -69,7 +68,8 @@ const alertStatus = (a) => {
   return 'warn'
 }
 
-export default function ServiceDetails({ serviceID }) {
+export default function ServiceDetails() {
+  const { serviceID } = useParams()
   const [showEdit, setShowEdit] = useState(false)
   const [showDelete, setShowDelete] = useState(false)
   const { data, loading, error } = useQuery(query, {
@@ -164,8 +164,4 @@ export default function ServiceDetails({ serviceID }) {
       )}
     </React.Fragment>
   )
-}
-
-ServiceDetails.propTypes = {
-  serviceID: p.string.isRequired,
 }

--- a/web/src/app/services/ServiceLabelList.js
+++ b/web/src/app/services/ServiceLabelList.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import p from 'prop-types'
+import { useParams } from 'react-router-dom'
 import Grid from '@mui/material/Grid'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
@@ -36,7 +36,8 @@ const sortItems = (a, b) => {
 
 const useStyles = makeStyles({ spacing: { marginBottom: 96 } })
 
-export default function ServiceLabelList({ serviceID }) {
+export default function ServiceLabelList() {
+  const { serviceID } = useParams()
   const [create, setCreate] = useState(false)
   const [editKey, setEditKey] = useState(null)
   const [deleteKey, setDeleteKey] = useState(null)
@@ -114,8 +115,4 @@ export default function ServiceLabelList({ serviceID }) {
       )}
     </React.Fragment>
   )
-}
-
-ServiceLabelList.propTypes = {
-  serviceID: p.string.isRequired,
 }

--- a/web/src/app/services/ServiceRouter.js
+++ b/web/src/app/services/ServiceRouter.js
@@ -62,50 +62,34 @@ export default function ServiceRouter() {
     )
   }
 
-  function renderDetails({ match }) {
-    return <ServiceDetails serviceID={match.params.serviceID} />
-  }
-
-  function renderAlerts({ match }) {
-    return <ServiceAlerts serviceID={match.params.serviceID} />
-  }
-
-  function renderKeys({ match }) {
-    return <IntegrationKeyList serviceID={match.params.serviceID} />
-  }
-
-  function renderHeartbeatMonitors({ match }) {
-    return <HeartbeatMonitorList serviceID={match.params.serviceID} />
-  }
-
-  function renderLabels({ match }) {
-    return <ServiceLabelList serviceID={match.params.serviceID} />
-  }
-
-  function renderAlertMetrics({ match }) {
-    return <AlertMetrics serviceID={match.params.serviceID} />
-  }
-
   return (
     <Switch>
       <Route exact path='/services' render={renderList} />
-      <Route exact path='/services/:serviceID/alerts' render={renderAlerts} />
-      <Route exact path='/services/:serviceID' render={renderDetails} />
+      <Route
+        exact
+        path='/services/:serviceID/alerts'
+        component={ServiceAlerts}
+      />
+      <Route exact path='/services/:serviceID' component={ServiceDetails} />
       <Route
         exact
         path='/services/:serviceID/integration-keys'
-        render={renderKeys}
+        component={IntegrationKeyList}
       />
       <Route
         exact
         path='/services/:serviceID/heartbeat-monitors'
-        render={renderHeartbeatMonitors}
+        component={HeartbeatMonitorList}
       />
-      <Route exact path='/services/:serviceID/labels' render={renderLabels} />
+      <Route
+        exact
+        path='/services/:serviceID/labels'
+        component={ServiceLabelList}
+      />
       <Route
         exact
         path='/services/:serviceID/alert-metrics'
-        render={renderAlertMetrics}
+        component={AlertMetrics}
       />
       <Route component={PageNotFound} />
     </Switch>

--- a/web/src/app/users/UserCalendarSubscriptionList.js
+++ b/web/src/app/users/UserCalendarSubscriptionList.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { useQuery, gql } from '@apollo/client'
+import p from 'prop-types'
 import { useParams } from 'react-router-dom'
 import { Card, Alert } from '@mui/material'
 import FlatList from '../lists/FlatList'
@@ -35,8 +36,9 @@ export const calendarSubscriptionsQuery = gql`
   }
 `
 
-export default function UserCalendarSubscriptionList() {
-  const { userID } = useParams()
+export default function UserCalendarSubscriptionList(props) {
+  const { userID: _userID } = useParams()
+  const userID = props.userID || _userID
   const [creationDisabled] = useConfigValue(
     'General.DisableCalendarSubscriptions',
   )
@@ -149,4 +151,8 @@ export default function UserCalendarSubscriptionList() {
       )}
     </React.Fragment>
   )
+}
+
+UserCalendarSubscriptionList.propTypes = {
+  userID: p.string,
 }

--- a/web/src/app/users/UserCalendarSubscriptionList.js
+++ b/web/src/app/users/UserCalendarSubscriptionList.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { useQuery, gql } from '@apollo/client'
-import { PropTypes as p } from 'prop-types'
+import { useParams } from 'react-router-dom'
 import { Card, Alert } from '@mui/material'
 import FlatList from '../lists/FlatList'
 import OtherActions from '../util/OtherActions'
@@ -35,7 +35,8 @@ export const calendarSubscriptionsQuery = gql`
   }
 `
 
-export default function UserCalendarSubscriptionList(props) {
+export default function UserCalendarSubscriptionList() {
+  const { userID } = useParams()
   const [creationDisabled] = useConfigValue(
     'General.DisableCalendarSubscriptions',
   )
@@ -45,7 +46,7 @@ export default function UserCalendarSubscriptionList(props) {
 
   const { data, loading, error } = useQuery(calendarSubscriptionsQuery, {
     variables: {
-      id: props.userID,
+      id: userID,
     },
   })
 
@@ -148,8 +149,4 @@ export default function UserCalendarSubscriptionList(props) {
       )}
     </React.Fragment>
   )
-}
-
-UserCalendarSubscriptionList.propTypes = {
-  userID: p.string.isRequired,
 }

--- a/web/src/app/users/UserDetails.js
+++ b/web/src/app/users/UserDetails.js
@@ -225,7 +225,7 @@ export default function UserDetails(props) {
             : [
                 <StatusUpdateNotification
                   key='primary-action-status-updates'
-                userID={userID}
+                  userID={userID}
                 />,
               ]
         }
@@ -251,7 +251,7 @@ export default function UserDetails(props) {
             : [
                 <QuerySetFavoriteButton
                   key='secondary-action-favorite'
-                id={userID}
+                  id={userID}
                   type='user'
                 />,
               ]

--- a/web/src/app/users/UserDetails.js
+++ b/web/src/app/users/UserDetails.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { useQuery, gql } from '@apollo/client'
 import p from 'prop-types'
+import { useParams } from 'react-router-dom'
 import Delete from '@mui/icons-material/Delete'
 import EditIcon from '@mui/icons-material/Edit'
 import DetailsPage from '../details/DetailsPage'
@@ -85,6 +86,8 @@ function serviceCount(onCallSteps = []) {
 }
 
 export default function UserDetails(props) {
+  const { userID: _userID } = useParams()
+  const userID = props.userID || _userID
   const {
     userID: currentUserID,
     isAdmin,
@@ -101,13 +104,10 @@ export default function UserDetails(props) {
     data,
     loading: isQueryLoading,
     error,
-  } = useQuery(
-    isAdmin || props.userID === currentUserID ? profileQuery : userQuery,
-    {
-      variables: { id: props.userID },
-      skip: !isSessionReady,
-    },
-  )
+  } = useQuery(isAdmin || userID === currentUserID ? profileQuery : userQuery, {
+    variables: { id: userID },
+    skip: !isSessionReady,
+  })
 
   const loading = !isSessionReady || isQueryLoading
 
@@ -117,7 +117,7 @@ export default function UserDetails(props) {
   const user = _.get(data, 'user')
   const svcCount = serviceCount(user.onCallSteps)
   const sessCount =
-    isAdmin || props.userID === currentUserID ? user.sessions.length : 0
+    isAdmin || userID === currentUserID ? user.sessions.length : 0
 
   const disableNR = user.contactMethods.length === 0
 
@@ -131,7 +131,7 @@ export default function UserDetails(props) {
     },
   ]
 
-  if (props.userID === currentUserID) {
+  if (userID === currentUserID) {
     links.push({
       label: 'Schedule Calendar Subscriptions',
       url: 'schedule-calendar-subscriptions',
@@ -139,7 +139,7 @@ export default function UserDetails(props) {
     })
   }
 
-  if (isAdmin || props.userID === currentUserID) {
+  if (isAdmin || userID === currentUserID) {
     links.push({
       label: 'Active Sessions',
       url: 'sessions',
@@ -154,13 +154,13 @@ export default function UserDetails(props) {
       {showEdit && (
         <UserEditDialog
           onClose={() => setShowEdit(false)}
-          userID={props.userID}
+          userID={userID}
           role={user.role}
         />
       )}
       {showUserDeleteDialog && (
         <UserDeleteDialog
-          userID={props.userID}
+          userID={userID}
           onClose={() => setShowUserDeleteDialog(false)}
         />
       )}
@@ -184,7 +184,7 @@ export default function UserDetails(props) {
       )}
       {createCM && (
         <UserContactMethodCreateDialog
-          userID={props.userID}
+          userID={userID}
           disclaimer={disclaimer}
           onClose={(result) => {
             setCreateCM(false)
@@ -202,22 +202,19 @@ export default function UserDetails(props) {
       )}
       {createNR && (
         <UserNotificationRuleCreateDialog
-          userID={props.userID}
+          userID={userID}
           onClose={() => setCreateNR(false)}
         />
       )}
       <DetailsPage
-        avatar={<UserAvatar userID={props.userID} />}
+        avatar={<UserAvatar userID={userID} />}
         title={user.name + (svcCount ? ' (On-Call)' : '')}
         subheader={user.email}
         pageContent={
           <Grid container spacing={2}>
-            <UserContactMethodList
-              userID={props.userID}
-              readOnly={props.readOnly}
-            />
+            <UserContactMethodList userID={userID} readOnly={props.readOnly} />
             <UserNotificationRuleList
-              userID={props.userID}
+              userID={userID}
               readOnly={props.readOnly}
             />
           </Grid>
@@ -228,7 +225,7 @@ export default function UserDetails(props) {
             : [
                 <StatusUpdateNotification
                   key='primary-action-status-updates'
-                  userID={props.userID}
+                userID={userID}
                 />,
               ]
         }
@@ -247,14 +244,14 @@ export default function UserDetails(props) {
                 },
                 <QuerySetFavoriteButton
                   key='secondary-action-favorite'
-                  id={props.userID}
+                  id={userID}
                   type='user'
                 />,
               ]
             : [
                 <QuerySetFavoriteButton
                   key='secondary-action-favorite'
-                  id={props.userID}
+                id={userID}
                   type='user'
                 />,
               ]

--- a/web/src/app/users/UserDetails.js
+++ b/web/src/app/users/UserDetails.js
@@ -263,6 +263,6 @@ export default function UserDetails(props) {
 }
 
 UserDetails.propTypes = {
-  userID: p.string.isRequired,
+  userID: p.string,
   readOnly: p.bool,
 }

--- a/web/src/app/users/UserOnCallAssignmentList.tsx
+++ b/web/src/app/users/UserOnCallAssignmentList.tsx
@@ -82,9 +82,11 @@ function services(onCallSteps: OnCallStep[] = []): Service[] {
 }
 
 export default function UserOnCallAssignmentList(props: {
+  userID?: string
   currentUser?: boolean
 }): JSX.Element {
-  const { userID } = useParams<{ userID: string }>()
+  const { userID: _userID } = useParams<{ userID: string }>()
+  const userID = props.userID || _userID
   const { data, loading, error } = useQuery(query, {
     variables: { id: userID },
   })

--- a/web/src/app/users/UserOnCallAssignmentList.tsx
+++ b/web/src/app/users/UserOnCallAssignmentList.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { gql, useQuery } from '@apollo/client'
+import { useParams } from 'react-router-dom'
 import { Card } from '@mui/material'
 import FlatList from '../lists/FlatList'
 import { sortBy, values } from 'lodash'
@@ -81,11 +82,11 @@ function services(onCallSteps: OnCallStep[] = []): Service[] {
 }
 
 export default function UserOnCallAssignmentList(props: {
-  userID: string
   currentUser?: boolean
 }): JSX.Element {
+  const { userID } = useParams<{ userID: string }>()
   const { data, loading, error } = useQuery(query, {
-    variables: { id: props.userID },
+    variables: { id: userID },
   })
 
   if (!data && loading) {

--- a/web/src/app/users/UserRouter.js
+++ b/web/src/app/users/UserRouter.js
@@ -42,9 +42,7 @@ export default function UserRouter() {
       <Route
         exact
         path='/users/:userID'
-        render={({ match }) => (
-          <UserDetails userID={match.params.userID} readOnly />
-        )}
+        component={() => <UserDetails readOnly />}
       />
 
       <Route
@@ -55,17 +53,11 @@ export default function UserRouter() {
       <Route
         exact
         path='/users/:userID/on-call-assignments'
-        render={({ match }) => (
-          <UserOnCallAssignmentList userID={match.params.userID} />
-        )}
+        component={UserOnCallAssignmentList}
       />
 
       <Route exact path='/profile/sessions' component={UserSessionList} />
-      <Route
-        exact
-        path='/users/:userID/sessions'
-        render={({ match }) => <UserSessionList userID={match.params.userID} />}
-      />
+      <Route exact path='/users/:userID/sessions' component={UserSessionList} />
 
       <Route
         exact
@@ -75,9 +67,7 @@ export default function UserRouter() {
       <Route
         exact
         path='/users/:userID/schedule-calendar-subscriptions'
-        render={({ match }) => (
-          <UserCalendarSubscriptionList userID={match.params.userID} />
-        )}
+        component={UserCalendarSubscriptionList}
       />
 
       <Route component={PageNotFound} />

--- a/web/src/app/users/UserRouter.js
+++ b/web/src/app/users/UserRouter.js
@@ -39,11 +39,7 @@ export default function UserRouter() {
         path={[`/users/${userID}`, '/profile']}
         component={UserProfile}
       />
-      <Route
-        exact
-        path='/users/:userID'
-        component={() => <UserDetails readOnly />}
-      />
+      <Route exact path='/users/:userID' render={() => <UserDetails readOnly />} />
 
       <Route
         exact

--- a/web/src/app/users/UserRouter.js
+++ b/web/src/app/users/UserRouter.js
@@ -39,7 +39,11 @@ export default function UserRouter() {
         path={[`/users/${userID}`, '/profile']}
         component={UserProfile}
       />
-      <Route exact path='/users/:userID' render={() => <UserDetails readOnly />} />
+      <Route
+        exact
+        path='/users/:userID'
+        render={() => <UserDetails readOnly />}
+      />
 
       <Route
         exact

--- a/web/src/app/users/UserSessionList.tsx
+++ b/web/src/app/users/UserSessionList.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import FlatList from '../lists/FlatList'
+import { useParams } from 'react-router-dom'
 import {
   QueryHookOptions,
   useMutation,
@@ -58,10 +59,6 @@ const mutationLogoutAll = gql`
   }
 `
 
-export interface UserSessionListProps {
-  userID?: string
-}
-
 function friendlyUAString(ua: string): string {
   if (!ua) return 'Unknown device'
   const b = Bowser.getParser(ua)
@@ -90,13 +87,11 @@ type Session = {
   userAgent: string
 }
 
-export default function UserSessionList(
-  props: UserSessionListProps,
-): JSX.Element {
+export default function UserSessionList(): JSX.Element {
+  const { userID } = useParams<{ userID: string }>()
   // handles both logout all and logout individual sessions
   const [endSession, setEndSession] = useState<Session | 'all' | null>(null)
 
-  const userID = props.userID
   const options: QueryHookOptions = {}
   if (userID) {
     options.variables = { userID }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Upgrades to use `useParams()` hook for getting router's internal state as recommended by [react-router v5.1](https://reactrouter.com/docs/en/v6/upgrading/v5#upgrade-to-react-router-v51).

**Which issue(s) this PR fixes:**
Required for #2108 
