### PR TITLE
calsub: move subscription updates to gorm

### DIFF
--- a/calsub/render.go
+++ b/calsub/render.go
@@ -1,0 +1,81 @@
+package calsub
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"html/template"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/target/goalert/oncall"
+	"github.com/target/goalert/version"
+)
+
+type iCalRenderData struct {
+	ApplicationName string
+	Shifts          []oncall.Shift
+	ReminderMinutes []int
+	Version         string
+	GeneratedAt     time.Time
+	EventUIDs       []string
+}
+
+// RFC can be found at https://tools.ietf.org/html/rfc5545
+var iCalTemplate = template.Must(template.New("ical").Parse(strings.ReplaceAll(`BEGIN:VCALENDAR
+PRODID:-//{{.ApplicationName}}//{{.Version}}//EN
+VERSION:2.0
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+{{- $mins := .ReminderMinutes }}
+{{- $genTime := .GeneratedAt }}
+{{- $eventUIDs := .EventUIDs}}
+{{- range $i, $s := .Shifts}}
+BEGIN:VEVENT
+UID:{{index $eventUIDs $i}}
+SUMMARY:On-Call Shift{{if $s.Truncated}} Begins*
+DESCRIPTION:The end time of this shift is unknown and will continue beyond what is displayed.
+{{- end }}
+DTSTAMP:{{$genTime.UTC.Format "20060102T150405Z"}}
+DTSTART:{{.Start.UTC.Format "20060102T150405Z"}}
+DTEND:{{.End.UTC.Format "20060102T150405Z"}}
+{{- range $mins}}
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:REMINDER
+TRIGGER:-PT{{.}}M
+END:VALARM
+{{- end}}
+END:VEVENT
+{{- end}}
+END:VCALENDAR
+`, "\n", "\r\n")))
+
+func (cs Subscription) renderICalFromShifts(appName string, shifts []oncall.Shift, generatedAt time.Time) ([]byte, error) {
+	var eventUIDs []string
+	for _, s := range shifts {
+		t := s.End
+		if s.Truncated {
+			t = s.Start
+		}
+		sum := sha256.Sum256([]byte(s.UserID + cs.ScheduleID + t.Format(time.RFC3339)))
+		eventUIDs = append(eventUIDs, hex.EncodeToString(sum[:]))
+	}
+	data := iCalRenderData{
+		ApplicationName: appName,
+		Shifts:          shifts,
+		ReminderMinutes: cs.Config.ReminderMinutes,
+		Version:         version.GitVersion(),
+		GeneratedAt:     generatedAt,
+		EventUIDs:       eventUIDs,
+	}
+	buf := bytes.NewBuffer(nil)
+
+	err := iCalTemplate.Execute(buf, data)
+	if err != nil {
+		return nil, errors.Wrap(err, "render ical template:")
+	}
+
+	return buf.Bytes(), nil
+}

--- a/calsub/store.go
+++ b/calsub/store.go
@@ -21,15 +21,13 @@ import (
 
 // Store allows the lookup and management of calendar subscriptions
 type Store struct {
-	db         *sql.DB
-	findOne    *sql.Stmt
-	create     *sql.Stmt
-	update     *sql.Stmt
-	delete     *sql.Stmt
-	findAll    *sql.Stmt
-	findOneUpd *sql.Stmt
-	authUser   *sql.Stmt
-	now        *sql.Stmt
+	db       *sql.DB
+	findOne  *sql.Stmt
+	create   *sql.Stmt
+	delete   *sql.Stmt
+	findAll  *sql.Stmt
+	authUser *sql.Stmt
+	now      *sql.Stmt
 
 	keys keyring.Keyring
 	oc   oncall.Store
@@ -64,11 +62,6 @@ func NewStore(ctx context.Context, db *sql.DB, apiKeyring keyring.Keyring, oc on
 			VALUES ($1, $2, $3, $4, $5, $6)
 			RETURNING created_at
 		`),
-		update: p.P(`
-			UPDATE user_calendar_subscriptions
-			SET name = $3, disabled = $4, config = $5, last_update = now()
-			WHERE id = $1 AND user_id = $2
-		`),
 		delete: p.P(`
 			DELETE FROM user_calendar_subscriptions
 			WHERE id = any($1) AND user_id = $2
@@ -78,12 +71,6 @@ func NewStore(ctx context.Context, db *sql.DB, apiKeyring keyring.Keyring, oc on
 				id, name, user_id, disabled, schedule_id, config, last_access
 			FROM user_calendar_subscriptions
 			WHERE user_id = $1
-		`),
-		findOneUpd: p.P(`
-			SELECT
-				id, name, user_id, disabled, schedule_id, config, last_access
-			FROM user_calendar_subscriptions
-			WHERE id = $1 AND user_id = $2
 		`),
 	}, p.Err
 }

--- a/calsub/subscription.go
+++ b/calsub/subscription.go
@@ -11,12 +11,12 @@ import (
 
 // Subscription stores the information from user subscriptions
 type Subscription struct {
-	ID         string
+	ID         string `gorm:"<-:create"`
 	Name       string
-	UserID     string
-	ScheduleID string
+	UserID     string    `gorm:"<-:create"`
+	ScheduleID string    `gorm:"<-:create"`
 	LastUpdate time.Time `gorm:"autoUpdateTime"`
-	LastAccess time.Time
+	LastAccess time.Time `gorm:"<-:create"`
 	Disabled   bool
 
 	// Config provides necessary parameters CalendarSubscription Config (i.e. ReminderMinutes)
@@ -37,12 +37,10 @@ func (cs *Subscription) BeforeUpdate(db *gorm.DB) error {
 		return err
 	}
 
-	db.Statement.
-		// if not the same user, they will get not-found
-		Where("user_id = ?", permission.UserID(db.Statement.Context)).
+	// force user ID
+	cs.UserID = permission.UserID(db.Statement.Context)
+	db.Statement.Where(cs, "UserID")
 
-		// limit updatable fields
-		Select("name", "disabled", "config", "last_update")
 	return nil
 }
 

--- a/calsub/subscriptionconfig.go
+++ b/calsub/subscriptionconfig.go
@@ -1,0 +1,38 @@
+package calsub
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
+// SubscriptionConfig is the configuration for a calendar subscription.
+type SubscriptionConfig struct {
+	ReminderMinutes []int
+}
+
+var (
+	_ = driver.Valuer(SubscriptionConfig{})
+	_ = sql.Scanner(&SubscriptionConfig{})
+)
+
+func (scfg SubscriptionConfig) Value() (driver.Value, error) {
+	data, err := json.Marshal(scfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func (scfg *SubscriptionConfig) Scan(v interface{}) error {
+	switch v := v.(type) {
+	case []byte:
+		return json.Unmarshal(v, scfg)
+	case string:
+		return json.Unmarshal([]byte(v), scfg)
+	default:
+		return fmt.Errorf("unsupported type %T", v)
+	}
+}

--- a/graphql2/graphqlapp/calendarsubscription.go
+++ b/graphql2/graphqlapp/calendarsubscription.go
@@ -5,11 +5,16 @@ import (
 	"database/sql"
 	"net/url"
 
+	"github.com/pkg/errors"
 	"github.com/target/goalert/calsub"
 	"github.com/target/goalert/config"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/schedule"
+	"github.com/target/goalert/util/sqlutil"
+	"github.com/target/goalert/validation"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type UserCalendarSubscription App
@@ -21,9 +26,11 @@ func (a *App) UserCalendarSubscription() graphql2.UserCalendarSubscriptionResolv
 func (a *UserCalendarSubscription) ReminderMinutes(ctx context.Context, obj *calsub.Subscription) ([]int, error) {
 	return obj.Config.ReminderMinutes, nil
 }
+
 func (a *UserCalendarSubscription) Schedule(ctx context.Context, obj *calsub.Subscription) (*schedule.Schedule, error) {
 	return a.ScheduleStore.FindOne(ctx, obj.ScheduleID)
 }
+
 func (a *UserCalendarSubscription) URL(ctx context.Context, obj *calsub.Subscription) (*string, error) {
 	tok := obj.Token()
 	if tok == "" {
@@ -63,11 +70,17 @@ func (m *Mutation) CreateUserCalendarSubscription(ctx context.Context, input gra
 }
 
 func (m *Mutation) UpdateUserCalendarSubscription(ctx context.Context, input graphql2.UpdateUserCalendarSubscriptionInput) (bool, error) {
-	err := withContextTx(ctx, m.DB, func(ctx context.Context, tx *sql.Tx) error {
-		cs, err := m.CalSubStore.FindOneForUpdateTx(ctx, tx, permission.UserID(ctx), input.ID)
+	err := sqlutil.Transaction(ctx, func(ctx context.Context, db *gorm.DB) error {
+		var cs calsub.Subscription
+		err := db.
+			Where("id = ?", input.ID).
+			Where("user_id", permission.UserID(ctx)).
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Take(&cs).Error
 		if err != nil {
 			return err
 		}
+
 		if input.Name != nil {
 			cs.Name = *input.Name
 		}
@@ -77,7 +90,12 @@ func (m *Mutation) UpdateUserCalendarSubscription(ctx context.Context, input gra
 		if input.ReminderMinutes != nil {
 			cs.Config.ReminderMinutes = input.ReminderMinutes
 		}
-		return m.CalSubStore.UpdateTx(ctx, tx, cs)
+
+		return db.Save(&cs).Error
 	})
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return false, validation.NewGenericError("unknown calendar subscription id")
+	}
+
 	return err == nil, err
 }

--- a/graphql2/graphqlapp/calendarsubscription.go
+++ b/graphql2/graphqlapp/calendarsubscription.go
@@ -73,8 +73,10 @@ func (m *Mutation) UpdateUserCalendarSubscription(ctx context.Context, input gra
 	err := sqlutil.Transaction(ctx, func(ctx context.Context, db *gorm.DB) error {
 		var cs calsub.Subscription
 		err := db.
-			Where("id = ?", input.ID).
-			Where("user_id", permission.UserID(ctx)).
+			Where(calsub.Subscription{
+				ID:     input.ID,
+				UserID: permission.UserID(ctx),
+			}).
 			Clauses(clause.Locking{Strength: "UPDATE"}).
 			Take(&cs).Error
 		if err != nil {


### PR DESCRIPTION
**Description:**
This PR replaces `calsub.Subscription` Store updates with calls into form.

- added a `BeforeUpdate` hook with relevant validation and scope
- moved render/iCal to it's own file
