### PR TITLE
switchover/dbsync: add smoketest to detect table configuration problems

### DIFF
--- a/migrate/migrations/20220224125018-schedule-data-id.sql
+++ b/migrate/migrations/20220224125018-schedule-data-id.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+ALTER TABLE schedule_data
+    ADD COLUMN id BIGSERIAL UNIQUE NOT NULL;
+
+-- +migrate Down
+ALTER TABLE schedule_data
+    DROP COLUMN id;

--- a/smoketest/switchover_test.go
+++ b/smoketest/switchover_test.go
@@ -1,0 +1,20 @@
+package smoketest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/target/goalert/smoketest/harness"
+	"github.com/target/goalert/switchover/dbsync"
+)
+
+func TestDBSyncTables(t *testing.T) {
+	t.Parallel()
+
+	h := harness.NewHarness(t, "", "")
+	defer h.Close()
+
+	_, err := dbsync.Tables(context.Background(), h.App().DB())
+	assert.NoError(t, err)
+}

--- a/smoketest/switchover_test.go
+++ b/smoketest/switchover_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/target/goalert/switchover/dbsync"
 )
 
+// TestDBSyncTables ensures the latest state of the database is compatible with the dbsync package.
 func TestDBSyncTables(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**Description:**
This PR adds a unique `id` column to `schedule_data` required for switchover operation. Without it updating this table (or any missing a unique `id` column) in any way during a switchover would result in an error during the `change_log` trigger.

In addition, a smoketest has been added to detect this and any other configuration problems, like circular dependencies, during testing.
