### PR TITLE
graphql2/graphqlapp/alert: fix alert metrics query and graph

### DIFF
--- a/graphql2/graphqlapp/alert.go
+++ b/graphql2/graphqlapp/alert.go
@@ -250,8 +250,8 @@ func (q *Query) AlertMetrics(ctx context.Context, opts graphql2.AlertMetricsOpti
 
 	alerts, err := q.AlertStore.Search(ctx, &alert.SearchOptions{
 		Status:    []alert.Status{alert.StatusClosed},
-		Before:    opts.RInterval.Start,
-		NotBefore: opts.RInterval.End(),
+		NotBefore: opts.RInterval.Start,
+		Before:    opts.RInterval.End(),
 		ServiceFilter: alert.IDFilter{
 			IDs:   opts.FilterByServiceID,
 			Valid: true,

--- a/web/src/app/services/AlertMetrics/AlertMetrics.tsx
+++ b/web/src/app/services/AlertMetrics/AlertMetrics.tsx
@@ -80,7 +80,7 @@ export default function AlertMetrics(): JSX.Element {
       },
       alertMetricsInput: {
         rInterval: `R${Math.floor(
-          maxDate.diff(minDate, 'days').toObject().days || 0,
+          until.diff(since, 'days').days,
         )}/${since.toISO()}/P1D`,
         filterByServiceID: [serviceID],
       },


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR introduces 2 fixes for the alert metrics graph:
1. Fix the query bounds which were reversed
2. Fix the graph so it shows correct number of days per select option
