### PR TITLE
darkmode: fix generic errors and red-on-black for fav and links

### DIFF
--- a/web/src/app/error-pages/Errors.js
+++ b/web/src/app/error-pages/Errors.js
@@ -39,12 +39,13 @@ ObjectNotFound.propTypes = {
 }
 
 export function GenericError(props) {
+  const theme = useTheme()
   let errorText
   if (props.error) {
     errorText = <Typography variant='caption'>{props.error}</Typography>
   }
   return (
-    <div style={{ textAlign: 'center' }}>
+    <div style={{ textAlign: 'center', color: theme.palette.text.primary }}>
       <SentimentVeryDissatisfied style={{ height: '33vh', width: '33vw' }} />
       <Typography variant='h5'>Sorry, an error occurred.</Typography>
       {errorText}

--- a/web/src/app/main/App.js
+++ b/web/src/app/main/App.js
@@ -24,6 +24,13 @@ import { useIsWidthDown } from '../util/useWidth'
 import { isIOS } from '../util/browsers'
 
 const useStyles = makeStyles((theme) => ({
+  '@global': {
+    a: {
+      textDecoration: 'none',
+      color:
+        theme.palette.mode === 'dark' ? theme.palette.primary.main : '#cd1831',
+    },
+  },
   root: {
     flexGrow: 1,
     zIndex: 1,

--- a/web/src/app/styles/base/elements.css
+++ b/web/src/app/styles/base/elements.css
@@ -9,11 +9,6 @@ body {
   height: 100%;
 }
 
-a {
-  text-decoration: none;
-  color: #cd1831;
-}
-
 a:hover {
   text-decoration: underline;
 }

--- a/web/src/app/util/SetFavoriteButton.tsx
+++ b/web/src/app/util/SetFavoriteButton.tsx
@@ -5,6 +5,7 @@ import NotFavoriteIcon from '@mui/icons-material/FavoriteBorder'
 import Tooltip from '@mui/material/Tooltip'
 import makeStyles from '@mui/styles/makeStyles'
 import _ from 'lodash'
+import { Theme } from '@mui/material'
 
 interface SetFavoriteButtonProps {
   typeName: 'rotation' | 'service' | 'schedule' | 'escalationPolicy' | 'user'
@@ -13,14 +14,17 @@ interface SetFavoriteButtonProps {
   loading?: boolean
 }
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme: Theme) => ({
   favorited: {
-    color: 'rgb(205, 24, 49)',
+    color:
+      theme.palette.mode === 'dark'
+        ? theme.palette.primary.main
+        : 'rgb(205, 24, 49)',
   },
   notFavorited: {
     color: 'inherit',
   },
-})
+}))
 
 export function FavoriteIcon(): JSX.Element {
   const classes = useStyles()


### PR DESCRIPTION
**Description:**
Fixes a few dark mode color issues missed in review:
- GenericError was rendering black-on-black, updated to match the rest of the error components
- Replace red-on-black with primary color for both fav buttons and links

More info:
https://accessibility.psu.edu/color/colorvisiondetails/

---
Old vs. New
![image](https://user-images.githubusercontent.com/595010/155617956-cdd69fdb-597f-4be4-ae51-a7fdd144cd79.png) ![image](https://user-images.githubusercontent.com/595010/155617312-cfeb1e09-1599-41b7-8946-c6040bc95fe3.png)

Simulated examples:

Protanopia (no red)
![image](https://user-images.githubusercontent.com/595010/155618011-c0fcb0a4-f2f7-4dcd-a2c9-82c02c2d7c84.png) ![image](https://user-images.githubusercontent.com/595010/155617422-0075e3e5-8c20-4659-82fe-fe3f07e3aafe.png)

Deuteranopia (no green)
![image](https://user-images.githubusercontent.com/595010/155618054-9dcf59b3-596b-4b76-aaef-207a3a80f050.png) ![image](https://user-images.githubusercontent.com/595010/155617474-c3a46a11-50ab-4c33-a55f-9234168563b6.png)

Tritanopia (no blue)
![image](https://user-images.githubusercontent.com/595010/155618088-1f2fb6cb-1970-418a-b724-231e9b4c7115.png) ![image](https://user-images.githubusercontent.com/595010/155617516-db5c1a7d-18fc-41c0-9703-511c68dc1d5b.png)

Achromatopsia (no color)
![image](https://user-images.githubusercontent.com/595010/155618120-3a2d126e-0ee6-4612-9a0a-97befc4cddb8.png) ![image](https://user-images.githubusercontent.com/595010/155617672-7ed37f47-97cc-47ef-9ebd-710ac68f95a9.png)

Contrast Loss
![image](https://user-images.githubusercontent.com/595010/155618149-c05658ac-de4b-45d6-8fc5-a496a519d701.png) ![image](https://user-images.githubusercontent.com/595010/155617715-2618ade5-9a33-41aa-b760-bf9373f974ac.png)


