### PR TITLE
dev: fix resetdb

### DIFF
--- a/devtools/resetdb/main.go
+++ b/devtools/resetdb/main.go
@@ -277,6 +277,10 @@ func fillDB(ctx context.Context, url string) error {
 	dt.Wait()
 	_, err = pool.Exec(ctx, "alter table alerts enable trigger all")
 	must(err)
+
+	// fix sequences
+	_, err = pool.Exec(ctx, "SELECT pg_catalog.setval('public.alerts_id_seq', (select count(*) from public.alerts), true);")
+	must(err)
 	return nil
 }
 

--- a/devtools/resetdb/main.go
+++ b/devtools/resetdb/main.go
@@ -279,7 +279,7 @@ func fillDB(ctx context.Context, url string) error {
 	must(err)
 
 	// fix sequences
-	_, err = pool.Exec(ctx, "SELECT pg_catalog.setval('public.alerts_id_seq', (select count(*) from public.alerts), true);")
+	_, err = pool.Exec(ctx, "SELECT pg_catalog.setval('public.alerts_id_seq', (select max(id)+1 from public.alerts), true);")
 	must(err)
 	return nil
 }

--- a/devtools/resetdb/main.go
+++ b/devtools/resetdb/main.go
@@ -20,9 +20,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	adminID string
-)
+var adminID string
 
 func main() {
 	log.SetFlags(log.Lshortfile)
@@ -75,7 +73,6 @@ func main() {
 	if err != nil {
 		log.Fatal("insert random data:", err)
 	}
-
 }
 
 func fillDB(ctx context.Context, url string) error {
@@ -279,7 +276,7 @@ func fillDB(ctx context.Context, url string) error {
 	must(err)
 
 	// fix sequences
-	_, err = pool.Exec(ctx, "SELECT pg_catalog.setval('public.alerts_id_seq', (select max(id)+1 from public.alerts), true);")
+	_, err = pool.Exec(ctx, "SELECT pg_catalog.setval('public.alerts_id_seq', (select max(id)+1 from public.alerts), true)")
 	must(err)
 	return nil
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes a regression in which the alerts table's alerts_id_seq sequence was not being updated after the COPY command. Without this, a developer cannot readily create alerts locally.
