### PR TITLE
ui/theme: make EP form field badges accessible

### DIFF
--- a/web/src/app/escalation-policies/PolicyStepForm.js
+++ b/web/src/app/escalation-policies/PolicyStepForm.js
@@ -30,7 +30,7 @@ const useStyles = makeStyles((theme) => ({
     top: -1,
     right: -1,
     // TODO if practical, use themed color for light mode
-    backgroundColor: theme.palette.mode === 'dark' ? 'primary' : '#cd1831',
+    backgroundColor: theme.palette.mode === 'dark' ? 'secondary' : '#cd1831',
   },
   optional: {
     float: 'left',

--- a/web/src/app/escalation-policies/PolicyStepForm.js
+++ b/web/src/app/escalation-policies/PolicyStepForm.js
@@ -25,11 +25,12 @@ import { SlackBW as SlackIcon } from '../icons/components/Icons'
 import { Config } from '../util/RequireConfig'
 import NumberField from '../util/NumberField'
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   badge: {
     top: -1,
     right: -1,
-    backgroundColor: '#cd1831',
+    // TODO if practical, use themed color for light mode
+    backgroundColor: theme.palette.mode === 'dark' ? 'primary' : '#cd1831',
   },
   optional: {
     float: 'left',


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR makes the escalation policy step form field badges accessible in dark mode.

**Which issue(s) this PR fixes:**
Part of #2214 

**Screenshots:**
Before: 
<img width="202" alt="Screen Shot 2022-03-10 at 10 11 54 AM" src="https://user-images.githubusercontent.com/17692467/157706179-81a7cbf5-fccc-4c87-b326-f2a90b2c396a.png">

After:
<img width="90" alt="Screen Shot 2022-03-10 at 10 09 42 AM" src="https://user-images.githubusercontent.com/17692467/157706231-f6a4fec3-81c2-476e-9376-47c9cd741fda.png">


