### PR TITLE
db: add startup check for use_next_db

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -128,6 +128,30 @@ type App struct {
 
 // NewApp constructs a new App and binds the listening socket.
 func NewApp(c Config, db *sql.DB) (*App, error) {
+	var err error
+	permission.SudoContext(context.Background(), func(ctx context.Context) {
+		// Should not be possible for the app to ever see `use_next_db` unless misconfigured.
+		//
+		// In switchover mode, the connector wrapper will check this and provide the app with
+		// a connection to the next DB instead, if this was set.
+		//
+		// This is a sanity check to ensure that the app is not accidentally using the previous DB
+		// after a switchover.
+		err = db.QueryRowContext(ctx, `select true from switchover_state where current_state = 'use_next_db'`).Scan(new(bool))
+		if errors.Is(err, sql.ErrNoRows) {
+			err = nil
+			return
+		}
+		if err != nil {
+			return
+		}
+
+		err = fmt.Errorf("refusing to connect to stale database (switchover_state table has use_next_db set)")
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	l, err := net.Listen("tcp", c.ListenAddr)
 	if err != nil {
 		return nil, errors.Wrapf(err, "bind address %s", c.ListenAddr)


### PR DESCRIPTION
**Description:**
Adds a sanity check at startup to refuse to connect to a DB that has been explicitly marked as stale by a switchover.

**Review Tips:**
Set the `current_state` column to `use_next_db` in the `switchover_state` table to validate the application refuses to start.

You can also change the query to be invalid inside app.go to ensure other DB errors also result in it failing to start.

Lastly, the app should start and work normally as long as `use_next_db` is not set.