### PR TITLE
ui/theme: make admin config dialog accessible

### DIFF
--- a/web/src/app/util/Diff.tsx
+++ b/web/src/app/util/Diff.tsx
@@ -1,31 +1,8 @@
 import React from 'react'
 import { diffChars, diffWords, Change } from 'diff'
 import Typography from '@mui/material/Typography'
-import makeStyles from '@mui/styles/makeStyles'
-
-const useStyles = makeStyles({
-  // bg color for the whole first line
-  oldLine: {
-    backgroundColor: '#FFEEF0',
-  },
-  // removed chars darker red
-  removed: {
-    backgroundColor: '#FCB8C0',
-  },
-  // bg color for the whole second line
-  newLine: {
-    backgroundColor: '#E6FFED',
-  },
-  // added chars darker green
-  added: {
-    backgroundColor: '#AEF1BE',
-  },
-  // spacing on +/- symbols in diff
-  symbol: {
-    minWidth: '2em',
-    display: 'inline-block',
-  },
-})
+import { green, red, lightGreen } from '@mui/material/colors'
+import { useTheme } from '@mui/material'
 
 interface DiffProps {
   oldValue: string
@@ -39,9 +16,14 @@ interface DiffProps {
  */
 export default function Diff(props: DiffProps): JSX.Element {
   const { oldValue, newValue, type } = props
+  const theme = useTheme()
 
-  const classes = useStyles()
-  const { oldLine, removed, newLine, added } = classes
+  const [oldLine, newLine, removed, added] =
+    theme.palette.mode === 'dark'
+      ? [red[900] + '50', green[900] + '50', red[600] + '90', green[600] + '90']
+      : [red[100], lightGreen[100], red.A100, lightGreen.A400]
+
+  const symbol = { minWidth: '2em', display: 'inline-block' }
 
   let diff: Change[] = []
   if (type === 'chars') diff = diffChars(oldValue, newValue)
@@ -51,9 +33,13 @@ export default function Diff(props: DiffProps): JSX.Element {
     if (part.added) return
 
     return (
-      <span key={idx} className={part.removed ? removed : undefined}>
+      <Typography
+        key={idx}
+        sx={{ bgcolor: part.removed ? removed : undefined }}
+        component='span'
+      >
         {part.value}
-      </span>
+      </Typography>
     )
   })
 
@@ -61,9 +47,13 @@ export default function Diff(props: DiffProps): JSX.Element {
     if (part.removed) return
 
     return (
-      <span key={idx} className={part.added ? added : undefined}>
+      <Typography
+        key={idx}
+        sx={{ bgcolor: part.added ? added : undefined }}
+        component='span'
+      >
         {part.value}
-      </span>
+      </Typography>
     )
   })
 
@@ -73,14 +63,18 @@ export default function Diff(props: DiffProps): JSX.Element {
   return (
     <React.Fragment>
       {!hideRemoved && (
-        <Typography className={oldLine} data-cy='old'>
-          <span className={classes.symbol}>&nbsp;-</span>
+        <Typography sx={{ bgcolor: oldLine }} data-cy='old'>
+          <Typography sx={symbol} component='span'>
+            &nbsp;-
+          </Typography>
           {oldWithRemoved}
         </Typography>
       )}
       {!hideAdded && (
-        <Typography className={newLine} data-cy='new'>
-          <span className={classes.symbol}>&nbsp;+</span>
+        <Typography sx={{ bgcolor: newLine }} data-cy='new'>
+          <Typography sx={symbol} component='span'>
+            &nbsp;+
+          </Typography>
           {newWithAdded}
         </Typography>
       )}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR makes the admin diff dialog accessible in dark mode.

**Screenshots:**
Before:
<img width="616" alt="Screen Shot 2022-03-14 at 9 12 48 AM" src="https://user-images.githubusercontent.com/17692467/158190165-3c408a60-f780-4deb-b745-3f68b764ee45.png">
After, dark:
<img width="614" alt="Screen Shot 2022-03-14 at 9 05 51 AM" src="https://user-images.githubusercontent.com/17692467/158190163-bc95baf8-3d0d-4bc8-9863-bbce3363a921.png">
After, light:
<img width="614" alt="Screen Shot 2022-03-14 at 9 05 58 AM" src="https://user-images.githubusercontent.com/17692467/158190166-a9124278-d04a-47dd-b024-90b71cc56034.png">

