### PR TITLE
ui/theme: use secondary for EP step badges

### DIFF
--- a/web/src/app/escalation-policies/PolicyStepForm.js
+++ b/web/src/app/escalation-policies/PolicyStepForm.js
@@ -25,12 +25,10 @@ import { SlackBW as SlackIcon } from '../icons/components/Icons'
 import { Config } from '../util/RequireConfig'
 import NumberField from '../util/NumberField'
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles({
   badge: {
     top: -1,
     right: -1,
-    // TODO if practical, use themed color for light mode
-    backgroundColor: theme.palette.mode === 'dark' ? 'secondary' : '#cd1831',
   },
   optional: {
     float: 'left',
@@ -39,7 +37,7 @@ const useStyles = makeStyles((theme) => ({
   label: {
     paddingRight: '0.4em',
   },
-}))
+})
 
 function PolicyStepForm(props) {
   const [step, setStep] = useState(0)
@@ -72,7 +70,7 @@ function PolicyStepForm(props) {
   const badgeMeUpScotty = (len, txt) => (
     <Badge
       badgeContent={len}
-      color='primary'
+      color='secondary'
       invisible={!len}
       classes={{
         badge: classes.badge,


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This Pr makes the EP form use the secondary variant for EP step badges.

**Screenshots:**
<img width="210" alt="Screen Shot 2022-03-15 at 10 30 02 AM" src="https://user-images.githubusercontent.com/17692467/158413405-d79228c5-2daf-4f8f-81cd-65469eb2899a.png">
<img width="227" alt="Screen Shot 2022-03-15 at 10 29 53 AM" src="https://user-images.githubusercontent.com/17692467/158413408-b86ecc38-2431-4f29-aaf1-0bade7b783dd.png">
