### PR TITLE
ui/theme: apply theme coloring to calendar

### DIFF
--- a/web/src/app/schedules/calendar/ScheduleCalendar.tsx
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentType, useContext } from 'react'
 import { Card, Button } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
-import { darken, useTheme, Theme, lighten } from '@mui/material/styles'
+import { darken, lighten, useTheme, Theme } from '@mui/material/styles'
 import Grid from '@mui/material/Grid'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import Switch from '@mui/material/Switch'
@@ -31,19 +31,31 @@ import ScheduleCalendarEventWrapper from './ScheduleCalendarEventWrapper'
 
 const localizer = LuxonLocalizer(DateTime, { firstDayOfWeek: 0 })
 
+function getBorder(theme: Theme): string {
+  if (theme.palette.mode === 'dark') {
+    return '0.5px solid ' + lighten(theme.palette.background.paper, 0.2)
+  }
+
+  return '0.5px solid ' + darken(theme.palette.background.paper, 0.2)
+}
+
 const useStyles = makeStyles((theme: Theme) => ({
   calendar: {
     height: '45rem',
     fontFamily: theme.typography.body2.fontFamily,
     fontSize: theme.typography.body2.fontSize,
-    '& .rbc-month-row': {
-      'border-top': '1px solid ' + theme.palette.background.default,
+    '& .rbc-month-view': {
+      border: getBorder(theme),
     },
-    // weekly current time divider
+    '& .rbc-month-row': { 'border-top': 'none' },
+    '& .rbc-header': {
+      border: getBorder(theme),
+    },
+    // weekly current time divider line
     '& .rbc-time-content .rbc-current-time-indicator': {
       backgroundColor: theme.palette.primary.main,
     },
-    // weekly current time circle by divider
+    // weekly current time circle by divider line
     '& .rbc-time-content .rbc-current-time-indicator::before': {
       content: '',
       display: 'inline-block',
@@ -176,15 +188,24 @@ function ScheduleCalendar(props: ScheduleCalendarProps): JSX.Element {
     if (theme.palette.mode === 'dark' && (outOfBounds || currentDay)) {
       return {
         style: {
-          backgroundColor: lighten(theme.palette.background.default, 0.1),
-          border: '1px solid ' + theme.palette.background.default,
+          backgroundColor: lighten(theme.palette.background.paper, 0.1),
+          border: getBorder(theme),
+        },
+      }
+    }
+
+    if (outOfBounds || currentDay) {
+      return {
+        style: {
+          backgroundColor: darken(theme.palette.background.paper, 0.1),
+          border: getBorder(theme),
         },
       }
     }
 
     return {
       style: {
-        border: '1px solid ' + theme.palette.background.default,
+        border: getBorder(theme),
       },
     }
   }

--- a/web/src/app/schedules/calendar/ScheduleCalendar.tsx
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.tsx
@@ -44,13 +44,13 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: '45rem',
     fontFamily: theme.typography.body2.fontFamily,
     fontSize: theme.typography.body2.fontSize,
-    '& .rbc-month-view': {
+    '& .rbc-month-view, .rbc-header, .rbc-time-view, .rbc-timeslot-group': {
       border: getBorder(theme),
     },
-    '& .rbc-month-row': { 'border-top': 'none' },
-    '& .rbc-header': {
-      border: getBorder(theme),
-    },
+    '& .rbc-month-row, .rbc-time-header, .rbc-time-header-content, .rbc-time-slot, .rbc-time-content, .rbc-events-container':
+      {
+        border: 'none',
+      },
     // weekly current time divider line
     '& .rbc-time-content .rbc-current-time-indicator': {
       backgroundColor: theme.palette.primary.main,

--- a/web/src/app/schedules/calendar/ScheduleCalendar.tsx
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.tsx
@@ -146,7 +146,27 @@ function ScheduleCalendar(props: ScheduleCalendarProps): JSX.Element {
   const [userFilter, setUserFilter] = useURLParam<string[]>('userFilter', [])
   const resetFilter = useResetURLParams('userFilter', 'activeOnly')
 
-  const dayStyleGetter = (date: Date): React.HTMLAttributes<HTMLDivElement> => {
+  function eventStyleGetter(
+    event: ScheduleCalendarEvent,
+  ): React.HTMLAttributes<HTMLDivElement> {
+    if (event.type === 'tempSched' || event.type === 'override') {
+      return {
+        style: {
+          backgroundColor: theme.palette.secondary.main,
+          color: theme.palette.getContrastText(theme.palette.secondary.main),
+        },
+      }
+    }
+
+    return {
+      style: {
+        backgroundColor: theme.palette.primary.main,
+        color: theme.palette.getContrastText(theme.palette.primary.main),
+      },
+    }
+  }
+
+  function dayStyleGetter(date: Date): React.HTMLAttributes<HTMLDivElement> {
     const outOfBounds =
       DateTime.fromISO(start).month !== DateTime.fromJSDate(date).month
     const currentDay = DateTime.local().hasSame(
@@ -370,6 +390,7 @@ function ScheduleCalendar(props: ScheduleCalendarProps): JSX.Element {
             views={['month', 'week']}
             view={weekly ? 'week' : 'month'}
             showAllEvents
+            eventPropGetter={eventStyleGetter}
             dayPropGetter={dayStyleGetter}
             onNavigate={() => {}} // stub to hide false console err
             onView={() => {}} // stub to hide false console err

--- a/web/src/app/schedules/calendar/ScheduleCalendar.tsx
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.tsx
@@ -55,18 +55,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     '& .rbc-time-content .rbc-current-time-indicator': {
       backgroundColor: theme.palette.primary.main,
     },
-    // weekly current time circle by divider line
-    '& .rbc-time-content .rbc-current-time-indicator::before': {
-      content: '',
-      display: 'inline-block',
-      width: 10,
-      height: 10,
-      left: -6,
-      top: -4.5,
-      borderRadius: 5,
-      backgroundColor: theme.palette.primary.main,
-      position: 'absolute',
-    },
   },
   card: {
     padding: theme.spacing(2),

--- a/web/src/app/schedules/calendar/ScheduleCalendar.tsx
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.tsx
@@ -138,44 +138,13 @@ function ScheduleCalendar(props: ScheduleCalendarProps): JSX.Element {
   const classes = useStyles()
   const theme = useTheme()
 
-  const { setOverrideDialog } = useContext(ScheduleCalendarContext)
-
+  const { shifts, temporarySchedules } = props
   const { weekly, start } = useCalendarNavigation()
+  const { setOverrideDialog } = useContext(ScheduleCalendarContext)
 
   const [activeOnly, setActiveOnly] = useURLParam<boolean>('activeOnly', false)
   const [userFilter, setUserFilter] = useURLParam<string[]>('userFilter', [])
   const resetFilter = useResetURLParams('userFilter', 'activeOnly')
-
-  const { shifts, temporarySchedules } = props
-
-  const eventStyleGetter = (
-    calEvent: ScheduleCalendarEvent,
-    start: Date | string,
-    end: Date | string,
-    isSelected: boolean,
-  ): React.HTMLAttributes<HTMLDivElement> => {
-    const green = '#0C6618'
-    const lavender = '#BB7E8C'
-
-    if (calEvent.type === 'tempSched' || calEvent.type === 'tempSchedShift') {
-      return {
-        style: {
-          backgroundColor: isSelected ? darken(green, 0.3) : green,
-          borderColor: darken(green, 0.3),
-        },
-      }
-    }
-    if (calEvent.type === 'override') {
-      return {
-        style: {
-          backgroundColor: isSelected ? darken(lavender, 0.3) : lavender,
-          borderColor: darken(lavender, 0.3),
-        },
-      }
-    }
-
-    return {}
-  }
 
   const dayStyleGetter = (date: Date): React.HTMLAttributes<HTMLDivElement> => {
     const outOfBounds =
@@ -401,7 +370,6 @@ function ScheduleCalendar(props: ScheduleCalendarProps): JSX.Element {
             views={['month', 'week']}
             view={weekly ? 'week' : 'month'}
             showAllEvents
-            eventPropGetter={eventStyleGetter}
             dayPropGetter={dayStyleGetter}
             onNavigate={() => {}} // stub to hide false console err
             onView={() => {}} // stub to hide false console err

--- a/web/src/app/schedules/calendar/ScheduleCalendar.tsx
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentType, useContext } from 'react'
 import { Card, Button } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
-import { darken, useTheme, Theme } from '@mui/material/styles'
+import { darken, useTheme, Theme, lighten } from '@mui/material/styles'
 import Grid from '@mui/material/Grid'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import Switch from '@mui/material/Switch'
@@ -32,6 +32,30 @@ import ScheduleCalendarEventWrapper from './ScheduleCalendarEventWrapper'
 const localizer = LuxonLocalizer(DateTime, { firstDayOfWeek: 0 })
 
 const useStyles = makeStyles((theme: Theme) => ({
+  calendar: {
+    height: '45rem',
+    fontFamily: theme.typography.body2.fontFamily,
+    fontSize: theme.typography.body2.fontSize,
+    '& .rbc-month-row': {
+      'border-top': '1px solid ' + theme.palette.background.default,
+    },
+    // weekly current time divider
+    '& .rbc-time-content .rbc-current-time-indicator': {
+      backgroundColor: theme.palette.primary.main,
+    },
+    // weekly current time circle by divider
+    '& .rbc-time-content .rbc-current-time-indicator::before': {
+      content: '',
+      display: 'inline-block',
+      width: 10,
+      height: 10,
+      left: -6,
+      top: -4.5,
+      borderRadius: 5,
+      backgroundColor: theme.palette.primary.main,
+      position: 'absolute',
+    },
+  },
   card: {
     padding: theme.spacing(2),
   },
@@ -152,12 +176,17 @@ function ScheduleCalendar(props: ScheduleCalendarProps): JSX.Element {
     if (theme.palette.mode === 'dark' && (outOfBounds || currentDay)) {
       return {
         style: {
-          backgroundColor: theme.palette.background.default,
+          backgroundColor: lighten(theme.palette.background.default, 0.1),
+          border: '1px solid ' + theme.palette.background.default,
         },
       }
     }
 
-    return {}
+    return {
+      style: {
+        border: '1px solid ' + theme.palette.background.default,
+      },
+    }
   }
 
   const getOverrideTitle = (o: UserOverride): JSX.Element => {
@@ -346,11 +375,7 @@ function ScheduleCalendar(props: ScheduleCalendarProps): JSX.Element {
             date={DateTime.fromISO(start).toJSDate()}
             localizer={localizer}
             events={getCalEvents(shifts, temporarySchedules, props.overrides)}
-            style={{
-              height: weekly ? '100%' : '45rem',
-              fontFamily: theme.typography.body2.fontFamily,
-              fontSize: theme.typography.body2.fontSize,
-            }}
+            className={classes.calendar}
             tooltipAccessor={() => ''}
             views={['month', 'week']}
             view={weekly ? 'week' : 'month'}

--- a/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.tsx
+++ b/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.tsx
@@ -9,7 +9,6 @@ import Button from '@mui/material/Button'
 import Grid from '@mui/material/Grid'
 import Popover from '@mui/material/Popover'
 import Typography from '@mui/material/Typography'
-import { darken, useTheme } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
 import { DateTime } from 'luxon'
 import { ScheduleCalendarContext } from '../ScheduleDetails'
@@ -40,17 +39,17 @@ const useStyles = makeStyles({
 })
 
 interface ScheduleCalendarEventWrapperProps {
-  event: ScheduleCalendarEvent
   children: JSX.Element
+  event: ScheduleCalendarEvent
+  style: React.CSSProperties
 }
 
 export default function ScheduleCalendarEventWrapper(
   props: ScheduleCalendarEventWrapperProps,
 ): ReactNode {
-  const classes = useStyles()
-  const theme = useTheme()
   const { event, children } = props
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
+  const classes = useStyles()
 
   const [showEditDialog, setShowEditDialog] = useState('')
   const [showDeleteDialog, setShowDeleteDialog] = useState('')
@@ -60,39 +59,6 @@ export default function ScheduleCalendarEventWrapper(
   )
   const open = Boolean(anchorEl)
   const id = open ? 'shift-popover' : undefined
-
-  function getEventStyle(): React.CSSProperties {
-    if (
-      anchorEl &&
-      (props.event.type === 'tempSched' || props.event.type === 'override')
-    ) {
-      const bg = darken(theme.palette.secondary.main, 0.2)
-      return {
-        backgroundColor: bg,
-        color: theme.palette.getContrastText(bg),
-      }
-    }
-
-    if (props.event.type === 'tempSched' || props.event.type === 'override') {
-      return {
-        backgroundColor: theme.palette.secondary.main,
-        color: theme.palette.getContrastText(theme.palette.secondary.main),
-      }
-    }
-
-    if (anchorEl) {
-      const bg = darken(theme.palette.primary.main, 0.2)
-      return {
-        backgroundColor: bg,
-        color: theme.palette.getContrastText(bg),
-      }
-    }
-
-    return {
-      backgroundColor: theme.palette.primary.main,
-      color: theme.palette.getContrastText(theme.palette.primary.main),
-    }
-  }
 
   function handleClick(e: MouseEvent<HTMLButtonElement>): void {
     setAnchorEl(e.currentTarget)
@@ -312,7 +278,6 @@ export default function ScheduleCalendarEventWrapper(
         role: 'button',
         'aria-pressed': open,
         'aria-describedby': id,
-        style: getEventStyle(),
       })}
       {showEditDialog && (
         <ScheduleOverrideEditDialog

--- a/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.tsx
+++ b/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.tsx
@@ -9,6 +9,7 @@ import Button from '@mui/material/Button'
 import Grid from '@mui/material/Grid'
 import Popover from '@mui/material/Popover'
 import Typography from '@mui/material/Typography'
+import { darken, useTheme } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
 import { DateTime } from 'luxon'
 import { ScheduleCalendarContext } from '../ScheduleDetails'
@@ -29,15 +30,6 @@ const useStyles = makeStyles({
   cardActionContainer: {
     width: '100%',
   },
-  button: {
-    padding: '4px',
-    minHeight: 0,
-    fontSize: 12,
-  },
-  buttonContainer: {
-    display: 'flex',
-    alignItems: 'center',
-  },
   flexGrow: {
     flexGrow: 1,
   },
@@ -52,11 +44,12 @@ interface ScheduleCalendarEventWrapperProps {
   children: JSX.Element
 }
 
-export default function ScheduleCalendarEventWrapper({
-  event,
-  children,
-}: ScheduleCalendarEventWrapperProps): ReactNode {
+export default function ScheduleCalendarEventWrapper(
+  props: ScheduleCalendarEventWrapperProps,
+): ReactNode {
   const classes = useStyles()
+  const theme = useTheme()
+  const { event, children } = props
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
 
   const [showEditDialog, setShowEditDialog] = useState('')
@@ -67,6 +60,39 @@ export default function ScheduleCalendarEventWrapper({
   )
   const open = Boolean(anchorEl)
   const id = open ? 'shift-popover' : undefined
+
+  function getEventStyle(): React.CSSProperties {
+    if (
+      anchorEl &&
+      (props.event.type === 'tempSched' || props.event.type === 'override')
+    ) {
+      const bg = darken(theme.palette.secondary.main, 0.2)
+      return {
+        backgroundColor: bg,
+        color: theme.palette.getContrastText(bg),
+      }
+    }
+
+    if (props.event.type === 'tempSched' || props.event.type === 'override') {
+      return {
+        backgroundColor: theme.palette.secondary.main,
+        color: theme.palette.getContrastText(theme.palette.secondary.main),
+      }
+    }
+
+    if (anchorEl) {
+      const bg = darken(theme.palette.primary.main, 0.2)
+      return {
+        backgroundColor: bg,
+        color: theme.palette.getContrastText(bg),
+      }
+    }
+
+    return {
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.getContrastText(theme.palette.primary.main),
+    }
+  }
 
   function handleClick(e: MouseEvent<HTMLButtonElement>): void {
     setAnchorEl(e.currentTarget)
@@ -286,6 +312,7 @@ export default function ScheduleCalendarEventWrapper({
         role: 'button',
         'aria-pressed': open,
         'aria-describedby': id,
+        style: getEventStyle(),
       })}
       {showEditDialog && (
         <ScheduleOverrideEditDialog

--- a/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.tsx
+++ b/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.tsx
@@ -48,8 +48,8 @@ export default function ScheduleCalendarEventWrapper(
   props: ScheduleCalendarEventWrapperProps,
 ): ReactNode {
   const { event, children } = props
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
   const classes = useStyles()
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
 
   const [showEditDialog, setShowEditDialog] = useState('')
   const [showDeleteDialog, setShowDeleteDialog] = useState('')

--- a/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.tsx
+++ b/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.tsx
@@ -41,13 +41,12 @@ const useStyles = makeStyles({
 interface ScheduleCalendarEventWrapperProps {
   children: JSX.Element
   event: ScheduleCalendarEvent
-  style: React.CSSProperties
 }
 
-export default function ScheduleCalendarEventWrapper(
-  props: ScheduleCalendarEventWrapperProps,
-): ReactNode {
-  const { event, children } = props
+export default function ScheduleCalendarEventWrapper({
+  event,
+  children,
+}: ScheduleCalendarEventWrapperProps): ReactNode {
   const classes = useStyles()
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
 

--- a/web/src/app/styles/base/elements.css
+++ b/web/src/app/styles/base/elements.css
@@ -11,20 +11,3 @@ body {
 a:hover {
   text-decoration: underline;
 }
-
-/* react-big-calendar */
-.rbc-time-content .rbc-current-time-indicator {
-  background-color: #343434;
-}
-
-.rbc-time-content .rbc-current-time-indicator::before {
-  content: "";
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  left: -6px;
-  top: -4.5px;
-  border-radius: 5px;
-  background-color: #343434;
-  position: absolute;
-}


### PR DESCRIPTION
**Description:**
Updates the border styling and shift colors for the schedule calendar to better-fit dark and light modes.

**Which issue(s) this PR fixes:**
Part of #2214

**Out of scope:**
Coloring when a shift is selected is not altered. It seems this is a bug in master as well. Left out of scope for now though I did give it my best effort- might open a separate issue.

---

**Light Mode - Monthly View, Before**

<img width="1095" alt="before- light monthly" src="https://user-images.githubusercontent.com/11381794/158474870-6d168d3c-2090-4d4d-9495-a3bb215562ed.png">

**Light Mode - Monthly View, After**

<img width="1095" alt="after- light monthly" src="https://user-images.githubusercontent.com/11381794/158474891-76e73160-1004-455b-8bb1-5c274b4419a5.png">

---

**Dark Mode - Monthly View, Before**

<img width="1103" alt="before- dark monthly" src="https://user-images.githubusercontent.com/11381794/158474907-9bfbabab-8526-411b-bf2a-080c2553cd9f.png">

**Dark Mode - Monthly View, After**

<img width="1094" alt="after- dark monthly" src="https://user-images.githubusercontent.com/11381794/158474919-ac0024e5-5a01-4905-820a-e7934b0b4603.png">

---

**Light Mode - Weekly View, Before**

<img width="1094" alt="before- light weekly" src="https://user-images.githubusercontent.com/11381794/158474930-de550f0a-5b07-4da6-bc6a-b939f802c58e.png">

**Light Mode - Weekly View, After**

<img width="1091" alt="after- light weekly" src="https://user-images.githubusercontent.com/11381794/158474958-30efdca2-7af2-42a7-84db-c75d2708793e.png">

---

**Dark Mode - Weekly View, Before**

<img width="1094" alt="before- dark weekly" src="https://user-images.githubusercontent.com/11381794/158474970-8e9a66f8-8130-429e-ac03-b9ab79e7124f.png">

**Dark Mode - Weekly View, After**

<img width="1095" alt="after- dark weekly" src="https://user-images.githubusercontent.com/11381794/158474978-53a16504-e7d9-4068-b75f-e4770e99a1f3.png">
