### PR TITLE
ui/theme: use primary variant for link color

### DIFF
--- a/web/src/app/util/AppLink.tsx
+++ b/web/src/app/util/AppLink.tsx
@@ -39,7 +39,6 @@ const AppLink: ForwardRefRenderFunction<HTMLAnchorElement, AppLinkProps> =
         to={to}
         href={to}
         component={external ? 'a' : RRLink}
-        color='secondary'
         {...other}
       />
     )


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR uses the default link color instead of the `secondary` variant that is currently implemented. Both pass the a11y contrast tests, but the default (`primary`) color stands out and matches the nav link button colors.

**Screenshots:**
Before:
<img width="1167" alt="Screen Shot 2022-03-16 at 12 49 48 PM" src="https://user-images.githubusercontent.com/17692467/158655430-57db60af-8243-4102-90d1-0e8b40d7a5c5.png">
<img width="1166" alt="Screen Shot 2022-03-16 at 12 48 22 PM" src="https://user-images.githubusercontent.com/17692467/158655449-c8161584-52f5-420a-b168-86c8ad11a401.png">

After:
<img width="1158" alt="Screen Shot 2022-03-16 at 12 49 26 PM" src="https://user-images.githubusercontent.com/17692467/158655424-92a1e8cb-eb06-4455-919f-6f5cb80d5dcb.png">
<img width="1171" alt="Screen Shot 2022-03-16 at 12 48 02 PM" src="https://user-images.githubusercontent.com/17692467/158655439-c3f7cdfd-3187-4914-9bf5-8419af248e52.png">


**Additional Info:**
Discussion in #2229 
