### PR TITLE
engine/metrics: populate closed_at field in alert_metrics

### DIFF
--- a/engine/metricsmanager/db.go
+++ b/engine/metricsmanager/db.go
@@ -15,8 +15,7 @@ type DB struct {
 	db   *sql.DB
 	lock *processinglock.Lock
 
-	scanLogs           *sql.Stmt
-	scanLogsFromCursor *sql.Stmt
+	scanLogs *sql.Stmt
 
 	insertMetrics *sql.Stmt
 }
@@ -40,8 +39,7 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 		db:   db,
 		lock: lock,
 
-		scanLogs:           p.P(`select alert_id, timestamp, id from alert_logs where event='closed' order by timestamp, id limit 500`),
-		scanLogsFromCursor: p.P(`select alert_id, timestamp, id from alert_logs where event='closed' and ((timestamp = $1 and id > $2) or timestamp > $1) order by timestamp, id limit 500`),
+		scanLogs: p.P(`select alert_id, timestamp, id from alert_logs where event='closed' and ((timestamp = $1 and id > $2) or timestamp > $1) order by timestamp, id limit 500`),
 
 		insertMetrics: p.P(`
 			insert into alert_metrics (alert_id, service_id, time_to_ack, time_to_close, escalated, closed_at)

--- a/engine/metricsmanager/db.go
+++ b/engine/metricsmanager/db.go
@@ -40,8 +40,8 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 		db:   db,
 		lock: lock,
 
-		scanLogs:           p.P(`select distinct alert_id, timestamp, id from alert_logs where event='closed' order by timestamp, id limit 500`),
-		scanLogsFromCursor: p.P(`select distinct alert_id, timestamp, id from alert_logs where event='closed' and timestamp > $1 and id > $2 order by timestamp, id limit 500`),
+		scanLogs:           p.P(`select alert_id, timestamp, id from alert_logs where event='closed' order by timestamp, id limit 500`),
+		scanLogsFromCursor: p.P(`select alert_id, timestamp, id from alert_logs where event='closed' and ((timestamp = $1 and id > $2) or timestamp > $1) order by timestamp, id limit 500`),
 
 		insertMetrics: p.P(`
 			insert into alert_metrics (alert_id, service_id, time_to_ack, time_to_close, escalated, closed_at)

--- a/engine/metricsmanager/update.go
+++ b/engine/metricsmanager/update.go
@@ -11,7 +11,7 @@ import (
 )
 
 type State struct {
-	V1 struct {
+	V2 struct {
 		NextAlertID int
 	}
 }
@@ -87,21 +87,21 @@ func (db *DB) UpdateAll(ctx context.Context) error {
 		return fmt.Errorf("load state: %w", err)
 	}
 
-	if state.V1.NextAlertID == 0 || state.V1.NextAlertID < int(minAlertID.Int64) {
+	if state.V2.NextAlertID == 0 || state.V2.NextAlertID < int(minAlertID.Int64) {
 		// no state, or reset, set to the highest alert id from the db
-		err = tx.StmtContext(ctx, db.highAlertID).QueryRowContext(ctx).Scan(&state.V1.NextAlertID)
+		err = tx.StmtContext(ctx, db.highAlertID).QueryRowContext(ctx).Scan(&state.V2.NextAlertID)
 		if err != nil {
 			return fmt.Errorf("query high alert id: %w", err)
 		}
 	}
 
 	// clamp min alert ID 500 below next
-	if int(minAlertID.Int64) < state.V1.NextAlertID-500 {
-		minAlertID.Int64 = int64(state.V1.NextAlertID) - 500
+	if int(minAlertID.Int64) < state.V2.NextAlertID-500 {
+		minAlertID.Int64 = int64(state.V2.NextAlertID) - 500
 	}
 
 	// fetch alerts to update
-	rows, err = tx.StmtContext(ctx, db.scanAlerts).QueryContext(ctx, minAlertID, state.V1.NextAlertID)
+	rows, err = tx.StmtContext(ctx, db.scanAlerts).QueryContext(ctx, minAlertID, state.V2.NextAlertID)
 	if err != nil {
 		return fmt.Errorf("query alerts: %w", err)
 	}
@@ -124,7 +124,7 @@ func (db *DB) UpdateAll(ctx context.Context) error {
 	}
 
 	// update and save state
-	state.V1.NextAlertID = int(minAlertID.Int64) - 1
+	state.V2.NextAlertID = int(minAlertID.Int64) - 1
 	err = lockState.Save(ctx, &state)
 	if err != nil {
 		return fmt.Errorf("save state: %w", err)

--- a/engine/metricsmanager/update.go
+++ b/engine/metricsmanager/update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/util/log"
@@ -12,7 +13,8 @@ import (
 
 type State struct {
 	V2 struct {
-		NextAlertID int
+		LastLogTime time.Time
+		LastLogID   int
 	}
 }
 
@@ -20,10 +22,9 @@ type State struct {
 	Theory of Operation:
 
 	1. Aquire processing lock
-	2. Look for recently closed alerts without a metrics entry
-	3. If any, insert metrics for them and exit
-	4. If no state, start scan from last closed alert id
-	5. If state, resume scan until min closed alert id
+	2. Get batch of oldest alert IDs (if cursor not blank, must be > cursor)
+	3. Insert metrics for these alerts
+	4. Set cursor to last inserted
 
 */
 
@@ -41,75 +42,34 @@ func (db *DB) UpdateAll(ctx context.Context) error {
 	}
 	defer tx.Rollback()
 
-	rows, err := tx.StmtContext(ctx, db.recentlyClosed).QueryContext(ctx)
-	if err != nil {
-		return fmt.Errorf("query recently closed alerts: %w", err)
-	}
-	defer rows.Close()
-
 	var alertIDs []int
-	for rows.Next() {
-		var alertID int
-		err = rows.Scan(&alertID)
-		if err != nil {
-			return fmt.Errorf("scan alert id: %w", err)
-		}
-		alertIDs = append(alertIDs, alertID)
-	}
-
-	if len(alertIDs) > 0 {
-		_, err = tx.StmtContext(ctx, db.insertMetrics).ExecContext(ctx, sqlutil.IntArray(alertIDs))
-		if err != nil {
-			return fmt.Errorf("insert metrics: %w", err)
-		}
-		err = tx.Commit()
-		if err != nil {
-			return fmt.Errorf("commit: %w", err)
-		}
-		return nil
-	}
-
-	// fetch min alert id from db for later
-	var minAlertID sql.NullInt64
-	err = tx.StmtContext(ctx, db.lowAlertID).QueryRowContext(ctx).Scan(&minAlertID)
-	if err != nil {
-		return fmt.Errorf("query min alert id: %w", err)
-	}
-
-	if !minAlertID.Valid {
-		// no alerts
-		return nil
-	}
-
+	var zeroTime, lastLogTime time.Time
+	var lastLogID int
 	var state State
 	err = lockState.Load(ctx, &state)
 	if err != nil {
 		return fmt.Errorf("load state: %w", err)
 	}
 
-	if state.V2.NextAlertID == 0 || state.V2.NextAlertID < int(minAlertID.Int64) {
-		// no state, or reset, set to the highest alert id from the db
-		err = tx.StmtContext(ctx, db.highAlertID).QueryRowContext(ctx).Scan(&state.V2.NextAlertID)
+	var rows *sql.Rows
+	if state.V2.LastLogTime == zeroTime {
+		// no state
+		rows, err = tx.StmtContext(ctx, db.scanLogs).QueryContext(ctx)
 		if err != nil {
-			return fmt.Errorf("query high alert id: %w", err)
+			return fmt.Errorf("scan logs: %w", err)
+		}
+	} else {
+		rows, err = tx.StmtContext(ctx, db.scanLogsFromCursor).QueryContext(ctx, state.V2.LastLogTime, state.V2.LastLogID)
+		if err != nil {
+			return fmt.Errorf("scan logs from cursor: %w", err)
 		}
 	}
 
-	// clamp min alert ID 500 below next
-	if int(minAlertID.Int64) < state.V2.NextAlertID-500 {
-		minAlertID.Int64 = int64(state.V2.NextAlertID) - 500
-	}
-
-	// fetch alerts to update
-	rows, err = tx.StmtContext(ctx, db.scanAlerts).QueryContext(ctx, minAlertID, state.V2.NextAlertID)
-	if err != nil {
-		return fmt.Errorf("query alerts: %w", err)
-	}
 	defer rows.Close()
 
 	for rows.Next() {
 		var alertID int
-		err = rows.Scan(&alertID)
+		err = rows.Scan(&alertID, &lastLogTime, &lastLogID)
 		if err != nil {
 			return fmt.Errorf("scan alert id: %w", err)
 		}
@@ -121,13 +81,14 @@ func (db *DB) UpdateAll(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("insert metrics: %w", err)
 		}
-	}
 
-	// update and save state
-	state.V2.NextAlertID = int(minAlertID.Int64) - 1
-	err = lockState.Save(ctx, &state)
-	if err != nil {
-		return fmt.Errorf("save state: %w", err)
+		// update and save state
+		state.V2.LastLogTime = lastLogTime
+		state.V2.LastLogID = lastLogID
+		err = lockState.Save(ctx, &state)
+		if err != nil {
+			return fmt.Errorf("save state: %w", err)
+		}
 	}
 
 	err = tx.Commit()

--- a/engine/metricsmanager/update.go
+++ b/engine/metricsmanager/update.go
@@ -13,8 +13,12 @@ import (
 
 type State struct {
 	V2 struct {
+
+		// LastLogTime is a cursor for processed alert_logs
 		LastLogTime time.Time
-		LastLogID   int
+
+		// LastLogID breaks ties for the LastLogTime cursor
+		LastLogID int
 	}
 }
 
@@ -22,7 +26,7 @@ type State struct {
 	Theory of Operation:
 
 	1. Aquire processing lock
-	2. Get batch of oldest alert IDs (if cursor not blank, must be > cursor)
+	2. Get batch of oldest alert IDs after cursor (use LastLogID as a tie breaker)
 	3. Insert metrics for these alerts
 	4. Set cursor to last inserted
 

--- a/engine/metricsmanager/update.go
+++ b/engine/metricsmanager/update.go
@@ -43,7 +43,7 @@ func (db *DB) UpdateAll(ctx context.Context) error {
 	defer tx.Rollback()
 
 	var alertIDs []int
-	var zeroTime, lastLogTime time.Time
+	var lastLogTime time.Time
 	var lastLogID int
 	var state State
 	err = lockState.Load(ctx, &state)
@@ -52,17 +52,9 @@ func (db *DB) UpdateAll(ctx context.Context) error {
 	}
 
 	var rows *sql.Rows
-	if state.V2.LastLogTime == zeroTime {
-		// no state
-		rows, err = tx.StmtContext(ctx, db.scanLogs).QueryContext(ctx)
-		if err != nil {
-			return fmt.Errorf("scan logs: %w", err)
-		}
-	} else {
-		rows, err = tx.StmtContext(ctx, db.scanLogsFromCursor).QueryContext(ctx, state.V2.LastLogTime, state.V2.LastLogID)
-		if err != nil {
-			return fmt.Errorf("scan logs from cursor: %w", err)
-		}
+	rows, err = tx.StmtContext(ctx, db.scanLogs).QueryContext(ctx, state.V2.LastLogTime, state.V2.LastLogID)
+	if err != nil {
+		return fmt.Errorf("scan logs: %w", err)
 	}
 
 	defer rows.Close()

--- a/migrate/migrations/20220317153438-alert-metrics-add-closed-at.sql
+++ b/migrate/migrations/20220317153438-alert-metrics-add-closed-at.sql
@@ -1,7 +1,7 @@
 -- +migrate Up
 
 UPDATE engine_processing_versions
-SET "version" = 2
+SET "version" = 2, state = DEFAULT
 WHERE type_id = 'metrics';
 
 ALTER TABLE alert_metrics ADD COLUMN closed_at TIMESTAMP WITH TIME ZONE NOT NULL;
@@ -14,7 +14,7 @@ TRUNCATE alert_metrics;
 ALTER TABLE alert_metrics DROP COLUMN closed_at;
 
 UPDATE engine_processing_versions
-SET "version" = 1
+SET "version" = 1, state = DEFAULT
 WHERE type_id = 'metrics';
 
 TRUNCATE alert_metrics;

--- a/migrate/migrations/20220317153438-alert-metrics-add-closed-at.sql
+++ b/migrate/migrations/20220317153438-alert-metrics-add-closed-at.sql
@@ -4,10 +4,9 @@ UPDATE engine_processing_versions
 SET "version" = 2, state = DEFAULT
 WHERE type_id = 'metrics';
 
-ALTER TABLE alert_metrics ADD COLUMN closed_at TIMESTAMP WITH TIME ZONE NOT NULL;
-
 TRUNCATE alert_metrics;
 
+ALTER TABLE alert_metrics ADD COLUMN closed_at TIMESTAMP WITH TIME ZONE NOT NULL;
 
 -- +migrate Down
 

--- a/migrate/migrations/20220317153438-alert-metrics-add-closed-at.sql
+++ b/migrate/migrations/20220317153438-alert-metrics-add-closed-at.sql
@@ -1,0 +1,18 @@
+-- +migrate Up
+
+UPDATE engine_processing_versions
+SET "version" = 2
+WHERE type_id = 'metrics';
+
+ALTER TABLE alert_metrics ADD COLUMN closed_at TIMESTAMP WITH TIME ZONE;
+
+TRUNCATE alert_metrics;
+
+
+-- +migrate Down
+
+ALTER TABLE alert_metrics DROP COLUMN closed_at;
+
+UPDATE engine_processing_versions
+SET "version" = 1
+WHERE type_id = 'metrics';

--- a/migrate/migrations/20220317153438-alert-metrics-add-closed-at.sql
+++ b/migrate/migrations/20220317153438-alert-metrics-add-closed-at.sql
@@ -4,7 +4,7 @@ UPDATE engine_processing_versions
 SET "version" = 2
 WHERE type_id = 'metrics';
 
-ALTER TABLE alert_metrics ADD COLUMN closed_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE alert_metrics ADD COLUMN closed_at TIMESTAMP WITH TIME ZONE NOT NULL;
 
 TRUNCATE alert_metrics;
 
@@ -16,3 +16,5 @@ ALTER TABLE alert_metrics DROP COLUMN closed_at;
 UPDATE engine_processing_versions
 SET "version" = 1
 WHERE type_id = 'metrics';
+
+TRUNCATE alert_metrics;


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR populates a `closed_at` column in `alert_metrics` that will help with the implementation of #2122 

It also refactors the operation to work from oldest to newest, maintaining a `(timestamp, id)` cursor in the engine's state. To regenerate `alert_metrics` e.g. to catch any that were missed, one only needs to reset the engine state.

**How to validate:**
1. `make regendb` and `make start`
2. For each engine cycle, observe `alert_metrics` being populated (500 at a time) and the `engine_processing_version.state` value incrementing in a forward fashion
3. Wait for step 2 to finish, and observe that count(alert_metrics) == count(alerts where status = 'closed')
4. Create and close an alert
5. Wait two minutes before observing the new row in `alert_metrics` and the new `engine_processing_version.state` value

Optionally:

1. Delete some number of rows from `alert_metrics`
2. Clear `engine_processing_version.state` and observe the deleted rows regenerate
