### PR TITLE
ui/alerts: fix log events order

### DIFF
--- a/web/src/app/alerts/AlertDetailLogs.js
+++ b/web/src/app/alerts/AlertDetailLogs.js
@@ -17,8 +17,10 @@ const QUERY_LIMIT = 35
 const query = gql`
   query getAlert($id: Int!, $input: AlertRecentEventsOptions) {
     alert(id: $id) {
+      id
       recentEvents(input: $input) {
         nodes {
+          id
           timestamp
           message
           state {
@@ -49,7 +51,11 @@ export default function AlertDetailLogs(props) {
     variables: { id: props.alertID, input: { limit: QUERY_LIMIT } },
   })
 
-  const events = _.get(data, 'alert.recentEvents.nodes', [])
+  const events = _.orderBy(
+    data?.alert?.recentEvents?.nodes ?? [],
+    ['timestamp'],
+    ['desc'],
+  )
   const pageInfo = _.get(data, 'alert.recentEvents.pageInfo', {})
 
   const doFetchMore = () => {


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes an issue in which alert log events would be shuffled at random upon Apollo polling. The solution orders the log entries by timestamp in desc order. We also query the `id` fields for improved cacheing.

To validate, create an alert with many event log entries and observe the list for a minute to make sure polling does not shuffle the list items.
