### PR TITLE
ui/theme: invert background colors in light mode

### DIFF
--- a/web/src/app/theme/themeConfig.tsx
+++ b/web/src/app/theme/themeConfig.tsx
@@ -34,7 +34,7 @@ function getPalette(mode: MUIThemeMode): PaletteOptions {
       secondary: { main: '#b5cad6', light: '#d0e6f3', dark: '#354a54' },
       background: {
         default: '#191c1e',
-        paper: '#191c1e',
+        paper: '#191c1e', // m3 surface
       },
       error: { main: '#ffb4a9', light: '#ffdad4', dark: '#930006' },
     }
@@ -49,7 +49,7 @@ function getPalette(mode: MUIThemeMode): PaletteOptions {
     },
     secondary: { main: '#4d616b', light: '#d0e6f3', dark: '#081e27' },
     background: {
-      default: '#dce3e8',
+      default: '#dce3e8', // m3 surface variant
       paper: '#fbfcfe',
     },
     error: { main: '#ba1b1b', light: '#ffdad4', dark: '#410001' },

--- a/web/src/app/theme/themeConfig.tsx
+++ b/web/src/app/theme/themeConfig.tsx
@@ -34,7 +34,7 @@ function getPalette(mode: MUIThemeMode): PaletteOptions {
       secondary: { main: '#b5cad6', light: '#d0e6f3', dark: '#354a54' },
       background: {
         default: '#191c1e',
-        paper: '#191c1e', // m3 surface
+        paper: '#191c1e',
       },
       error: { main: '#ffb4a9', light: '#ffdad4', dark: '#930006' },
     }
@@ -49,8 +49,8 @@ function getPalette(mode: MUIThemeMode): PaletteOptions {
     },
     secondary: { main: '#4d616b', light: '#d0e6f3', dark: '#081e27' },
     background: {
-      default: '#fbfcfe',
-      paper: '#dce3e8', // m3 surface variant
+      default: '#dce3e8',
+      paper: '#fbfcfe',
     },
     error: { main: '#ba1b1b', light: '#ffdad4', dark: '#410001' },
   }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR changes the background colors in light mode to aid a11y by increasing contrast on the cards. I think this is the only place in #2217 in which we strayed from the generated palette and I think it shows.

<img width="1163" alt="Screen Shot 2022-03-23 at 1 48 58 PM" src="https://user-images.githubusercontent.com/17692467/159776776-1cbe3a14-563d-4fdd-b0b1-6b7b21638d47.png">

**Which issue(s) this PR fixes:**
Closes #2260 

