### PR TITLE
engine/metricsmanager: add `daily_alert_metrics` table

### DIFF
--- a/devtools/resetdb/datagen.go
+++ b/devtools/resetdb/datagen.go
@@ -342,7 +342,7 @@ func (d *datagen) NewAlert(status alert.Status) {
 	}
 	d.Alerts = append(d.Alerts, alert.Alert{
 		ID:        len(d.Alerts) + 1,
-		CreatedAt: gofakeit.DateRange(time.Now().Add(-2*time.Hour), time.Now().Add(-1*time.Hour)),
+		CreatedAt: gofakeit.DateRange(time.Now().Add(-30*24*time.Hour), time.Now().Add(-1*time.Hour)),
 		Status:    status,
 		ServiceID: serviceID,
 		Summary:   d.ids.Gen(func() string { return gofakeit.Sentence(rand.Intn(10) + 3) }, serviceID),

--- a/engine/metricsmanager/db.go
+++ b/engine/metricsmanager/db.go
@@ -49,7 +49,7 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 		scanLogs: p.P(`
 			select alert_id, timestamp, id 
 			from alert_logs 
-			where event='closed' and (timestamp > $1 and timestamp < $3 or (timestamp = $1 and id > $2)) 
+			where event='closed' and timestamp < $3 and (timestamp > $1 or (timestamp = $1 and id > $2)) 
 			order by timestamp, id 
 			limit 500`),
 

--- a/engine/metricsmanager/db.go
+++ b/engine/metricsmanager/db.go
@@ -43,7 +43,7 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 		db:   db,
 		lock: lock,
 
-		// NOTE: uses a buffer to allow for in-flight requests to settle
+		// NOTE: this buffer provides time for in-flight requests to settle
 		boundNow: p.P(`select now() - '2 minutes'::interval`),
 
 		scanLogs: p.P(`

--- a/engine/metricsmanager/db.go
+++ b/engine/metricsmanager/db.go
@@ -71,7 +71,7 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 			select (date(timezone('UTC'::text, closed_at))) from alert_metrics 
 			where  (date(timezone('UTC'::text, closed_at))) > $1::date 
 			and    (date(timezone('UTC'::text, closed_at))) < $2::date
-			order by closed_at
+			order by (date(timezone('UTC'::text, closed_at)))
 			limit 1;
 		`),
 

--- a/engine/metricsmanager/db.go
+++ b/engine/metricsmanager/db.go
@@ -67,11 +67,11 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 			on conflict do nothing
 		`),
 
-		// NOTE: we avoid having to order by closed_at::date via the ordered index on closed_at::date
 		nextDailyMetricsDate: p.P(`
 			select (date(timezone('UTC'::text, closed_at))) from alert_metrics 
 			where  (date(timezone('UTC'::text, closed_at))) > $1::date 
 			and    (date(timezone('UTC'::text, closed_at))) < $2::date
+			order by closed_at
 			limit 1;
 		`),
 

--- a/engine/metricsmanager/update.go
+++ b/engine/metricsmanager/update.go
@@ -22,6 +22,26 @@ type State struct {
 	}
 }
 
+func (db *DB) UpdateAll(ctx context.Context) error {
+	err := permission.LimitCheckAny(ctx, permission.System)
+	if err != nil {
+		return err
+	}
+
+	err = db.UpdateAlertMetrics(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = db.UpdateDailyAlertMetrics(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdateAlertMetrics will update the alert metrics table
 /*
 	Theory of Operation:
 
@@ -31,14 +51,8 @@ type State struct {
 	4. Set cursor to last inserted
 
 */
-
-// UpdateAll will update the alert metrics table
-func (db *DB) UpdateAll(ctx context.Context) error {
-	err := permission.LimitCheckAny(ctx, permission.System)
-	if err != nil {
-		return err
-	}
-	log.Debugf(ctx, "Running metrics operations.")
+func (db *DB) UpdateAlertMetrics(ctx context.Context) error {
+	log.Debugf(ctx, "Running alert_metrics operations.")
 
 	tx, lockState, err := db.lock.BeginTxWithState(ctx, nil)
 	if err != nil {
@@ -93,4 +107,12 @@ func (db *DB) UpdateAll(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// UpdateDailyAlertMetrics will update the daily alert metrics table
+func (db *DB) UpdateDailyAlertMetrics(ctx context.Context) error {
+	log.Debugf(ctx, "Running daily_alert_metrics operations.")
+
+	return nil
+
 }

--- a/migrate/migrations/20220329170727-add-daily-alert-metrics.sql
+++ b/migrate/migrations/20220329170727-add-daily-alert-metrics.sql
@@ -1,0 +1,25 @@
+-- +migrate Up
+
+CREATE TABLE daily_alert_metrics (
+    id BIGSERIAL PRIMARY KEY,
+    service_id UUID NOT NULL,
+    date DATE NOT NULL,
+    alert_count INT DEFAULT 0 NOT NULL,
+    avg_time_to_ack INTERVAL,
+    avg_time_to_close INTERVAL,
+    escalated_count INT DEFAULT 0 NOT NULL,
+
+    UNIQUE(service_id, date)
+);
+
+CREATE INDEX alert_metrics_closed_date_idx ON alert_metrics (DATE(closed_at AT TIME ZONE 'UTC' ) ASC);
+
+-- +migrate Down
+
+DROP INDEX alert_metrics_closed_date_idx;
+
+DROP TABLE daily_alert_metrics;
+
+UPDATE engine_processing_versions 
+SET state = DEFAULT
+WHERE type_id = 'metrics';


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adds a new `daily_alert_metrics` table that aggregates metrics from `alert_metrics`. We do this basically as a cacheing strategy for the metrics API targets. 

**How to test:**
1. `make regendb`
2. `make start`
3. Watch `engine_processing_versions.state` update where `type_id = 'metrics'`
4. The state's `LastMetricsDate` will never exceed the date of `LastLogTime`. Therefore, to get metrics for the current day, one must look in `alert_metrics`.
5. Observe rows being added in `alert_metrics` and `daily_alert_metrics` over time.


**Which issue(s) this PR fixes:**
Closes #2122 

**Additional Information:**
This PR modifies the local dev alert generation to be spread across the previous 30 days as opposed to 2 hours. This makes testing more interesting and realistic.