### PR TITLE
engine/metricsmanager: fix scanLogs logic

### DIFF
--- a/engine/metricsmanager/db.go
+++ b/engine/metricsmanager/db.go
@@ -42,7 +42,7 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 		scanLogs: p.P(`
 			select alert_id, timestamp, id 
 			from alert_logs 
-			where event='closed' and (timestamp > $1 and timestamp < now() - '2 minutes'::interval or (timestamp = $1 and id > $2)) 
+			where event='closed' and timestamp < now() - '2 minutes'::interval and (timestamp > $1 or (timestamp = $1 and id > $2)) 
 			order by timestamp, id 
 			limit 500`),
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x]  Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes the logic around scanning which alert_logs to process. To be eligible, a log must be: closed, before now() - 2mins, and be after the cursor time (using ID as a tiebreaker).
