### PR TITLE
web: fix cache-control header syntax

### DIFF
--- a/web/etaghandler.go
+++ b/web/etaghandler.go
@@ -56,7 +56,7 @@ func (e *etagHandler) etag(name string) string {
 
 func (e *etagHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if tag := e.etag(req.URL.Path); tag != "" {
-		w.Header().Set("Cache-Control", "public; max-age=60, stale-while-revalidate=600, stale-if-error=259200")
+		w.Header().Set("Cache-Control", "public, max-age=60, stale-while-revalidate=600, stale-if-error=259200")
 		w.Header().Set("ETag", tag)
 	}
 

--- a/web/handler.go
+++ b/web/handler.go
@@ -77,7 +77,7 @@ func serveTemplate(uiDir string, w http.ResponseWriter, req *http.Request, tmpl 
 	w.Header().Set("ETag", etagValue)
 
 	if uiDir == "" {
-		w.Header().Set("Cache-Control", "private; max-age=60, stale-while-revalidate=600, stale-if-error=259200")
+		w.Header().Set("Cache-Control", "private, max-age=60, stale-while-revalidate=600, stale-if-error=259200")
 	} else {
 		w.Header().Set("Cache-Control", "no-store")
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes the Cache-Control HTTP response header syntax

**Additional Info:**
You can confirm the issue for different deployments using https://redbot.org
