### PR TITLE
devtools/pgdump-lite: exclude tables option

### DIFF
--- a/devtools/pgdump-lite/cmd/pgdump-lite/main.go
+++ b/devtools/pgdump-lite/cmd/pgdump-lite/main.go
@@ -16,7 +16,7 @@ func main() {
 	file := flag.String("f", "", "Output file (default is stdout).")
 	db := flag.String("d", os.Getenv("DBURL"), "DB URL") // use same env var as pg_dump
 	dataOnly := flag.Bool("a", false, "dump only the data, not the schema")
-	skip := flag.String("s", "", "skip tables")
+	skip := flag.String("T", "", "skip tables")
 	flag.Parse()
 
 	out := os.Stdout

--- a/devtools/pgdump-lite/cmd/pgdump-lite/main.go
+++ b/devtools/pgdump-lite/cmd/pgdump-lite/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/jackc/pgx/v4"
 	"github.com/target/goalert/devtools/pgdump-lite"
@@ -15,6 +16,7 @@ func main() {
 	file := flag.String("f", "", "Output file (default is stdout).")
 	db := flag.String("d", os.Getenv("DBURL"), "DB URL") // use same env var as pg_dump
 	dataOnly := flag.Bool("a", false, "dump only the data, not the schema")
+	skip := flag.String("s", "", "skip tables")
 	flag.Parse()
 
 	out := os.Stdout
@@ -40,7 +42,7 @@ func main() {
 	}
 	defer conn.Close(ctx)
 
-	err = pgdump.DumpData(ctx, conn, out)
+	err = pgdump.DumpData(ctx, conn, out, strings.Split(*skip, ","))
 	if err != nil {
 		log.Fatalln("ERROR: dump data:", err)
 	}

--- a/smoketest/harness/harness.go
+++ b/smoketest/harness/harness.go
@@ -361,6 +361,7 @@ func (h *Harness) modifyDBOffset(d time.Duration) {
 
 	h.setDBOffset(h.delayOffset)
 }
+
 func (h *Harness) setDBOffset(d time.Duration) {
 	h.mx.Lock()
 	defer h.mx.Unlock()
@@ -579,7 +580,7 @@ func (h *Harness) dumpDB() {
 	if err != nil {
 		h.t.Fatalf("failed to get abs dump path: %v", err)
 	}
-	os.MkdirAll(filepath.Dir(file), 0755)
+	os.MkdirAll(filepath.Dir(file), 0o755)
 	var t time.Time
 	err = h.db.QueryRow(context.Background(), "select now()").Scan(&t)
 	if err != nil {
@@ -598,7 +599,7 @@ func (h *Harness) dumpDB() {
 	}
 	defer fd.Close()
 
-	err = pgdump.DumpData(context.Background(), conn.Conn(), fd)
+	err = pgdump.DumpData(context.Background(), conn.Conn(), fd, nil)
 	if err != nil {
 		h.t.Errorf("failed to dump database '%s': %v", h.dbName, err)
 	}


### PR DESCRIPTION
**Description:**
Adds a skip/exclude tables option as `-T`, similar to the exclude tables option in `pg_dump`.
