### PR TITLE
devtools/simpleproxy: add round-robin support

### DIFF
--- a/devtools/simpleproxy/main.go
+++ b/devtools/simpleproxy/main.go
@@ -22,13 +22,18 @@ func main() {
 			parts = []string{"/", parts[0]}
 		}
 
-		u, err := url.Parse(parts[1])
-		if err != nil {
-			log.Fatalf("ERORR: parse %s: %v", parts[1], err)
-		}
+		var rr RR
+		hosts := strings.Split(parts[1], ",")
+		for _, host := range hosts {
 
-		p := httputil.NewSingleHostReverseProxy(u)
-		h := http.Handler(p)
+			u, err := url.Parse(host)
+			if err != nil {
+				log.Fatalf("ERORR: parse %s: %v", host, err)
+			}
+
+			rr.h = append(rr.h, httputil.NewSingleHostReverseProxy(u))
+		}
+		h := http.Handler(&rr)
 		if *trim {
 			h = http.StripPrefix(parts[0], h)
 		}

--- a/devtools/simpleproxy/roundrobin.go
+++ b/devtools/simpleproxy/roundrobin.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+	"sync"
+)
+
+type RR struct {
+	h  []http.Handler
+	n  int
+	mx sync.Mutex
+}
+
+func (r *RR) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	r.mx.Lock()
+	handler := r.h[r.n]
+	r.n = (r.n + 1) % len(r.h)
+	r.mx.Unlock()
+	handler.ServeHTTP(w, req)
+}


### PR DESCRIPTION
**Description:**
Allows multiple destinations separated by commas and performs round-robin-based load balancing to the `simpleproxy` tool.

**Review**

Add a second instance of goalert and the proxy to `Procfile.local` (create if it doesn't exist)
```Procfile
goalert2: ./bin/goalert -l=localhost:3032 --ui-dir=web/src/build --db-url=postgres://goalert@localhost
proxy: go run ./devtools/simpleproxy -addr=localhost:3033 http://localhost:3030,http://localhost:3032
```

- run `make start`
- visit `http://localhost:3033`
- perform some mutations and ensure both `goalert` and `goalert2` show up in the log output and the requests are successful.

