### PR TITLE
devtools/slowproxy: add slowproxy tool to emulate slow network conditions

### DIFF
--- a/Makefile.binaries.mk
+++ b/Makefile.binaries.mk
@@ -363,6 +363,25 @@ $(BIN_DIR)/windows-amd64/simpleproxy.exe: $(GO_DEPS)
 	GOOS=windows GOARCH=amd64 go build -trimpath  -o $@ ./devtools/simpleproxy
 
 
+$(BIN_DIR)/slowproxy: $(GO_DEPS) 
+	go build  -o $@ ./devtools/slowproxy
+
+$(BIN_DIR)/darwin-amd64/slowproxy: $(GO_DEPS)  
+	GOOS=darwin GOARCH=amd64 go build -trimpath  -o $@ ./devtools/slowproxy
+
+$(BIN_DIR)/linux-amd64/slowproxy: $(GO_DEPS)  
+	GOOS=linux GOARCH=amd64 go build -trimpath  -o $@ ./devtools/slowproxy
+
+$(BIN_DIR)/linux-arm/slowproxy: $(GO_DEPS)  
+	GOOS=linux GOARCH=arm GOARM=7 go build -trimpath  -o $@ ./devtools/slowproxy
+
+$(BIN_DIR)/linux-arm64/slowproxy: $(GO_DEPS)  
+	GOOS=linux GOARCH=arm64 go build -trimpath  -o $@ ./devtools/slowproxy
+
+$(BIN_DIR)/windows-amd64/slowproxy.exe: $(GO_DEPS)  
+	GOOS=windows GOARCH=amd64 go build -trimpath  -o $@ ./devtools/slowproxy
+
+
 $(BIN_DIR)/waitfor: $(GO_DEPS) 
 	go build  -o $@ ./devtools/waitfor
 
@@ -384,27 +403,27 @@ $(BIN_DIR)/windows-amd64/waitfor.exe: $(GO_DEPS)
 
 
 
-$(BIN_DIR)/darwin-amd64/_all: $(BIN_DIR)/darwin-amd64/goalert-smoketest $(BIN_DIR)/darwin-amd64/goalert $(BIN_DIR)/darwin-amd64/goalert-slack-email-sync $(BIN_DIR)/darwin-amd64/mockslack $(BIN_DIR)/darwin-amd64/pgdump-lite $(BIN_DIR)/darwin-amd64/procwrap $(BIN_DIR)/darwin-amd64/psql-lite $(BIN_DIR)/darwin-amd64/resetdb $(BIN_DIR)/darwin-amd64/runproc $(BIN_DIR)/darwin-amd64/sendit $(BIN_DIR)/darwin-amd64/sendit-server $(BIN_DIR)/darwin-amd64/sendit-token $(BIN_DIR)/darwin-amd64/simpleproxy $(BIN_DIR)/darwin-amd64/waitfor
+$(BIN_DIR)/darwin-amd64/_all: $(BIN_DIR)/darwin-amd64/goalert-smoketest $(BIN_DIR)/darwin-amd64/goalert $(BIN_DIR)/darwin-amd64/goalert-slack-email-sync $(BIN_DIR)/darwin-amd64/mockslack $(BIN_DIR)/darwin-amd64/pgdump-lite $(BIN_DIR)/darwin-amd64/procwrap $(BIN_DIR)/darwin-amd64/psql-lite $(BIN_DIR)/darwin-amd64/resetdb $(BIN_DIR)/darwin-amd64/runproc $(BIN_DIR)/darwin-amd64/sendit $(BIN_DIR)/darwin-amd64/sendit-server $(BIN_DIR)/darwin-amd64/sendit-token $(BIN_DIR)/darwin-amd64/simpleproxy $(BIN_DIR)/darwin-amd64/slowproxy $(BIN_DIR)/darwin-amd64/waitfor
 
 $(BIN_DIR)/darwin-amd64/goalert-smoketest: $(GO_DEPS)
 	GOOS=darwin GOARCH=amd64 go test ./smoketest -c -o $@
 
-$(BIN_DIR)/linux-amd64/_all: $(BIN_DIR)/linux-amd64/goalert-smoketest $(BIN_DIR)/linux-amd64/goalert $(BIN_DIR)/linux-amd64/goalert-slack-email-sync $(BIN_DIR)/linux-amd64/mockslack $(BIN_DIR)/linux-amd64/pgdump-lite $(BIN_DIR)/linux-amd64/procwrap $(BIN_DIR)/linux-amd64/psql-lite $(BIN_DIR)/linux-amd64/resetdb $(BIN_DIR)/linux-amd64/runproc $(BIN_DIR)/linux-amd64/sendit $(BIN_DIR)/linux-amd64/sendit-server $(BIN_DIR)/linux-amd64/sendit-token $(BIN_DIR)/linux-amd64/simpleproxy $(BIN_DIR)/linux-amd64/waitfor
+$(BIN_DIR)/linux-amd64/_all: $(BIN_DIR)/linux-amd64/goalert-smoketest $(BIN_DIR)/linux-amd64/goalert $(BIN_DIR)/linux-amd64/goalert-slack-email-sync $(BIN_DIR)/linux-amd64/mockslack $(BIN_DIR)/linux-amd64/pgdump-lite $(BIN_DIR)/linux-amd64/procwrap $(BIN_DIR)/linux-amd64/psql-lite $(BIN_DIR)/linux-amd64/resetdb $(BIN_DIR)/linux-amd64/runproc $(BIN_DIR)/linux-amd64/sendit $(BIN_DIR)/linux-amd64/sendit-server $(BIN_DIR)/linux-amd64/sendit-token $(BIN_DIR)/linux-amd64/simpleproxy $(BIN_DIR)/linux-amd64/slowproxy $(BIN_DIR)/linux-amd64/waitfor
 
 $(BIN_DIR)/linux-amd64/goalert-smoketest: $(GO_DEPS)
 	GOOS=linux GOARCH=amd64 go test ./smoketest -c -o $@
 
-$(BIN_DIR)/linux-arm/_all: $(BIN_DIR)/linux-arm/goalert-smoketest $(BIN_DIR)/linux-arm/goalert $(BIN_DIR)/linux-arm/goalert-slack-email-sync $(BIN_DIR)/linux-arm/mockslack $(BIN_DIR)/linux-arm/pgdump-lite $(BIN_DIR)/linux-arm/procwrap $(BIN_DIR)/linux-arm/psql-lite $(BIN_DIR)/linux-arm/resetdb $(BIN_DIR)/linux-arm/runproc $(BIN_DIR)/linux-arm/sendit $(BIN_DIR)/linux-arm/sendit-server $(BIN_DIR)/linux-arm/sendit-token $(BIN_DIR)/linux-arm/simpleproxy $(BIN_DIR)/linux-arm/waitfor
+$(BIN_DIR)/linux-arm/_all: $(BIN_DIR)/linux-arm/goalert-smoketest $(BIN_DIR)/linux-arm/goalert $(BIN_DIR)/linux-arm/goalert-slack-email-sync $(BIN_DIR)/linux-arm/mockslack $(BIN_DIR)/linux-arm/pgdump-lite $(BIN_DIR)/linux-arm/procwrap $(BIN_DIR)/linux-arm/psql-lite $(BIN_DIR)/linux-arm/resetdb $(BIN_DIR)/linux-arm/runproc $(BIN_DIR)/linux-arm/sendit $(BIN_DIR)/linux-arm/sendit-server $(BIN_DIR)/linux-arm/sendit-token $(BIN_DIR)/linux-arm/simpleproxy $(BIN_DIR)/linux-arm/slowproxy $(BIN_DIR)/linux-arm/waitfor
 
 $(BIN_DIR)/linux-arm/goalert-smoketest: $(GO_DEPS)
 	GOOS=linux GOARCH=arm GOARM=7 go test ./smoketest -c -o $@
 
-$(BIN_DIR)/linux-arm64/_all: $(BIN_DIR)/linux-arm64/goalert-smoketest $(BIN_DIR)/linux-arm64/goalert $(BIN_DIR)/linux-arm64/goalert-slack-email-sync $(BIN_DIR)/linux-arm64/mockslack $(BIN_DIR)/linux-arm64/pgdump-lite $(BIN_DIR)/linux-arm64/procwrap $(BIN_DIR)/linux-arm64/psql-lite $(BIN_DIR)/linux-arm64/resetdb $(BIN_DIR)/linux-arm64/runproc $(BIN_DIR)/linux-arm64/sendit $(BIN_DIR)/linux-arm64/sendit-server $(BIN_DIR)/linux-arm64/sendit-token $(BIN_DIR)/linux-arm64/simpleproxy $(BIN_DIR)/linux-arm64/waitfor
+$(BIN_DIR)/linux-arm64/_all: $(BIN_DIR)/linux-arm64/goalert-smoketest $(BIN_DIR)/linux-arm64/goalert $(BIN_DIR)/linux-arm64/goalert-slack-email-sync $(BIN_DIR)/linux-arm64/mockslack $(BIN_DIR)/linux-arm64/pgdump-lite $(BIN_DIR)/linux-arm64/procwrap $(BIN_DIR)/linux-arm64/psql-lite $(BIN_DIR)/linux-arm64/resetdb $(BIN_DIR)/linux-arm64/runproc $(BIN_DIR)/linux-arm64/sendit $(BIN_DIR)/linux-arm64/sendit-server $(BIN_DIR)/linux-arm64/sendit-token $(BIN_DIR)/linux-arm64/simpleproxy $(BIN_DIR)/linux-arm64/slowproxy $(BIN_DIR)/linux-arm64/waitfor
 
 $(BIN_DIR)/linux-arm64/goalert-smoketest: $(GO_DEPS)
 	GOOS=linux GOARCH=arm64 go test ./smoketest -c -o $@
 
-$(BIN_DIR)/windows-amd64/_all: $(BIN_DIR)/windows-amd64/goalert-smoketest $(BIN_DIR)/windows-amd64/goalert.exe $(BIN_DIR)/windows-amd64/goalert-slack-email-sync.exe $(BIN_DIR)/windows-amd64/mockslack.exe $(BIN_DIR)/windows-amd64/pgdump-lite.exe $(BIN_DIR)/windows-amd64/procwrap.exe $(BIN_DIR)/windows-amd64/psql-lite.exe $(BIN_DIR)/windows-amd64/resetdb.exe $(BIN_DIR)/windows-amd64/runproc.exe $(BIN_DIR)/windows-amd64/sendit.exe $(BIN_DIR)/windows-amd64/sendit-server.exe $(BIN_DIR)/windows-amd64/sendit-token.exe $(BIN_DIR)/windows-amd64/simpleproxy.exe $(BIN_DIR)/windows-amd64/waitfor.exe
+$(BIN_DIR)/windows-amd64/_all: $(BIN_DIR)/windows-amd64/goalert-smoketest $(BIN_DIR)/windows-amd64/goalert.exe $(BIN_DIR)/windows-amd64/goalert-slack-email-sync.exe $(BIN_DIR)/windows-amd64/mockslack.exe $(BIN_DIR)/windows-amd64/pgdump-lite.exe $(BIN_DIR)/windows-amd64/procwrap.exe $(BIN_DIR)/windows-amd64/psql-lite.exe $(BIN_DIR)/windows-amd64/resetdb.exe $(BIN_DIR)/windows-amd64/runproc.exe $(BIN_DIR)/windows-amd64/sendit.exe $(BIN_DIR)/windows-amd64/sendit-server.exe $(BIN_DIR)/windows-amd64/sendit-token.exe $(BIN_DIR)/windows-amd64/simpleproxy.exe $(BIN_DIR)/windows-amd64/slowproxy.exe $(BIN_DIR)/windows-amd64/waitfor.exe
 
 $(BIN_DIR)/windows-amd64/goalert-smoketest: $(GO_DEPS)
 	GOOS=windows GOARCH=amd64 go test ./smoketest -c -o $@

--- a/devtools/slowproxy/main.go
+++ b/devtools/slowproxy/main.go
@@ -8,12 +8,12 @@ import (
 )
 
 func main() {
-	rateOut := flag.Int("o", 0, "Max data rate (in bytes/sec) to DB.")
-	rateIn := flag.Int("i", 0, "Max data rate (in bytes/sec) from DB.")
+	rateOut := flag.Int("o", 0, "Max data rate (in bytes/sec) from client to server.")
+	rateIn := flag.Int("i", 0, "Max data rate (in bytes/sec) from server to client.")
 	latency := flag.Duration("d", 0, "Min latency (one-way).")
 	jitter := flag.Duration("j", 0, "Jitter in (random +/- to latency).")
 	l := flag.String("l", "localhost:5435", "Listen address.")
-	c := flag.String("c", "localhost:5432", "Connect address.")
+	c := flag.String("c", "localhost:5432", "Server connect address.")
 	flag.Parse()
 	log.SetFlags(log.Lshortfile)
 

--- a/devtools/slowproxy/main.go
+++ b/devtools/slowproxy/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"log"
+	"net"
+)
+
+func main() {
+	rateOut := flag.Int("o", 0, "Max data rate (in bytes/sec) to DB.")
+	rateIn := flag.Int("i", 0, "Max data rate (in bytes/sec) from DB.")
+	latency := flag.Duration("d", 0, "Min latency (one-way).")
+	jitter := flag.Duration("j", 0, "Jitter in (random +/- to latency).")
+	l := flag.String("l", "localhost:5435", "Listen address.")
+	c := flag.String("c", "localhost:5432", "Connect address.")
+	flag.Parse()
+	log.SetFlags(log.Lshortfile)
+
+	limitOut := newRateLimiter(*rateOut, *latency, *jitter)
+	limitIn := newRateLimiter(*rateIn, *latency, *jitter)
+
+	srv, err := net.Listen("tcp", *l)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	proxy := func(dst, src net.Conn, limiter *rateLimiter) {
+		defer dst.Close()
+		defer src.Close()
+
+		io.Copy(limiter.NewWriter(dst), src)
+	}
+
+	for {
+		conn, err := srv.Accept()
+		if err != nil {
+			log.Fatal(err)
+		}
+		go func() {
+			dbConn, err := net.Dial("tcp", *c)
+			if err != nil {
+				log.Println("connect error:", err)
+				conn.Close()
+				return
+			}
+
+			log.Println("CONNECT", conn.RemoteAddr().String())
+			go proxy(conn, dbConn, limitOut)
+			go proxy(dbConn, conn, limitIn)
+		}()
+	}
+}

--- a/devtools/slowproxy/ratelimiter.go
+++ b/devtools/slowproxy/ratelimiter.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"io"
+	"math/rand"
+	"time"
+)
+
+type rateLimiter struct {
+	bucket   chan int
+	overflow chan int
+	latency  time.Duration
+	jitter   time.Duration
+}
+
+func newRateLimiter(bps int, latency, jitter time.Duration) *rateLimiter {
+	ch := make(chan int)
+	go func() {
+		t := time.NewTicker(time.Second)
+		for range t.C {
+			ch <- bps
+		}
+	}()
+	return &rateLimiter{
+		bucket:   ch,
+		overflow: make(chan int, 1000),
+		latency:  latency,
+		jitter:   jitter,
+	}
+}
+
+func (r *rateLimiter) WaitFor(count int) time.Duration {
+	var n int
+	for n < count {
+		select {
+		case val := <-r.bucket:
+			n += val
+		case val := <-r.overflow:
+			n += val
+		}
+	}
+	if n > count {
+		r.overflow <- n - count
+	}
+	return (r.latency - (r.jitter / 2) + time.Duration(rand.Float64()*float64(r.jitter))) / 2
+}
+
+func (r *rateLimiter) NewWriter(w io.Writer) io.Writer {
+	return &rateLimitWriter{
+		w: w,
+		l: r,
+	}
+}
+
+type rateLimitWriter struct {
+	l *rateLimiter
+	w io.Writer
+}
+
+func (w *rateLimitWriter) Write(p []byte) (int, error) {
+	dur := w.l.WaitFor(len(p))
+	time.Sleep(dur)
+	defer time.Sleep(dur)
+	return w.w.Write(p)
+}


### PR DESCRIPTION
**Description:**
Adds a new tool, `slowproxy` that can simulate network latency, jitter, and throughput constraints for testing.

**Review**
Add slowproxy to `Procfile.local` (create if necessary)
```Procfile
proxy: go run ./devtools/slowproxy -l localhost:3033 -c localhost:3030 -d 25ms -j 10ms
```

- run `make start`
- visit `http://localhost:3033`
- verify application works
- try other options to change behavior

```
$ go run ./devtools/slowproxy -h
Usage of /tmp/go-build2557664850/b001/exe/slowproxy:
  -c string
    	Server connect address. (default "localhost:5432")
  -d duration
    	Min latency (one-way).
  -i int
    	Max data rate (in bytes/sec) from server to client.
  -j duration
    	Jitter in (random +/- to latency).
  -l string
    	Listen address. (default "localhost:5435")
  -o int
    	Max data rate (in bytes/sec) from client to server.
```



