### PR TITLE
ui: fix appbar icon buttons in light mode

### DIFF
--- a/web/src/app/main/components/ToolbarAction.js
+++ b/web/src/app/main/components/ToolbarAction.js
@@ -44,6 +44,9 @@ function ToolbarAction(props) {
           data-cy='nav-menu-icon'
           onClick={() => props.openMobileSidebar(true)}
           size='large'
+          sx={(theme) => ({
+            color: theme.palette.mode === 'light' ? 'inherit' : undefined,
+          })}
         >
           <MenuIcon />
         </IconButton>

--- a/web/src/app/util/Search.js
+++ b/web/src/app/util/Search.js
@@ -108,6 +108,9 @@ export default function Search(props) {
           data-cy='open-search'
           onClick={() => setShowMobile(true)}
           size='large'
+          sx={(theme) => ({
+            color: theme.palette.mode === 'light' ? 'inherit' : undefined,
+          })}
         >
           <SearchIcon />
         </IconButton>

--- a/web/src/app/util/Search.js
+++ b/web/src/app/util/Search.js
@@ -135,6 +135,9 @@ export default function Search(props) {
                 aria-label='Cancel'
                 data-cy='close-search'
                 size='large'
+                sx={(theme) => ({
+                  color: theme.palette.mode === 'light' ? 'inherit' : undefined,
+                })}
               >
                 <CloseIcon />
               </IconButton>


### PR DESCRIPTION
fixes the invisible icon buttons in the appbar when in mobile/light mode

in light mode, both the appbar and icon buttons are set to the primary color. in dark mode, the appbar is a shade of grey. dark mode is unaffected by this change.

before:

<img width="410" alt="Screen Shot 2022-04-18 at 1 34 58 PM" src="https://user-images.githubusercontent.com/11381794/163873960-b8caf58d-3920-43a0-924f-ae046f4b4f03.png">

<img width="421" alt="Screen Shot 2022-04-18 at 1 50 46 PM" src="https://user-images.githubusercontent.com/11381794/163876235-bf0deaba-28be-4680-b53b-bca6c993adde.png">


after:

<img width="411" alt="Screen Shot 2022-04-18 at 1 34 39 PM" src="https://user-images.githubusercontent.com/11381794/163873977-d3765818-3c86-4330-a128-792e3450a516.png">

<img width="411" alt="Screen Shot 2022-04-18 at 1 51 51 PM" src="https://user-images.githubusercontent.com/11381794/163876242-fbf9ac1b-5be7-44cf-94ce-1ece8f8931c4.png">