### PR TITLE
ui/services/alertmetrics: fix alert metrics graph styles

### DIFF
--- a/web/src/app/services/AlertMetrics/AlertCountGraph.tsx
+++ b/web/src/app/services/AlertMetrics/AlertCountGraph.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Grid } from '@mui/material'
+import { Grid, Paper, Typography } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles/makeStyles'
-import { Theme } from '@mui/material/styles'
+import { Theme, useTheme } from '@mui/material/styles'
 import {
   XAxis,
   YAxis,
@@ -33,6 +33,7 @@ export default function AlertCountGraph(
   props: AlertCountGraphProps,
 ): JSX.Element {
   const classes = useStyles()
+  const theme = useTheme()
   return (
     <Grid container className={classes.graphContent}>
       <Grid item xs={12} data-cy='metrics-graph'>
@@ -47,19 +48,40 @@ export default function AlertCountGraph(
               bottom: 50,
             }}
           >
-            <CartesianGrid strokeDasharray='4' vertical={false} />
-            <XAxis dataKey='date' type='category' />
-            <YAxis allowDecimals={false} dataKey='count' />
+            <CartesianGrid
+              strokeDasharray='4'
+              vertical={false}
+              stroke={theme.palette.text.secondary}
+            />
+            <XAxis
+              dataKey='date'
+              type='category'
+              stroke={theme.palette.text.secondary}
+            />
+            <YAxis
+              allowDecimals={false}
+              dataKey='count'
+              stroke={theme.palette.text.secondary}
+            />
             <Tooltip
               data-cy='metrics-tooltip'
-              labelFormatter={(label, props) => {
-                return props?.length ? props[0].payload.label : label
+              cursor={{ fill: theme.palette.background.default }}
+              content={(props) => {
+                const dataStr = props.payload?.length
+                  ? `${props.payload[0].name}: ${props.payload[0].value}`
+                  : ''
+                return (
+                  <Paper variant='outlined' sx={{ p: 1 }}>
+                    <Typography variant='body2'>{props.label}</Typography>
+                    <Typography variant='body2'>{dataStr}</Typography>
+                  </Paper>
+                )
               }}
             />
             <Legend />
             <Bar
               dataKey='count'
-              fill='rgb(205, 24, 49)'
+              fill={theme.palette.primary.main}
               className={classes.bar}
               name='Alert Count'
             />

--- a/web/src/cypress/integration/services.ts
+++ b/web/src/cypress/integration/services.ts
@@ -661,7 +661,7 @@ function testServices(screen: ScreenFormat): void {
       cy.get('path[name="Alert Count"]')
         .should('have.length', 1)
         .trigger('mouseover')
-      cy.get('[data-cy=metrics-graph]').should('contain', 'Alert Count : 1')
+      cy.get('[data-cy=metrics-graph]').should('contain', 'Alert Count: 1')
     })
   })
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This styles the alert metrics graph using our MUI theme and MUI Paper, Typography elements for the graph's tooltip.

**Which issue(s) this PR fixes:**
Fixes #2310

**Screenshots:**

https://user-images.githubusercontent.com/17692467/164507385-4747787f-04b3-4cec-bab6-3051f4fe6911.mov


