### PR TITLE
ui/schedule: update timezone hint text

### DIFF
--- a/web/src/app/schedules/ScheduleOverrideForm.js
+++ b/web/src/app/schedules/ScheduleOverrideForm.js
@@ -99,7 +99,7 @@ export default function ScheduleOverrideForm(props) {
         )}
         <Grid item xs={12}>
           <Typography color='textSecondary' sx={{ fontStyle: 'italic' }}>
-            Configuring in {zone || '...'}
+            Times shown in schedule timezone ({zone || '...'})
           </Typography>
         </Grid>
         <Grid item xs={12}>

--- a/web/src/app/schedules/ScheduleRuleForm.js
+++ b/web/src/app/schedules/ScheduleRuleForm.js
@@ -231,7 +231,7 @@ export default function ScheduleRuleForm(props) {
           </Grid>
           <Grid item xs={12}>
             <Typography color='textSecondary' sx={{ fontStyle: 'italic' }}>
-              Configuring in {zone || '...'}
+              Times shown in schedule timezone ({zone || '...'})
             </Typography>
           </Grid>
           <Grid item xs={12} style={{ paddingTop: 0 }}>

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsForm.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsForm.tsx
@@ -85,7 +85,7 @@ export default function ScheduleOnCallNotificationsForm(
             className={classes.tzNote}
             style={{ visibility: props.value.time ? 'visible' : 'hidden' }}
           >
-            Configuring in {zone}
+            Times shown in schedule timezone ({zone})
           </Typography>
         </Grid>
         <Grid item>

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -291,7 +291,7 @@ export default function TempSchedDialog({
 
               <Grid item xs={12}>
                 <Typography color='textSecondary' className={classes.tzNote}>
-                  Configuring in {zone}
+                  Times shown in schedule timezone ({zone})
                 </Typography>
               </Grid>
 


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Now that the displayed times can't be toggled between zones in schedule dialogs, we're updating the hint text from "Configuring in America/Chicago" to "Times shown in schedule timezone (America/Chicago)".

**Which issue(s) this PR fixes:**
https://github.com/target/goalert/issues/2280

**Screenshots:**
schedule override - before
<img width="543" alt="schedule override - before" src="https://user-images.githubusercontent.com/52386267/165840232-6dd9b8db-90c4-4957-9ba5-6c9b3f21d508.png">
schedule override - after
<img width="543" alt="schedule override - after" src="https://user-images.githubusercontent.com/52386267/165840230-7f41a64b-b4aa-4baf-9c72-be9ba9108169.png">

temp schedule - before
<img width="880" alt="temp schedule - before" src="https://user-images.githubusercontent.com/52386267/165840290-3cbb772c-28a9-407e-92b8-1b3899595f3f.png">
temp schedule - after
<img width="879" alt="temp schedule - after" src="https://user-images.githubusercontent.com/52386267/165840282-b9a445f7-c260-4ca9-ae2a-b88b89d1f734.png">

edit notification rule - before
<img width="441" alt="edit notifcation rule - before" src="https://user-images.githubusercontent.com/52386267/165840289-cc9b80d8-475f-4cbf-94db-d8a33a1b649d.png">
edit notification rule - after
<img width="439" alt="edit notifcation rule - after" src="https://user-images.githubusercontent.com/52386267/165840288-09a1d525-8b58-4f91-8eb9-c6064663d57f.png">

edit rotation rules - before
<img width="812" alt="edit rotation rules - before" src="https://user-images.githubusercontent.com/52386267/165840292-f03236ad-03fe-4e73-9a28-f2d9ecc1db5f.png">
edit rotation rules - after
<img width="814" alt="edit rotation rules - after" src="https://user-images.githubusercontent.com/52386267/165840294-435dccdb-0d9e-4ed8-8163-3c4333d08e9d.png">
