### PR TITLE
run temp sched tests on future time

### DIFF
--- a/web/src/cypress/integration/temporarySchedule.ts
+++ b/web/src/cypress/integration/temporarySchedule.ts
@@ -9,6 +9,9 @@ const dialog = '[role=dialog] #dialog-form'
 function testTemporarySchedule(screen: string): void {
   if (screen !== 'widescreen') return
 
+  let monthStart: DateTime = DateTime.local()
+    .startOf('month')
+    .plus({ month: 2 })
   let schedule: Schedule
   const manualAddUser = users[0]
   const graphQLAddUser = users[1]
@@ -16,7 +19,9 @@ function testTemporarySchedule(screen: string): void {
   beforeEach(() => {
     cy.createSchedule({ timeZone: 'Europe/Berlin' }).then((s: Schedule) => {
       schedule = s
-      cy.visit('/schedules/' + s.id)
+      cy.visit(
+        '/schedules/' + s.id + '?start=' + monthStart.toFormat('yyyy-MM-dd'),
+      )
     })
   })
 
@@ -94,11 +99,11 @@ function testTemporarySchedule(screen: string): void {
 
   // seems buggy when shift list has overflow
   it('should edit and remove and add to a temporary schedule', () => {
-    const now = DateTime.utc()
+    const startTime = monthStart.plus({ week: 1 })
 
     cy.createTemporarySchedule({
       scheduleID: schedule.id,
-      start: now.toISO(),
+      start: startTime.toISO(),
       shifts: [{ userID: graphQLAddUser.id }],
     }).then(() => {
       cy.reload()
@@ -119,7 +124,7 @@ function testTemporarySchedule(screen: string): void {
       cy.get('[data-cy="add-shift-expander"]').click()
       cy.dialogForm({
         userID: manualAddUser.name,
-        'shift-start': schedTZ(now.plus({ hour: 1 })),
+        'shift-start': schedTZ(startTime.plus({ hour: 1 })),
       })
       cy.get('[data-cy="shifts-list"]').should(
         'not.contain',
@@ -137,11 +142,11 @@ function testTemporarySchedule(screen: string): void {
   })
 
   it('should edit and remove from a temporary schedule', () => {
-    const now = DateTime.utc()
+    const startTime = monthStart.plus({ week: 1 })
 
     cy.createTemporarySchedule({
       scheduleID: schedule.id,
-      start: now.toISO(),
+      start: startTime.toISO(),
       shifts: [
         { userID: graphQLAddUser.id },
         { userID: graphQLAddSecondUser.id },
@@ -172,11 +177,11 @@ function testTemporarySchedule(screen: string): void {
   })
 
   it('should edit and add to a temporary schedule', () => {
-    const now = DateTime.utc()
+    const startTime = monthStart.plus({ week: 1 })
 
     cy.createTemporarySchedule({
       scheduleID: schedule.id,
-      start: now.toISO(),
+      start: startTime.toISO(),
       shifts: [{ userID: graphQLAddUser.id }],
     }).then(() => {
       cy.reload()
@@ -188,7 +193,7 @@ function testTemporarySchedule(screen: string): void {
       cy.get('[data-cy="add-shift-expander"]').click()
       cy.dialogForm({
         userID: manualAddUser.name,
-        'shift-start': schedTZ(now.plus({ hour: 1 })),
+        'shift-start': schedTZ(startTime.plus({ hour: 1 })),
       })
       cy.get('[data-cy="shifts-list"]').should(
         'not.contain',
@@ -206,8 +211,10 @@ function testTemporarySchedule(screen: string): void {
   })
 
   it('should delete a temporary schedule', () => {
+    const startTime = monthStart.plus({ week: 1 })
+
     cy.createTemporarySchedule({
-      start: DateTime.utc().plus({ hour: 1 }).toISO(),
+      start: startTime.toISO(),
       scheduleID: schedule.id,
     }).then(() => {
       cy.reload()
@@ -253,9 +260,9 @@ function testTemporarySchedule(screen: string): void {
   })
 
   it('should be able to click no coverage to update times', () => {
-    const start = DateTime.utc()
+    const start = monthStart
+      .plus({ week: 1 })
       .setZone(schedule.timeZone)
-      .plus({ day: 1 })
       .startOf('day')
 
     const end = start.plus({ days: 2 })

--- a/web/src/cypress/integration/temporarySchedule.ts
+++ b/web/src/cypress/integration/temporarySchedule.ts
@@ -9,7 +9,7 @@ const dialog = '[role=dialog] #dialog-form'
 function testTemporarySchedule(screen: string): void {
   if (screen !== 'widescreen') return
 
-  let monthStart: DateTime = DateTime.local()
+  const monthStart: DateTime = DateTime.local()
     .startOf('month')
     .plus({ month: 2 })
   let schedule: Schedule


### PR DESCRIPTION
**Description:**
Fixes flakiness on temporary schedule tests on month edges by fixing start times of tests to begining of a future month instead of the current time.
