### PR TITLE
cypress/overridelist: don't update queryVariables on every state change

### DIFF
--- a/web/src/app/schedules/ScheduleOverrideList.js
+++ b/web/src/app/schedules/ScheduleOverrideList.js
@@ -49,6 +49,7 @@ export default function ScheduleOverrideList() {
 
   const [userFilter, setUserFilter] = useURLParam('userFilter', [])
   const [showPast, setShowPast] = useURLParam('showPast', false)
+  const now = React.useMemo(() => new Date().toISOString(), [showPast])
   const [zone] = useURLParam('tz', 'local')
   const resetFilter = useResetURLParams('userFilter', 'showPast', 'tz')
 
@@ -108,7 +109,7 @@ export default function ScheduleOverrideList() {
         variables={{
           input: {
             scheduleID: scheduleID,
-            start: showPast ? null : new Date().toISOString(),
+            start: showPast ? null : now,
             filterAnyUserID: userFilter,
           },
         }}


### PR DESCRIPTION
The schedule override list was querying for data on every state change (e.g. when opening the create override dialog) because the `start` query variable was being recalculated each time. This was causing consistent test failures due to a race condition where the list may or may not have been loading while the Cypress runner was attempting to click on elements.

Example screenshot of loading the override list and then clicking the create override fab shortly after. You can see that the start time is slightly in the future.

<img width="917" alt="Screen Shot 2022-05-04 at 12 59 49 PM" src="https://user-images.githubusercontent.com/11381794/166820080-45a073c4-8085-4c22-8ae3-b031f3e4db4b.png">

With this change, `start` will only be calculated and used if the filter changes from `showPast === true`, back to using a start time of now.