### PR TITLE
engine/metricsmanager: fix daily alert metrics out of sync

### DIFF
--- a/engine/metricsmanager/db.go
+++ b/engine/metricsmanager/db.go
@@ -86,7 +86,8 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 				count(*) filter (where escalated=true)
 			from alert_metrics
 			where (date(timezone('UTC'::text, closed_at))) = $1
-			group by service_id;
+			group by service_id
+			on conflict do nothing
 		`),
 	}, p.Err
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR updates the metrics manager to do nothing if data gets out of sync on inserting to daily alert metrics table.

**Which issue(s) this PR fixes:**
Fixes #2368 