### PR TITLE
calendar subscription: increase calculated shifts from 1 month to 1 year

### DIFF
--- a/calsub/http.go
+++ b/calsub/http.go
@@ -30,7 +30,7 @@ func (s *Store) ServeICalData(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	shifts, err := s.oc.HistoryBySchedule(ctx, cs.ScheduleID, n, n.AddDate(0, 1, 0))
+	shifts, err := s.oc.HistoryBySchedule(ctx, cs.ScheduleID, n, n.AddDate(1, 0, 0))
 	if errutil.HTTPError(ctx, w, err) {
 		return
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR increases the calendar subscription window of calculated shifts from 1 month to 1 year.

**Which issue(s) this PR fixes:**
Fixes #1459 

**Describe any introduced user-facing changes:**
This change will not require any action from any users that have existing subscriptions created.  The next time a calendar agent fetches from subscription endpoint, data for the full year will be pulled. 

**Notes:**
An analysis of impact using a worst case scenario for number of shifts (hourly rotation with 2 users, on call 24x7) resulted in a payload of 1.2 MB for 1 year (from 102 KB for 1 month).  No noticeable detrimental effect on query execution times or request duration on calendar subscription endpoint.  Application logs were reviewed and real-world payload sizes were substantially smaller than test case above, so the increase in window duration should not be impactful. 