### PR TITLE
ui: fix appbar icon color in light mode

### DIFF
--- a/web/src/app/main/components/ToolbarAction.js
+++ b/web/src/app/main/components/ToolbarAction.js
@@ -29,6 +29,9 @@ function ToolbarAction(props) {
         data-cy='nav-back-icon'
         onClick={() => navigate(route)}
         size='large'
+        sx={(theme) => ({
+          color: theme.palette.mode === 'light' ? 'white' : undefined,
+        })}
       >
         <ChevronLeft />
       </IconButton>


### PR DESCRIPTION
Fixes the "Back a Page" button color when in light mode.

MUI renders the appbar in light mode as `primary`, but as the `surface` color when in dark mode. This causes conflicts as our icon buttons default to a `primary` color. Because of this I opted to make a fix inline as opposed to a change at the theme level.

Before:

![image](https://user-images.githubusercontent.com/11381794/168138602-bc80c643-e99f-4c2c-a96a-9f82ef4f24e2.png)

![image-1](https://user-images.githubusercontent.com/11381794/168138695-dc869555-25aa-493c-a14f-32a4845bdc2a.png)

After:

![Screen Shot 2022-05-12 at 10 53 40 AM](https://user-images.githubusercontent.com/11381794/168138634-2564e85b-2f58-4e0d-bf05-ce29d4188637.png)

![Screen Shot 2022-05-12 at 10 53 50 AM](https://user-images.githubusercontent.com/11381794/168138716-24d5f7a7-463d-44cc-9f06-8d6f1d0672e6.png)