### PR TITLE
ui: fix slow typing in admin config fields

### DIFF
--- a/web/src/app/admin/AdminConfig.tsx
+++ b/web/src/app/admin/AdminConfig.tsx
@@ -92,6 +92,10 @@ export default function AdminConfig(): JSX.Element {
   const [section, setSection] = useState(false as false | string)
 
   const { data, loading, error } = useQuery(query)
+  if (error) return <GenericError error={error.message} />
+  if (loading && !data) return <Spinner />
+
+  const configValues: ConfigValue[] = data.config
 
   const updateValue = (id: string, value: null | string): void => {
     const newVal: ConfigValues = { ...values }
@@ -104,11 +108,6 @@ export default function AdminConfig(): JSX.Element {
 
     setValues(newVal)
   }
-
-  if (error) return <GenericError error={error.message} />
-  if (loading && !data) return <Spinner />
-
-  const configValues: ConfigValue[] = data.config
 
   const groups = uniq(
     configValues.map((f: ConfigValue) => f.id.split('.')[0]),

--- a/web/src/app/admin/AdminConfig.tsx
+++ b/web/src/app/admin/AdminConfig.tsx
@@ -93,16 +93,6 @@ export default function AdminConfig(): JSX.Element {
 
   const { data, loading, error } = useQuery(query)
 
-  if (error) {
-    return <GenericError error={error.message} />
-  }
-
-  if (loading && !data) {
-    return <Spinner />
-  }
-
-  const configValues: ConfigValue[] = data.config
-
   const updateValue = (id: string, value: null | string): void => {
     const newVal: ConfigValues = { ...values }
 
@@ -114,6 +104,11 @@ export default function AdminConfig(): JSX.Element {
 
     setValues(newVal)
   }
+
+  if (error) return <GenericError error={error.message} />
+  if (loading && !data) return <Spinner />
+
+  const configValues: ConfigValue[] = data.config
 
   const groups = uniq(
     configValues.map((f: ConfigValue) => f.id.split('.')[0]),

--- a/web/src/app/admin/AdminSection.tsx
+++ b/web/src/app/admin/AdminSection.tsx
@@ -23,20 +23,16 @@ const components = {
   boolean: BoolInput,
 }
 
+type OnChange = (id: string, value: null | string) => void
 interface FieldProps extends ConfigValue {
   label: string
 }
-
-type Value = { [id: string]: string }
-type OnChange = (id: string, value: null | string) => void
-
 interface AdminSectionProps {
   headerNote?: string
-  value: Value
+  value: { [id: string]: string }
   fields: FieldProps[]
   onChange: OnChange
 }
-
 interface AdminFieldProps extends FieldProps {
   index: number
   onChange: OnChange

--- a/web/src/app/admin/AdminSection.tsx
+++ b/web/src/app/admin/AdminSection.tsx
@@ -69,7 +69,7 @@ interface AdminFieldProps extends FieldProps {
 function AdminField(props: AdminFieldProps): JSX.Element {
   const classes = useStyles()
   const Field = components[props.type]
-  const [fieldValue, setFieldValue] = useState<string | null>(props.value)
+  const [fieldValue, setFieldValue] = useState<string>(props.value)
 
   // debounce to set the value
   useEffect(() => {
@@ -94,9 +94,11 @@ function AdminField(props: AdminFieldProps): JSX.Element {
       <div className={classes.listItemAction}>
         <Field
           name={props.id}
-          value={fieldValue ?? ''}
+          value={fieldValue}
           password={props.password}
-          onChange={(val) => setFieldValue(val === props.value ? null : val)}
+          onChange={(val) =>
+            setFieldValue(val === props.value || val === null ? '' : val)
+          }
         />
       </div>
     </ListItem>

--- a/web/src/app/admin/AdminSection.tsx
+++ b/web/src/app/admin/AdminSection.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
 import ListItemText from '@mui/material/ListItemText'
 import Typography from '@mui/material/Typography'
 import { FormContainer } from '../forms'
-import _, { defaultTo } from 'lodash'
+import _ from 'lodash'
 import { Theme } from '@mui/material/styles'
 import makeStyles from '@mui/styles/makeStyles'
 import {
@@ -14,6 +14,7 @@ import {
   BoolInput,
 } from './AdminFieldComponents'
 import { ConfigValue } from '../../schema'
+import { DEBOUNCE_DELAY } from '../config'
 
 const components = {
   string: StringInput,
@@ -26,11 +27,14 @@ interface FieldProps extends ConfigValue {
   label: string
 }
 
+type Value = { [id: string]: string }
+type OnChange = (id: string, value: null | string) => void
+
 interface AdminSectionProps {
   headerNote?: string
-  value: { [id: string]: string }
+  value: Value
   fields: FieldProps[]
-  onChange: (id: string, value: null | string) => void
+  onChange: OnChange
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -56,9 +60,51 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }))
 
+interface AdminFieldProps extends FieldProps {
+  index: number
+  onChange: OnChange
+  fieldsLength: number
+}
+
+function AdminField(props: AdminFieldProps): JSX.Element {
+  const classes = useStyles()
+  const Field = components[props.type]
+  const [fieldValue, setFieldValue] = useState<string | null>(props.value)
+
+  // debounce to set the value
+  useEffect(() => {
+    const t = setTimeout(() => {
+      props.onChange(props.id, fieldValue)
+    }, DEBOUNCE_DELAY)
+    return () => clearTimeout(t)
+  }, [fieldValue])
+
+  return (
+    <ListItem
+      key={props.id}
+      className={classes.listItem}
+      divider={props.index !== props.fieldsLength - 1}
+      selected={_.has(props.value, props.id)}
+    >
+      <ListItemText
+        className={classes.listItemText}
+        primary={props.label}
+        secondary={props.description}
+      />
+      <div className={classes.listItemAction}>
+        <Field
+          name={props.id}
+          value={fieldValue ?? ''}
+          password={props.password}
+          onChange={(val) => setFieldValue(val === props.value ? null : val)}
+        />
+      </div>
+    </ListItem>
+  )
+}
+
 export default function AdminSection(props: AdminSectionProps): JSX.Element {
   // TODO: add 'reset to default' buttons
-  const classes = useStyles()
   const { fields, value, headerNote } = props
 
   return (
@@ -75,33 +121,16 @@ export default function AdminSection(props: AdminSectionProps): JSX.Element {
             />
           </ListItem>
         )}
-        {fields.map((f: FieldProps, idx: number) => {
-          const Field = components[f.type]
-          return (
-            <ListItem
-              key={f.id}
-              className={classes.listItem}
-              divider={idx !== fields.length - 1}
-              selected={_.has(value, f.id)}
-            >
-              <ListItemText
-                className={classes.listItemText}
-                primary={f.label}
-                secondary={f.description}
-              />
-              <div className={classes.listItemAction}>
-                <Field
-                  name={f.id}
-                  value={defaultTo(value[f.id], f.value)}
-                  password={f.password}
-                  onChange={(val) =>
-                    props.onChange(f.id, val === f.value ? null : val)
-                  }
-                />
-              </div>
-            </ListItem>
-          )
-        })}
+        {fields.map((f: FieldProps, index: number) => (
+          <AdminField
+            key={f.id}
+            {...f}
+            index={index}
+            value={value[f.id] ?? f.value}
+            fieldsLength={fields.length}
+            onChange={props.onChange}
+          />
+        ))}
       </List>
     </FormContainer>
   )

--- a/web/src/app/admin/AdminSection.tsx
+++ b/web/src/app/admin/AdminSection.tsx
@@ -37,6 +37,12 @@ interface AdminSectionProps {
   onChange: OnChange
 }
 
+interface AdminFieldProps extends FieldProps {
+  index: number
+  onChange: OnChange
+  fieldsLength: number
+}
+
 const useStyles = makeStyles((theme: Theme) => ({
   listItem: {
     // leaves some room around fields without descriptions
@@ -59,12 +65,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     justifyContent: 'flex-end',
   },
 }))
-
-interface AdminFieldProps extends FieldProps {
-  index: number
-  onChange: OnChange
-  fieldsLength: number
-}
 
 function AdminField(props: AdminFieldProps): JSX.Element {
   const classes = useStyles()


### PR DESCRIPTION
In the admin config, typing is very non-performant presumably because we are re-rendering the form on every keystroke change.

Letting the fields use local state and debouncing setting the value for the mutation solves this issue.

I'm opening this as a draft because I'm currently seeing an issue where on page load the last field is rendering like it has changes to save. Clicking reset causes it to go away (until you refresh the page again). Pic shown in details below.

<details>
<img src="https://user-images.githubusercontent.com/11381794/168168913-c07cc5a9-45cf-4031-8b09-6598f0ae6763.png" />
</details>
