### PR TITLE
dev: Single build image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,12 @@ export PATH := $(PWD)/bin:$(PATH)
 export GOOS = $(shell go env GOOS)
 export GOALERT_DB_URL_NEXT = $(DB_URL_NEXT)
 
+PROD_PROC = Procfile.cypress.prod
+
+ifeq ($(CI), 1)
+PROD_CY_PROC = Procfile.cypress.ci
+endif
+
 ifeq ($(PUSH), 1)
 PUSH_FLAG=--push
 endif
@@ -74,9 +80,9 @@ cy-wide: cypress
 cy-mobile: cypress
 	CONTAINER_TOOL=$(CONTAINER_TOOL) CYPRESS_viewportWidth=375 CYPRESS_viewportHeight=667 go run ./devtools/runproc -f Procfile.cypress
 cy-wide-prod: web/src/build/static/app.js cypress
-	CONTAINER_TOOL=$(CONTAINER_TOOL) CYPRESS_viewportWidth=1440 CYPRESS_viewportHeight=900 CY_ACTION=$(CY_ACTION) go run ./devtools/runproc -f Procfile.cypress.prod
+	CONTAINER_TOOL=$(CONTAINER_TOOL) CYPRESS_viewportWidth=1440 CYPRESS_viewportHeight=900 CY_ACTION=$(CY_ACTION) go run ./devtools/runproc -f $(PROD_CY_PROC)
 cy-mobile-prod: web/src/build/static/app.js cypress
-	CONTAINER_TOOL=$(CONTAINER_TOOL) CYPRESS_viewportWidth=375 CYPRESS_viewportHeight=667 CY_ACTION=$(CY_ACTION) go run ./devtools/runproc -f Procfile.cypress.prod
+	CONTAINER_TOOL=$(CONTAINER_TOOL) CYPRESS_viewportWidth=375 CYPRESS_viewportHeight=667 CY_ACTION=$(CY_ACTION) go run ./devtools/runproc -f $(PROD_CY_PROC)
 cy-wide-prod-run: web/src/build/static/app.js cypress
 	$(MAKE) $(MFLAGS) cy-wide-prod CY_ACTION=run CONTAINER_TOOL=$(CONTAINER_TOOL) BUNDLE=1
 cy-mobile-prod-run: web/src/build/static/app.js cypress

--- a/Procfile.cypress
+++ b/Procfile.cypress
@@ -13,6 +13,7 @@ slack: go run ./devtools/mockslack/cmd/mockslack -client-id=000000000000.0000000
 
 proxy: go run ./devtools/simpleproxy -addr=localhost:3040 /slack/=http://localhost:3046 http://localhost:3042
 
+@oneshot
 cypress: go run ./devtools/waitfor http://localhost:3042 && CYPRESS_DB_URL=postgres://postgres@localhost:5433 yarn workspace goalert-web --cwd=bin/build/integration cypress open --config baseUrl=http://localhost:3040$GOALERT_HTTP_PREFIX
 
 db: $CONTAINER_TOOL rm -f smoketest-postgres || true; $CONTAINER_TOOL run -it --rm --name smoketest-postgres -p5433:5432 -e=POSTGRES_HOST_AUTH_METHOD=trust postgres:13-alpine

--- a/Procfile.cypress.ci
+++ b/Procfile.cypress.ci
@@ -1,0 +1,10 @@
+@oneshot
+cypress: go run ./devtools/waitfor http://localhost:3042 && CYPRESS_DB_URL=$DB_URL yarn workspace goalert-web --cwd=bin/build/integration cypress $CY_ACTION --config baseUrl=http://localhost:3040$GOALERT_HTTP_PREFIX
+
+goalert: go run ./devtools/waitfor $DB_URL && go run ./devtools/procwrap -test=localhost:3042 bin/goalert -l=localhost:3042 --db-url=$DB_URL --slack-base-url=http://localhost:3040/slack --log-errors-only
+
+slack: go run ./devtools/mockslack/cmd/mockslack -client-id=000000000000.000000000000 -client-secret=00000000000000000000000000000000 -access-token=xoxp-000000000000-000000000000-000000000000-00000000000000000000000000000000 -prefix=/slack -single-user=bob -addr=localhost:3046
+
+proxy: go run ./devtools/simpleproxy -addr=localhost:3040 /slack/=http://localhost:3046 http://localhost:3042
+
+db: tail -f /var/log/postgresql/server.log

--- a/Procfile.cypress.prod
+++ b/Procfile.cypress.prod
@@ -7,6 +7,7 @@ slack: go run ./devtools/mockslack/cmd/mockslack -client-id=000000000000.0000000
 
 proxy: go run ./devtools/simpleproxy -addr=localhost:3040 /slack/=http://localhost:3046 http://localhost:3042
 
+@oneshot
 cypress: go run ./devtools/waitfor http://localhost:3042 && CYPRESS_DB_URL=postgres://postgres@localhost:5433 yarn workspace goalert-web --cwd=bin/build/integration cypress $CY_ACTION --config baseUrl=http://localhost:3040$GOALERT_HTTP_PREFIX
 
 db: $CONTAINER_TOOL rm -f smoketest-postgres || true; $CONTAINER_TOOL run -it --rm --name smoketest-postgres -p5433:5432 -e=POSTGRES_HOST_AUTH_METHOD=trust postgres:13-alpine

--- a/devtools/ci/dockerfiles/build-env/Dockerfile
+++ b/devtools/ci/dockerfiles/build-env/Dockerfile
@@ -24,7 +24,7 @@ RUN \
     rm -rf /var/lib/apt/lists/*
 
 # Postgres
-ENV PGDATA=/var/lib/postgresql/data PGUSER=goalert DB_URL=postgresql://goalert@
+ENV PGDATA=/var/lib/postgresql/data PGUSER=postgres DB_URL=postgresql://postgres@
 RUN mkdir -p ${PGDATA} /run/postgresql /var/log/postgresql &&\
     chown postgres ${PGDATA} /run/postgresql /var/log/postgresql &&\
     su postgres -c "/usr/lib/postgresql/13/bin/initdb $PGDATA" &&\
@@ -39,3 +39,4 @@ COPY stop_postgres.sh /usr/bin/stop_postgres
 ENV QT_X11_NO_MITSHM=1 _X11_NO_MITSHM=1 _MITSHM=0 CYPRESS_CACHE_FOLDER=/root/.cache/Cypress
 ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
 
+ENV CI=1

--- a/devtools/ci/dockerfiles/build-env/Dockerfile
+++ b/devtools/ci/dockerfiles/build-env/Dockerfile
@@ -24,7 +24,7 @@ RUN \
     rm -rf /var/lib/apt/lists/*
 
 # Postgres
-ENV PGDATA=/var/lib/postgresql/data PGUSER=postgres DB_URL=postgresql://postgres@
+ENV PGDATA=/var/lib/postgresql/data PGUSER=postgres DB_URL=postgresql://postgres@?client_encoding=UTF8
 RUN mkdir -p ${PGDATA} /run/postgresql /var/log/postgresql &&\
     chown postgres ${PGDATA} /run/postgresql /var/log/postgresql &&\
     su postgres -c "/usr/lib/postgresql/13/bin/initdb $PGDATA" &&\

--- a/devtools/ci/dockerfiles/build-env/Dockerfile
+++ b/devtools/ci/dockerfiles/build-env/Dockerfile
@@ -1,18 +1,41 @@
-FROM docker.io/library/golang:1.18.1-alpine3.14
+FROM docker.io/library/golang:1.18.2-bullseye
 
-ENV PGDATA=/var/lib/postgresql/data PGUSER=postgres DB_URL=postgresql://postgres@
-RUN apk --no-cache add git nodejs yarn make postgresql postgresql-contrib
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.33-r0/glibc-2.33-r0.apk && \
-    apk add glibc-2.33-r0.apk && \
-    rm glibc-2.33-r0.apk
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg-agent \
+    software-properties-common \
+    build-essential \
+    nodejs npm \
+    postgresql-13 postgresql-client-13 \
+    dbus-x11 xvfb && \
+    rm -rf /var/lib/apt/lists/*
+
+# yarn
+RUN npm install -g yarn
+
+# google chrome
+RUN \
+    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
+    apt-get update && \
+    apt-get install -y google-chrome-stable && \
+    rm -rf /var/lib/apt/lists/*
+
+# Postgres
+ENV PGDATA=/var/lib/postgresql/data PGUSER=goalert DB_URL=postgresql://goalert@
 RUN mkdir -p ${PGDATA} /run/postgresql /var/log/postgresql &&\
     chown postgres ${PGDATA} /run/postgresql /var/log/postgresql &&\
-    su postgres -c "initdb $PGDATA" &&\
+    su postgres -c "/usr/lib/postgresql/13/bin/initdb $PGDATA" &&\
     echo "host all  all    0.0.0.0/0  md5" >> $PGDATA/pg_hba.conf &&\
     echo "listen_addresses='*'" >> $PGDATA/postgresql.conf &&\
     echo "fsync = off" >> $PGDATA/postgresql.conf &&\
     echo "full_page_writes = off" >> $PGDATA/postgresql.conf
-
 COPY start_postgres.sh /usr/bin/start_postgres
 COPY stop_postgres.sh /usr/bin/stop_postgres
+
+# Cypress
+ENV QT_X11_NO_MITSHM=1 _X11_NO_MITSHM=1 _MITSHM=0 CYPRESS_CACHE_FOLDER=/root/.cache/Cypress
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+

--- a/devtools/ci/dockerfiles/build-env/start_postgres.sh
+++ b/devtools/ci/dockerfiles/build-env/start_postgres.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-su postgres -c "pg_ctl start -w -l /var/log/postgresql/server.log"
+su postgres -c "/usr/lib/postgresql/13/bin/pg_ctl start -w -l /var/log/postgresql/server.log"

--- a/devtools/ci/dockerfiles/build-env/stop_postgres.sh
+++ b/devtools/ci/dockerfiles/build-env/stop_postgres.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-su postgres -c "pg_ctl stop -m immediate"
+su postgres -c "/usr/lib/postgresql/13/bin/pg_ctl stop -m immediate"

--- a/devtools/ci/dockerfiles/goalert/Dockerfile
+++ b/devtools/ci/dockerfiles/goalert/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/goalert/build-env:go1.18.1-postgres13 AS build
+FROM docker.io/goalert/build-env:test-all.1 AS build
 COPY / /build/
 WORKDIR /build
 RUN make bin/build/goalert-linux-amd64

--- a/devtools/ci/dockerfiles/goalert/Dockerfile
+++ b/devtools/ci/dockerfiles/goalert/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/goalert/build-env:test-all.1 AS build
+FROM docker.io/goalert/build-env:go1.18.2-postgres13 AS build
 COPY / /build/
 WORKDIR /build
 RUN make bin/build/goalert-linux-amd64

--- a/devtools/ci/tasks/build-all.yml
+++ b/devtools/ci/tasks/build-all.yml
@@ -11,7 +11,7 @@ outputs:
   - name: bin
 image_resource:
   type: registry-image
-  source: { repository: goalert/build-env, tag: test-all.1 }
+  source: { repository: goalert/build-env, tag: go1.18.2-postgres13 }
 run:
   path: sh
   dir: goalert

--- a/devtools/ci/tasks/build-all.yml
+++ b/devtools/ci/tasks/build-all.yml
@@ -1,0 +1,18 @@
+platform: linux
+caches:
+  - path: ../../../go/pkg
+  - path: goalert/node_modules
+  - path: goalert/web/src/node_modules
+  - path: ../../../usr/local/share/.cache
+  - path: ../../../root/.cache
+inputs:
+  - name: goalert
+outputs:
+  - name: bin
+image_resource:
+  type: registry-image
+  source: { repository: goalert/build-env, tag: test-all.1 }
+run:
+  path: sh
+  dir: goalert
+  args: [-e, ./devtools/ci/tasks/scripts/build-all.sh, ../bin/]

--- a/devtools/ci/tasks/build-binaries.yml
+++ b/devtools/ci/tasks/build-binaries.yml
@@ -13,7 +13,7 @@ outputs:
   - name: bin
 image_resource:
   type: registry-image
-  source: { repository: goalert/build-env, tag: test-all.1 }
+  source: { repository: goalert/build-env, tag: go1.18.2-postgres13 }
 run:
   path: sh
   dir: goalert

--- a/devtools/ci/tasks/build-binaries.yml
+++ b/devtools/ci/tasks/build-binaries.yml
@@ -13,7 +13,7 @@ outputs:
   - name: bin
 image_resource:
   type: registry-image
-  source: { repository: goalert/build-env, tag: go1.18.1-postgres13 }
+  source: { repository: goalert/build-env, tag: test-all.1 }
 run:
   path: sh
   dir: goalert

--- a/devtools/ci/tasks/scripts/build-all.sh
+++ b/devtools/ci/tasks/scripts/build-all.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -ex
+PREFIX=$1
+make check test smoketest cy-wide-prod-run cy-mobile-prod-run bin/goalert BUNDLE=1 CI=1 DB_URL=$DB_URL
+./bin/goalert self-test --offline
+VERSION=$(./bin/goalert version | head -n 1 |awk '{print $2}')
+
+for PLATFORM in darwin-amd64 linux-amd64 linux-arm linux-arm64
+do
+    SRC=bin/goalert-${PLATFORM}.tgz
+    make $SRC
+    cp $SRC ${PREFIX}goalert-${VERSION}-${PLATFORM}.tgz
+done

--- a/devtools/ci/tasks/scripts/build-all.sh
+++ b/devtools/ci/tasks/scripts/build-all.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -ex
 PREFIX=$1
+
+start_postgres
+trap "stop_postgres" EXIT
+
 make check test smoketest cy-wide-prod-run cy-mobile-prod-run bin/goalert BUNDLE=1 CI=1 DB_URL=$DB_URL
 ./bin/goalert self-test --offline
 VERSION=$(./bin/goalert version | head -n 1 |awk '{print $2}')

--- a/devtools/ci/tasks/scripts/build-binaries.sh
+++ b/devtools/ci/tasks/scripts/build-binaries.sh
@@ -6,8 +6,6 @@ make check test bin/goalert BUNDLE=1
 VERSION=$(./bin/goalert version | head -n 1 |awk '{print $2}')
 BVERSION=$(date +%s)-$(git rev-parse --short HEAD)
 
-make smoketest cy-wide-prod-run cy-mobile-prod-run CI=1 DB_URL=$DB_URL
-
 for PLATFORM in darwin-amd64 linux-amd64 linux-arm linux-arm64
 do
     SRC=bin/goalert-${PLATFORM}.tgz

--- a/devtools/ci/tasks/scripts/build-binaries.sh
+++ b/devtools/ci/tasks/scripts/build-binaries.sh
@@ -6,6 +6,8 @@ make check test bin/goalert BUNDLE=1
 VERSION=$(./bin/goalert version | head -n 1 |awk '{print $2}')
 BVERSION=$(date +%s)-$(git rev-parse --short HEAD)
 
+make smoketest cy-wide-prod-run cy-mobile-prod-run CI=1 DB_URL=$DB_URL
+
 for PLATFORM in darwin-amd64 linux-amd64 linux-arm linux-arm64
 do
     SRC=bin/goalert-${PLATFORM}.tgz

--- a/devtools/ci/tasks/scripts/codecheck.sh
+++ b/devtools/ci/tasks/scripts/codecheck.sh
@@ -21,7 +21,7 @@ if [ "$PKG_JSON_VER" != "$DOCKERFILE_VER" ]; then
 fi
 
 # assert build-env versions are identical
-BUILD_ENV_VER=test-all.1
+BUILD_ENV_VER=go1.18.2-postgres13
 for file in $(find devtools -name 'Dockerfile*')
 do
   if ! grep -q "goalert/build-env" "$file"; then

--- a/devtools/ci/tasks/scripts/codecheck.sh
+++ b/devtools/ci/tasks/scripts/codecheck.sh
@@ -21,7 +21,7 @@ if [ "$PKG_JSON_VER" != "$DOCKERFILE_VER" ]; then
 fi
 
 # assert build-env versions are identical
-BUILD_ENV_VER=go1.18.1-postgres13
+BUILD_ENV_VER=test-all.1
 for file in $(find devtools -name 'Dockerfile*')
 do
   if ! grep -q "goalert/build-env" "$file"; then

--- a/devtools/ci/tasks/test-smoketest.yml
+++ b/devtools/ci/tasks/test-smoketest.yml
@@ -8,7 +8,7 @@ outputs:
   - name: debug
 image_resource:
   type: registry-image
-  source: { repository: goalert/build-env, tag: test-all.1 }
+  source: { repository: goalert/build-env, tag: go1.18.2-postgres13 }
 run:
   path: sh
   dir: goalert

--- a/devtools/ci/tasks/test-smoketest.yml
+++ b/devtools/ci/tasks/test-smoketest.yml
@@ -8,7 +8,7 @@ outputs:
   - name: debug
 image_resource:
   type: registry-image
-  source: { repository: goalert/build-env, tag: go1.18.1-postgres13 }
+  source: { repository: goalert/build-env, tag: test-all.1 }
 run:
   path: sh
   dir: goalert

--- a/devtools/pgdump-lite/dumpdata.go
+++ b/devtools/pgdump-lite/dumpdata.go
@@ -77,7 +77,11 @@ func contains(s []string, e string) bool {
 }
 
 func DumpData(ctx context.Context, conn *pgx.Conn, out io.Writer, skip []string) error {
-	tx, err := conn.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead})
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:       pgx.Serializable,
+		DeferrableMode: pgx.Deferrable,
+		AccessMode:     pgx.ReadOnly,
+	})
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}

--- a/devtools/runproc/parse.go
+++ b/devtools/runproc/parse.go
@@ -35,6 +35,8 @@ func Parse(r io.Reader) ([]Task, error) {
 			// parameter
 			parts := strings.SplitN(str[1:], "=", 2)
 			switch strings.TrimSpace(parts[0]) {
+			case "oneshot":
+				t.OneShot = true
 			case "watch-file":
 				if len(parts) != 2 {
 					return nil, fmt.Errorf("line %d: missing file path for watch-file", line)

--- a/devtools/runproc/prefixer.go
+++ b/devtools/runproc/prefixer.go
@@ -49,6 +49,11 @@ func (w *prefixer) Write(p []byte) (int, error) {
 		}
 		w.buf = w.buf[:0]
 
+		_, err = w.out.Write([]byte("\x1b[0m"))
+		if err != nil {
+			return n, err
+		}
+
 		p = p[l+1:]
 	}
 }

--- a/devtools/runproc/process.go
+++ b/devtools/runproc/process.go
@@ -93,11 +93,13 @@ func (p *Process) logError(err error) {
 	defer logMx.Unlock()
 	color.New(color.Reset, color.FgRed).Fprintln(p.p, err.Error())
 }
+
 func (p *Process) logAction(s string) {
 	logMx.Lock()
 	defer logMx.Unlock()
 	color.New(color.Reset, color.Bold).Fprintln(p.p, s)
 }
+
 func (p *Process) Stop() {
 	s := <-p.state
 	if s != ProcessStateRunning {
@@ -213,7 +215,7 @@ func (p *Process) Start() {
 func (p *Process) Wait() bool {
 	<-p.exited
 
-	return p.result
+	return p.result && p.OneShot
 }
 
 func (p *Process) Done() bool {

--- a/devtools/runproc/runner.go
+++ b/devtools/runproc/runner.go
@@ -65,8 +65,11 @@ func (r *Runner) Run() error {
 
 	var err error
 	for range r.procs {
-		<-result
-		go r.stopOnce.Do(r._stopFail)
+		if <-result {
+			go r.stopOnce.Do(r._stop)
+		} else {
+			go r.stopOnce.Do(r._stopFail)
+		}
 	}
 
 	if r.failed {

--- a/devtools/runproc/task.go
+++ b/devtools/runproc/task.go
@@ -9,4 +9,9 @@ type Task struct {
 
 	// WatchFiles will cause the process to restart if any if the files change (can be patterns).
 	WatchFiles []string
+
+	// OneShot indicates that the process should run and then exit.
+	//
+	// Useful for running tests.
+	OneShot bool
 }


### PR DESCRIPTION
**Description:**
This PR updates the `build-env` image to have the necessary dependencies to run Cypress tests, allowing all build steps to be run in the same container.

- New `Procfile.cypress.ci` added for running Cypress tests in CI
- runproc has a new annotation `@oneshot` allowing it to be used for running tests
- `build-env` is now based on debian instead of alpine and contains google chrome pre-installed
- A new `build-all.yml` task was added to replace the smoketest, binary, and integration steps
- `pgdump-lite` now sets proper isolation options

**Out of Scope**
This PR is just a first step, adding the new build task which will be transitioned to at a later time. The primary change with this PR is the tool fixes and the build-env image having missing deps added. Existing pipeline should otherwise work as-is.
