### PR TITLE
cypress: add reset for engine processing version state

### DIFF
--- a/web/src/cypress/support/util.ts
+++ b/web/src/cypress/support/util.ts
@@ -16,9 +16,11 @@ const userVals = allUsers
   .join(',\n')
 
 const resetQuery = `
-truncate table escalation_policies, rotations, schedules, users CASCADE;
+truncate table escalation_policies, rotations, schedules, alert_metrics, users CASCADE;
 select setval(pg_get_serial_sequence('alerts', 'id'), coalesce(max(id), 0)+10000 , false) from alerts;
 delete from users where id in (${ids});
+
+update engine_processing_versions set state = '{}' where type_id = 'metrics';
 
 insert into users (id, name, email, role)
 values


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR fixes an issue with the alert metrics cypress tests failing on retry because the engine processing state needed to be reset before each test.
