### PR TITLE
ci: disable cypress video

### DIFF
--- a/web/src/cypress.json
+++ b/web/src/cypress.json
@@ -7,6 +7,7 @@
   "requestTimeout": 15000,
   "defaultCommandTimeout": 15000,
   "ignoreTestFiles": "*.map",
+  "video": false,
   "retries": {
     "runMode": 2,
     "openMode": 0


### PR DESCRIPTION
**Description:**
At the moment we don't collect video or screenshots from CI, so waiting for video encoding just makes builds take longer.
