### PR TITLE
breadcrumbs: only return name for UUID values

### DIFF
--- a/web/src/app/main/components/ToolbarPageTitle.tsx
+++ b/web/src/app/main/components/ToolbarPageTitle.tsx
@@ -108,7 +108,7 @@ function useName(type = '', id = ''): string {
     pause: !type || !isUUID,
   })
 
-  if (result?.data?.data?.name) {
+  if (type && isUUID && result?.data?.data?.name) {
     return result.data.data.name
   }
 


### PR DESCRIPTION
**Description:**
Fixes an issue with the new breadcrumb code where navigating to an admin page from a details page would show the details item name (e.g., a schedule) as the second link instead of the proper admin page.
