### PR TITLE
dev: upgrade time circuits and add a flux capacitor (engine cycle monitor and pgmocktime)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ goalert-client.key: system.ca.pem plugin.ca.key plugin.ca.pem
 goalert-client.ca.pem: system.ca.pem plugin.ca.key plugin.ca.pem
 	go run ./cmd/goalert gen-cert client
 
-cypress: bin/goalert bin/psql-lite node_modules web/src/schema.d.ts
+cypress: bin/goalert bin/psql-lite bin/pgmocktime node_modules web/src/schema.d.ts
 	yarn cypress install
 
 cy-wide: cypress

--- a/Makefile.binaries.mk
+++ b/Makefile.binaries.mk
@@ -212,6 +212,25 @@ $(BIN_DIR)/windows-amd64/pgdump-lite.exe: $(GO_DEPS)
 	GOOS=windows GOARCH=amd64 go build -trimpath  -o $@ ./devtools/pgdump-lite/cmd/pgdump-lite
 
 
+$(BIN_DIR)/pgmocktime: $(GO_DEPS) 
+	go build  -o $@ ./devtools/pgmocktime/cmd/pgmocktime
+
+$(BIN_DIR)/darwin-amd64/pgmocktime: $(GO_DEPS)  
+	GOOS=darwin GOARCH=amd64 go build -trimpath  -o $@ ./devtools/pgmocktime/cmd/pgmocktime
+
+$(BIN_DIR)/linux-amd64/pgmocktime: $(GO_DEPS)  
+	GOOS=linux GOARCH=amd64 go build -trimpath  -o $@ ./devtools/pgmocktime/cmd/pgmocktime
+
+$(BIN_DIR)/linux-arm/pgmocktime: $(GO_DEPS)  
+	GOOS=linux GOARCH=arm GOARM=7 go build -trimpath  -o $@ ./devtools/pgmocktime/cmd/pgmocktime
+
+$(BIN_DIR)/linux-arm64/pgmocktime: $(GO_DEPS)  
+	GOOS=linux GOARCH=arm64 go build -trimpath  -o $@ ./devtools/pgmocktime/cmd/pgmocktime
+
+$(BIN_DIR)/windows-amd64/pgmocktime.exe: $(GO_DEPS)  
+	GOOS=windows GOARCH=amd64 go build -trimpath  -o $@ ./devtools/pgmocktime/cmd/pgmocktime
+
+
 $(BIN_DIR)/procwrap: $(GO_DEPS) 
 	go build  -o $@ ./devtools/procwrap
 
@@ -404,27 +423,27 @@ $(BIN_DIR)/windows-amd64/waitfor.exe: $(GO_DEPS)
 
 
 
-$(BIN_DIR)/darwin-amd64/_all: $(BIN_DIR)/darwin-amd64/goalert-smoketest $(BIN_DIR)/darwin-amd64/goalert $(BIN_DIR)/darwin-amd64/goalert-slack-email-sync $(BIN_DIR)/darwin-amd64/mockslack $(BIN_DIR)/darwin-amd64/pgdump-lite $(BIN_DIR)/darwin-amd64/procwrap $(BIN_DIR)/darwin-amd64/psql-lite $(BIN_DIR)/darwin-amd64/resetdb $(BIN_DIR)/darwin-amd64/runproc $(BIN_DIR)/darwin-amd64/sendit $(BIN_DIR)/darwin-amd64/sendit-server $(BIN_DIR)/darwin-amd64/sendit-token $(BIN_DIR)/darwin-amd64/simpleproxy $(BIN_DIR)/darwin-amd64/slowproxy $(BIN_DIR)/darwin-amd64/waitfor
+$(BIN_DIR)/darwin-amd64/_all: $(BIN_DIR)/darwin-amd64/goalert-smoketest $(BIN_DIR)/darwin-amd64/goalert $(BIN_DIR)/darwin-amd64/goalert-slack-email-sync $(BIN_DIR)/darwin-amd64/mockslack $(BIN_DIR)/darwin-amd64/pgdump-lite $(BIN_DIR)/darwin-amd64/pgmocktime $(BIN_DIR)/darwin-amd64/procwrap $(BIN_DIR)/darwin-amd64/psql-lite $(BIN_DIR)/darwin-amd64/resetdb $(BIN_DIR)/darwin-amd64/runproc $(BIN_DIR)/darwin-amd64/sendit $(BIN_DIR)/darwin-amd64/sendit-server $(BIN_DIR)/darwin-amd64/sendit-token $(BIN_DIR)/darwin-amd64/simpleproxy $(BIN_DIR)/darwin-amd64/slowproxy $(BIN_DIR)/darwin-amd64/waitfor
 
 $(BIN_DIR)/darwin-amd64/goalert-smoketest: $(GO_DEPS)
 	GOOS=darwin GOARCH=amd64 go test ./smoketest -c -o $@
 
-$(BIN_DIR)/linux-amd64/_all: $(BIN_DIR)/linux-amd64/goalert-smoketest $(BIN_DIR)/linux-amd64/goalert $(BIN_DIR)/linux-amd64/goalert-slack-email-sync $(BIN_DIR)/linux-amd64/mockslack $(BIN_DIR)/linux-amd64/pgdump-lite $(BIN_DIR)/linux-amd64/procwrap $(BIN_DIR)/linux-amd64/psql-lite $(BIN_DIR)/linux-amd64/resetdb $(BIN_DIR)/linux-amd64/runproc $(BIN_DIR)/linux-amd64/sendit $(BIN_DIR)/linux-amd64/sendit-server $(BIN_DIR)/linux-amd64/sendit-token $(BIN_DIR)/linux-amd64/simpleproxy $(BIN_DIR)/linux-amd64/slowproxy $(BIN_DIR)/linux-amd64/waitfor
+$(BIN_DIR)/linux-amd64/_all: $(BIN_DIR)/linux-amd64/goalert-smoketest $(BIN_DIR)/linux-amd64/goalert $(BIN_DIR)/linux-amd64/goalert-slack-email-sync $(BIN_DIR)/linux-amd64/mockslack $(BIN_DIR)/linux-amd64/pgdump-lite $(BIN_DIR)/linux-amd64/pgmocktime $(BIN_DIR)/linux-amd64/procwrap $(BIN_DIR)/linux-amd64/psql-lite $(BIN_DIR)/linux-amd64/resetdb $(BIN_DIR)/linux-amd64/runproc $(BIN_DIR)/linux-amd64/sendit $(BIN_DIR)/linux-amd64/sendit-server $(BIN_DIR)/linux-amd64/sendit-token $(BIN_DIR)/linux-amd64/simpleproxy $(BIN_DIR)/linux-amd64/slowproxy $(BIN_DIR)/linux-amd64/waitfor
 
 $(BIN_DIR)/linux-amd64/goalert-smoketest: $(GO_DEPS)
 	GOOS=linux GOARCH=amd64 go test ./smoketest -c -o $@
 
-$(BIN_DIR)/linux-arm/_all: $(BIN_DIR)/linux-arm/goalert-smoketest $(BIN_DIR)/linux-arm/goalert $(BIN_DIR)/linux-arm/goalert-slack-email-sync $(BIN_DIR)/linux-arm/mockslack $(BIN_DIR)/linux-arm/pgdump-lite $(BIN_DIR)/linux-arm/procwrap $(BIN_DIR)/linux-arm/psql-lite $(BIN_DIR)/linux-arm/resetdb $(BIN_DIR)/linux-arm/runproc $(BIN_DIR)/linux-arm/sendit $(BIN_DIR)/linux-arm/sendit-server $(BIN_DIR)/linux-arm/sendit-token $(BIN_DIR)/linux-arm/simpleproxy $(BIN_DIR)/linux-arm/slowproxy $(BIN_DIR)/linux-arm/waitfor
+$(BIN_DIR)/linux-arm/_all: $(BIN_DIR)/linux-arm/goalert-smoketest $(BIN_DIR)/linux-arm/goalert $(BIN_DIR)/linux-arm/goalert-slack-email-sync $(BIN_DIR)/linux-arm/mockslack $(BIN_DIR)/linux-arm/pgdump-lite $(BIN_DIR)/linux-arm/pgmocktime $(BIN_DIR)/linux-arm/procwrap $(BIN_DIR)/linux-arm/psql-lite $(BIN_DIR)/linux-arm/resetdb $(BIN_DIR)/linux-arm/runproc $(BIN_DIR)/linux-arm/sendit $(BIN_DIR)/linux-arm/sendit-server $(BIN_DIR)/linux-arm/sendit-token $(BIN_DIR)/linux-arm/simpleproxy $(BIN_DIR)/linux-arm/slowproxy $(BIN_DIR)/linux-arm/waitfor
 
 $(BIN_DIR)/linux-arm/goalert-smoketest: $(GO_DEPS)
 	GOOS=linux GOARCH=arm GOARM=7 go test ./smoketest -c -o $@
 
-$(BIN_DIR)/linux-arm64/_all: $(BIN_DIR)/linux-arm64/goalert-smoketest $(BIN_DIR)/linux-arm64/goalert $(BIN_DIR)/linux-arm64/goalert-slack-email-sync $(BIN_DIR)/linux-arm64/mockslack $(BIN_DIR)/linux-arm64/pgdump-lite $(BIN_DIR)/linux-arm64/procwrap $(BIN_DIR)/linux-arm64/psql-lite $(BIN_DIR)/linux-arm64/resetdb $(BIN_DIR)/linux-arm64/runproc $(BIN_DIR)/linux-arm64/sendit $(BIN_DIR)/linux-arm64/sendit-server $(BIN_DIR)/linux-arm64/sendit-token $(BIN_DIR)/linux-arm64/simpleproxy $(BIN_DIR)/linux-arm64/slowproxy $(BIN_DIR)/linux-arm64/waitfor
+$(BIN_DIR)/linux-arm64/_all: $(BIN_DIR)/linux-arm64/goalert-smoketest $(BIN_DIR)/linux-arm64/goalert $(BIN_DIR)/linux-arm64/goalert-slack-email-sync $(BIN_DIR)/linux-arm64/mockslack $(BIN_DIR)/linux-arm64/pgdump-lite $(BIN_DIR)/linux-arm64/pgmocktime $(BIN_DIR)/linux-arm64/procwrap $(BIN_DIR)/linux-arm64/psql-lite $(BIN_DIR)/linux-arm64/resetdb $(BIN_DIR)/linux-arm64/runproc $(BIN_DIR)/linux-arm64/sendit $(BIN_DIR)/linux-arm64/sendit-server $(BIN_DIR)/linux-arm64/sendit-token $(BIN_DIR)/linux-arm64/simpleproxy $(BIN_DIR)/linux-arm64/slowproxy $(BIN_DIR)/linux-arm64/waitfor
 
 $(BIN_DIR)/linux-arm64/goalert-smoketest: $(GO_DEPS)
 	GOOS=linux GOARCH=arm64 go test ./smoketest -c -o $@
 
-$(BIN_DIR)/windows-amd64/_all: $(BIN_DIR)/windows-amd64/goalert-smoketest $(BIN_DIR)/windows-amd64/goalert.exe $(BIN_DIR)/windows-amd64/goalert-slack-email-sync.exe $(BIN_DIR)/windows-amd64/mockslack.exe $(BIN_DIR)/windows-amd64/pgdump-lite.exe $(BIN_DIR)/windows-amd64/procwrap.exe $(BIN_DIR)/windows-amd64/psql-lite.exe $(BIN_DIR)/windows-amd64/resetdb.exe $(BIN_DIR)/windows-amd64/runproc.exe $(BIN_DIR)/windows-amd64/sendit.exe $(BIN_DIR)/windows-amd64/sendit-server.exe $(BIN_DIR)/windows-amd64/sendit-token.exe $(BIN_DIR)/windows-amd64/simpleproxy.exe $(BIN_DIR)/windows-amd64/slowproxy.exe $(BIN_DIR)/windows-amd64/waitfor.exe
+$(BIN_DIR)/windows-amd64/_all: $(BIN_DIR)/windows-amd64/goalert-smoketest $(BIN_DIR)/windows-amd64/goalert.exe $(BIN_DIR)/windows-amd64/goalert-slack-email-sync.exe $(BIN_DIR)/windows-amd64/mockslack.exe $(BIN_DIR)/windows-amd64/pgdump-lite.exe $(BIN_DIR)/windows-amd64/pgmocktime.exe $(BIN_DIR)/windows-amd64/procwrap.exe $(BIN_DIR)/windows-amd64/psql-lite.exe $(BIN_DIR)/windows-amd64/resetdb.exe $(BIN_DIR)/windows-amd64/runproc.exe $(BIN_DIR)/windows-amd64/sendit.exe $(BIN_DIR)/windows-amd64/sendit-server.exe $(BIN_DIR)/windows-amd64/sendit-token.exe $(BIN_DIR)/windows-amd64/simpleproxy.exe $(BIN_DIR)/windows-amd64/slowproxy.exe $(BIN_DIR)/windows-amd64/waitfor.exe
 
 $(BIN_DIR)/windows-amd64/goalert-smoketest: $(GO_DEPS)
 	GOOS=windows GOARCH=amd64 go test ./smoketest -c -o $@
@@ -501,10 +520,10 @@ $(BIN_DIR)/goalert-windows-amd64.zip: $(BIN_DIR)/build/goalert-windows-amd64
 
 
 
-$(BIN_DIR)/build/integration-darwin-amd64: $(BIN_DIR)/darwin-amd64/goalert $(BIN_DIR)/darwin-amd64/mockslack $(BIN_DIR)/darwin-amd64/pgdump-lite $(BIN_DIR)/darwin-amd64/psql-lite $(BIN_DIR)/darwin-amd64/procwrap $(BIN_DIR)/darwin-amd64/simpleproxy $(BIN_DIR)/darwin-amd64/waitfor $(BIN_DIR)/build/integration
+$(BIN_DIR)/build/integration-darwin-amd64: $(BIN_DIR)/darwin-amd64/goalert $(BIN_DIR)/darwin-amd64/mockslack $(BIN_DIR)/darwin-amd64/pgdump-lite $(BIN_DIR)/darwin-amd64/psql-lite $(BIN_DIR)/darwin-amd64/procwrap $(BIN_DIR)/darwin-amd64/simpleproxy $(BIN_DIR)/darwin-amd64/waitfor $(BIN_DIR)/darwin-amd64/pgmocktime $(BIN_DIR)/build/integration
 	rm -rf $@
 	mkdir -p $@/goalert/bin/
-	cp  $(BIN_DIR)/darwin-amd64/goalert $(BIN_DIR)/darwin-amd64/mockslack $(BIN_DIR)/darwin-amd64/pgdump-lite $(BIN_DIR)/darwin-amd64/psql-lite $(BIN_DIR)/darwin-amd64/procwrap $(BIN_DIR)/darwin-amd64/simpleproxy $(BIN_DIR)/darwin-amd64/waitfor $@/goalert/bin/
+	cp  $(BIN_DIR)/darwin-amd64/goalert $(BIN_DIR)/darwin-amd64/mockslack $(BIN_DIR)/darwin-amd64/pgdump-lite $(BIN_DIR)/darwin-amd64/psql-lite $(BIN_DIR)/darwin-amd64/procwrap $(BIN_DIR)/darwin-amd64/simpleproxy $(BIN_DIR)/darwin-amd64/waitfor $(BIN_DIR)/darwin-amd64/pgmocktime $@/goalert/bin/
 	cp -r  $(BIN_DIR)/build/integration/. $@/goalert/
 	touch $@
 
@@ -515,10 +534,10 @@ $(BIN_DIR)/integration-darwin-amd64.zip: $(BIN_DIR)/build/integration-darwin-amd
 	rm -f $@
 	cd $(BIN_DIR)/build/integration-darwin-amd64 && zip -r $(abspath $@) .
 
-$(BIN_DIR)/build/integration-linux-amd64: $(BIN_DIR)/linux-amd64/goalert $(BIN_DIR)/linux-amd64/mockslack $(BIN_DIR)/linux-amd64/pgdump-lite $(BIN_DIR)/linux-amd64/psql-lite $(BIN_DIR)/linux-amd64/procwrap $(BIN_DIR)/linux-amd64/simpleproxy $(BIN_DIR)/linux-amd64/waitfor $(BIN_DIR)/build/integration
+$(BIN_DIR)/build/integration-linux-amd64: $(BIN_DIR)/linux-amd64/goalert $(BIN_DIR)/linux-amd64/mockslack $(BIN_DIR)/linux-amd64/pgdump-lite $(BIN_DIR)/linux-amd64/psql-lite $(BIN_DIR)/linux-amd64/procwrap $(BIN_DIR)/linux-amd64/simpleproxy $(BIN_DIR)/linux-amd64/waitfor $(BIN_DIR)/linux-amd64/pgmocktime $(BIN_DIR)/build/integration
 	rm -rf $@
 	mkdir -p $@/goalert/bin/
-	cp  $(BIN_DIR)/linux-amd64/goalert $(BIN_DIR)/linux-amd64/mockslack $(BIN_DIR)/linux-amd64/pgdump-lite $(BIN_DIR)/linux-amd64/psql-lite $(BIN_DIR)/linux-amd64/procwrap $(BIN_DIR)/linux-amd64/simpleproxy $(BIN_DIR)/linux-amd64/waitfor $@/goalert/bin/
+	cp  $(BIN_DIR)/linux-amd64/goalert $(BIN_DIR)/linux-amd64/mockslack $(BIN_DIR)/linux-amd64/pgdump-lite $(BIN_DIR)/linux-amd64/psql-lite $(BIN_DIR)/linux-amd64/procwrap $(BIN_DIR)/linux-amd64/simpleproxy $(BIN_DIR)/linux-amd64/waitfor $(BIN_DIR)/linux-amd64/pgmocktime $@/goalert/bin/
 	cp -r  $(BIN_DIR)/build/integration/. $@/goalert/
 	touch $@
 
@@ -529,10 +548,10 @@ $(BIN_DIR)/integration-linux-amd64.zip: $(BIN_DIR)/build/integration-linux-amd64
 	rm -f $@
 	cd $(BIN_DIR)/build/integration-linux-amd64 && zip -r $(abspath $@) .
 
-$(BIN_DIR)/build/integration-linux-arm: $(BIN_DIR)/linux-arm/goalert $(BIN_DIR)/linux-arm/mockslack $(BIN_DIR)/linux-arm/pgdump-lite $(BIN_DIR)/linux-arm/psql-lite $(BIN_DIR)/linux-arm/procwrap $(BIN_DIR)/linux-arm/simpleproxy $(BIN_DIR)/linux-arm/waitfor $(BIN_DIR)/build/integration
+$(BIN_DIR)/build/integration-linux-arm: $(BIN_DIR)/linux-arm/goalert $(BIN_DIR)/linux-arm/mockslack $(BIN_DIR)/linux-arm/pgdump-lite $(BIN_DIR)/linux-arm/psql-lite $(BIN_DIR)/linux-arm/procwrap $(BIN_DIR)/linux-arm/simpleproxy $(BIN_DIR)/linux-arm/waitfor $(BIN_DIR)/linux-arm/pgmocktime $(BIN_DIR)/build/integration
 	rm -rf $@
 	mkdir -p $@/goalert/bin/
-	cp  $(BIN_DIR)/linux-arm/goalert $(BIN_DIR)/linux-arm/mockslack $(BIN_DIR)/linux-arm/pgdump-lite $(BIN_DIR)/linux-arm/psql-lite $(BIN_DIR)/linux-arm/procwrap $(BIN_DIR)/linux-arm/simpleproxy $(BIN_DIR)/linux-arm/waitfor $@/goalert/bin/
+	cp  $(BIN_DIR)/linux-arm/goalert $(BIN_DIR)/linux-arm/mockslack $(BIN_DIR)/linux-arm/pgdump-lite $(BIN_DIR)/linux-arm/psql-lite $(BIN_DIR)/linux-arm/procwrap $(BIN_DIR)/linux-arm/simpleproxy $(BIN_DIR)/linux-arm/waitfor $(BIN_DIR)/linux-arm/pgmocktime $@/goalert/bin/
 	cp -r  $(BIN_DIR)/build/integration/. $@/goalert/
 	touch $@
 
@@ -543,10 +562,10 @@ $(BIN_DIR)/integration-linux-arm.zip: $(BIN_DIR)/build/integration-linux-arm
 	rm -f $@
 	cd $(BIN_DIR)/build/integration-linux-arm && zip -r $(abspath $@) .
 
-$(BIN_DIR)/build/integration-linux-arm64: $(BIN_DIR)/linux-arm64/goalert $(BIN_DIR)/linux-arm64/mockslack $(BIN_DIR)/linux-arm64/pgdump-lite $(BIN_DIR)/linux-arm64/psql-lite $(BIN_DIR)/linux-arm64/procwrap $(BIN_DIR)/linux-arm64/simpleproxy $(BIN_DIR)/linux-arm64/waitfor $(BIN_DIR)/build/integration
+$(BIN_DIR)/build/integration-linux-arm64: $(BIN_DIR)/linux-arm64/goalert $(BIN_DIR)/linux-arm64/mockslack $(BIN_DIR)/linux-arm64/pgdump-lite $(BIN_DIR)/linux-arm64/psql-lite $(BIN_DIR)/linux-arm64/procwrap $(BIN_DIR)/linux-arm64/simpleproxy $(BIN_DIR)/linux-arm64/waitfor $(BIN_DIR)/linux-arm64/pgmocktime $(BIN_DIR)/build/integration
 	rm -rf $@
 	mkdir -p $@/goalert/bin/
-	cp  $(BIN_DIR)/linux-arm64/goalert $(BIN_DIR)/linux-arm64/mockslack $(BIN_DIR)/linux-arm64/pgdump-lite $(BIN_DIR)/linux-arm64/psql-lite $(BIN_DIR)/linux-arm64/procwrap $(BIN_DIR)/linux-arm64/simpleproxy $(BIN_DIR)/linux-arm64/waitfor $@/goalert/bin/
+	cp  $(BIN_DIR)/linux-arm64/goalert $(BIN_DIR)/linux-arm64/mockslack $(BIN_DIR)/linux-arm64/pgdump-lite $(BIN_DIR)/linux-arm64/psql-lite $(BIN_DIR)/linux-arm64/procwrap $(BIN_DIR)/linux-arm64/simpleproxy $(BIN_DIR)/linux-arm64/waitfor $(BIN_DIR)/linux-arm64/pgmocktime $@/goalert/bin/
 	cp -r  $(BIN_DIR)/build/integration/. $@/goalert/
 	touch $@
 
@@ -557,10 +576,10 @@ $(BIN_DIR)/integration-linux-arm64.zip: $(BIN_DIR)/build/integration-linux-arm64
 	rm -f $@
 	cd $(BIN_DIR)/build/integration-linux-arm64 && zip -r $(abspath $@) .
 
-$(BIN_DIR)/build/integration-windows-amd64: $(BIN_DIR)/windows-amd64/goalert.exe $(BIN_DIR)/windows-amd64/mockslack.exe $(BIN_DIR)/windows-amd64/pgdump-lite.exe $(BIN_DIR)/windows-amd64/psql-lite.exe $(BIN_DIR)/windows-amd64/procwrap.exe $(BIN_DIR)/windows-amd64/simpleproxy.exe $(BIN_DIR)/windows-amd64/waitfor.exe $(BIN_DIR)/build/integration
+$(BIN_DIR)/build/integration-windows-amd64: $(BIN_DIR)/windows-amd64/goalert.exe $(BIN_DIR)/windows-amd64/mockslack.exe $(BIN_DIR)/windows-amd64/pgdump-lite.exe $(BIN_DIR)/windows-amd64/psql-lite.exe $(BIN_DIR)/windows-amd64/procwrap.exe $(BIN_DIR)/windows-amd64/simpleproxy.exe $(BIN_DIR)/windows-amd64/waitfor.exe $(BIN_DIR)/windows-amd64/pgmocktime.exe $(BIN_DIR)/build/integration
 	rm -rf $@
 	mkdir -p $@/goalert/bin/
-	cp  $(BIN_DIR)/windows-amd64/goalert.exe $(BIN_DIR)/windows-amd64/mockslack.exe $(BIN_DIR)/windows-amd64/pgdump-lite.exe $(BIN_DIR)/windows-amd64/psql-lite.exe $(BIN_DIR)/windows-amd64/procwrap.exe $(BIN_DIR)/windows-amd64/simpleproxy.exe $(BIN_DIR)/windows-amd64/waitfor.exe $@/goalert/bin/
+	cp  $(BIN_DIR)/windows-amd64/goalert.exe $(BIN_DIR)/windows-amd64/mockslack.exe $(BIN_DIR)/windows-amd64/pgdump-lite.exe $(BIN_DIR)/windows-amd64/psql-lite.exe $(BIN_DIR)/windows-amd64/procwrap.exe $(BIN_DIR)/windows-amd64/simpleproxy.exe $(BIN_DIR)/windows-amd64/waitfor.exe $(BIN_DIR)/windows-amd64/pgmocktime.exe $@/goalert/bin/
 	cp -r  $(BIN_DIR)/build/integration/. $@/goalert/
 	touch $@
 

--- a/app/healthcheck.go
+++ b/app/healthcheck.go
@@ -1,9 +1,10 @@
 package app
 
 import (
+	"io"
 	"net/http"
 
-	"github.com/pkg/errors"
+	"github.com/google/uuid"
 	"github.com/target/goalert/app/lifecycle"
 	"github.com/target/goalert/util/errutil"
 )
@@ -32,6 +33,31 @@ func (app *App) engineStatus(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err := app.Engine.WaitNextCycle(req.Context())
-	errutil.HTTPError(req.Context(), w, errors.Wrap(err, "engine cycle"))
+	var id uuid.UUID
+	if nStr := req.FormValue("id"); nStr != "" {
+		_id, err := uuid.Parse(nStr)
+		if err != nil {
+			http.Error(w, "invalid id", http.StatusBadRequest)
+			return
+		}
+		id = _id
+	} else {
+		id = app.Engine.NextCycleID()
+	}
+
+	errutil.HTTPError(req.Context(), w, app.Engine.WaitCycleID(req.Context(), id))
+}
+
+func (app *App) engineCycle(w http.ResponseWriter, req *http.Request) {
+	if app.mgr.Status() == lifecycle.StatusShutdown {
+		http.Error(w, "server shutting down", http.StatusBadRequest)
+		return
+	}
+
+	if app.cfg.APIOnly {
+		http.Error(w, "engine not running", http.StatusBadRequest)
+		return
+	}
+
+	io.WriteString(w, app.Engine.NextCycleID().String())
 }

--- a/app/inithttp.go
+++ b/app/inithttp.go
@@ -246,6 +246,7 @@ func (app *App) initHTTP(ctx context.Context) error {
 
 	mux.HandleFunc("/health", app.healthCheck)
 	mux.HandleFunc("/health/engine", app.engineStatus)
+	mux.HandleFunc("/health/engine/cycle", app.engineCycle)
 
 	webH, err := web.NewHandler(app.cfg.UIDir, app.cfg.HTTPPrefix)
 	if err != nil {

--- a/devtools/genmake/run.go
+++ b/devtools/genmake/run.go
@@ -83,6 +83,7 @@ func main() {
 				"procwrap",
 				"simpleproxy",
 				"waitfor",
+				"pgmocktime",
 			},
 		},
 	}

--- a/devtools/pgmocktime/cmd/pgmocktime/main.go
+++ b/devtools/pgmocktime/cmd/pgmocktime/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"time"
+
+	"github.com/target/goalert/devtools/pgmocktime"
+)
+
+func main() {
+	log.SetFlags(log.Lshortfile)
+	url := flag.String("d", os.Getenv("DBURL"), "DB URL") // use same env var as pg_dump
+	speed := flag.Float64("s", 1.0, "Speed of time (1.0 = real time).")
+	setTime := flag.String("t", "", "Set time to the provided value.")
+	advTime := flag.Duration("a", 0, "Advance time by this offset.")
+	reset := flag.Bool("reset", false, "Reset time and speed.")
+	inject := flag.Bool("inject", false, "Inject instrumentation.")
+	remove := flag.Bool("remove", false, "Remove instrumentation.")
+	flag.Parse()
+
+	ctx := context.Background()
+
+	m, err := pgmocktime.New(ctx, *url)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer m.Close()
+
+	if *inject {
+		err = m.Inject(ctx)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	if *reset {
+		err = m.Reset(ctx)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	var setSpeed bool
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "s" {
+			setSpeed = true
+		}
+	})
+
+	if setSpeed {
+		err = m.SetSpeed(ctx, *speed)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	if *setTime != "" {
+		t, err := time.Parse(time.RFC3339Nano, *setTime)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = m.SetTime(ctx, t)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	if *advTime != 0 {
+		err = m.AdvanceTime(ctx, *advTime)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	if *remove {
+		err = m.Remove(ctx)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}

--- a/devtools/pgmocktime/mocker.go
+++ b/devtools/pgmocktime/mocker.go
@@ -37,20 +37,6 @@ func New(ctx context.Context, dbURL string) (*Mocker, error) {
 	return &Mocker{db: db, dbName: dbName, schema: "pgmocktime"}, nil
 }
 
-func (m *Mocker) timestamp(ctx context.Context) time.Time {
-	if m.err != nil {
-		return time.Time{}
-	}
-
-	var t time.Time
-	m.err = m.db.QueryRow(ctx, `SELECT current_timestamp`).Scan(&t)
-	if m.err != nil {
-		m.err = fmt.Errorf("select current time: %w", m.err)
-	}
-
-	return t
-}
-
 func (m *Mocker) exec(ctx context.Context, queryFormat string, args ...interface{}) {
 	if m.err != nil {
 		log.Println("skipping", queryFormat, args)

--- a/devtools/pgmocktime/mocker.go
+++ b/devtools/pgmocktime/mocker.go
@@ -1,0 +1,234 @@
+package pgmocktime
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+type Mocker struct {
+	db     *pgxpool.Pool
+	dbName string
+
+	schema string
+	err    error
+}
+
+// New creates a new Mocker capable of manipulating time in a postgres database.
+func New(ctx context.Context, dbURL string) (*Mocker, error) {
+	db, err := pgxpool.Connect(context.Background(), dbURL)
+	if err != nil {
+		return nil, fmt.Errorf("connect to database: %w", err)
+	}
+
+	var dbName string
+	err = db.QueryRow(ctx, `SELECT current_database()`).Scan(&dbName)
+	if err != nil {
+		return nil, fmt.Errorf("select current time: %w", err)
+	}
+
+	return &Mocker{db: db, dbName: dbName, schema: "pgmocktime"}, nil
+}
+
+func (m *Mocker) setSpeed(ctx context.Context, s float64) {
+	if m.err != nil {
+		return
+	}
+
+	m.exec(ctx, `
+	create or replace function %s.time_speed()
+	returns float
+	as $$
+		begin
+		return %f;
+		end;
+	$$ language plpgsql;
+	`,
+		m.safeSchema(),
+		s,
+	)
+}
+
+func (m *Mocker) setOffset(ctx context.Context, offset time.Duration) {
+	if m.err != nil {
+		return
+	}
+
+	m.exec(ctx, `
+	create or replace function %s.time_offset()
+	returns interval
+	as $$
+		begin
+		return '%d milliseconds'::interval;
+		end;
+	$$ language plpgsql;
+	`,
+		m.safeSchema(),
+		offset/time.Millisecond,
+	)
+}
+
+func (m *Mocker) timestamp(ctx context.Context) time.Time {
+	if m.err != nil {
+		return time.Time{}
+	}
+
+	var t time.Time
+	m.err = m.db.QueryRow(ctx, `SELECT current_timestamp`).Scan(&t)
+	if m.err != nil {
+		m.err = fmt.Errorf("select current time: %w", m.err)
+	}
+
+	return t
+}
+
+func (m *Mocker) exec(ctx context.Context, queryFormat string, args ...interface{}) {
+	if m.err != nil {
+		log.Println("skipping", queryFormat, args)
+		return
+	}
+
+	query := fmt.Sprintf(queryFormat, args...)
+	_, err := m.db.Exec(ctx, query)
+	if err != nil {
+		m.err = fmt.Errorf("exec: %s: %w", query, err)
+	}
+}
+
+func (m *Mocker) safeSchema() string {
+	return pgx.Identifier{m.schema}.Sanitize()
+}
+
+func (m *Mocker) safeDB() string {
+	return pgx.Identifier{m.dbName}.Sanitize()
+}
+
+func (m *Mocker) readErr(action string) (err error) {
+	err = m.err
+	m.err = nil
+	if err != nil {
+		return fmt.Errorf("%s: %w", action, err)
+	}
+	return nil
+}
+
+// Inject instruments the database for the manipulation of time.
+func (m *Mocker) Inject(ctx context.Context) error {
+	m.exec(ctx, `create schema if not exists %s`, m.safeSchema())
+	m.setOffset(ctx, 0)
+	m.setSpeed(ctx, 1.0)
+
+	refTime := m.timestamp(ctx)
+	if refTime.IsZero() {
+		return m.readErr("inject")
+	}
+	m.exec(ctx, `
+	create or replace function %s.now()
+	returns timestamptz
+	as $$
+		begin
+		return '%s'::timestamptz + (current_timestamp - '%s'::timestamptz) * time_speed() + time_offset();
+		end;
+	$$ language plpgsql;
+	`,
+		m.safeSchema(),
+		refTime.Format(time.RFC3339Nano),
+		refTime.Format(time.RFC3339Nano),
+	)
+
+	m.exec(ctx, `alter database %s set search_path = "$user", public, %s, pg_catalog`, m.safeDB(), m.safeSchema())
+	if m.err != nil {
+		log.Println("skipping", m.err)
+		return m.readErr("inject")
+	}
+
+	// update all columns from `pg_catalog.now()` to `schema.now()`
+	rows, err := m.db.Query(ctx, `select table_name, column_name from information_schema.columns where column_default = 'pg_catalog.now()' or column_default = 'now()'`)
+	if err != nil {
+		return fmt.Errorf("update columns: %w", err)
+	}
+	defer rows.Close()
+
+	type col struct {
+		table string
+		name  string
+	}
+	var cols []col
+
+	for rows.Next() {
+		var c col
+		if err := rows.Scan(&c.table, &c.name); err != nil {
+			return fmt.Errorf("scan columns: %w", err)
+		}
+		cols = append(cols, c)
+	}
+
+	for _, c := range cols {
+		m.exec(ctx, `alter table %s alter column %s set default %s.now()`,
+			pgx.Identifier{c.table}.Sanitize(),
+			pgx.Identifier{c.name}.Sanitize(),
+			m.safeSchema(),
+		)
+	}
+
+	return m.readErr("inject")
+}
+
+// Remove removes instrumentation from the database.
+func (m *Mocker) Remove(ctx context.Context) error {
+	m.exec(ctx, `alter database %s reset search_path`, m.safeDB())
+	m.exec(ctx, `drop schema if exists %s cascade`, m.safeSchema())
+	return m.readErr("remove")
+}
+
+// Close closes the database connection.
+func (m *Mocker) Close() error { m.db.Close(); return nil }
+
+// AdvanceTime advances the time by the given duration.
+func (m *Mocker) AdvanceTime(ctx context.Context, d time.Duration) error {
+	var offset time.Duration
+	err := m.db.QueryRow(ctx, fmt.Sprintf(`SELECT %s.time_offset()`, m.safeSchema())).Scan(&offset)
+	if err != nil {
+		return fmt.Errorf("select time offset: %w", err)
+	}
+
+	m.setOffset(ctx, offset+d)
+	return m.readErr("advance time")
+}
+
+// SetOffset sets the offset of time to the given absolute duration compared to the current real-world time.
+func (m *Mocker) SetOffset(ctx context.Context, offset time.Duration) error {
+	m.setOffset(ctx, offset)
+	return m.readErr("set offset")
+}
+
+// SetTime sets the database time to the given time.
+func (m *Mocker) SetTime(ctx context.Context, t time.Time) error {
+	var curTime time.Time
+	var offset time.Duration
+	err := m.db.QueryRow(ctx, fmt.Sprintf(`SELECT %s.time_offset(), %s.now()`, m.safeSchema(), m.safeSchema())).Scan(&offset, &t)
+	if err != nil {
+		return fmt.Errorf("select time offset: %w", err)
+	}
+
+	offset += t.Sub(curTime)
+	m.setOffset(ctx, offset)
+	return m.readErr("set time")
+}
+
+// SetSpeed sets the speed of time, 1.0 is the normal flow of time.
+func (m *Mocker) SetSpeed(ctx context.Context, speed float64) error {
+	m.setSpeed(ctx, speed)
+	return m.readErr("set speed")
+}
+
+// Reset sets the time to the current real time and resumes the normal flow of time.
+func (m *Mocker) Reset(ctx context.Context) error {
+	m.setOffset(ctx, 0)
+	m.setSpeed(ctx, 1.0)
+	return m.readErr("reset")
+}

--- a/devtools/pgmocktime/mocker.go
+++ b/devtools/pgmocktime/mocker.go
@@ -37,49 +37,6 @@ func New(ctx context.Context, dbURL string) (*Mocker, error) {
 	return &Mocker{db: db, dbName: dbName, schema: "pgmocktime"}, nil
 }
 
-func (m *Mocker) setSpeed(ctx context.Context, s float64) {
-	if m.err != nil {
-		return
-	}
-
-	mx.Lock()
-	defer mx.Unlock()
-
-	m.exec(ctx, `
-	create or replace function %s.time_speed()
-	returns float
-	as $$
-		begin
-		return %f;
-		end;
-	$$ language plpgsql;
-	`,
-		m.safeSchema(),
-		s,
-	)
-}
-
-func (m *Mocker) setOffset(ctx context.Context, offset time.Duration) {
-	if m.err != nil {
-		return
-	}
-
-	mx.Lock()
-	defer mx.Unlock()
-	m.exec(ctx, `
-	create or replace function %s.time_offset()
-	returns interval
-	as $$
-		begin
-		return '%d milliseconds'::interval;
-		end;
-	$$ language plpgsql;
-	`,
-		m.safeSchema(),
-		offset/time.Millisecond,
-	)
-}
-
 func (m *Mocker) timestamp(ctx context.Context) time.Time {
 	if m.err != nil {
 		return time.Time{}
@@ -127,27 +84,35 @@ func (m *Mocker) readErr(action string) (err error) {
 // Inject instruments the database for the manipulation of time.
 func (m *Mocker) Inject(ctx context.Context) error {
 	m.exec(ctx, `create schema if not exists %s`, m.safeSchema())
-	m.setOffset(ctx, 0)
-	m.setSpeed(ctx, 1.0)
 
-	refTime := m.timestamp(ctx)
-	if refTime.IsZero() {
-		return m.readErr("inject")
-	}
+	m.exec(ctx, `
+	create unlogged table if not exists %s.flux_capacitor (
+		ok BOOL PRIMARY KEY,
+		ref_time TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+		base_time TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+		speed FLOAT NOT NULL DEFAULT 1.0,
+		CHECK(ok)
+	)`, m.safeSchema())
+
+	m.exec(ctx, `insert into %s.flux_capacitor (ok) values (true)`, m.safeSchema())
 
 	mx.Lock()
 	m.exec(ctx, `
 	create or replace function %s.now()
-	returns timestamptz
-	as $$
-		begin
-		return '%s'::timestamptz + (current_timestamp - '%s'::timestamptz) * time_speed() + time_offset();
+	RETURNS timestamptz
+	AS $$
+		DECLARE
+			_ref_time timestamptz;
+			_base_time timestamptz;
+			_speed FLOAT;
+		BEGIN
+			SELECT ref_time, base_time, speed INTO _ref_time, _base_time, _speed FROM %s.flux_capacitor;
+			RETURN _base_time + (current_timestamp - _ref_time) * _speed;
 		end;
 	$$ language plpgsql;
 	`,
 		m.safeSchema(),
-		refTime.Format(time.RFC3339Nano),
-		refTime.Format(time.RFC3339Nano),
+		m.safeSchema(),
 	)
 	mx.Unlock()
 
@@ -201,45 +166,24 @@ func (m *Mocker) Close() error { m.db.Close(); return nil }
 
 // AdvanceTime advances the time by the given duration.
 func (m *Mocker) AdvanceTime(ctx context.Context, d time.Duration) error {
-	var offset time.Duration
-	err := m.db.QueryRow(ctx, fmt.Sprintf(`SELECT %s.time_offset()`, m.safeSchema())).Scan(&offset)
-	if err != nil {
-		return fmt.Errorf("select time offset: %w", err)
-	}
-
-	m.setOffset(ctx, offset+d)
+	m.exec(ctx, `update %s.flux_capacitor set ref_time = current_timestamp, base_time = %s.now() + '%d milliseconds'::interval`, m.safeSchema(), m.safeSchema(), d/time.Millisecond)
 	return m.readErr("advance time")
-}
-
-// SetOffset sets the offset of time to the given absolute duration compared to the current real-world time.
-func (m *Mocker) SetOffset(ctx context.Context, offset time.Duration) error {
-	m.setOffset(ctx, offset)
-	return m.readErr("set offset")
 }
 
 // SetTime sets the database time to the given time.
 func (m *Mocker) SetTime(ctx context.Context, t time.Time) error {
-	var curTime time.Time
-	var offset time.Duration
-	err := m.db.QueryRow(ctx, fmt.Sprintf(`SELECT %s.time_offset(), %s.now()`, m.safeSchema(), m.safeSchema())).Scan(&offset, &t)
-	if err != nil {
-		return fmt.Errorf("select time offset: %w", err)
-	}
-
-	offset += t.Sub(curTime)
-	m.setOffset(ctx, offset)
+	m.exec(ctx, `update %s.flux_capacitor set ref_time = current_timestamp, base_time = '%s'::timestamptz`, m.safeSchema(), t.Format(time.RFC3339Nano))
 	return m.readErr("set time")
 }
 
 // SetSpeed sets the speed of time, 1.0 is the normal flow of time.
 func (m *Mocker) SetSpeed(ctx context.Context, speed float64) error {
-	m.setSpeed(ctx, speed)
+	m.exec(ctx, `update %s.flux_capacitor set speed = %f, ref_time = current_timestamp, base_time = %s.now()`, m.safeSchema(), speed, m.safeSchema())
 	return m.readErr("set speed")
 }
 
 // Reset sets the time to the current real time and resumes the normal flow of time.
 func (m *Mocker) Reset(ctx context.Context) error {
-	m.setOffset(ctx, 0)
-	m.setSpeed(ctx, 1.0)
+	m.exec(ctx, `update %s.flux_capacitor set speed = 1.0, ref_time = current_timestamp, base_time = current_timestamp`, m.safeSchema())
 	return m.readErr("reset")
 }

--- a/devtools/pgmocktime/mocker.go
+++ b/devtools/pgmocktime/mocker.go
@@ -80,7 +80,7 @@ func (m *Mocker) Inject(ctx context.Context) error {
 		CHECK(ok)
 	)`, m.safeSchema())
 
-	m.exec(ctx, `insert into %s.flux_capacitor (ok) values (true)`, m.safeSchema())
+	m.exec(ctx, `insert into %s.flux_capacitor (ok) values (true) on conflict do nothing`, m.safeSchema())
 
 	mx.Lock()
 	m.exec(ctx, `

--- a/engine/cyclemonitor.go
+++ b/engine/cyclemonitor.go
@@ -1,0 +1,85 @@
+package engine
+
+import (
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/target/goalert/validation"
+)
+
+const cycleHist = 10
+
+type cycleMonitor struct {
+	mx sync.Mutex
+
+	cycles  map[uuid.UUID]chan struct{}
+	history [cycleHist]uuid.UUID
+}
+
+func newCycleMonitor() *cycleMonitor {
+	m := &cycleMonitor{
+		cycles: make(map[uuid.UUID]chan struct{}, cycleHist),
+	}
+	m._newID()
+	return m
+}
+
+func (c *cycleMonitor) _newID() {
+	// remove oldest cycle
+	delete(c.cycles, c.history[cycleHist-1])
+
+	// shift history
+	copy(c.history[:], c.history[1:])
+
+	// add new cycle
+	c.history[0] = uuid.New()
+	c.cycles[c.history[0]] = make(chan struct{})
+}
+
+// startNextCycle marks the begining of the next engine cycle.
+// It returns a func that should be called when the cycle is finished.
+func (c *cycleMonitor) startNextCycle() func() {
+	c.mx.Lock()
+	defer c.mx.Unlock()
+
+	ch := c.cycles[c.history[0]]
+	c._newID()
+
+	return func() { close(ch) }
+}
+
+// WaitCycleID waits for the engine cycle with the given UUID to finish.
+func (c *cycleMonitor) WaitCycleID(ctx context.Context, cycleID uuid.UUID) error {
+	if c == nil {
+		// engine is disabled
+		return validation.NewGenericError("engine is disabled")
+	}
+
+	c.mx.Lock()
+	ch, ok := c.cycles[cycleID]
+	c.mx.Unlock()
+	if !ok {
+		return validation.NewGenericError("unknown cycle ID")
+	}
+
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// NextCycleID returns the UUID of the next engine cycle.
+func (c *cycleMonitor) NextCycleID() uuid.UUID {
+	if c == nil {
+		// engine is disabled
+		return uuid.Nil
+	}
+
+	c.mx.Lock()
+	defer c.mx.Unlock()
+
+	return c.history[0]
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -42,11 +42,11 @@ type Engine struct {
 	b   *backend
 	mgr *lifecycle.Manager
 
-	shutdownCh  chan struct{}
-	triggerCh   chan chan struct{}
-	runLoopExit chan struct{}
+	*cycleMonitor
 
-	nextCycle chan chan struct{}
+	shutdownCh  chan struct{}
+	triggerCh   chan struct{}
+	runLoopExit chan struct{}
 
 	modules []updater
 	msg     *message.DB
@@ -74,10 +74,10 @@ func NewEngine(ctx context.Context, db *sql.DB, c *Config) (*Engine, error) {
 	p := &Engine{
 		cfg:            c,
 		shutdownCh:     make(chan struct{}),
-		triggerCh:      make(chan chan struct{}),
+		triggerCh:      make(chan struct{}),
 		triggerPauseCh: make(chan *pauseReq),
 		runLoopExit:    make(chan struct{}),
-		nextCycle:      make(chan chan struct{}),
+		cycleMonitor:   newCycleMonitor(),
 
 		a: c.AlertStore,
 	}
@@ -153,21 +153,6 @@ func NewEngine(ctx context.Context, db *sql.DB, c *Config) (*Engine, error) {
 	return p, nil
 }
 
-// WaitNextCycle will return after the next engine cycle starts and then finishes.
-func (p *Engine) WaitNextCycle(ctx context.Context) error {
-	select {
-	case ch := <-p.nextCycle:
-		select {
-		case <-ch:
-			return nil
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-}
-
 func (p *Engine) processModule(ctx context.Context, m updater) {
 	defer recoverPanic(ctx, m.Name())
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -221,28 +206,7 @@ func recoverPanic(ctx context.Context, name string) {
 }
 
 // Trigger will force notifications to be processed immediately.
-func (p *Engine) Trigger() {
-	<-p.triggerCh
-}
-
-// TriggerAndWaitNextCycle will force notifications to be processed immediately
-// and will return after the next engine cycle starts and then finishes.
-func (p *Engine) TriggerAndWaitNextCycle(ctx context.Context) error {
-	var waitCh chan struct{}
-	select {
-	case waitCh = <-p.triggerCh: // cause new trigger
-	case waitCh = <-p.nextCycle: // cycle started for some other reason
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-
-	select {
-	case <-waitCh:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-}
+func (p *Engine) Trigger() { <-p.triggerCh }
 
 // Pause will attempt to gracefully stop engine processing.
 func (p *Engine) Pause(ctx context.Context) error {
@@ -486,18 +450,9 @@ func monitorCycle(ctx context.Context, start time.Time) (cancel func()) {
 }
 
 func (p *Engine) cycle(ctx context.Context) {
+	// track start of next cycle, and defer the call to the returned sfinish function
+	defer p.startNextCycle()()
 	ctx = p.cfg.ConfigSource.Config().Context(ctx)
-
-	ch := make(chan struct{})
-	defer close(ch)
-passSignals:
-	for {
-		select {
-		case p.nextCycle <- ch:
-		default:
-			break passSignals
-		}
-	}
 
 	if p.mgr.IsPausing() {
 		log.Logf(ctx, "Engine cycle disabled (paused or shutting down).")
@@ -544,7 +499,7 @@ func (p *Engine) _run(ctx context.Context) error {
 				return ctx.Err()
 			case <-p.shutdownCh:
 				return nil
-			case p.triggerCh <- ch:
+			case p.triggerCh <- struct{}{}:
 				log.Logf(ctx, "Ignoring engine trigger (API-only mode).")
 			}
 		}
@@ -573,13 +528,11 @@ func (p *Engine) _run(ctx context.Context) error {
 		default:
 		}
 
-		nextTrigger := make(chan struct{})
 		select {
 		case req := <-p.triggerPauseCh:
 			p.handlePause(req.ctx, req.ch)
-		case p.triggerCh <- nextTrigger:
+		case p.triggerCh <- struct{}{}:
 			p.cycle(log.WithField(ctx, "Trigger", "DIRECT"))
-			close(nextTrigger)
 		case <-alertTicker.C:
 			p.cycle(log.WithField(ctx, "Trigger", "INTERVAL"))
 		case <-ctx.Done():

--- a/smoketest/harness/harness.go
+++ b/smoketest/harness/harness.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v4"
-	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/jackc/pgx/v4/stdlib"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -31,6 +30,7 @@ import (
 	"github.com/target/goalert/devtools/mockslack"
 	"github.com/target/goalert/devtools/mocktwilio"
 	"github.com/target/goalert/devtools/pgdump-lite"
+	"github.com/target/goalert/devtools/pgmocktime"
 	"github.com/target/goalert/migrate"
 	"github.com/target/goalert/notification/twilio"
 	"github.com/target/goalert/permission"
@@ -87,22 +87,16 @@ type Harness struct {
 	slackApp  mockslack.AppInfo
 	slackUser mockslack.UserInfo
 
+	pgTime *pgmocktime.Mocker
+
 	ignoreErrors []string
 
 	backend     *app.App
 	backendLogs io.Closer
 
-	dbURL       string
-	dbName      string
-	delayOffset time.Duration
-	mx          sync.Mutex
-
-	start          time.Time
-	resumed        time.Time
-	lastTimeChange time.Time
-	pgResume       time.Time
-
-	db *pgxpool.Pool
+	dbURL  string
+	dbName string
+	mx     sync.Mutex
 
 	userGeneratedIndex int
 
@@ -159,7 +153,6 @@ func NewStoppedHarness(t *testing.T, initSQL string, sqlData interface{}, migrat
 	}
 
 	t.Logf("Using DB URL: %s", dbURL)
-	start := time.Now()
 	name := strings.Replace("smoketest_"+time.Now().Format("2006_01_02_15_04_05")+uuid.New().String(), "-", "", -1)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -184,14 +177,18 @@ func NewStoppedHarness(t *testing.T, initSQL string, sqlData interface{}, migrat
 		MinQueueTime: 100 * time.Millisecond, // until we have a stateless backend for answering calls
 	}
 
+	pgTime, err := pgmocktime.New(ctx, DBURL(name))
+	if err != nil {
+		t.Fatal("create pgmocktime:", err)
+	}
+
 	h := &Harness{
-		uuidG:          NewDataGen(t, "UUID", DataGenFunc(GenUUID)),
-		phoneCCG:       NewDataGen(t, "Phone", DataGenArgFunc(GenPhoneCC)),
-		emailG:         NewDataGen(t, "Email", DataGenFunc(func() string { return GenUUID() + "@example.com" })),
-		dbName:         name,
-		dbURL:          DBURL(name),
-		lastTimeChange: start,
-		start:          start,
+		uuidG:    NewDataGen(t, "UUID", DataGenFunc(GenUUID)),
+		phoneCCG: NewDataGen(t, "Phone", DataGenArgFunc(GenPhoneCC)),
+		emailG:   NewDataGen(t, "Email", DataGenFunc(func() string { return GenUUID() + "@example.com" })),
+		dbName:   name,
+		dbURL:    DBURL(name),
+		pgTime:   pgTime,
 
 		gqlSessions: make(map[string]string),
 
@@ -213,20 +210,14 @@ func NewStoppedHarness(t *testing.T, initSQL string, sqlData interface{}, migrat
 
 	h.twS = httptest.NewServer(h.tw)
 
-	// freeze DB time until backend starts
-	h.execQuery(`
-		create schema testing_overrides;
-		alter database `+sqlutil.QuoteID(name)+` set search_path = "$user", public,testing_overrides, pg_catalog;
-		
-
-		create or replace function testing_overrides.now()
-		returns timestamp with time zone
-		as $$
-			begin
-			return '`+start.Format(dbTimeFormat)+`';
-			end;
-		$$ language plpgsql;
-	`, nil)
+	err = h.pgTime.Inject(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = h.pgTime.SetSpeed(ctx, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	h.Migrate(migrationName)
 	h.initSlack()
@@ -270,25 +261,10 @@ func (h *Harness) Start() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	poolCfg, err := pgxpool.ParseConfig(h.dbURL)
+	err = h.pgTime.SetSpeed(ctx, 1)
 	if err != nil {
-		h.t.Fatalf("failed to parse db url: %v", err)
+		h.t.Fatalf("resume flow of time: %v", err)
 	}
-	poolCfg.MaxConns = 2
-
-	h.db, err = pgxpool.ConnectConfig(ctx, poolCfg)
-	if err != nil {
-		h.t.Fatalf("failed to connect to db: %v", err)
-	}
-
-	// resume the flow of time
-	err = h.db.QueryRow(ctx, `select pg_catalog.now()`).Scan(&h.pgResume)
-	if err != nil {
-		h.t.Fatalf("failed to get postgres timestamp: %v", err)
-	}
-	h.resumed = time.Now()
-	h.lastTimeChange = time.Now().Add(100 * time.Millisecond)
-	h.modifyDBOffset(0)
 
 	appCfg := app.Defaults()
 	appCfg.Logger = log.NewLogger()
@@ -350,47 +326,13 @@ func (h *Harness) IgnoreErrorsWith(substr string) {
 	h.ignoreErrors = append(h.ignoreErrors, substr)
 }
 
-func (h *Harness) modifyDBOffset(d time.Duration) {
-	n := time.Now()
-	d -= n.Sub(h.lastTimeChange)
-	if n.After(h.lastTimeChange) {
-		h.lastTimeChange = n
-	}
-
-	h.delayOffset += d
-
-	h.setDBOffset(h.delayOffset)
-}
-
-func (h *Harness) setDBOffset(d time.Duration) {
-	h.mx.Lock()
-	defer h.mx.Unlock()
-	elapsed := time.Since(h.resumed)
-	h.t.Logf("Updating DB time offset to: %s (+ %s elapsed = %s since test start)", h.delayOffset.String(), elapsed.String(), (h.delayOffset + elapsed).String())
-
-	if h.App() != nil {
-		h.App().SetTimeOffset(d)
-	}
-
-	h.execQuery(fmt.Sprintf(`
-		create or replace function testing_overrides.now()
-		returns timestamp with time zone
-		as $$
-			begin
-			return cast('%s' as timestamp with time zone) + (pg_catalog.now() - cast('%s' as timestamp with time zone))::interval;
-			end;
-		$$ language plpgsql;
-	`,
-		h.start.Add(d).Format(dbTimeFormat),
-		h.pgResume.Format(dbTimeFormat),
-	), nil)
-}
-
 func (h *Harness) FastForward(d time.Duration) {
 	h.t.Helper()
 	h.t.Logf("Fast-forward %s", d.String())
-	h.delayOffset += d
-	h.setDBOffset(h.delayOffset)
+	err := h.pgTime.AdvanceTime(context.Background(), d)
+	if err != nil {
+		h.t.Fatalf("failed to fast-forward time: %v", err)
+	}
 }
 
 func (h *Harness) execQuery(sql string, data interface{}) {
@@ -583,17 +525,18 @@ func (h *Harness) dumpDB() {
 		h.t.Fatalf("failed to get abs dump path: %v", err)
 	}
 	os.MkdirAll(filepath.Dir(file), 0o755)
-	var t time.Time
-	err = h.db.QueryRow(context.Background(), "select now()").Scan(&t)
-	if err != nil {
-		h.t.Fatalf("failed to get current timestamp: %v", err)
-	}
 
-	conn, err := h.db.Acquire(context.Background())
+	conn, err := pgx.Connect(context.Background(), h.dbURL)
 	if err != nil {
 		h.t.Fatalf("failed to get db connection: %v", err)
 	}
-	defer conn.Release()
+	defer conn.Close(context.Background())
+
+	var t time.Time
+	err = conn.QueryRow(context.Background(), "select now()").Scan(&t)
+	if err != nil {
+		h.t.Fatalf("failed to get current timestamp: %v", err)
+	}
 
 	fd, err := os.Create(file)
 	if err != nil {
@@ -601,7 +544,7 @@ func (h *Harness) dumpDB() {
 	}
 	defer fd.Close()
 
-	err = pgdump.DumpData(context.Background(), conn.Conn(), fd, nil)
+	err = pgdump.DumpData(context.Background(), conn, fd, nil)
 	if err != nil {
 		h.t.Errorf("failed to dump database '%s': %v", h.dbName, err)
 	}
@@ -642,7 +585,7 @@ func (h *Harness) Close() error {
 	h.tw.Close()
 	h.dumpDB()
 
-	h.db.Close()
+	h.pgTime.Close()
 
 	conn, err := pgx.Connect(ctx, DBURL(""))
 	if err != nil {

--- a/smoketest/harness/harness.go
+++ b/smoketest/harness/harness.go
@@ -543,7 +543,9 @@ func (h *Harness) AddNotificationRule(userID, cmID string, delayMinutes int) {
 
 // Trigger will trigger, and wait for, an engine cycle.
 func (h *Harness) Trigger() {
-	h.backend.Engine.TriggerAndWaitNextCycle(context.Background())
+	id := h.backend.Engine.NextCycleID()
+	go h.backend.Engine.Trigger()
+	h.backend.Engine.WaitCycleID(context.Background(), id)
 }
 
 // Escalate will escalate an alert in the database, when 'level' matches.

--- a/smoketest/harness/harness.go
+++ b/smoketest/harness/harness.go
@@ -40,8 +40,6 @@ import (
 	"github.com/target/goalert/util/sqlutil"
 )
 
-const dbTimeFormat = "2006-01-02 15:04:05.999999-07:00"
-
 var (
 	dbURLStr string
 	dbURL    *url.URL

--- a/web/src/cypress/integration/calendarSubscriptions.ts
+++ b/web/src/cypress/integration/calendarSubscriptions.ts
@@ -100,7 +100,7 @@ function testSubs(screen: ScreenFormat): void {
         .should('not.contain', multipleSubsCptn)
 
       cy.createCalendarSubscription({ scheduleID: sched.id })
-      cy.window().invoke('refetchAll')
+      cy.refetchAll()
 
       cy.get(subsribeBtn)
         .trigger('mouseover')
@@ -110,7 +110,7 @@ function testSubs(screen: ScreenFormat): void {
         .should('not.contain', multipleSubsCptn)
 
       cy.createCalendarSubscription({ scheduleID: sched.id })
-      cy.window().invoke('refetchAll')
+      cy.refetchAll()
 
       cy.get(subsribeBtn)
         .trigger('mouseover')

--- a/web/src/cypress/integration/profile.ts
+++ b/web/src/cypress/integration/profile.ts
@@ -59,7 +59,7 @@ function testProfile(): void {
             epID: svc.epID,
             targets: [{ type: 'user', id: profile.id }],
           })
-          .task('engine:trigger')
+          .engineTrigger()
           .then(() => svc.id)
       })
       .then((svcID: string) => {

--- a/web/src/cypress/integration/services.ts
+++ b/web/src/cypress/integration/services.ts
@@ -646,6 +646,7 @@ function testServices(screen: ScreenFormat): void {
           closedAlert = a
           cy.closeAlert(a.id)
           cy.fastForward('5m')
+          cy.setTimeSpeed(1) // resume the flow of time
           // non-closed alert
           return cy.createAlert({ serviceID: a.serviceID })
         })

--- a/web/src/cypress/integration/services.ts
+++ b/web/src/cypress/integration/services.ts
@@ -640,10 +640,12 @@ function testServices(screen: ScreenFormat): void {
     let openAlert: Alert
     beforeEach(() =>
       cy
+        .setTimeSpeed(0)
         .createAlert()
         .then((a: Alert) => {
           closedAlert = a
           cy.closeAlert(a.id)
+          cy.fastForward('5m')
           // non-closed alert
           return cy.createAlert({ serviceID: a.serviceID })
         })
@@ -657,8 +659,6 @@ function testServices(screen: ScreenFormat): void {
       cy.get('[data-cy=metrics-table]')
         .should('contain', closedAlert.summary)
         .should('not.contain', openAlert.summary)
-
-      cy.fastForward('5 minutes')
 
       cy.get('path[name="Alert Count"]')
         .should('have.length', 1)

--- a/web/src/cypress/integration/users.ts
+++ b/web/src/cypress/integration/users.ts
@@ -114,7 +114,7 @@ function testUsers(screen: ScreenFormat): void {
                 epID: svc.epID,
                 targets: [{ type: 'user', id: user.id }],
               })
-              .task('engine:trigger')
+              .engineTrigger()
               .then(() => svc.id)
           })
           .then((svcID: string) => {

--- a/web/src/cypress/plugins/index.js
+++ b/web/src/cypress/plugins/index.js
@@ -2,28 +2,39 @@
 const http = require('http')
 const { exec } = require('child_process')
 
-function makeDoCall(path) {
+function makeDoCall(path, base = 'http://127.0.0.1:3033') {
   return () =>
     new Promise((resolve, reject) => {
-      http.get('http://127.0.0.1:3033' + path, (res) => {
+      http.get(base + path, (res) => {
         if (res.statusCode !== 200) {
-          reject(new Error('request failed: ' + res.statusCode))
+          reject(
+            new Error(`request failed: ${res.statusCode}; url=${base + path}`),
+          )
           return
         }
-        resolve(null)
+        let data = ''
+        res.on('data', (chunk) => {
+          data += chunk
+        })
+        res.on('end', () => {
+          resolve(data)
+        })
+
+        res.on('error', (err) => {
+          reject(err)
+        })
       })
     })
 }
 
-function execQuery(query) {
+function pgmocktime(flags) {
   return new Promise((resolve, reject) => {
     exec(
-      `psql-lite -d "$DB" -c "$QUERY"`,
+      `pgmocktime -d "$DB" ${flags}`,
       {
         env: {
           PATH: process.env.PATH,
           DB: process.env.CYPRESS_DB_URL,
-          QUERY: query,
         },
       },
       (err, stdout, stderr) => {
@@ -38,40 +49,44 @@ function execQuery(query) {
   })
 }
 
-let durations = []
-
 function fastForwardDB(duration) {
-  if (duration) durations.push(duration)
+  if (!duration) {
+    return pgmocktime('--inject --reset')
+  }
 
-  const durStr = durations.map((d) => `'${d}'::interval`).join(' + ')
-
-  const query = `
-    create schema if not exists testing_overrides;
-    alter database postgres set search_path = "$user", public, testing_overrides, pg_catalog;
-		create or replace function testing_overrides.now()
-		returns timestamp with time zone
-		as $$
-			begin
-			return (pg_catalog.now()${durStr ? ` + ${durStr}` : ''});
-			end;
-		$$ language plpgsql;
-  `
-
-  return execQuery(query)
+  return pgmocktime('-a ' + duration)
 }
 
 let failed = false
-module.exports = (on) => {
+module.exports = (on, config) => {
+  async function engineCycle() {
+    const cycleID = await makeDoCall('/health/engine/cycle', config.baseUrl)()
+    await makeDoCall('/signal?sig=SIGUSR2')()
+    await makeDoCall('/health/engine?id=' + cycleID, config.baseUrl)()
+    return null
+  }
+
+  const stopBackend = makeDoCall('/stop')
+  const startBackend = makeDoCall('/start')
+  async function fastForward(dur) {
+    await fastForwardDB(dur)
+    await engineCycle()
+    return null
+  }
+
   on('task', {
-    'engine:trigger': makeDoCall('/signal?sig=SIGUSR2'),
-    'db:fastforward': fastForwardDB,
-    'db:resettime': () => {
-      durations = []
-      return fastForwardDB()
-    },
-    'engine:start': makeDoCall('/start'),
-    'engine:stop': makeDoCall('/stop'),
+    'engine:trigger': engineCycle,
+    'db:setTimeSpeed': (speed) => pgmocktime('-s ' + speed),
+    'db:fastforward': fastForward,
+    'db:resettime': () => fastForwardDB(),
+    'engine:start': startBackend,
+    'engine:stop': stopBackend,
     'check:abort': () => failed,
+  })
+
+  on('before:spec', async () => {
+    await pgmocktime('--inject --reset')
+    await fastForwardDB()
   })
 
   on('after:spec', (spec, results) => {

--- a/web/src/cypress/support/sql.ts
+++ b/web/src/cypress/support/sql.ts
@@ -4,14 +4,27 @@ declare global {
       /** Executes a query directly against the test DB (no results). */
       sql: typeof sql
 
-      /** Fast-forwards the test DB clock by the specified duration. */
+      /** Fast-forwards the test DB clock by the specified duration and triggers a data refetch after. */
       fastForward: typeof fastForward
+
+      /** Alters the passage of time. */
+      setTimeSpeed: typeof setTimeSpeed
+
+      /** Triggers the engine to run and triggers a data refetch after. */
+      engineTrigger: typeof engineTrigger
+
+      /** Refetches all data from the backend. */
+      refetchAll: typeof refetchAll
     }
   }
 }
 
+function refetchAll(): Cypress.Chainable {
+  return cy.window().invoke('refetchAll')
+}
+
 function fastForward(duration: string): Cypress.Chainable {
-  return cy.task('db:fastforward', duration).task('engine:trigger')
+  return cy.task('db:fastforward', duration)
 }
 
 function sql(query: string): Cypress.Chainable {
@@ -26,7 +39,18 @@ function sql(query: string): Cypress.Chainable {
   })
 }
 
+function engineTrigger(): Cypress.Chainable {
+  return cy.task('engine:trigger').refetchAll()
+}
+
+function setTimeSpeed(speed: number): Cypress.Chainable {
+  return cy.task('db:setTimeSpeed', speed)
+}
+
 Cypress.Commands.add('sql', sql)
 Cypress.Commands.add('fastForward', fastForward)
+Cypress.Commands.add('engineTrigger', engineTrigger)
+Cypress.Commands.add('refetchAll', refetchAll)
+Cypress.Commands.add('setTimeSpeed', setTimeSpeed)
 
 export {}


### PR DESCRIPTION
**Description:**
This PR allows for the manipulation of space and time within the confines of a Postgres database.

It is now possible to move time forward, back, alter its speed, reverse its flow, and even go back to a specific point in the future. Engine cycles can be triggered using 2-stages for more efficient test runs (grab ID, trigger cycle, wait for ID).

This work also resolves a long-standing issue where the DB time code for smoketests changed the engine's perception of time, but failed to account for DEFAULT values in the tables. It is now possible to control things like alert-log timestamps to the millisecond, by freezing altering the passage of time.

- There is a new endpoint `/health/engine/cycle` that will return the next engine cycle ID
- The `/health/engine` endpoint now accepts an optional `id=` parameter
- The `pgmocktime` tool was added that has both an API and CLI interface
- Engine cycle triggering/monitoring was refactored into its own struct
- Time and engine tasks have been moved into discrete cypress helper methods (instead of `.task(...)`)
- refactored cypress engine trigger code to wait for a full cycle cleanly (mirroring backend tests)

**Screenshots:**
![image](https://user-images.githubusercontent.com/595010/172683426-4e372fb2-95d4-49c3-8126-a78668a53d63.png)
