### PR TITLE
nav: remove redundant toTitleCase call

### DIFF
--- a/web/src/app/main/components/ToolbarPageTitle.tsx
+++ b/web/src/app/main/components/ToolbarPageTitle.tsx
@@ -59,7 +59,7 @@ const renderCrumb = (
         color: getContrastColor,
       }}
     >
-      {toTitleCase(title)}
+      {title}
     </Typography>
   )
 
@@ -148,6 +148,7 @@ export default function ToolbarPageTitle(): JSX.Element {
   const [title, crumbs] = useBreadcrumbs()
   const [applicationName] = useConfigValue('General.ApplicationName')
   const isMobile = useIsWidthDown('md')
+  console.log(crumbs)
 
   React.useLayoutEffect(() => {
     document.title = `${applicationName || appName} - ${title}`

--- a/web/src/app/main/components/ToolbarPageTitle.tsx
+++ b/web/src/app/main/components/ToolbarPageTitle.tsx
@@ -148,7 +148,6 @@ export default function ToolbarPageTitle(): JSX.Element {
   const [title, crumbs] = useBreadcrumbs()
   const [applicationName] = useConfigValue('General.ApplicationName')
   const isMobile = useIsWidthDown('md')
-  console.log(crumbs)
 
   React.useLayoutEffect(() => {
     document.title = `${applicationName || appName} - ${title}`

--- a/web/src/cypress/support/navigate-to-and-from.ts
+++ b/web/src/cypress/support/navigate-to-and-from.ts
@@ -27,7 +27,7 @@ function navigateToAndFrom(
   route: string,
 ): void {
   const pageName = startCase(_pageName)
-  const targetName = startCase(_targetName)
+  const targetName = _targetName // target name formatting should be preserved
   const linkName = startCase(_linkName).replace('On Call', 'On-Call')
 
   // navigate to extended details view


### PR DESCRIPTION
**Description:**
Fixed issue with breadcrumb names (e.g., services, schedules, etc...) being transformed incorrectly by removing a redundant call to `toTitleCase` as the `useName` helper already does this.
