### PR TITLE
slack: omit details from notifications

### DIFF
--- a/smoketest/slackinteraction_test.go
+++ b/smoketest/slackinteraction_test.go
@@ -38,7 +38,7 @@ func TestSlackInteraction(t *testing.T) {
 	a := h.CreateAlertWithDetails(h.UUID("sid"), "testing", "details")
 
 	ch := h.Slack().Channel("test")
-	msg := ch.ExpectMessage("testing", "details")
+	msg := ch.ExpectMessage("testing")
 	msg.AssertColor("#862421")
 	msg.AssertActions("Acknowledge", "Close")
 
@@ -50,14 +50,14 @@ func TestSlackInteraction(t *testing.T) {
 	msg.Action("Acknowledge").Click()
 
 	updated := msg.ExpectUpdate()
-	updated.AssertText("Ack", "testing", "details")
+	updated.AssertText("Ack", "testing")
 	updated.AssertColor("#867321")
 	updated.AssertActions("Close")
 
 	a.Escalate()
 
 	updated = msg.ExpectUpdate()
-	updated.AssertText("Escalated", "testing", "details")
+	updated.AssertText("Escalated", "testing")
 	updated.AssertColor("#862421")
 	updated.AssertActions("Acknowledge", "Close")
 	msg.ExpectBroadcastReply("testing")

--- a/smoketest/statusupdateschannel_test.go
+++ b/smoketest/statusupdateschannel_test.go
@@ -34,20 +34,22 @@ func TestStatusUpdatesChannel(t *testing.T) {
 	defer h.Close()
 
 	a := h.CreateAlertWithDetails(h.UUID("sid"), "testing", "details")
-	msg := h.Slack().Channel("test").ExpectMessage("testing", "details")
+	msg := h.Slack().Channel("test").ExpectMessage("testing")
 	msg.AssertColor("#862421")
 	msg.AssertActions()
 	a.Ack()
 
 	updated := msg.ExpectUpdate()
-	updated.AssertText("Ack", "testing", "details")
+	updated.AssertText("Ack", "testing")
+	updated.AssertNotText("details")
 	updated.AssertColor("#867321")
 	updated.AssertActions()
 
 	a.Escalate()
 
 	updated = msg.ExpectUpdate()
-	updated.AssertText("Escalated", "testing", "details")
+	updated.AssertText("Escalated", "testing")
+	updated.AssertNotText("details")
 	updated.AssertColor("#862421")
 	updated.AssertActions()
 	msg.ExpectBroadcastReply("testing")
@@ -60,5 +62,4 @@ func TestStatusUpdatesChannel(t *testing.T) {
 	updated.AssertColor("#218626")
 
 	updated.AssertActions() // no actions
-
 }


### PR DESCRIPTION
**Description:**
This PR updates the Slack notification sender to only include the summary in the message payload.

The `summary` field is intended to be included in messages, whereas the `details` field is Markdown and intended to be viewed in the web application. This causes misformatted messages and unnecessary noise in Slack channels.

Details will continue to be available in the included direct link, similar to SMS messages.
