### PR TITLE
rotation: deadlock fixes

### DIFF
--- a/engine/rotationmanager/db.go
+++ b/engine/rotationmanager/db.go
@@ -14,6 +14,7 @@ type DB struct {
 
 	currentTime *sql.Stmt
 
+	lockPart   *sql.Stmt
 	rotate     *sql.Stmt
 	rotateData *sql.Stmt
 }
@@ -36,6 +37,7 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 		lock: lock,
 
 		currentTime: p.P(`select now()`),
+		lockPart:    p.P(`lock rotation_participants, rotation_state in exclusive mode`),
 		rotate: p.P(`
 			update rotation_state
 			set

--- a/graphql2/graphqlapp/rotation.go
+++ b/graphql2/graphqlapp/rotation.go
@@ -303,12 +303,14 @@ func (m *Mutation) updateRotationParticipants(ctx context.Context, tx *sql.Tx, r
 		return err
 	}
 	return nil
-
 }
 
 func (m *Mutation) UpdateRotation(ctx context.Context, input graphql2.UpdateRotationInput) (res bool, err error) {
 	err = withContextTx(ctx, m.DB, func(ctx context.Context, tx *sql.Tx) error {
 		result, err := m.RotationStore.FindRotationForUpdateTx(ctx, tx, input.ID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return validation.NewFieldError("id", "Rotation not found")
+		}
 		if err != nil {
 			return err
 		}
@@ -346,7 +348,6 @@ func (m *Mutation) UpdateRotation(ctx context.Context, input graphql2.UpdateRota
 		if update {
 			err = m.RotationStore.UpdateRotationTx(ctx, tx, result)
 			if err != nil {
-
 				return err
 			}
 		}

--- a/user/store.go
+++ b/user/store.go
@@ -496,6 +496,9 @@ func (s *Store) removeUserFromRotation(ctx context.Context, tx *sql.Tx, userID, 
 			}
 		}
 	}
+	if activeIndex > curIndex {
+		activeIndex = 0
+	}
 
 	// delete in reverse order from the end
 	deletePart := tx.StmtContext(ctx, s.deleteRotationPart)

--- a/user/store.go
+++ b/user/store.go
@@ -38,6 +38,7 @@ type Store struct {
 	deleteRotationPart *sql.Stmt
 	rotActiveIndex     *sql.Stmt
 	rotSetActive       *sql.Stmt
+	lockRotTables      *sql.Stmt
 
 	findOneForUpdate *sql.Stmt
 
@@ -89,6 +90,7 @@ func NewStore(ctx context.Context, db *sql.DB) (*Store, error) {
 
 		rotActiveIndex: p.P(`SELECT position FROM rotation_state WHERE rotation_id = $1 FOR UPDATE`),
 		rotSetActive:   p.P(`UPDATE rotation_state SET position = $2, rotation_participant_id = $3 WHERE rotation_id = $1`),
+		lockRotTables:  p.P(`LOCK TABLE rotation_participants, rotation_state IN EXCLUSIVE MODE`),
 
 		setUserRole: p.P(`UPDATE users SET role = $2 WHERE id = $1`),
 		findAuthSubjects: p.P(`
@@ -408,6 +410,11 @@ func (s *Store) retryDeleteTx(ctx context.Context, tx *sql.Tx, id string) error 
 }
 
 func (s *Store) _deleteTx(ctx context.Context, tx *sql.Tx, id string) error {
+	_, err := tx.StmtContext(ctx, s.lockRotTables).ExecContext(ctx)
+	if err != nil {
+		return err
+	}
+
 	// cleanup rotations first
 	rows, err := tx.StmtContext(ctx, s.userRotations).QueryContext(ctx, id)
 	if errors.Is(err, sql.ErrNoRows) {


### PR DESCRIPTION
**Description:**
This PR fixes a number of deadlock issues around rotations by introducing some rather aggressive locks.

This is necessary until we can remove the dependency on triggers that cause different locking orders resulting in deadlocks depending on what changes happen when.

Any changes to rotation participants or state (including deleting a user) now acquire locks on both `rotation_participants` and `rotation_state` first, in the same order, before being allowed to continue.

Additionally, a bug was fixed that prevented deleting a user if they were the last member of a rotation and currently active.