### PR TITLE
ui/rotations: resolve form validation issue

### DIFF
--- a/web/src/app/rotations/RotationEditDialog.tsx
+++ b/web/src/app/rotations/RotationEditDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { gql, useQuery, useMutation } from 'urql'
 
 import { fieldErrors, nonFieldErrors } from '../util/errutil'
@@ -50,6 +50,11 @@ export default function RotationEditDialog(props: {
 
   const [editRotationStatus, editRotation] = useMutation(mutation)
 
+  useEffect(() => {
+    if (!editRotationStatus.data) return
+    props.onClose()
+  }, [editRotationStatus.data])
+
   if (fetching && !data) return <Spinner />
   if (error) return <GenericError error={error.message} />
 
@@ -67,7 +72,7 @@ export default function RotationEditDialog(props: {
             },
           },
           { additionalTypenames: ['Rotation'] },
-        ).then(() => props.onClose())
+        )
       }
       form={
         <RotationForm

--- a/web/src/cypress/integration/rotations.ts
+++ b/web/src/cypress/integration/rotations.ts
@@ -178,6 +178,7 @@ function testRotations(): void {
           const newName = c.word({ length: 15 })
           const newDesc = c.sentence({ words: 3 })
           const newTz = 'Africa/Accra'
+          const invalidName = 'a'
 
           cy.visit(`/rotations/${r.id}`)
           cy.get('[data-cy="card-actions"]')
@@ -185,6 +186,13 @@ function testRotations(): void {
             .click()
 
           cy.dialogTitle('Edit Rotation')
+
+          cy.dialogForm({
+            name: invalidName,
+          })
+          cy.dialogClick('Submit')
+          cy.get('body').should('contain', 'Must be at least 2 characters')
+
           cy.dialogForm({
             name: newName,
             description: newDesc,
@@ -192,7 +200,7 @@ function testRotations(): void {
             type: 'Weekly',
             shiftLength: '5',
           })
-          cy.dialogFinish('Submit')
+          cy.dialogFinish('Retry')
 
           cy.get('body')
             .should('contain', newName)


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR resolves an issue where form validations errors were't showing up for invalid inputs. The issue was related to migrating over to useMutation from urql during typescript conversions. 

**Which issue(s) this PR fixes:**
Related to https://github.com/target/goalert/issues/2318 for 'RotationEditDialog' component. PR: https://github.com/target/goalert/pull/2473

