### PR TITLE
ui/selection: display email as subtext on user select

### DIFF
--- a/web/src/app/selection/MaterialSelect.tsx
+++ b/web/src/app/selection/MaterialSelect.tsx
@@ -9,12 +9,14 @@ import {
   TextField,
   MenuItem,
   ListItemIcon,
-  Typography,
   Paper,
   Chip,
   InputProps,
   Alert,
   Autocomplete,
+  List,
+  ListItem,
+  ListItemText,
 } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
 
@@ -35,6 +37,13 @@ const useStyles = makeStyles({
   padding0: {
     padding: 0,
   },
+  list: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 0,
+  },
 })
 
 interface AutocompleteInputProps extends InputProps {
@@ -43,6 +52,7 @@ interface AutocompleteInputProps extends InputProps {
 
 interface SelectOption {
   icon?: ReactElement
+  subText?: string
   isCreate?: boolean
   label: string
   value: string
@@ -216,7 +226,7 @@ export default function MaterialSelect(
           />
         )
       }}
-      renderOption={(props, { label, icon, value }) => (
+      renderOption={(props, { label, subText, icon, value }) => (
         <MenuItem
           {...props}
           component='span'
@@ -224,10 +234,16 @@ export default function MaterialSelect(
           selected={isSelected(value)}
           data-cy='search-select-item'
         >
-          <Typography noWrap>{label}</Typography>
-          {icon && (
-            <ListItemIcon className={classes.listItemIcon}>{icon}</ListItemIcon>
-          )}
+          <List className={classes.list}>
+            <ListItem>
+              <ListItemText primary={label} secondary={subText || null} />
+            </ListItem>
+            {icon && (
+              <ListItemIcon className={classes.listItemIcon}>
+                {icon}
+              </ListItemIcon>
+            )}
+          </List>
         </MenuItem>
       )}
       PaperComponent={(params) => (

--- a/web/src/app/selection/QuerySelect.js
+++ b/web/src/app/selection/QuerySelect.js
@@ -15,10 +15,16 @@ function valueCheck(props, ...args) {
   return p.string(props, ...args)
 }
 
-const defaultMapNode = ({ name: label, id: value, isFavorite }) => ({
+const defaultMapNode = ({
+  name: label,
+  id: value,
+  isFavorite,
+  email: subText,
+}) => ({
   label,
   value,
   isFavorite,
+  subText,
 })
 
 const asArray = (value) => {
@@ -238,6 +244,7 @@ export function makeQuerySelect(displayName, options) {
           .map((opt) => ({
             ...opt,
             icon: opt.isFavorite ? <FavoriteIcon /> : null,
+            subText: opt.subText || null,
           }))
           .map(cachify)}
         placeholder={

--- a/web/src/app/selection/QuerySelect.js
+++ b/web/src/app/selection/QuerySelect.js
@@ -15,16 +15,10 @@ function valueCheck(props, ...args) {
   return p.string(props, ...args)
 }
 
-const defaultMapNode = ({
-  name: label,
-  id: value,
-  isFavorite,
-  email: subText,
-}) => ({
+const defaultMapNode = ({ name: label, id: value, isFavorite }) => ({
   label,
   value,
   isFavorite,
-  subText,
 })
 
 const asArray = (value) => {

--- a/web/src/app/selection/QuerySelect.js
+++ b/web/src/app/selection/QuerySelect.js
@@ -238,7 +238,6 @@ export function makeQuerySelect(displayName, options) {
           .map((opt) => ({
             ...opt,
             icon: opt.isFavorite ? <FavoriteIcon /> : null,
-            subText: opt.subText || null,
           }))
           .map(cachify)}
         placeholder={

--- a/web/src/app/selection/UserSelect.js
+++ b/web/src/app/selection/UserSelect.js
@@ -7,6 +7,7 @@ const query = gql`
       nodes {
         id
         name
+        email
         isFavorite
       }
     }
@@ -18,6 +19,7 @@ const valueQuery = gql`
     user(id: $id) {
       id
       name
+      email
       isFavorite
     }
   }

--- a/web/src/app/selection/UserSelect.js
+++ b/web/src/app/selection/UserSelect.js
@@ -30,4 +30,10 @@ export const UserSelect = makeQuerySelect('UserSelect', {
   defaultQueryVariables: { favoritesFirst: true },
   query,
   valueQuery,
+  mapDataNode: (u) => ({
+    value: u.id,
+    label: u.name,
+    subText: u.email,
+    isFavorite: u.isFavorite,
+  }),
 })

--- a/web/src/cypress/integration/rotations.ts
+++ b/web/src/cypress/integration/rotations.ts
@@ -99,6 +99,25 @@ function testRotations(): void {
         .should('contain', rot.users[1].name)
     })
 
+    it('should display users with the same name correctly when selecting users to add', () => {
+      const name = 'John Smith'
+      const email = 'johnSmith@test.com'
+      const dupEmail = 'johnSmith2@test.com'
+      cy.createUser({ name, email: email })
+      cy.createUser({ name, email: dupEmail })
+
+      cy.pageFab()
+      cy.dialogTitle('Add User')
+      cy.get('input').click().type(name)
+
+      cy.get('body').should('contain', email)
+      cy.get('body').should('contain', dupEmail)
+
+      cy.get('p').contains(email).click()
+      cy.dialogFinish('Submit')
+      cy.get('ul[data-cy=users]').find('li').should('contain', name)
+    })
+
     it('should allow re-ordering participants', () => {
       // ensure list has fully loaded before drag/drop
       cy.get('ul[data-cy=users]').find('li').should('have.length', 4)


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adds email as a subtext when selecting users to add to a rotation or escalation policy step. This allows  differentiating between users with the same display names. 

**Which issue(s) this PR fixes:**
https://github.com/target/goalert/issues/2496

**Screenshots:**

BEFORE:
<img width="2212" alt="before" src="https://user-images.githubusercontent.com/52386267/180313828-f3aabbf7-b9a8-494a-b927-be36bcd2f99b.png">

AFTER:

![Emails as subtext](https://user-images.githubusercontent.com/52386267/180313849-15c06240-cb3d-4745-9308-d6d8a23b8953.png)

<img width="2208" alt="Screen Shot 2022-07-21 at 3 55 46 PM" src="https://user-images.githubusercontent.com/52386267/180313867-9206b912-f819-4cb9-9cb6-a423d95d2037.png">

