### PR TITLE
remotemonitor: add support for testing SMTP

### DIFF
--- a/remotemonitor/config.go
+++ b/remotemonitor/config.go
@@ -21,6 +21,11 @@ type Config struct {
 		FromNumber string
 	}
 
+	SMTP struct {
+		Address    string
+		User, Pass string
+	}
+
 	// Instances determine what remote GoAlert instances will be monitored and send potential errors.
 	Instances []Instance
 }

--- a/remotemonitor/config.go
+++ b/remotemonitor/config.go
@@ -1,5 +1,11 @@
 package remotemonitor
 
+import (
+	"errors"
+	"fmt"
+	"net/url"
+)
+
 // Config contains all necessary values for remote monitoring.
 type Config struct {
 	// Location is the unique location name of this monitor.
@@ -28,4 +34,43 @@ type Config struct {
 
 	// Instances determine what remote GoAlert instances will be monitored and send potential errors.
 	Instances []Instance
+}
+
+func (cfg Config) Validate() error {
+	if cfg.Location == "" {
+		return errors.New("location is required")
+	}
+	if cfg.PublicURL == "" {
+		return errors.New("public URL is required")
+	}
+	_, err := url.Parse(cfg.PublicURL)
+	if err != nil {
+		return fmt.Errorf("parse public URL: %v", err)
+	}
+
+	if cfg.ListenAddr == "" {
+		return errors.New("listen address is required")
+	}
+
+	if cfg.CheckMinutes < 1 {
+		return errors.New("check minutes is required")
+	}
+
+	if cfg.Twilio.AccountSID == "" {
+		return errors.New("twilio account SID is required")
+	}
+	if cfg.Twilio.AuthToken == "" {
+		return errors.New("twilio auth token is required")
+	}
+	if cfg.Twilio.FromNumber == "" {
+		return errors.New("twilio from number is required")
+	}
+
+	for idx, i := range cfg.Instances {
+		if err := i.Validate(); err != nil {
+			return fmt.Errorf("instance[%d] %q: %v", idx, i.Location, err)
+		}
+	}
+
+	return nil
 }

--- a/remotemonitor/config.go
+++ b/remotemonitor/config.go
@@ -28,7 +28,9 @@ type Config struct {
 	}
 
 	SMTP struct {
-		Address    string
+		From string
+
+		ServerAddr string
 		User, Pass string
 	}
 

--- a/remotemonitor/instance.go
+++ b/remotemonitor/instance.go
@@ -19,6 +19,11 @@ type Instance struct {
 	// before escalating to a human. It should send initial notifications to the monitor via SMS.
 	GenericAPIKey string
 
+	// EmailAPIKey is used to create test alerts.
+	// The service it points to should have an escalation policy that allows at least 60 seconds
+	// before escalating to a human. It should send initial notifications to the monitor via SMS.
+	EmailAPIKey string
+
 	// ErrorAPIKey is the key used to create new alerts for encountered errors.
 	ErrorAPIKey string
 

--- a/remotemonitor/instance.go
+++ b/remotemonitor/instance.go
@@ -14,10 +14,10 @@ type Instance struct {
 	// Location must be unique.
 	Location string
 
-	// TestAPIKey is used to create test alerts.
+	// GenericAPIKey is used to create test alerts.
 	// The service it points to should have an escalation policy that allows at least 60 seconds
 	// before escalating to a human. It should send initial notifications to the monitor via SMS.
-	TestAPIKey string
+	GenericAPIKey string
 
 	// ErrorAPIKey is the key used to create new alerts for encountered errors.
 	ErrorAPIKey string
@@ -61,6 +61,7 @@ func (i *Instance) createAlert(key, dedup, summary, details string) error {
 	v.Set("dedup", dedup)
 	return i.doReq("/api/v2/generic/incoming", v)
 }
+
 func (i *Instance) heartbeat() []error {
 	errCh := make(chan error, len(i.HeartbeatURLs))
 	var wg sync.WaitGroup

--- a/remotemonitor/instance.go
+++ b/remotemonitor/instance.go
@@ -1,6 +1,7 @@
 package remotemonitor
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"sync"
@@ -40,6 +41,31 @@ type Instance struct {
 	// ErrorsOnly, if set, will disable creating test alerts for the instance. Any error-alerts will
 	// still be generated, however.
 	ErrorsOnly bool
+}
+
+func (i Instance) Validate() error {
+	if i.Location == "" {
+		return errors.New("location is required")
+	}
+	if i.PublicURL == "" {
+		return errors.New("public URL is required")
+	}
+	_, err := url.Parse(i.PublicURL)
+	if err != nil {
+		return fmt.Errorf("parse public URL: %v", err)
+	}
+	if i.Phone == "" {
+		return errors.New("phone is required")
+	}
+	if i.ErrorAPIKey == "" {
+		return errors.New("error API key is required")
+	}
+
+	if i.GenericAPIKey == "" && i.EmailAPIKey == "" {
+		return errors.New("at least one of Email or Generic API key is required")
+	}
+
+	return nil
 }
 
 func (i *Instance) doReq(path string, v url.Values) error {

--- a/remotemonitor/instance.go
+++ b/remotemonitor/instance.go
@@ -84,7 +84,7 @@ func (i *Instance) doReq(path string, v url.Values) error {
 	return nil
 }
 
-func (i *Instance) createAlert(key, dedup, summary, details string) error {
+func (i *Instance) createGenericAlert(key, dedup, summary, details string) error {
 	v := make(url.Values)
 	v.Set("token", key)
 	v.Set("summary", summary)

--- a/remotemonitor/monitor.go
+++ b/remotemonitor/monitor.go
@@ -32,7 +32,6 @@ type Monitor struct {
 
 func setRequestScheme(scheme string, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-
 		// required for Twilio sig validation to work
 		req.URL.Host = req.Host
 		req.URL.Scheme = scheme
@@ -51,7 +50,8 @@ func NewMonitor(cfg Config) (*Monitor, error) {
 	if err != nil {
 		return nil, err
 	}
-	m := &Monitor{cfg: cfg,
+	m := &Monitor{
+		cfg:        cfg,
 		tw:         twilio.Config{},
 		shutdownCh: make(chan struct{}),
 		startCh:    make(chan string),
@@ -98,6 +98,7 @@ func NewMonitor(cfg Config) (*Monitor, error) {
 
 	return m, nil
 }
+
 func (m *Monitor) serve(l net.Listener) {
 	err := m.srv.Serve(l)
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -120,6 +121,7 @@ func (m *Monitor) reportErr(i Instance, err error, action string) {
 	}
 	log.Println("ERROR:", summary)
 }
+
 func (m *Monitor) waitLoop() {
 	t := time.NewTicker(100 * time.Millisecond)
 	for {
@@ -142,6 +144,7 @@ func (m *Monitor) waitLoop() {
 		}
 	}
 }
+
 func (m *Monitor) loop() {
 	delay := time.Duration(m.cfg.CheckMinutes) * time.Minute
 	t := time.NewTicker(delay)
@@ -162,7 +165,7 @@ If it is not automatically closed within a minute, there may be a problem with S
 			}
 			m.startCh <- i.Location
 			go func(i Instance) {
-				err := i.createAlert(i.TestAPIKey, dedup, summary, details)
+				err := i.createAlert(i.GenericAPIKey, dedup, summary, details)
 				if err != nil {
 					m.reportErr(i, err, "create new alert")
 				}

--- a/remotemonitor/monitor.go
+++ b/remotemonitor/monitor.go
@@ -42,6 +42,11 @@ func setRequestScheme(scheme string, h http.Handler) http.Handler {
 
 // NewMonitor creates and starts a new Monitor with the given Config.
 func NewMonitor(cfg Config) (*Monitor, error) {
+	err := cfg.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	http.DefaultTransport.(*http.Transport).DisableKeepAlives = true
 	http.DefaultTransport = &requestIDTransport{
 		RoundTripper: http.DefaultTransport,


### PR DESCRIPTION
**Description:**
This PR updates the remote monitor to support verifying email integration keys.

- configuration is now validated on startup
- EmailAPIKey added to remote monitor instance config
- SMTP config has been added and is now required if EmailAPIKey is used
- TestAPIKey was renamed to GenericAPIKey
- Fixed issue with fast shutdown

**Which issue(s) this PR fixes:**
Closes #2514 
