### PR TITLE
use prefixSearch for services, schedules, EPs, and rotations

### DIFF
--- a/escalation/search.go
+++ b/escalation/search.go
@@ -55,7 +55,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		AND NOT pol.id = any(:omit)
 	{{end}}
 	{{if .Search}}
-		AND {{textSearch "search" "pol.name" "pol.description"}}
+		AND {{prefixSearch "search" "pol.name"}}
 	{{end}}
 	{{if .After.Name}}
 		AND

--- a/schedule/rotation/search.go
+++ b/schedule/rotation/search.go
@@ -57,7 +57,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		AND NOT rot.id = any(:omit)
 	{{end}}
 	{{if .Search}}
-		AND {{textSearch "search" "rot.name" "rot.description"}}
+		AND {{prefixSearch "search" "rot.name"}}
 	{{end}}
 	{{if .After.Name}}
 		AND

--- a/schedule/search.go
+++ b/schedule/search.go
@@ -56,7 +56,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		AND NOT sched.id = any(:omit)
 	{{end}}
 	{{if .Search}}
-		AND {{textSearch "search" "sched.name" "sched.description"}}
+		AND {{prefixSearch "search" "sched.name"}}
 	{{end}}
 	{{if .After.Name}}
 		AND

--- a/service/search.go
+++ b/service/search.go
@@ -72,7 +72,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		)
 	{{end}}
 	{{- if and .Search (not .LabelKey)}}
-		AND {{textSearch "search" "svc.name" "svc.description"}}
+		AND {{prefixSearch "search" "svc.name"}}
 	{{- end}}
 	{{- if .After.Name}}
 		AND


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR changes `textSearch` helper function to `prefixSearch` which allows partial text matching search capabilities for services, schedules, EPs, and rotations. 

**Which issue(s) this PR fixes:**
https://github.com/target/goalert/issues/2125

**Screenshots:**
![prefix sample](https://user-images.githubusercontent.com/52386267/181061347-17c827ba-c006-45e2-9bc5-01aae70cc405.gif)

