### PR TITLE
ui/alerts: make alert detail width 100%

### DIFF
--- a/web/src/app/alerts/components/AlertDetails.tsx
+++ b/web/src/app/alerts/components/AlertDetails.tsx
@@ -312,7 +312,7 @@ export default function AlertDetails(props: AlertDetailsProps): JSX.Element {
         data-cy='alert-details'
         className={classes.cardContainer}
       >
-        <Card>
+        <Card sx={{ width: '100%' }}>
           <CardContent>
             <Typography component='h3' variant='h5'>
               Details


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR makes the alert detail width 100% and fixes the minor ui bug we're seeing in prod. 

**Screenshots:**
![alertdetails width](https://user-images.githubusercontent.com/52386267/181783156-88033dfd-bf3d-4868-971e-0c11c1e13c5b.gif)

