### PR TITLE
intkeys: return 401 for invalid integration keys

### DIFF
--- a/calsub/store.go
+++ b/calsub/store.go
@@ -99,13 +99,13 @@ func (cs *Subscription) scanFrom(scanFn func(...interface{}) error) error {
 // or otherwise can not be authenticated, an error is returned.
 func (s *Store) Authorize(ctx context.Context, tok authtoken.Token) (context.Context, error) {
 	if tok.Type != authtoken.TypeCalSub {
-		return ctx, validation.NewFieldError("token", "invalid type")
+		return ctx, permission.Unauthorized()
 	}
 
 	var userID string
 	err := s.authUser.QueryRowContext(ctx, tok.ID, tok.CreatedAt).Scan(&userID)
 	if errors.Is(err, sql.ErrNoRows) {
-		return ctx, validation.NewFieldError("sub", "invalid")
+		return ctx, permission.Unauthorized()
 	}
 	if err != nil {
 		return ctx, err

--- a/integrationkey/store.go
+++ b/integrationkey/store.go
@@ -8,7 +8,6 @@ import (
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/util"
 	"github.com/target/goalert/util/sqlutil"
-	"github.com/target/goalert/validation"
 	"github.com/target/goalert/validation/validate"
 
 	"github.com/google/uuid"
@@ -46,7 +45,7 @@ func (s *Store) Authorize(ctx context.Context, tok authtoken.Token, t Type) (con
 		serviceID, err = s.GetServiceID(c, tok.ID.String(), t)
 	})
 	if errors.Is(err, sql.ErrNoRows) {
-		return ctx, validation.NewFieldError("IntegrationKeyID", "not found")
+		return ctx, permission.Unauthorized()
 	}
 	if err != nil {
 		return ctx, errors.Wrap(err, "lookup serviceID")
@@ -116,9 +115,11 @@ func (s *Store) CreateKeyTx(ctx context.Context, tx *sql.Tx, i *IntegrationKey) 
 func (s *Store) Delete(ctx context.Context, id string) error {
 	return s.DeleteTx(ctx, nil, id)
 }
+
 func (s *Store) DeleteTx(ctx context.Context, tx *sql.Tx, id string) error {
 	return s.DeleteManyTx(ctx, tx, []string{id})
 }
+
 func (s *Store) DeleteManyTx(ctx context.Context, tx *sql.Tx, ids []string) error {
 	err := permission.LimitCheckAny(ctx, permission.Admin, permission.User)
 	if err != nil {
@@ -159,7 +160,6 @@ func (s *Store) FindOne(ctx context.Context, id string) (*IntegrationKey, error)
 	}
 
 	return &i, nil
-
 }
 
 func (s *Store) FindAllByService(ctx context.Context, serviceID string) ([]IntegrationKey, error) {

--- a/permission/error.go
+++ b/permission/error.go
@@ -32,6 +32,11 @@ func NewAccessDenied(reason string) error {
 	return newGeneric(false, reason)
 }
 
+// Unauthorized will return an unauthorized error.
+func Unauthorized() error {
+	return newGeneric(true, "")
+}
+
 func (e genericError) ClientError() bool { return true }
 
 func (e genericError) Permission() bool   { return true }


### PR DESCRIPTION
**Description:**
This PR resolves an issue where invalid integration keys would return validation errors resulting in a `400 Bad Request` instead of `401 Unauthorized`.

**Which issue(s) this PR fixes:**
Closes #2541

**Describe any introduced API changes:**
Properly formatted but invalid/deleted integration keys will now return a 401 status code, instead of 400.
