### PR TITLE
switchover: use new db for new db listener

### DIFF
--- a/switchover/mainloop.go
+++ b/switchover/mainloop.go
@@ -16,7 +16,9 @@ func (h *Handler) setState(ctx context.Context, newState State) {
 	switch newState {
 	case StatePaused, StatePauseWait, StatePausing:
 	default:
-		h.app.Resume()
+		if h.app != nil {
+			h.app.Resume()
+		}
 	}
 	if h.state == StateComplete && newState != StateStarting {
 		return
@@ -38,6 +40,7 @@ func (h *Handler) setState(ctx context.Context, newState State) {
 		log.Log(ctx, err)
 	}
 }
+
 func (s State) oneOf(state []State) bool {
 	for _, st := range state {
 		if st == s {
@@ -46,6 +49,7 @@ func (s State) oneOf(state []State) bool {
 	}
 	return false
 }
+
 func (h *Handler) allNodes(state ...State) bool {
 	for _, s := range h.nodeStatus {
 		if !s.State.oneOf(state) {
@@ -72,6 +76,7 @@ func (h *Handler) CheckDBNextID(id string) bool {
 
 	return h.dbNextID == id
 }
+
 func (h *Handler) updateNodeStatus(ctx context.Context, s *Status) bool {
 	if !h.CheckDBID(s.DBID) {
 		log.Logf(ctx, "Switch-Over Abort: NodeID="+s.NodeID+" has mismatched DB ID")
@@ -203,7 +208,7 @@ func (h *Handler) loop() {
 				continue
 			case StateStarting:
 				log.Logf(ctx, "Switch-Over: Got reset signal.")
-				abort() //reset
+				abort() // reset
 				h.nodeStatus = make(map[string]Status)
 			default:
 				log.Logf(ctx, "Switch-Over: Got signal '%s'.", state)

--- a/switchover/notify.go
+++ b/switchover/notify.go
@@ -24,7 +24,7 @@ func (h *Handler) initNewDBListen(name string) error {
 		return err
 	}
 	cfg.RuntimeParams["application_name"] = fmt.Sprintf("GoAlert %s (S/O Listener)", version.GitVersion())
-	l, err := sqlutil.NewListener(context.Background(), h.logger, h.old.db, DBIDChannel, StateChannel)
+	l, err := sqlutil.NewListener(context.Background(), h.logger, h.new.db, DBIDChannel, StateChannel)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description:**
- Fixes a regression that resulted in switchover reporting invalid config for all nodes.
- Fixes a bug where a node with invalid config on startup may cause the startup of new nodes to fail.

The first was introduced when moving from passing connection strings to using the DB connectors directly for the Listener sqlutil. Previously the code relied on parsed config from the URL which determined which DB to listen to for the ID message. The changes introduced in #2305 incorrectly passed the `old.db` instance where a message was expected from the `new` DB.

The second was a long-standing race where an invalid config, which triggers a reset, was detected before the node had fully started and `SetApp` had not yet been called.
