### PR TITLE
dev: allow setting public url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ export GOALERT_DB_URL_NEXT = $(DB_URL_NEXT)
 
 PROD_CY_PROC = Procfile.cypress.prod
 
+PUBLIC_URL := http://localhost:3030$(HTTP_PREFIX)
+export GOALERT_PUBLIC_URL := $(PUBLIC_URL)
+
 ifeq ($(CI), 1)
 PROD_CY_PROC = Procfile.cypress.ci
 endif

--- a/Procfile
+++ b/Procfile
@@ -1,7 +1,7 @@
 build: while true; do make -qs bin/goalert || make bin/goalert || (echo '\033[0;31mBuild Failure'; sleep 3); sleep 0.1; done
 
 @watch-file=./bin/goalert
-goalert: ./bin/goalert -l=localhost:3030 --ui-dir=web/src/build --db-url=postgres://goalert@localhost --listen-sysapi=localhost:1234 --listen-prometheus=localhost:2112 --public-url=http://localhost:3030$HTTP_PREFIX
+goalert: ./bin/goalert -l=localhost:3030 --ui-dir=web/src/build --db-url=postgres://goalert@localhost --listen-sysapi=localhost:1234 --listen-prometheus=localhost:2112
 
 smtp: go run github.com/mailhog/MailHog -ui-bind-addr=localhost:8025 -api-bind-addr=localhost:8025 -smtp-bind-addr=localhost:1025 | grep -v KEEPALIVE
 prom: bin/tools/prometheus --log.level=warn --config.file=devtools/prometheus/prometheus.yml --storage.tsdb.path=bin/prom-data/ --web.listen-address=localhost:9090

--- a/Procfile.prod
+++ b/Procfile.prod
@@ -1,7 +1,7 @@
 build: while true; do make -qs bin/goalert BUNDLE=1 || make bin/goalert BUNDLE=1 || (echo '\033[0;31mBuild Failure'; sleep 3); sleep 0.1; done
 
 @watch-file=./bin/goalert
-goalert: ./bin/goalert -l=localhost:3030 --db-url=postgres://goalert@localhost --listen-sysapi=localhost:1234 --listen-prometheus=localhost:2112 --public-url=http://localhost:3030$HTTP_PREFIX
+goalert: ./bin/goalert -l=localhost:3030 --db-url=postgres://goalert@localhost --listen-sysapi=localhost:1234 --listen-prometheus=localhost:2112
 
 smtp: go run github.com/mailhog/MailHog -ui-bind-addr=localhost:8025 -api-bind-addr=localhost:8025 -smtp-bind-addr=localhost:1025 | grep -v KEEPALIVE
 prom: bin/tools/prometheus --log.level=warn --config.file=devtools/prometheus/prometheus.yml --storage.tsdb.path=bin/prom-data/ --web.listen-address=localhost:9090

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -23,6 +23,20 @@ podman machine ssh sudo rpm-ostree install qemu-user-static
 podman machine ssh sudo systemctl reboot
 ```
 
+## External Traffic
+
+To do local development with external traffic you will need a publicly-routable URL and can start localdev with `PUBLIC_URL` set. For example:
+
+```bash
+make start PUBLIC_URL=http://localdev.example.com
+```
+
+You may add additional startup commands to the `Procfile.local` file to have them automatically run with `make start` and similar commands.
+
+```bash
+ngrok: ngrok http -subdomain=localdev 3030
+```
+
 ## Database (PostgreSQL)
 
 GoAlert is built and tested against Postgres 11. Version 9.6 should still work as of this writing, but is not recommended as future versions may begin using newer features.


### PR DESCRIPTION
**Description:**
This PR updates the `make start` and `make start-prod` commands to allow setting `PUBLIC_URL` for instances where external traffic is required for development of a feature.

Part of #2554 
