### PR TITLE
fix for go 1.19

### DIFF
--- a/devtools/gettool/fetchfile.go
+++ b/devtools/gettool/fetchfile.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 )
@@ -19,7 +18,7 @@ func fetchFile(url string) (*os.File, int64, error) {
 		return nil, 0, fmt.Errorf("non-200 response: %s", resp.Status)
 	}
 
-	fd, err := ioutil.TempFile("", "*.zip")
+	fd, err := os.CreateTemp("", "*.zip")
 	if err != nil {
 		return nil, 0, fmt.Errorf("create temp file: %w", err)
 	}

--- a/grafana/grafana.go
+++ b/grafana/grafana.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"text/template"
@@ -182,7 +182,7 @@ func GrafanaToEventsAPI(aDB *alert.Store, intDB *integrationkey.Store) http.Hand
 		}
 		serviceID := permission.ServiceID(ctx)
 
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		if errutil.HTTPError(ctx, w, err) {
 			return
 		}

--- a/notification/twilio/twiml_test.go
+++ b/notification/twilio/twiml_test.go
@@ -1,7 +1,7 @@
 package twilio
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,7 +20,7 @@ func TestTwiMLResponse(t *testing.T) {
 		resp := rec.Result()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Contains(t, resp.Header.Get("Content-Type"), "application/xml")
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
@@ -41,7 +41,7 @@ func TestTwiMLResponse(t *testing.T) {
 		resp := rec.Result()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Contains(t, resp.Header.Get("Content-Type"), "application/xml")
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
@@ -61,7 +61,7 @@ func TestTwiMLResponse(t *testing.T) {
 		resp := rec.Result()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Contains(t, resp.Header.Get("Content-Type"), "application/xml")
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
@@ -83,7 +83,7 @@ func TestTwiMLResponse(t *testing.T) {
 		resp := rec.Result()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Contains(t, resp.Header.Get("Content-Type"), "application/xml")
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
@@ -108,7 +108,7 @@ func TestTwiMLResponse(t *testing.T) {
 		resp := rec.Result()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Contains(t, resp.Header.Get("Content-Type"), "application/xml")
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, `<?xml version="1.0" encoding="UTF-8"?>
 <Response>

--- a/smoketest/webhook_test.go
+++ b/smoketest/webhook_test.go
@@ -7,9 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/target/goalert/smoketest/harness"
 )
 

--- a/smoketest/webhook_test.go
+++ b/smoketest/webhook_test.go
@@ -2,11 +2,12 @@ package smoketest
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/require"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/target/goalert/smoketest/harness"
@@ -27,7 +28,7 @@ func TestWebhookAlert(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var alert WebhookTestingAlert
 
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		require.Nil(t, err)
 
 		err = json.Unmarshal(data, &alert)


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Updated deprecated ioutils to work with go 1.19

**Which issue(s) this PR fixes:**
https://github.com/target/goalert/issues/2562

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Fixes #2562 

**Out of Scope:**
NA

**Screenshots:**
NA

**Describe any introduced user-facing changes:**
NA

**Describe any introduced API changes:**
NA

**Additional Info:**
NA
