### PR TITLE
twilio: update SMS restrictions

### DIFF
--- a/notification/twilio/alertsms.go
+++ b/notification/twilio/alertsms.go
@@ -89,12 +89,16 @@ func mapGSM(r rune) rune {
 	return '?'
 }
 
-func oneOfPrefixes(s string, prefixes ...string) bool {
+// hasAnyPrefix returns true if any of the prefixes are present in the string.
+func hasAnyPrefix(s string, prefixes ...string) bool {
 	for _, p := range prefixes {
-		if strings.HasPrefix(s, p) {
-			return true
+		if !strings.HasPrefix(s, p) {
+			continue
 		}
+
+		return true
 	}
+
 	return false
 }
 
@@ -104,9 +108,10 @@ func canContainURL(ctx context.Context, number string) bool {
 		return false
 	}
 
-	// not extensive, but CN code numbers do not allow URLs in SMS
-	// https://www.twilio.com/guidelines/cn/sms
-	return !oneOfPrefixes(number, "+86")
+	return !hasAnyPrefix(number,
+		// Non-exhaustive list of dialing codes that forbid URLs.
+		"+86", // CN - https://www.twilio.com/guidelines/cn/sms
+	)
 }
 
 // hasTwoWaySMSSupport returns true if a number supports 2-way SMS messaging (replies).
@@ -115,8 +120,15 @@ func hasTwoWaySMSSupport(ctx context.Context, number string) bool {
 		return false
 	}
 
-	// not extensive
-	return !oneOfPrefixes(number, "+91", "+86", "+502", "+506", "+507", "+84")
+	return !hasAnyPrefix(number,
+		// Non-exhaustive list of dialing codes that do not support 2-way SMS.
+		"+91",  // IN - https://www.twilio.com/guidelines/in/sms
+		"+86",  // CN - https://www.twilio.com/guidelines/cn/sms
+		"+502", // GT - https://www.twilio.com/guidelines/gt/sms
+		"+506", // CR - https://www.twilio.com/guidelines/cr/sms
+		"+507", // PA - https://www.twilio.com/guidelines/pa/sms
+		"+84",  // VN - https://www.twilio.com/guidelines/vn/sms
+	)
 }
 
 func normalizeGSM(str string) (s string) {

--- a/notification/twilio/alertsms.go
+++ b/notification/twilio/alertsms.go
@@ -89,14 +89,34 @@ func mapGSM(r rune) rune {
 	return '?'
 }
 
+func oneOfPrefixes(s string, prefixes ...string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// canContainURL returns true if the message can contain a URL.
+func canContainURL(ctx context.Context, number string) bool {
+	if config.FromContext(ctx).General.DisableSMSLinks {
+		return false
+	}
+
+	// not extensive, but CN code numbers do not allow URLs in SMS
+	// https://www.twilio.com/guidelines/cn/sms
+	return !oneOfPrefixes(number, "+86")
+}
+
 // hasTwoWaySMSSupport returns true if a number supports 2-way SMS messaging (replies).
 func hasTwoWaySMSSupport(ctx context.Context, number string) bool {
 	if config.FromContext(ctx).Twilio.DisableTwoWaySMS {
 		return false
 	}
 
-	// India numbers do not support SMS replies.
-	return !strings.HasPrefix(number, "+91")
+	// not extensive
+	return !oneOfPrefixes(number, "+91", "+86", "+502", "+506", "+507", "+84")
 }
 
 func normalizeGSM(str string) (s string) {

--- a/notification/twilio/sms.go
+++ b/notification/twilio/sms.go
@@ -97,14 +97,16 @@ func (s *SMS) Send(ctx context.Context, msg notification.Message) (*notification
 	})
 
 	makeSMSCode := func(alertID int, serviceID string) int {
-		var code int
-		var err error
-		if hasTwoWaySMSSupport(ctx, destNumber) {
-			code, err = s.b.insertDB(ctx, destNumber, msg.ID(), alertID, serviceID)
-			if err != nil {
-				log.Log(ctx, errors.Wrap(err, "insert alert id for SMS callback -- sending 1-way SMS as fallback"))
-			}
+		if !hasTwoWaySMSSupport(ctx, destNumber) {
+			return 0
 		}
+
+		code, err := s.b.insertDB(ctx, destNumber, msg.ID(), alertID, serviceID)
+		if err != nil {
+			log.Log(ctx, errors.Wrap(err, "insert alert id for SMS callback -- sending 1-way SMS as fallback"))
+			return 0
+		}
+
 		return code
 	}
 

--- a/notification/twilio/sms.go
+++ b/notification/twilio/sms.go
@@ -39,10 +39,12 @@ type SMS struct {
 	limit *replyLimiter
 }
 
-var _ notification.ReceiverSetter = &SMS{}
-var _ notification.Sender = &SMS{}
-var _ notification.StatusChecker = &SMS{}
-var _ notification.FriendlyValuer = &SMS{}
+var (
+	_ notification.ReceiverSetter = &SMS{}
+	_ notification.Sender         = &SMS{}
+	_ notification.StatusChecker  = &SMS{}
+	_ notification.FriendlyValuer = &SMS{}
+)
 
 // NewSMS performs operations like validating essential parameters, registering the Twilio client and db
 // and adding routes for successful and unsuccessful message delivery to Twilio
@@ -116,14 +118,14 @@ func (s *SMS) Send(ctx context.Context, msg notification.Message) (*notification
 		message, err = renderAlertStatusMessage(maxLen, t)
 	case notification.AlertBundle:
 		var link string
-		if !cfg.General.DisableSMSLinks {
+		if canContainURL(ctx, destNumber) {
 			link = cfg.CallbackURL(fmt.Sprintf("/services/%s/alerts", t.ServiceID))
 		}
 
 		message, err = renderAlertBundleMessage(maxLen, t, link, makeSMSCode(0, t.ServiceID))
 	case notification.Alert:
 		var link string
-		if !cfg.General.DisableSMSLinks {
+		if canContainURL(ctx, destNumber) {
 			link = cfg.CallbackURL(fmt.Sprintf("/alerts/%d", t.AlertID))
 		}
 

--- a/test/smoke/twiliosmsrestrictions_test.go
+++ b/test/smoke/twiliosmsrestrictions_test.go
@@ -1,0 +1,58 @@
+package smoke
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/target/goalert/test/smoke/harness"
+)
+
+// TestTwilioSMSRestrictions checks for restrictions like 1-way and disabling of URLs in messages to certain country codes.
+func TestTwilioSMSRestrictions(t *testing.T) {
+	t.Parallel()
+
+	sql := `
+	insert into users (id, name, email, role) 
+	values 
+		({{uuid "user"}}, 'bob', 'joe', 'user');
+	insert into user_contact_methods (id, user_id, name, type, value) 
+	values
+		({{uuid "cm1"}}, {{uuid "user"}}, 'personal', 'SMS', {{phoneCC "+86" "1"}}),
+		({{uuid "cm2"}}, {{uuid "user"}}, 'personal2', 'SMS', {{phoneCC "+1" "2"}});
+
+	insert into user_notification_rules (user_id, contact_method_id, delay_minutes) 
+	values
+		({{uuid "user"}}, {{uuid "cm1"}}, 0),
+		({{uuid "user"}}, {{uuid "cm2"}}, 0);
+
+	insert into escalation_policies (id, name) 
+	values
+		({{uuid "eid"}}, 'esc policy');
+	insert into escalation_policy_steps (id, escalation_policy_id) 
+	values
+		({{uuid "esid"}}, {{uuid "eid"}});
+	insert into escalation_policy_actions (escalation_policy_step_id, user_id) 
+	values 
+		({{uuid "esid"}}, {{uuid "user"}});
+
+	insert into services (id, escalation_policy_id, name) 
+	values
+		({{uuid "sid"}}, {{uuid "eid"}}, 'service');
+`
+	h := harness.NewHarness(t, sql, "ids-to-uuids")
+	defer h.Close()
+
+	h.CreateAlert(h.UUID("sid"), "testing")
+
+	tw := h.Twilio(t)
+	cn := tw.Device(h.PhoneCC("+86", "1"))
+	us := tw.Device(h.PhoneCC("+1", "2"))
+
+	sms := us.ExpectSMS("testing")
+	assert.Contains(t, sms.Body(), "ack")
+	assert.Contains(t, sms.Body(), "http")
+
+	sms = cn.ExpectSMS("testing")
+	assert.NotContains(t, sms.Body(), "ack")
+	assert.NotContains(t, sms.Body(), "http")
+}

--- a/test/smoke/twiliosmsrestrictions_test.go
+++ b/test/smoke/twiliosmsrestrictions_test.go
@@ -18,12 +18,14 @@ func TestTwilioSMSRestrictions(t *testing.T) {
 	insert into user_contact_methods (id, user_id, name, type, value) 
 	values
 		({{uuid "cm1"}}, {{uuid "user"}}, 'personal', 'SMS', {{phoneCC "+86" "1"}}),
-		({{uuid "cm2"}}, {{uuid "user"}}, 'personal2', 'SMS', {{phoneCC "+1" "2"}});
+		({{uuid "cm2"}}, {{uuid "user"}}, 'personal2', 'SMS', {{phoneCC "+1" "1"}}),
+		({{uuid "cm3"}}, {{uuid "user"}}, 'personal3', 'SMS', {{phoneCC "+91" "1"}});
 
 	insert into user_notification_rules (user_id, contact_method_id, delay_minutes) 
 	values
 		({{uuid "user"}}, {{uuid "cm1"}}, 0),
-		({{uuid "user"}}, {{uuid "cm2"}}, 0);
+		({{uuid "user"}}, {{uuid "cm2"}}, 0),
+		({{uuid "user"}}, {{uuid "cm3"}}, 0);
 
 	insert into escalation_policies (id, name) 
 	values
@@ -45,14 +47,19 @@ func TestTwilioSMSRestrictions(t *testing.T) {
 	h.CreateAlert(h.UUID("sid"), "testing")
 
 	tw := h.Twilio(t)
-	cn := tw.Device(h.PhoneCC("+86", "1"))
-	us := tw.Device(h.PhoneCC("+1", "2"))
 
-	sms := us.ExpectSMS("testing")
+	// US number supports URLs and 2-way SMS
+	sms := tw.Device(h.PhoneCC("+1", "1")).ExpectSMS("testing")
 	assert.Contains(t, sms.Body(), "ack")
 	assert.Contains(t, sms.Body(), "http")
 
-	sms = cn.ExpectSMS("testing")
+	// CN number does not support URLs or 2-way SMS
+	sms = tw.Device(h.PhoneCC("+86", "1")).ExpectSMS("testing")
 	assert.NotContains(t, sms.Body(), "ack")
 	assert.NotContains(t, sms.Body(), "http")
+
+	// IN supports URLs but not 2-way SMS
+	sms = tw.Device(h.PhoneCC("+91", "1")).ExpectSMS("testing")
+	assert.NotContains(t, sms.Body(), "ack")
+	assert.Contains(t, sms.Body(), "http")
 }


### PR DESCRIPTION
**Description:**
This PR updates the SMS logic to account for additional SMS restrictions.
- URLs not allowed to some prefixes
- Added to list of prefixes that do not support 2-way SMS
