### PR TITLE
deps: update to Go 1.19.1

### DIFF
--- a/devtools/ci/dockerfiles/build-env/Dockerfile
+++ b/devtools/ci/dockerfiles/build-env/Dockerfile
@@ -7,10 +7,12 @@ RUN apt-get update && apt-get install -y \
     gnupg-agent \
     software-properties-common \
     build-essential \
-    nodejs npm \
     postgresql-13 postgresql-client-13 \
     dbus-x11 xvfb && \
     rm -rf /var/lib/apt/lists/*
+
+ADD https://nodejs.org/dist/v16.17.0/node-v16.17.0-linux-x64.tar.xz /tmp/node.tar.xz
+RUN tar -xvf /tmp/node.tar.xz -C /usr/local --strip-components=1 && rm /tmp/node.tar.xz
 
 # yarn
 RUN npm install -g yarn

--- a/devtools/ci/dockerfiles/build-env/Dockerfile
+++ b/devtools/ci/dockerfiles/build-env/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.18.2-bullseye
+FROM docker.io/library/golang:1.19.1-bullseye
 
 RUN apt-get update && apt-get install -y \
     apt-transport-https \

--- a/devtools/ci/dockerfiles/goalert/Dockerfile
+++ b/devtools/ci/dockerfiles/goalert/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/goalert/build-env:go1.18.2-postgres13 AS build
+FROM docker.io/goalert/build-env:go1.19.1-postgres13 AS build
 COPY / /build/
 WORKDIR /build
 RUN make bin/build/goalert-linux-amd64

--- a/devtools/ci/tasks/build-all.yml
+++ b/devtools/ci/tasks/build-all.yml
@@ -11,7 +11,7 @@ outputs:
   - name: bin
 image_resource:
   type: registry-image
-  source: { repository: goalert/build-env, tag: go1.18.2-postgres13 }
+  source: { repository: goalert/build-env, tag: go1.19.1-postgres13 }
 run:
   path: sh
   dir: goalert

--- a/devtools/ci/tasks/build-binaries.yml
+++ b/devtools/ci/tasks/build-binaries.yml
@@ -13,7 +13,7 @@ outputs:
   - name: bin
 image_resource:
   type: registry-image
-  source: { repository: goalert/build-env, tag: go1.18.2-postgres13 }
+  source: { repository: goalert/build-env, tag: go1.19.1-postgres13 }
 run:
   path: sh
   dir: goalert

--- a/devtools/ci/tasks/scripts/codecheck.sh
+++ b/devtools/ci/tasks/scripts/codecheck.sh
@@ -21,7 +21,7 @@ if [ "$PKG_JSON_VER" != "$DOCKERFILE_VER" ]; then
 fi
 
 # assert build-env versions are identical
-BUILD_ENV_VER=go1.18.2-postgres13
+BUILD_ENV_VER=go1.19.1-postgres13
 for file in $(find devtools -name 'Dockerfile*')
 do
   if ! grep -q "goalert/build-env" "$file"; then

--- a/devtools/ci/tasks/test-smoketest.yml
+++ b/devtools/ci/tasks/test-smoketest.yml
@@ -8,7 +8,7 @@ outputs:
   - name: debug
 image_resource:
   type: registry-image
-  source: { repository: goalert/build-env, tag: go1.18.2-postgres13 }
+  source: { repository: goalert/build-env, tag: go1.19.1-postgres13 }
 run:
   path: sh
   dir: goalert

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -1,6 +1,6 @@
 # Development Setup
 
-This guide assumes you have the commands `podman`, `go` (>= 1.18), `node`, `yarn`, and `make` installed/available.
+This guide assumes you have the commands `podman`, `go` (>= 1.19), `node`, `yarn`, and `make` installed/available.
 
 Targets like `make start` will automatically fallback to the `docker` command if `podman` is not available. The container tool command can be overriden by setting the `CONTAINER_TOOL` variable.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/target/goalert
 
-go 1.18
+go 1.19
 
 require (
 	github.com/99designs/gqlgen v0.17.9


### PR DESCRIPTION
**Description:**
Updates Go to 1.19.1 and bumps the min version in `go.mod` to `1.19`