### PR TITLE
admin: fix breadcrumb and page title formatting

### DIFF
--- a/web/src/app/main/components/ToolbarPageTitle.tsx
+++ b/web/src/app/main/components/ToolbarPageTitle.tsx
@@ -124,6 +124,11 @@ function useBreadcrumbs(): [string, JSX.Element[] | JSX.Element] {
   const name = useName(parts[1], parts[2])
   parts.slice(1).forEach((part, i) => {
     title = i === 1 ? name : toTitleCase(part)
+    if (parts[1] === 'admin') {
+      // admin doesn't have IDs to lookup
+      // and instead just has fixed sub-page names
+      title = toTitleCase(part)
+    }
     crumbs.push(renderCrumb(i, title, parts.slice(0, i + 2).join('/')))
   })
 


### PR DESCRIPTION
**Description:**
Adds a special case to properly format admin sub-page titles.

Before:
![image](https://user-images.githubusercontent.com/595010/192548514-d913b906-ab7e-4ad7-afc5-a5ab8178246b.png)

After:
![image](https://user-images.githubusercontent.com/595010/192548650-581e2ab2-dbbf-4480-8bfb-9b6a5b824efb.png)
