### PR TITLE
GraphQL: serviceID should be optional

### DIFF
--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -23801,7 +23801,7 @@ func (ec *executionContext) unmarshalInputCreateHeartbeatMonitorInput(ctx contex
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("serviceID"))
-			it.ServiceID, err = ec.unmarshalNID2string(ctx, v)
+			it.ServiceID, err = ec.unmarshalOID2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/graphql2/graphqlapp/heartbeatmonitor.go
+++ b/graphql2/graphqlapp/heartbeatmonitor.go
@@ -27,14 +27,17 @@ func (q *Query) HeartbeatMonitor(ctx context.Context, id string) (*heartbeat.Mon
 	return (*App)(q).FindOneHeartbeatMonitor(ctx, id)
 }
 
-func (m *Mutation) CreateHeartbeatMonitor(ctx context.Context, input graphql2.CreateHeartbeatMonitorInput) (*heartbeat.Monitor, error) {
-	hb := &heartbeat.Monitor{
-		ServiceID: input.ServiceID,
-		Name:      input.Name,
-		Timeout:   time.Duration(input.TimeoutMinutes) * time.Minute,
+func (m *Mutation) CreateHeartbeatMonitor(ctx context.Context, input graphql2.CreateHeartbeatMonitorInput) (hb *heartbeat.Monitor, err error) {
+	var serviceID string
+	if input.ServiceID != nil {
+		serviceID = *input.ServiceID
 	}
-	err := withContextTx(ctx, m.DB, func(ctx context.Context, tx *sql.Tx) error {
-		var err error
+	err = withContextTx(ctx, m.DB, func(ctx context.Context, tx *sql.Tx) error {
+		hb = &heartbeat.Monitor{
+			ServiceID: serviceID,
+			Name:      input.Name,
+			Timeout:   time.Duration(input.TimeoutMinutes) * time.Minute,
+		}
 		hb, err = m.HeartbeatStore.CreateTx(ctx, tx, hb)
 		return err
 	})

--- a/graphql2/graphqlapp/service.go
+++ b/graphql2/graphqlapp/service.go
@@ -171,7 +171,7 @@ func (m *Mutation) CreateService(ctx context.Context, input graphql2.CreateServi
 		}
 
 		for i, hb := range input.NewHeartbeatMonitors {
-			hb.ServiceID = result.ID
+			hb.ServiceID = &result.ID
 			_, err = m.CreateHeartbeatMonitor(ctx, hb)
 			if err != nil {
 				return validation.AddPrefix("newHeartbeatMonitors["+strconv.Itoa(i)+"].", err)

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -133,9 +133,9 @@ type CreateEscalationPolicyStepInput struct {
 }
 
 type CreateHeartbeatMonitorInput struct {
-	ServiceID      string `json:"serviceID"`
-	Name           string `json:"name"`
-	TimeoutMinutes int    `json:"timeoutMinutes"`
+	ServiceID      *string `json:"serviceID"`
+	Name           string  `json:"name"`
+	TimeoutMinutes int     `json:"timeoutMinutes"`
 }
 
 type CreateIntegrationKeyInput struct {

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -1011,7 +1011,7 @@ input CreateIntegrationKeyInput {
 }
 
 input CreateHeartbeatMonitorInput {
-  serviceID: ID!
+  serviceID: ID
   name: String!
   timeoutMinutes: Int!
 }

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -793,7 +793,7 @@ export interface CreateIntegrationKeyInput {
 }
 
 export interface CreateHeartbeatMonitorInput {
-  serviceID: string
+  serviceID?: null | string
   name: string
   timeoutMinutes: number
 }


### PR DESCRIPTION
**Description:**
When creating a new service with a heartbeat monitor, CreateHeartbeatMonitorInput is requiring a serviceID that has not yet been created.

**Which issue(s) this PR fixes:**
This change will make serviceID optional in the schema for CreateHeartbeatMonitorInput, allowing createService to create the heartbeat monitor when the service is created.