### PR TITLE
heartbeat-ui: force refetch of service info (incl. hb list) on create

### DIFF
--- a/web/src/app/services/HeartbeatMonitorCreateDialog.tsx
+++ b/web/src/app/services/HeartbeatMonitorCreateDialog.tsx
@@ -36,7 +36,7 @@ export default function HeartbeatMonitorCreateDialog(props: {
               serviceID: props.serviceID,
             },
           },
-          { additionalTypenames: ['HeartbeatMonitor'] },
+          { additionalTypenames: ['HeartbeatMonitor', 'Service'] },
         ).then((result) => {
           if (!result.error) {
             props.onClose()


### PR DESCRIPTION
**Description:**
Adding `Service` to the list of types updated so urql knows to re-fetch the list of heartbeat monitors (a prop of Service) when creating a new one.

**Which issue(s) this PR fixes:**
Fixes #2581 
