### PR TITLE
Added UI Configurable rate limits for each notification type

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -187,8 +187,12 @@ func (p *Engine) processMessages(ctx context.Context) {
 	defer recoverPanic(ctx, "MessageManager")
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
+	err := p.msg.Init(ctx)
+	if err != nil {
+		fmt.Println(err)
+	}
 
-	err := p.msg.SendMessages(ctx, p.sendMessage, p.cfg.NotificationManager.MessageStatus)
+	err = p.msg.SendMessages(ctx, p.sendMessage, p.cfg.NotificationManager.MessageStatus)
 	if errors.Is(err, processinglock.ErrNoLock) {
 		return
 	}

--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -343,7 +343,7 @@ func NewDB(ctx context.Context, db *sql.DB, a *alertlog.Store, pausable lifecycl
 		`),
 
 		deleteAny:    p.P(`delete from outgoing_messages where id = any($1)`),
-		getAllLimits: p.P(`select max from config_limits where id=any($1)`),
+		getAllLimits: p.P(`select max,array_position($1::enum_limit_type[],id) as ord  from config_limits where id=any($1::enum_limit_type[]) order by ord`),
 	}, p.Err
 }
 

--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -47,6 +47,7 @@ type DB struct {
 	failSMSVoice *sql.Stmt
 
 	sentByCMType *sql.Stmt
+	getAllLimits *sql.Stmt
 
 	updateCMStatusUpdate      *sql.Stmt
 	cleanupStatusUpdateOptOut *sql.Stmt
@@ -341,7 +342,8 @@ func NewDB(ctx context.Context, db *sql.DB, a *alertlog.Store, pausable lifecycl
 				(msg.contact_method_id isnull or msg.message_type = 'verification_message' or not cm.disabled)
 		`),
 
-		deleteAny: p.P(`delete from outgoing_messages where id = any($1)`),
+		deleteAny:    p.P(`delete from outgoing_messages where id = any($1)`),
+		getAllLimits: p.P(`select max from config_limits where id=any($1)`),
 	}, p.Err
 }
 

--- a/engine/message/ratelimit.go
+++ b/engine/message/ratelimit.go
@@ -1,9 +1,12 @@
 package message
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"github.com/target/goalert/notification"
+	"github.com/target/goalert/util/sqlutil"
 )
 
 // GlobalCMThrottle represents the rate limits for each notification type.
@@ -13,6 +16,35 @@ var GlobalCMThrottle ThrottleConfig = ThrottleRules{{Count: 5, Per: 5 * time.Sec
 var PerCMThrottle ThrottleConfig
 
 func init() {
+
+}
+
+func (db *DB) Init(ctx context.Context) error {
+
+	tx, err := db.lock.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	ids := sqlutil.StringArray{"max_sms_per_15_minutes", "max_sms_per_hour", "max_sms_per_3_hours", "max_voice_per_15_minutes", "max_voice_per_hour", "max_voice_per_3_hours", "max_all_for_alert_status_per_3_minutes", "max_all_for_alert_status_per_2_hours", "max_all_for_alert_status_per_20_minutes"}
+
+	rows, err := tx.StmtContext(ctx, db.getAllLimits).QueryContext(ctx, ids)
+	if err != nil {
+		return fmt.Errorf("set timeout: %w", err)
+	}
+	type MaxLimits struct {
+		MaxHours int
+	}
+	var a []MaxLimits
+	for rows.Next() {
+		var al MaxLimits
+		err = rows.Scan(&al.MaxHours)
+		if err != nil {
+			fmt.Println("Error fetching limits", err)
+		}
+		a = append(a, al)
+	}
+
 	var perCM ThrottleConfigBuilder
 
 	// Rate limit sms, voice and email types
@@ -33,29 +65,29 @@ func init() {
 		WithMsgTypes(notification.MessageTypeAlertStatus).
 		WithDestTypes(notification.DestTypeVoice, notification.DestTypeSMS, notification.DestTypeUserEmail).
 		AddRules([]ThrottleRule{
-			{Count: 1, Per: 3 * time.Minute},
-			{Count: 3, Per: 20 * time.Minute},
-			{Count: 8, Per: 120 * time.Minute, Smooth: true},
+			{Count: a[6].MaxHours, Per: 3 * time.Minute},
+			{Count: a[8].MaxHours, Per: 20 * time.Minute},
+			{Count: a[7].MaxHours, Per: 120 * time.Minute, Smooth: true},
 		})
-
 	// alert notifications
 	alertMessages := perCM.WithMsgTypes(notification.MessageTypeAlert, notification.MessageTypeAlertBundle)
 
 	alertMessages.
 		WithDestTypes(notification.DestTypeVoice).
 		AddRules([]ThrottleRule{
-			{Count: 3, Per: 15 * time.Minute},
-			{Count: 7, Per: time.Hour, Smooth: true},
-			{Count: 15, Per: 3 * time.Hour, Smooth: true},
+			{Count: a[3].MaxHours, Per: 15 * time.Minute},
+			{Count: a[4].MaxHours, Per: time.Hour, Smooth: true},
+			{Count: a[5].MaxHours, Per: 3 * time.Hour, Smooth: true},
 		})
 
 	alertMessages.
 		WithDestTypes(notification.DestTypeSMS).
 		AddRules([]ThrottleRule{
-			{Count: 5, Per: 15 * time.Minute},
-			{Count: 11, Per: time.Hour, Smooth: true},
-			{Count: 21, Per: 3 * time.Hour, Smooth: true},
+			{Count: a[0].MaxHours, Per: 15 * time.Minute},
+			{Count: a[1].MaxHours, Per: time.Hour, Smooth: true},
+			{Count: a[2].MaxHours, Per: 3 * time.Hour, Smooth: true},
 		})
 
 	PerCMThrottle = perCM.Config()
+	return nil
 }

--- a/engine/message/ratelimit.go
+++ b/engine/message/ratelimit.go
@@ -34,11 +34,12 @@ func (db *DB) Init(ctx context.Context) error {
 	}
 	type MaxLimits struct {
 		MaxHours int
+		Order    int
 	}
 	var a []MaxLimits
 	for rows.Next() {
 		var al MaxLimits
-		err = rows.Scan(&al.MaxHours)
+		err = rows.Scan(&al.MaxHours, &al.Order)
 		if err != nil {
 			fmt.Println("Error fetching limits", err)
 		}

--- a/graphql2/maplimit.go
+++ b/graphql2/maplimit.go
@@ -18,6 +18,15 @@ func MapLimitValues(l limit.Limits) []SystemLimit {
 		{ID: "EPStepsPerPolicy", Description: "Maximum number of steps on a single escalation policy.", Value: l[limit.EPStepsPerPolicy]},
 		{ID: "HeartbeatMonitorsPerService", Description: "Maximum number of heartbeat monitors per service.", Value: l[limit.HeartbeatMonitorsPerService]},
 		{ID: "IntegrationKeysPerService", Description: "Maximum number of integration keys per service.", Value: l[limit.IntegrationKeysPerService]},
+		{ID: "MaxAllForAlertStatusPer20Minutes", Description: "All Message Type Limit for alert notifications per 20 minutes.", Value: l[limit.MaxAllForAlertStatusPer20Minutes]},
+		{ID: "MaxAllForAlertStatusPer2Hours", Description: "All Message Type Limit for alert notifications per 2 hours.", Value: l[limit.MaxAllForAlertStatusPer2Hours]},
+		{ID: "MaxAllForAlertStatusPer3Minutes", Description: "All Message Type Limit for alert notifications per 3 minutes.", Value: l[limit.MaxAllForAlertStatusPer3Minutes]},
+		{ID: "MaxSMSPer15Minutes", Description: "SMS Limit for alert notifications per 15 minutes.", Value: l[limit.MaxSMSPer15Minutes]},
+		{ID: "MaxSMSPer3Hours", Description: "SMS Limit for alert notifications per 3 hours.", Value: l[limit.MaxSMSPer3Hours]},
+		{ID: "MaxSMSPerHour", Description: "SMS  Limit for alert notifications per hour.", Value: l[limit.MaxSMSPerHour]},
+		{ID: "MaxVoicePer15Minutes", Description: "Voice Limit for alert notifications per 15 minutes.", Value: l[limit.MaxVoicePer15Minutes]},
+		{ID: "MaxVoicePer3Hours", Description: "Voice Limit for alert notifications per 3 hours.", Value: l[limit.MaxVoicePer3Hours]},
+		{ID: "MaxVoicePerHour", Description: "Voice Limit for alert notifications per hour.", Value: l[limit.MaxVoicePerHour]},
 		{ID: "NotificationRulesPerUser", Description: "Maximum number of notification rules per user.", Value: l[limit.NotificationRulesPerUser]},
 		{ID: "ParticipantsPerRotation", Description: "Maximum number of participants per rotation.", Value: l[limit.ParticipantsPerRotation]},
 		{ID: "RulesPerSchedule", Description: "Pertains to all rules for all assignments/targets.", Value: l[limit.RulesPerSchedule]},
@@ -43,6 +52,24 @@ func ApplyLimitValues(l limit.Limits, vals []SystemLimitInput) (limit.Limits, er
 			l[limit.HeartbeatMonitorsPerService] = v.Value
 		case "IntegrationKeysPerService":
 			l[limit.IntegrationKeysPerService] = v.Value
+		case "MaxAllForAlertStatusPer20Minutes":
+			l[limit.MaxAllForAlertStatusPer20Minutes] = v.Value
+		case "MaxAllForAlertStatusPer2Hours":
+			l[limit.MaxAllForAlertStatusPer2Hours] = v.Value
+		case "MaxAllForAlertStatusPer3Minutes":
+			l[limit.MaxAllForAlertStatusPer3Minutes] = v.Value
+		case "MaxSMSPer15Minutes":
+			l[limit.MaxSMSPer15Minutes] = v.Value
+		case "MaxSMSPer3Hours":
+			l[limit.MaxSMSPer3Hours] = v.Value
+		case "MaxSMSPerHour":
+			l[limit.MaxSMSPerHour] = v.Value
+		case "MaxVoicePer15Minutes":
+			l[limit.MaxVoicePer15Minutes] = v.Value
+		case "MaxVoicePer3Hours":
+			l[limit.MaxVoicePer3Hours] = v.Value
+		case "MaxVoicePerHour":
+			l[limit.MaxVoicePerHour] = v.Value
 		case "NotificationRulesPerUser":
 			l[limit.NotificationRulesPerUser] = v.Value
 		case "ParticipantsPerRotation":

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -215,6 +215,15 @@ enum SystemLimitID {
   TargetsPerSchedule
   HeartbeatMonitorsPerService
   UserOverridesPerSchedule
+  MaxSMSPer15Minutes
+  MaxSMSPerHour
+  MaxSMSPer3Hours
+  MaxVoicePer15Minutes
+  MaxVoicePerHour
+  MaxVoicePer3Hours
+  MaxAllForAlertStatusPer3Minutes
+  MaxAllForAlertStatusPer2Hours
+  MaxAllForAlertStatusPer20Minutes
 }
 
 input UserOverrideSearchOptions {

--- a/limit/id.go
+++ b/limit/id.go
@@ -31,6 +31,24 @@ const (
 	UserOverridesPerSchedule ID = "user_overrides_per_schedule"
 	// Maximum number of calendar subscriptions per user.
 	CalendarSubscriptionsPerUser ID = "calendar_subscriptions_per_user"
+	// SMS Limit for alert notifications per 15 minutes.
+	MaxSMSPer15Minutes ID = "max_sms_per_15_minutes"
+	// SMS  Limit for alert notifications per hour.
+	MaxSMSPerHour ID = "max_sms_per_hour"
+	// SMS Limit for alert notifications per 3 hours.
+	MaxSMSPer3Hours ID = "max_sms_per_3_hours"
+	// Voice Limit for alert notifications per 15 minutes.
+	MaxVoicePer15Minutes ID = "max_voice_per_15_minutes"
+	// Voice Limit for alert notifications per hour.
+	MaxVoicePerHour ID = "max_voice_per_hour"
+	// Voice Limit for alert notifications per 3 hours.
+	MaxVoicePer3Hours ID = "max_voice_per_3_hours"
+	// All Message Type Limit for alert notifications per 3 minutes.
+	MaxAllForAlertStatusPer3Minutes ID = "max_all_for_alert_status_per_3_minutes"
+	// All Message Type Limit for alert notifications per 2 hours.
+	MaxAllForAlertStatusPer2Hours ID = "max_all_for_alert_status_per_2_hours"
+	// All Message Type Limit for alert notifications per 20 minutes.
+	MaxAllForAlertStatusPer20Minutes ID = "max_all_for_alert_status_per_20_minutes"
 )
 
 // Valid returns nil if a given ID is valid, a validation error is returned otherwise.
@@ -48,5 +66,14 @@ func (id ID) Valid() error {
 		HeartbeatMonitorsPerService,
 		UserOverridesPerSchedule,
 		CalendarSubscriptionsPerUser,
+		MaxSMSPer15Minutes,
+		MaxSMSPerHour,
+		MaxSMSPer3Hours,
+		MaxVoicePer15Minutes,
+		MaxVoicePerHour,
+		MaxVoicePer3Hours,
+		MaxAllForAlertStatusPer3Minutes,
+		MaxAllForAlertStatusPer2Hours,
+		MaxAllForAlertStatusPer20Minutes,
 	)
 }

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -134,6 +134,15 @@ export type SystemLimitID =
   | 'TargetsPerSchedule'
   | 'HeartbeatMonitorsPerService'
   | 'UserOverridesPerSchedule'
+  | 'MaxSMSPer15Minutes'
+  | 'MaxSMSPerHour'
+  | 'MaxSMSPer3Hours'
+  | 'MaxVoicePer15Minutes'
+  | 'MaxVoicePerHour'
+  | 'MaxVoicePer3Hours'
+  | 'MaxAllForAlertStatusPer3Minutes'
+  | 'MaxAllForAlertStatusPer2Hours'
+  | 'MaxAllForAlertStatusPer20Minutes'
 
 export interface UserOverrideSearchOptions {
   first?: null | number


### PR DESCRIPTION
**Description:**
Currently, we have rate limiting configuration set for each notification type per contact method. This is directly set in the code and not dynamic. If there's a need to change in the rate limits it needs redeployment of code everytime



Solution:
We can make the rate limits configurable in UI under admin panel. We have config limits set for unack alerts etc..Similarly we can have it for throttling which can be modified by the admin according to their needs. We can have entries added in config_limits table with the maximum limit as value.


**Which issue(s) this PR fixes:**
Fixes #2653



**Screenshots:**
<img width="1311" alt="Screenshot 2022-10-10 at 9 50 01 PM" src="https://user-images.githubusercontent.com/32451441/194924463-c5f95361-2e0c-4544-9c8a-fb8534421172.png">




**Additional Info:**
Need to add few rows in config_limits table and add values to config limit enum
alter type enum_limit_type add value 'max_all_for_alert_status_per_20_minutes';
alter type enum_limit_type add value 'max_sms_per_15_minutes';
alter type enum_limit_type add value 'max_sms_per_hour';
alter type enum_limit_type add value 'max_sms_per_3_hours';
alter type enum_limit_type add value 'max_voice_per_15_minutes';
alter type enum_limit_type add value 'max_voice_per_hour';
alter type enum_limit_type add value 'max_voice_per_3_hours';
alter type enum_limit_type add value 'max_all_for_alert_status_per_3_minutes';
alter type enum_limit_type add value 'max_all_for_alert_status_per_2_hours';

Rows to be inserted in table config_limits

"max_sms_per_15_minutes"	5
"max_sms_per_hour"	11
"max_sms_per_3_hours"	20
"max_voice_per_15_minutes"	3
"max_voice_per_hour"	7
"max_voice_per_3_hours"	15
"max_all_for_alert_status_per_3_minutes"	1
"max_all_for_alert_status_per_2_hours"	8
"max_all_for_alert_status_per_20_minutes"	3

