### PR TITLE
docs: update Postgres version in getting-started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ When running GoAlert behind a reverse proxy, make sure the `--public-url` includ
 
 ## Database
 
-We recommend using Postgres 11 for new installations as newer features will be used in the future.
+We recommend using Postgres 13 (or newer) for new installations as newer features will be used in the future.
 
 GoAlert requires the `pgcrypto` extension enabled (you can enable it with `CREATE EXTENSION pgcrypto;`).
 Upon first startup, it will attempt to enable the extension if it's not already enabled, but this requires elevated privileges that may not be available
@@ -28,7 +28,7 @@ It can be set to any value as it is internally passed through a key derivation f
 
 ## Running GoAlert
 
-To run GoAlert, you can start the binary directly, or from a container image. You will need to specify the `--db-url` and `--data-encryption-key` you plan to use.
+To run GoAlert, you can start the binary directly, or from a container image. You will need to specify the `--db-url`, `--public-url`, and `--data-encryption-key` you plan to use.
 
 The following examples use `postgres://goalert@localhost/goalert` and `super-awesome-secret-key` respectively.
 


### PR DESCRIPTION
**Description:**
Update recommended Postgres version in the getting started docs and add "or newer" to denote that newer versions are acceptable.
