### PR TITLE
ui: move profile add buttons

### DIFF
--- a/test/integration/email-cm.spec.ts
+++ b/test/integration/email-cm.spec.ts
@@ -7,13 +7,18 @@ test.describe.configure({ mode: 'parallel' })
 test.use({ storageState: userSessionFile })
 
 // test create, verify, and delete of an EMAIL contact method
-test('EMAIL contact method', async ({ page, browser }) => {
+test('EMAIL contact method', async ({ page, browser, isMobile }) => {
   const name = 'pw-email ' + c.name()
   const email = 'pw-email-' + c.email()
 
   await page.goto('./profile')
-  await page.click('[aria-label="Add Items"]')
-  await page.click('[aria-label="Add Contact Method"]')
+
+  if (isMobile) {
+    await page.click('[aria-label="Add Items"]')
+    await page.click('[aria-label="Add Contact Method"]')
+  } else {
+    await page.click('[aria-label="Add contact method"]')
+  }
 
   await page.fill('input[name=name]', name)
   await page.fill('input[name=type]', 'EMAIL')

--- a/web/src/app/main/components/NewUserSetup.js
+++ b/web/src/app/main/components/NewUserSetup.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import UserContactMethodCreateDialog from '../../users/UserContactMethodCreateDialog'
 import UserContactMethodVerificationDialog from '../../users/UserContactMethodVerificationDialog'
-import { useSessionInfo, useConfigValue } from '../../util/RequireConfig'
+import { useSessionInfo } from '../../util/RequireConfig'
 import { useResetURLParams, useURLParam } from '../../actions'
 
 export default function NewUserSetup() {
@@ -9,7 +9,6 @@ export default function NewUserSetup() {
   const clearIsFirstLogin = useResetURLParams('isFirstLogin')
   const [contactMethodID, setContactMethodID] = useState('')
   const { userID, ready } = useSessionInfo()
-  const [disclaimer] = useConfigValue('General.NotificationDisclaimer')
 
   if (!isFirstLogin || !ready) {
     return null
@@ -27,7 +26,6 @@ export default function NewUserSetup() {
     <UserContactMethodCreateDialog
       title='Welcome to GoAlert!'
       subtitle='To get started, please enter a contact method.'
-      disclaimer={disclaimer}
       userID={userID}
       onClose={(contactMethodID) => {
         if (contactMethodID) {

--- a/web/src/app/users/UserContactMethodCreateDialog.tsx
+++ b/web/src/app/users/UserContactMethodCreateDialog.tsx
@@ -37,7 +37,6 @@ const userConflictQuery = gql`
 export default function UserContactMethodCreateDialog(props: {
   userID: string
   onClose: (contactMethodID?: string) => void
-  disclaimer?: string
   title?: string
   subtitle?: string
 }): JSX.Element {
@@ -129,7 +128,6 @@ export default function UserContactMethodCreateDialog(props: {
       errors={fieldErrs}
       onChange={(CMValue: Value) => setCMValue(CMValue)}
       value={CMValue}
-      disclaimer={props.disclaimer}
     />
   )
 

--- a/web/src/app/users/UserContactMethodForm.tsx
+++ b/web/src/app/users/UserContactMethodForm.tsx
@@ -16,7 +16,6 @@ type Value = {
 
 export type UserContactMethodFormProps = {
   value: Value
-  disclaimer?: string
 
   errors?: Array<FieldError>
 
@@ -104,13 +103,15 @@ const isPhoneType = (val: Value): boolean =>
 export default function UserContactMethodForm(
   props: UserContactMethodFormProps,
 ): JSX.Element {
-  const { value, edit = false, disclaimer, ...other } = props
+  const { value, edit = false, ...other } = props
 
-  const [smsVoiceEnabled, emailEnabled, webhookEnabled] = useConfigValue(
-    'Twilio.Enable',
-    'SMTP.Enable',
-    'Webhook.Enable',
-  )
+  const [smsVoiceEnabled, emailEnabled, webhookEnabled, disclaimer] =
+    useConfigValue(
+      'Twilio.Enable',
+      'SMTP.Enable',
+      'Webhook.Enable',
+      'General.NotificationDisclaimer',
+    )
 
   return (
     <FormContainer

--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -163,13 +163,13 @@ export default function UserContactMethodList(
           title='Contact Methods'
           action={
             !mobile ? (
-              <Button
-                variant='contained'
-                startIcon={<Add />}
+              <IconButton
+                aria-label='Add contact method'
                 onClick={() => setShowAddDialog(true)}
+                size='large'
               >
-                Add
-              </Button>
+                <Add fontSize='large' />
+              </IconButton>
             ) : null
           }
         />

--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -4,6 +4,7 @@ import FlatList from '../lists/FlatList'
 import { Button, Card, CardHeader, Grid, IconButton } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
 import { Theme } from '@mui/material/styles'
+import { Add } from '@mui/icons-material'
 import { sortContactMethods } from './util'
 import OtherActions from '../util/OtherActions'
 import UserContactMethodDeleteDialog from './UserContactMethodDeleteDialog'
@@ -17,6 +18,8 @@ import SendTestDialog from './SendTestDialog'
 import AppLink from '../util/AppLink'
 import { styles as globalStyles } from '../styles/materialStyles'
 import { UserContactMethod } from '../../schema'
+import { useConfigValue } from '../util/RequireConfig'
+import UserContactMethodCreateDialog from './UserContactMethodCreateDialog'
 
 const query = gql`
   query cmList($id: ID!) {
@@ -52,7 +55,10 @@ export default function UserContactMethodList(
   props: UserContactMethodListProps,
 ): JSX.Element {
   const classes = useStyles()
-  const fullScreen = useIsWidthDown('md')
+  const mobile = useIsWidthDown('md')
+  const [disclaimer] = useConfigValue('General.NotificationDisclaimer')
+
+  const [showAddDialog, setShowAddDialog] = useState(false)
   const [showVerifyDialogByID, setShowVerifyDialogByID] = useState('')
   const [showEditDialogByID, setShowEditDialogByID] = useState('')
   const [showDeleteDialogByID, setShowDeleteDialogByID] = useState('')
@@ -115,7 +121,7 @@ export default function UserContactMethodList(
   function getSecondaryAction(cm: UserContactMethod): JSX.Element {
     return (
       <Grid container spacing={2} alignItems='center' wrap='nowrap'>
-        {cm.disabled && !props.readOnly && !fullScreen && (
+        {cm.disabled && !props.readOnly && !mobile && (
           <Grid item>
             <Button
               aria-label='Reactivate contact method'
@@ -155,6 +161,17 @@ export default function UserContactMethodList(
           className={classes.cardHeader}
           titleTypographyProps={{ component: 'h2', variant: 'h5' }}
           title='Contact Methods'
+          action={
+            !mobile ? (
+              <Button
+                variant='contained'
+                startIcon={<Add />}
+                onClick={() => setShowAddDialog(true)}
+              >
+                Add
+              </Button>
+            ) : null
+          }
         />
         <FlatList
           data-cy='contact-methods'
@@ -166,6 +183,16 @@ export default function UserContactMethodList(
           }))}
           emptyMessage='No contact methods'
         />
+        {showAddDialog && (
+          <UserContactMethodCreateDialog
+            userID={props.userID}
+            disclaimer={disclaimer?.toString()}
+            onClose={(contactMethodID = '') => {
+              setShowAddDialog(false)
+              setShowVerifyDialogByID(contactMethodID)
+            }}
+          />
+        )}
         {showVerifyDialogByID && (
           <UserContactMethodVerificationDialog
             contactMethodID={showVerifyDialogByID}

--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -18,7 +18,6 @@ import SendTestDialog from './SendTestDialog'
 import AppLink from '../util/AppLink'
 import { styles as globalStyles } from '../styles/materialStyles'
 import { UserContactMethod } from '../../schema'
-import { useConfigValue } from '../util/RequireConfig'
 import UserContactMethodCreateDialog from './UserContactMethodCreateDialog'
 
 const query = gql`
@@ -56,7 +55,6 @@ export default function UserContactMethodList(
 ): JSX.Element {
   const classes = useStyles()
   const mobile = useIsWidthDown('md')
-  const [disclaimer] = useConfigValue('General.NotificationDisclaimer')
 
   const [showAddDialog, setShowAddDialog] = useState(false)
   const [showVerifyDialogByID, setShowVerifyDialogByID] = useState('')
@@ -186,7 +184,6 @@ export default function UserContactMethodList(
         {showAddDialog && (
           <UserContactMethodCreateDialog
             userID={props.userID}
-            disclaimer={disclaimer?.toString()}
             onClose={(contactMethodID = '') => {
               setShowAddDialog(false)
               setShowVerifyDialogByID(contactMethodID)

--- a/web/src/app/users/UserDetails.tsx
+++ b/web/src/app/users/UserDetails.tsx
@@ -21,6 +21,7 @@ import UserEditDialog from './UserEditDialog'
 import UserDeleteDialog from './UserDeleteDialog'
 import { QuerySetFavoriteButton } from '../util/QuerySetFavoriteButton'
 import { EscalationPolicyStep } from '../../schema'
+import { useIsWidthDown } from '../util/useWidth'
 
 const userQuery = gql`
   query userInfo($id: ID!) {
@@ -102,6 +103,7 @@ export default function UserDetails(props: {
     string | null | undefined
   >(null)
   const [showUserDeleteDialog, setShowUserDeleteDialog] = useState(false)
+  const mobile = useIsWidthDown('md')
 
   const [{ data, fetching: isQueryLoading, error }] = useQuery({
     query: isAdmin || userID === currentUserID ? profileQuery : userQuery,
@@ -163,7 +165,7 @@ export default function UserDetails(props: {
           onClose={() => setShowUserDeleteDialog(false)}
         />
       )}
-      {props.readOnly ? null : (
+      {mobile && !props.readOnly ? (
         <SpeedDial
           label='Add Items'
           actions={[
@@ -180,7 +182,7 @@ export default function UserDetails(props: {
             },
           ]}
         />
-      )}
+      ) : null}
       {createCM && (
         <UserContactMethodCreateDialog
           userID={userID}

--- a/web/src/app/users/UserDetails.tsx
+++ b/web/src/app/users/UserDetails.tsx
@@ -16,7 +16,7 @@ import UserContactMethodVerificationDialog from './UserContactMethodVerification
 import _ from 'lodash'
 import Spinner from '../loading/components/Spinner'
 import { GenericError, ObjectNotFound } from '../error-pages'
-import { useConfigValue, useSessionInfo } from '../util/RequireConfig'
+import { useSessionInfo } from '../util/RequireConfig'
 import UserEditDialog from './UserEditDialog'
 import UserDeleteDialog from './UserDeleteDialog'
 import { QuerySetFavoriteButton } from '../util/QuerySetFavoriteButton'
@@ -95,7 +95,6 @@ export default function UserDetails(props: {
     isAdmin,
     ready: isSessionReady,
   } = useSessionInfo()
-  const [disclaimer] = useConfigValue('General.NotificationDisclaimer')
   const [createCM, setCreateCM] = useState(false)
   const [createNR, setCreateNR] = useState(false)
   const [showEdit, setShowEdit] = useState(false)
@@ -188,7 +187,6 @@ export default function UserDetails(props: {
       {createCM && (
         <UserContactMethodCreateDialog
           userID={userID}
-          disclaimer={disclaimer?.toString()}
           onClose={(contactMethodID) => {
             setCreateCM(false)
             setShowVerifyDialogByID(contactMethodID)

--- a/web/src/app/users/UserDetails.tsx
+++ b/web/src/app/users/UserDetails.tsx
@@ -165,6 +165,8 @@ export default function UserDetails(props: {
           onClose={() => setShowUserDeleteDialog(false)}
         />
       )}
+
+      {/* dialogs only shown on mobile via FAB button */}
       {mobile && !props.readOnly ? (
         <SpeedDial
           label='Add Items'

--- a/web/src/app/users/UserNotificationRuleList.tsx
+++ b/web/src/app/users/UserNotificationRuleList.tsx
@@ -1,13 +1,6 @@
 import React, { useState, ReactNode } from 'react'
 import { gql, QueryResult } from '@apollo/client'
-import {
-  Button,
-  Grid,
-  Card,
-  CardHeader,
-  IconButton,
-  Theme,
-} from '@mui/material'
+import { Grid, Card, CardHeader, IconButton, Theme } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
 import { Add, Delete } from '@mui/icons-material'
 import Query from '../util/Query'
@@ -63,13 +56,13 @@ export default function UserNotificationRuleList(props: {
             title='Notification Rules'
             action={
               !mobile ? (
-                <Button
-                  variant='contained'
-                  startIcon={<Add />}
+                <IconButton
+                  aria-label='Add notification rule'
                   onClick={() => setShowAddDialog(true)}
+                  size='large'
                 >
-                  Add
-                </Button>
+                  <Add fontSize='large' />
+                </IconButton>
               ) : null
             }
           />
@@ -81,7 +74,7 @@ export default function UserNotificationRuleList(props: {
                 <IconButton
                   aria-label='Delete notification rule'
                   onClick={() => setDeleteID(nr.id)}
-                  size='large'
+                  color='secondary'
                 >
                   <Delete />
                 </IconButton>

--- a/web/src/app/users/UserNotificationRuleList.tsx
+++ b/web/src/app/users/UserNotificationRuleList.tsx
@@ -1,13 +1,22 @@
 import React, { useState, ReactNode } from 'react'
-import Query from '../util/Query'
 import { gql, QueryResult } from '@apollo/client'
-import FlatList, { FlatListListItem } from '../lists/FlatList'
-import { Grid, Card, CardHeader, IconButton, Theme } from '@mui/material'
+import {
+  Button,
+  Grid,
+  Card,
+  CardHeader,
+  IconButton,
+  Theme,
+} from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
+import { Add, Delete } from '@mui/icons-material'
+import Query from '../util/Query'
+import FlatList, { FlatListListItem } from '../lists/FlatList'
 import { formatNotificationRule, sortNotificationRules } from './util'
-import { Delete } from '@mui/icons-material'
 import UserNotificationRuleDeleteDialog from './UserNotificationRuleDeleteDialog'
 import { styles as globalStyles } from '../styles/materialStyles'
+import UserNotificationRuleCreateDialog from './UserNotificationRuleCreateDialog'
+import { useIsWidthDown } from '../util/useWidth'
 
 const query = gql`
   query nrList($id: ID!) {
@@ -40,6 +49,8 @@ export default function UserNotificationRuleList(props: {
   readOnly: boolean
 }): JSX.Element {
   const classes = useStyles()
+  const mobile = useIsWidthDown('md')
+  const [showAddDialog, setShowAddDialog] = useState(false)
   const [deleteID, setDeleteID] = useState(null)
 
   function renderList(notificationRules: FlatListListItem[]): ReactNode {
@@ -50,6 +61,17 @@ export default function UserNotificationRuleList(props: {
             className={classes.cardHeader}
             titleTypographyProps={{ component: 'h2', variant: 'h5' }}
             title='Notification Rules'
+            action={
+              !mobile ? (
+                <Button
+                  variant='contained'
+                  startIcon={<Add />}
+                  onClick={() => setShowAddDialog(true)}
+                >
+                  Add
+                </Button>
+              ) : null
+            }
           />
           <FlatList
             data-cy='notification-rules'
@@ -68,6 +90,12 @@ export default function UserNotificationRuleList(props: {
             emptyMessage='No notification rules'
           />
         </Card>
+        {showAddDialog && (
+          <UserNotificationRuleCreateDialog
+            userID={props.userID}
+            onClose={() => setShowAddDialog(false)}
+          />
+        )}
         {deleteID && (
           <UserNotificationRuleDeleteDialog
             ruleID={deleteID}

--- a/web/src/app/users/UserNotificationRuleList.tsx
+++ b/web/src/app/users/UserNotificationRuleList.tsx
@@ -4,17 +4,21 @@ import { Grid, Card, CardHeader, IconButton, Theme } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
 import { Add, Delete } from '@mui/icons-material'
 import Query from '../util/Query'
-import FlatList, { FlatListListItem } from '../lists/FlatList'
+import FlatList from '../lists/FlatList'
 import { formatNotificationRule, sortNotificationRules } from './util'
 import UserNotificationRuleDeleteDialog from './UserNotificationRuleDeleteDialog'
 import { styles as globalStyles } from '../styles/materialStyles'
 import UserNotificationRuleCreateDialog from './UserNotificationRuleCreateDialog'
 import { useIsWidthDown } from '../util/useWidth'
+import { User } from '../../schema'
 
 const query = gql`
   query nrList($id: ID!) {
     user(id: $id) {
       id
+      contactMethods {
+        id
+      }
       notificationRules {
         id
         delayMinutes
@@ -46,7 +50,7 @@ export default function UserNotificationRuleList(props: {
   const [showAddDialog, setShowAddDialog] = useState(false)
   const [deleteID, setDeleteID] = useState(null)
 
-  function renderList(notificationRules: FlatListListItem[]): ReactNode {
+  function renderList(user: User): ReactNode {
     return (
       <Grid item xs={12}>
         <Card>
@@ -59,6 +63,7 @@ export default function UserNotificationRuleList(props: {
                 <IconButton
                   aria-label='Add notification rule'
                   onClick={() => setShowAddDialog(true)}
+                  disabled={user.contactMethods.length === 0}
                   size='large'
                 >
                   <Add fontSize='large' />
@@ -68,7 +73,7 @@ export default function UserNotificationRuleList(props: {
           />
           <FlatList
             data-cy='notification-rules'
-            items={sortNotificationRules(notificationRules).map((nr) => ({
+            items={sortNotificationRules(user.notificationRules).map((nr) => ({
               title: formatNotificationRule(nr.delayMinutes, nr.contactMethod),
               secondaryAction: props.readOnly ? null : (
                 <IconButton
@@ -102,9 +107,7 @@ export default function UserNotificationRuleList(props: {
     <Query
       query={query}
       variables={{ id: props.userID }}
-      render={({ data }: QueryResult) =>
-        renderList(data.user.notificationRules)
-      }
+      render={({ data }: QueryResult) => renderList(data.user)}
     />
   )
 }

--- a/web/src/app/util/OtherActions.js
+++ b/web/src/app/util/OtherActions.js
@@ -31,7 +31,7 @@ export default function OtherActions({
         aria-label='Other Actions'
         data-cy='other-actions'
         aria-expanded={Boolean(anchorEl)}
-        size='large'
+        color='secondary'
         onClick={(e) => {
           onClose.cancel()
           setAnchorEl(e.currentTarget)

--- a/web/src/cypress/integration/profile.ts
+++ b/web/src/cypress/integration/profile.ts
@@ -4,6 +4,7 @@ import profile from '../fixtures/profile.json'
 const c = new Chance()
 
 function countryCodeCheck(
+  screen: ScreenFormat,
   country: string,
   countryCode: string,
   value: string,
@@ -13,7 +14,12 @@ function countryCodeCheck(
     const name = 'CM SM ' + c.word({ length: 8 })
     const type = c.pickone(['SMS', 'VOICE'])
 
-    cy.pageFab('Contact')
+    if (screen === 'mobile') {
+      cy.pageFab('Add Contact Method')
+    } else {
+      cy.get('button[aria-label="Add contact method"]').click()
+    }
+
     cy.get('input[name=name]').type(name)
     cy.get('input[name=type]').selectByLabel(type)
     cy.get('input[name=value]').type(countryCode + value)
@@ -22,7 +28,7 @@ function countryCodeCheck(
   })
 }
 
-function testProfile(): void {
+function testProfile(screen: ScreenFormat): void {
   let cm: ContactMethod
 
   beforeEach(() =>
@@ -54,13 +60,15 @@ function testProfile(): void {
     return cy
       .createService({ name })
       .then((svc: Service) => {
-        return cy
-          .createEPStep({
-            epID: svc.epID,
-            targets: [{ type: 'user', id: profile.id }],
-          })
-          .engineTrigger()
-          .then(() => svc.id)
+        return (
+          cy
+            .createEPStep({
+              epID: svc.epID,
+              targets: [{ type: 'user', id: profile.id }],
+            })
+            // .engineTrigger()
+            .then(() => svc.id)
+        )
       })
       .then((svcID: string) => {
         cy.get('body').contains('a', 'On-Call').click()
@@ -151,7 +159,12 @@ function testProfile(): void {
 
   describe('Contact Methods', () => {
     function check(name: string, type: string, value: string): void {
-      cy.pageFab('Contact')
+      if (screen === 'mobile') {
+        cy.pageFab('Add Contact Method')
+      } else {
+        cy.get('button[aria-label="Add contact method"]').click()
+      }
+
       cy.dialogTitle('Create New Contact Method')
       cy.dialogForm({
         name,
@@ -220,7 +233,12 @@ function testProfile(): void {
     it('should return error with link to conflicting user', () => {
       cy.addContactMethod({ userID: profile.id }).then(
         (contactMethod: ContactMethod) => {
-          cy.pageFab('Add Contact Method')
+          if (screen === 'mobile') {
+            cy.pageFab('Add Contact Method')
+          } else {
+            cy.get('button[aria-label="Add contact method"]').click()
+          }
+
           cy.dialogTitle('Create New Contact Method')
           cy.dialogForm({
             name: c.word({ length: 8 }),
@@ -280,12 +298,18 @@ function testProfile(): void {
       cy.dialogTitle('Are you sure?')
       cy.dialogFinish('Confirm')
 
-      cy.get('button[data-cy=page-fab]').should('be.visible').click()
-      cy.get(
-        `span[aria-label*=${JSON.stringify(
-          'Add Notification Rule',
-        )}] button[role=menuitem]`,
-      ).should('be.disabled')
+      if (screen === 'mobile') {
+        cy.get('button[data-cy=page-fab]').should('be.visible').click()
+        cy.get(
+          `span[aria-label*=${JSON.stringify(
+            'Add Notification Rule',
+          )}] button[role=menuitem]`,
+        ).should('be.disabled')
+      } else {
+        cy.get('button[aria-label="Add notification rule"]').should(
+          'be.disabled',
+        )
+      }
     })
 
     it('should display notification disclaimer when enabled', () => {
@@ -297,7 +321,12 @@ function testProfile(): void {
       })
       cy.reload()
 
-      cy.pageFab('Add Contact Method')
+      if (screen === 'mobile') {
+        cy.pageFab('Add Contact Method')
+      } else {
+        cy.get('button[aria-label="Add contact method"]').click()
+      }
+
       cy.dialogTitle('New Contact Method')
       cy.dialogContains(disclaimer)
 
@@ -308,20 +337,30 @@ function testProfile(): void {
       })
       cy.reload()
 
-      cy.pageFab('Add Contact Method')
+      if (screen === 'mobile') {
+        cy.pageFab('Add Contact Method')
+      } else {
+        cy.get('button[aria-label="Add contact method"]').click()
+      }
+
       cy.dialogTitle('New Contact Method')
       cy.dialogContains('new disclaimer')
     })
 
-    countryCodeCheck('India', '+91', '1234567890', '+91 1234 567 890')
-    countryCodeCheck('UK', '+44', '7911123456', '+44 7911 123456')
+    countryCodeCheck(screen, 'India', '+91', '1234567890', '+91 1234 567 890')
+    countryCodeCheck(screen, 'UK', '+44', '7911123456', '+44 7911 123456')
 
     it('should not allow fake country codes', () => {
       const value = '810' + c.integer({ min: 3000000, max: 3999999 })
       const name = 'CM SM ' + c.word({ length: 8 })
       const type = c.pickone(['SMS', 'VOICE'])
 
-      cy.pageFab('Contact')
+      if (screen === 'mobile') {
+        cy.pageFab('Add Contact Method')
+      } else {
+        cy.get('button[aria-label="Add contact method"]').click()
+      }
+
       cy.dialogTitle('New Contact Method')
       cy.dialogForm({
         name,
@@ -364,7 +403,12 @@ function testProfile(): void {
       cy.dialogTitle('Are you sure?')
       cy.dialogFinish('Confirm')
 
-      cy.pageFab('Notification')
+      if (screen === 'mobile') {
+        cy.pageFab('Add Notification Rule')
+      } else {
+        cy.get('button[aria-label="Add notification rule"]').click()
+      }
+
       cy.dialogTitle('New Notification Rule')
       cy.dialogForm({ contactMethodID: cm.name })
       cy.dialogFinish('Submit')
@@ -390,7 +434,13 @@ function testProfile(): void {
 
       // create new rule
       const delay = c.integer({ min: 2, max: 15 })
-      cy.pageFab('Notification')
+
+      if (screen === 'mobile') {
+        cy.pageFab('Add Notification Rule')
+      } else {
+        cy.get('button[aria-label="Add notification rule"]').click()
+      }
+
       cy.dialogTitle('New Notification Rule')
       cy.dialogForm({
         contactMethodID: cm.name,

--- a/web/src/cypress/integration/profile.ts
+++ b/web/src/cypress/integration/profile.ts
@@ -60,15 +60,13 @@ function testProfile(screen: ScreenFormat): void {
     return cy
       .createService({ name })
       .then((svc: Service) => {
-        return (
-          cy
-            .createEPStep({
-              epID: svc.epID,
-              targets: [{ type: 'user', id: profile.id }],
-            })
-            // .engineTrigger()
-            .then(() => svc.id)
-        )
+        return cy
+          .createEPStep({
+            epID: svc.epID,
+            targets: [{ type: 'user', id: profile.id }],
+          })
+          .engineTrigger()
+          .then(() => svc.id)
       })
       .then((svcID: string) => {
         cy.get('body').contains('a', 'On-Call').click()


### PR DESCRIPTION
Part of #2693

Makes the create buttons for the profile page more visible when the browser width is large. On mobile, the two add buttons will remain as a FAB button in the bottom right.

Also updates the secondary action IconButton to be `color='secondary'` for `OtherActions`, and cleans up passing a prop through a couple components that can be pulled from an existing hook call.

Dark mode example

![Screen Shot 2022-11-29 at 12 19 17 PM](https://user-images.githubusercontent.com/11381794/204652958-86257e49-82b4-4fc8-8e1d-b2c1bdabd8f8.png)

Light mode example w/ notification rule add disabled when no contact methods are present

![Screen Shot 2022-11-29 at 1 33 39 PM](https://user-images.githubusercontent.com/11381794/204653008-2e9374e5-5ee0-4844-a65c-fa41bbef5384.png)
