### PR TITLE
fixed escalation policy update description

### DIFF
--- a/web/src/app/escalation-policies/PolicyEditDialog.tsx
+++ b/web/src/app/escalation-policies/PolicyEditDialog.tsx
@@ -59,7 +59,7 @@ function PolicyEditDialog(props: {
             input: {
               id: props.escalationPolicyID,
               name: value?.name || defaultValue.name,
-              description: value?.description || defaultValue.description,
+              description: value?.description,
               repeat: value?.repeat?.value ?? defaultValue.repeat.value,
             },
           },


### PR DESCRIPTION
**Description:**
While editing the description of the escalation policy with empty value, the empty value is getting updated with the last stored value and it never gets emptied though it is an optional field. Updating to other values is working as expected.
**Solution:**
In the current version, there is a default value assigned to description of the escalation policy when its empty. Solution is to remove the default value in the Escalation Policy Edit component (UI)
**Which issue(s) this PR fixes:**
Fixes #2716 



