### PR TITLE
add escalation policy created via service to favourites

### DIFF
--- a/web/src/app/services/ServiceCreateDialog.tsx
+++ b/web/src/app/services/ServiceCreateDialog.tsx
@@ -15,6 +15,7 @@ interface InputVar {
   newEscalationPolicy?: {
     name: string
     description: string
+    favorite: boolean
     steps: { delayMinutes: number; targets: { type: string; id: string }[] }[]
   }
 }
@@ -44,6 +45,7 @@ function inputVars(
     vars.newEscalationPolicy = {
       name: attempt ? `${name} Policy ${attempt}` : name + ' Policy',
       description: 'Auto-generated policy for ' + name,
+      favorite: true,
       steps: [
         {
           delayMinutes: 5,


### PR DESCRIPTION
**Description:**
Escalation policy auto-created while creating a new Service is not added to favourites

**Solution:**
Added favorite field(set it to true) while creating new EscalationPolicy

**Which issue(s) this PR fixes:**
Fixes #2724 
