### PR TITLE
ui: add desktop service create buttons

### DIFF
--- a/web/src/app/lists/FlatList.tsx
+++ b/web/src/app/lists/FlatList.tsx
@@ -36,6 +36,7 @@ import classnames from 'classnames'
 import { Notice, toSeverity } from '../details/Notices'
 import FlatListItem from './FlatListItem'
 import { DraggableListItem, getAnnouncements } from './DraggableListItem'
+import { useIsWidthDown } from '../util/useWidth'
 
 const useStyles = makeStyles({
   alert: {
@@ -52,9 +53,6 @@ const useStyles = makeStyles({
     borderRadius: 4,
   },
   background: { backgroundColor: 'transparent' },
-  listItemText: {
-    fontStyle: 'italic',
-  },
   slideEnter: {
     maxHeight: '0px',
     opacity: 0,
@@ -160,6 +158,7 @@ export default function FlatList({
     setDndItems(items.map((i, idx) => (i.id ? i.id : idx.toString())))
   }, [items])
 
+  const isMobile = useIsWidthDown('md')
   const [dragging, setDragging] = useState(false)
   const [draggable, setDraggable] = useState(false)
   const isFirstAnnouncement = useRef(false)
@@ -345,12 +344,15 @@ export default function FlatList({
     return (
       <List {...listProps} sx={sx}>
         {(headerNote || headerAction || onReorder) && (
-          <MUIListItem>
+          <MUIListItem sx={{ width: isMobile ? '100%' : '60%' }}>
             {toggleDnD && (
               <IconButton
                 onClick={() => setDraggable(!draggable)}
                 disabled={draggable && dragging}
-                sx={{ marginRight: (t) => t.spacing(2) }}
+                sx={{
+                  marginRight: (t) => t.spacing(2),
+                  textOverflow: 'wrap',
+                }}
                 aria-label='Toggle Drag and Drop'
               >
                 {draggable ? <DoneIcon /> : <EditIcon />}
@@ -362,10 +364,9 @@ export default function FlatList({
                 secondary={
                   <Typography color='textSecondary'>{headerNote}</Typography>
                 }
-                className={classes.listItemText}
+                sx={{ fontStyle: 'italic' }}
               />
             )}
-            <div style={{ flex: 1 }} />
             {headerAction && (
               <ListItemSecondaryAction>{headerAction}</ListItemSecondaryAction>
             )}

--- a/web/src/app/lists/FlatList.tsx
+++ b/web/src/app/lists/FlatList.tsx
@@ -9,7 +9,6 @@ import ButtonBase from '@mui/material/ButtonBase'
 import IconButton from '@mui/material/IconButton'
 import List, { ListProps } from '@mui/material/List'
 import MUIListItem from '@mui/material/ListItem'
-import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction'
 import ListItemText from '@mui/material/ListItemText'
 import Typography from '@mui/material/Typography'
 import ListSubheader from '@mui/material/ListSubheader'
@@ -36,7 +35,6 @@ import classnames from 'classnames'
 import { Notice, toSeverity } from '../details/Notices'
 import FlatListItem from './FlatListItem'
 import { DraggableListItem, getAnnouncements } from './DraggableListItem'
-import { useIsWidthDown } from '../util/useWidth'
 
 const useStyles = makeStyles({
   alert: {
@@ -158,7 +156,6 @@ export default function FlatList({
     setDndItems(items.map((i, idx) => (i.id ? i.id : idx.toString())))
   }, [items])
 
-  const isMobile = useIsWidthDown('md')
   const [dragging, setDragging] = useState(false)
   const [draggable, setDraggable] = useState(false)
   const isFirstAnnouncement = useRef(false)
@@ -344,7 +341,7 @@ export default function FlatList({
     return (
       <List {...listProps} sx={sx}>
         {(headerNote || headerAction || onReorder) && (
-          <MUIListItem sx={{ width: isMobile ? '100%' : '60%' }}>
+          <MUIListItem>
             {toggleDnD && (
               <IconButton
                 onClick={() => setDraggable(!draggable)}
@@ -364,12 +361,10 @@ export default function FlatList({
                 secondary={
                   <Typography color='textSecondary'>{headerNote}</Typography>
                 }
-                sx={{ fontStyle: 'italic' }}
+                sx={{ fontStyle: 'italic', pr: 2 }}
               />
             )}
-            {headerAction && (
-              <ListItemSecondaryAction>{headerAction}</ListItemSecondaryAction>
-            )}
+            {headerAction && <div>{headerAction}</div>}
           </MUIListItem>
         )}
         {!items.length && renderEmptyMessage()}

--- a/web/src/app/services/HeartbeatMonitorList.tsx
+++ b/web/src/app/services/HeartbeatMonitorList.tsx
@@ -1,5 +1,6 @@
 import React, { useState, ReactElement } from 'react'
 import { useQuery, gql } from 'urql'
+import Button from '@mui/material/Button'
 import Grid from '@mui/material/Grid'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
@@ -15,6 +16,8 @@ import CopyText from '../util/CopyText'
 import Spinner from '../loading/components/Spinner'
 import { GenericError } from '../error-pages'
 import { HeartbeatMonitor } from '../../schema'
+import { useIsWidthDown } from '../util/useWidth'
+import { Add } from '@mui/icons-material'
 
 // generates a single alert if a POST is not received before the timeout
 const HEARTBEAT_MONITOR_DESCRIPTION =
@@ -59,6 +62,7 @@ export default function HeartbeatMonitorList(props: {
   serviceID: string
 }): JSX.Element {
   const classes = useStyles()
+  const isMobile = useIsWidthDown('md')
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [showEditDialogByID, setShowEditDialogByID] = useState<string | null>(
     null,
@@ -118,6 +122,17 @@ export default function HeartbeatMonitorList(props: {
         emptyMessage='No heartbeat monitors exist for this service.'
         headerNote={HEARTBEAT_MONITOR_DESCRIPTION}
         items={items}
+        headerAction={
+          isMobile ? undefined : (
+            <Button
+              variant='contained'
+              onClick={() => setShowCreateDialog(true)}
+              startIcon={<Add />}
+            >
+              Create Heartbeat Monitor
+            </Button>
+          )
+        }
       />
     )
   }
@@ -131,10 +146,12 @@ export default function HeartbeatMonitorList(props: {
           </CardContent>
         </Card>
       </Grid>
-      <CreateFAB
-        onClick={() => setShowCreateDialog(true)}
-        title='Create Heartbeat Monitor'
-      />
+      {isMobile && (
+        <CreateFAB
+          onClick={() => setShowCreateDialog(true)}
+          title='Create Heartbeat Monitor'
+        />
+      )}
       {showCreateDialog && (
         <HeartbeatMonitorCreateDialog
           serviceID={props.serviceID}

--- a/web/src/app/services/IntegrationKeyList.tsx
+++ b/web/src/app/services/IntegrationKeyList.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode, useState } from 'react'
 import { gql, useQuery } from 'urql'
+import Button from '@mui/material/Button'
 import Grid from '@mui/material/Grid'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
@@ -12,7 +13,8 @@ import IntegrationKeyDeleteDialog from './IntegrationKeyDeleteDialog'
 import RequireConfig from '../util/RequireConfig'
 import CopyText from '../util/CopyText'
 import AppLink from '../util/AppLink'
-
+import { useIsWidthDown } from '../util/useWidth'
+import { Add } from '@mui/icons-material'
 import makeStyles from '@mui/styles/makeStyles'
 import Spinner from '../loading/components/Spinner'
 import { GenericError } from '../error-pages'
@@ -90,7 +92,7 @@ export default function IntegrationKeyList(props: {
   serviceID: string
 }): JSX.Element {
   const classes = useStyles()
-
+  const isMobile = useIsWidthDown('md')
   const [create, setCreate] = useState<boolean>(false)
   const [deleteDialog, setDeleteDialog] = useState<string | null>(null)
 
@@ -149,14 +151,28 @@ export default function IntegrationKeyList(props: {
               }
               emptyMessage='No integration keys exist for this service.'
               items={items}
+              headerAction={
+                isMobile ? undefined : (
+                  <Button
+                    variant='contained'
+                    onClick={(): void => setCreate(true)}
+                    startIcon={<Add />}
+                  >
+                    Create Integration Key
+                  </Button>
+                )
+              }
             />
           </CardContent>
         </Card>
       </Grid>
-      <CreateFAB
-        onClick={(): void => setCreate(true)}
-        title='Create Integration Key'
-      />
+      {isMobile && (
+        <CreateFAB
+          onClick={(): void => setCreate(true)}
+          title='Create Integration Key'
+        />
+      )}
+
       {create && (
         <IntegrationKeyCreateDialog
           serviceID={props.serviceID}

--- a/web/src/app/services/ServiceLabelList.tsx
+++ b/web/src/app/services/ServiceLabelList.tsx
@@ -85,7 +85,7 @@ export default function ServiceLabelList(props: {
         data-cy='label-list'
         emptyMessage='No labels exist for this service.'
         items={items}
-        headerNote='Labels are a way associate services with each other throughout GoAlert. Search using the format key1/key2=value'
+        headerNote='Labels are a way to associate services with each other throughout GoAlert. Search using the format key1/key2=value'
         headerAction={
           isMobile ? undefined : (
             <Button

--- a/web/src/app/services/ServiceLabelList.tsx
+++ b/web/src/app/services/ServiceLabelList.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, useState } from 'react'
+import Button from '@mui/material/Button'
 import Grid from '@mui/material/Grid'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
@@ -13,6 +14,8 @@ import ServiceLabelEditDialog from './ServiceLabelEditDialog'
 import ServiceLabelDeleteDialog from './ServiceLabelDeleteDialog'
 import { Label } from '../../schema'
 import Spinner from '../loading/components/Spinner'
+import { useIsWidthDown } from '../util/useWidth'
+import { Add } from '@mui/icons-material'
 
 const query = gql`
   query ($serviceID: ID!) {
@@ -42,6 +45,7 @@ export default function ServiceLabelList(props: {
   const [create, setCreate] = useState(false)
   const [editKey, setEditKey] = useState<string | null>(null)
   const [deleteKey, setDeleteKey] = useState<string | null>(null)
+  const isMobile = useIsWidthDown('md')
   const classes = useStyles()
 
   const [{ data, fetching }] = useQuery({
@@ -81,6 +85,18 @@ export default function ServiceLabelList(props: {
         data-cy='label-list'
         emptyMessage='No labels exist for this service.'
         items={items}
+        headerNote='Labels are a way associate services with each other throughout GoAlert. Search using the format key1/key2=value'
+        headerAction={
+          isMobile ? undefined : (
+            <Button
+              variant='contained'
+              onClick={() => setCreate(true)}
+              startIcon={<Add />}
+            >
+              Create Label
+            </Button>
+          )
+        }
       />
     )
   }
@@ -92,7 +108,9 @@ export default function ServiceLabelList(props: {
           <CardContent>{renderList(data.service.labels)}</CardContent>
         </Card>
       </Grid>
-      <CreateFAB onClick={() => setCreate(true)} title='Add Label' />
+      {isMobile && (
+        <CreateFAB onClick={() => setCreate(true)} title='Add Label' />
+      )}
       {create && (
         <ServiceLabelSetDialog
           serviceID={props.serviceID}


### PR DESCRIPTION
Part of #2715

Adds create buttons when on wide browser width for:
- Heartbeat monitors
- Labels
- Integration Keys

Also adds a header note for the service labels list