### PR TITLE
ui: some small fixes

### DIFF
--- a/web/src/app/alerts/components/AlertsListFilter.tsx
+++ b/web/src/app/alerts/components/AlertsListFilter.tsx
@@ -63,8 +63,6 @@ function AlertsListFilter(props: AlertsListFilterProps): JSX.Element {
     isMobile ? classes.drawer : classes.popover,
   )
 
-  console.log('is mobile: ', isMobile)
-
   function handleOpenFilters(event: MouseEvent<HTMLButtonElement>): void {
     setAnchorEl(event.currentTarget)
     setShow(true)

--- a/web/src/app/alerts/components/AlertsListFilter.tsx
+++ b/web/src/app/alerts/components/AlertsListFilter.tsx
@@ -16,7 +16,7 @@ import FormControlLabel from '@mui/material/FormControlLabel'
 import FormControl from '@mui/material/FormControl'
 import classnames from 'classnames'
 import { useURLParam, useResetURLParams } from '../../actions'
-import { useIsWidthUp } from '../../util/useWidth'
+import { useIsWidthDown } from '../../util/useWidth'
 
 const useStyles = makeStyles((theme: Theme) => ({
   filterActions: globalStyles(theme).filterActions,
@@ -57,10 +57,13 @@ function AlertsListFilter(props: AlertsListFilterProps): JSX.Element {
     false,
   )
   const resetAll = useResetURLParams('filter', 'allServices', 'fullTime') // don't reset search param
+  const isMobile = useIsWidthDown('md')
+  const gridClasses = classnames(
+    classes.grid,
+    isMobile ? classes.drawer : classes.popover,
+  )
 
-  // grabs class for width depending on breakpoints (md or higher uses popover width)
-  const widthClass = useIsWidthUp('md') ? classes.popover : classes.drawer
-  const gridClasses = classnames(classes.grid, widthClass)
+  console.log('is mobile: ', isMobile)
 
   function handleOpenFilters(event: MouseEvent<HTMLButtonElement>): void {
     setAnchorEl(event.currentTarget)
@@ -105,34 +108,36 @@ function AlertsListFilter(props: AlertsListFilterProps): JSX.Element {
               }
               label='Show full timestamps'
             />
-            <RadioGroup
-              aria-label='Alert Status Filters'
-              name='status-filters'
-              value={filter}
-              onChange={(e) => setFilter(e.target.value)}
-            >
-              <FormControlLabel
-                value='active'
-                control={<Radio />}
-                label='Active'
-              />
-              <FormControlLabel
-                value='unacknowledged'
-                control={<Radio />}
-                label='Unacknowledged'
-              />
-              <FormControlLabel
-                value='acknowledged'
-                control={<Radio />}
-                label='Acknowledged'
-              />
-              <FormControlLabel
-                value='closed'
-                control={<Radio />}
-                label='Closed'
-              />
-              <FormControlLabel value='all' control={<Radio />} label='All' />
-            </RadioGroup>
+            {isMobile && (
+              <RadioGroup
+                aria-label='Alert Status Filters'
+                name='status-filters'
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+              >
+                <FormControlLabel
+                  value='active'
+                  control={<Radio />}
+                  label='Active'
+                />
+                <FormControlLabel
+                  value='unacknowledged'
+                  control={<Radio />}
+                  label='Unacknowledged'
+                />
+                <FormControlLabel
+                  value='acknowledged'
+                  control={<Radio />}
+                  label='Acknowledged'
+                />
+                <FormControlLabel
+                  value='closed'
+                  control={<Radio />}
+                  label='Closed'
+                />
+                <FormControlLabel value='all' control={<Radio />} label='All' />
+              </RadioGroup>
+            )}
           </FormControl>
         </Grid>
         <Grid item xs={12} className={classes.filterActions}>

--- a/web/src/app/lists/ControlledPaginatedList.tsx
+++ b/web/src/app/lists/ControlledPaginatedList.tsx
@@ -152,7 +152,6 @@ export default function ControlledPaginatedList(
         className={classes.actionsContainer}
         item
         container
-        spacing={2}
       >
         <Grid item>
           <Checkbox

--- a/web/src/app/lists/ControlledPaginatedList.tsx
+++ b/web/src/app/lists/ControlledPaginatedList.tsx
@@ -164,6 +164,7 @@ export default function ControlledPaginatedList(
               checkedItems.length > 0 && itemIDs.length !== checkedItems.length
             }
             onChange={handleToggleSelectAll}
+            disabled={items.length === 0}
           />
         </Grid>
 
@@ -174,6 +175,7 @@ export default function ControlledPaginatedList(
         >
           <OtherActions
             IconComponent={ArrowDropDown}
+            disabled={items.length === 0}
             actions={[
               {
                 label: 'All',

--- a/web/src/app/main/AppRoutes.tsx
+++ b/web/src/app/main/AppRoutes.tsx
@@ -71,6 +71,7 @@ const alertQuery = gql`
 // Allow any component to be used as a route.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const routes: Record<string, JSXElementConstructor<any>> = {
+  '/': AlertsList,
   '/alerts': AlertsList,
   '/alerts/:alertID': AlertDetailPage,
 

--- a/web/src/app/main/NavBar.tsx
+++ b/web/src/app/main/NavBar.tsx
@@ -49,13 +49,13 @@ export default function NavBar(): JSX.Element {
 
   return (
     <React.Fragment>
-      <div aria-hidden className={classes.logoDiv}>
+      <a href='/' aria-hidden className={classes.logoDiv}>
         <img
           height={38}
           src={theme.palette.mode === 'dark' ? darkModeLogo : logo}
           alt='GoAlert Logo'
         />
-      </div>
+      </a>
       <Divider />
       <nav>
         <List role='navigation' className={classes.list} data-cy='nav-list'>

--- a/web/src/app/util/OtherActions.js
+++ b/web/src/app/util/OtherActions.js
@@ -20,6 +20,7 @@ export default function OtherActions({
   IconComponent,
   actions,
   placement,
+  disabled,
 }) {
   const [anchorEl, setAnchorEl] = useState(null)
   const onClose = cancelable(() => setAnchorEl(null))
@@ -32,6 +33,7 @@ export default function OtherActions({
         data-cy='other-actions'
         aria-expanded={Boolean(anchorEl)}
         color='secondary'
+        disabled={disabled}
         onClick={(e) => {
           onClose.cancel()
           setAnchorEl(e.currentTarget)
@@ -67,6 +69,7 @@ OtherActions.propTypes = {
       onClick: p.func.isRequired,
     }),
   ).isRequired,
+  disabled: p.boolean,
   color: p.string,
   IconComponent: p.elementType,
   placement: p.oneOf(['left', 'right']),

--- a/web/src/app/util/OtherActions.js
+++ b/web/src/app/util/OtherActions.js
@@ -69,7 +69,7 @@ OtherActions.propTypes = {
       onClick: p.func.isRequired,
     }),
   ).isRequired,
-  disabled: p.boolean,
+  disabled: p.bool,
   color: p.string,
   IconComponent: p.elementType,
   placement: p.oneOf(['left', 'right']),


### PR DESCRIPTION
From the [design discussion here](https://github.com/target/goalert/discussions/2489#discussioncomment-4210469):

- Reduces spacing on alerts checkbox controls between the box and the dropdown arrow
- Disables the checkbox controls if no items/no items in the list are being rendered
- Hides the alert tab filters from the dropdown menu when viewing on a wide screen browser (tabs are already present)
- Clicking the GoAlert logo in the top left will route you to the homepage ('/alerts')