### PR TITLE
ui: Fix default time not being set correctly for new schedule assignments

### DIFF
--- a/web/src/app/schedules/ScheduleRuleCreateDialog.js
+++ b/web/src/app/schedules/ScheduleRuleCreateDialog.js
@@ -34,10 +34,10 @@ export default function ScheduleRuleCreateDialog(props) {
     targetID: '',
     rules: [
       {
-        start: DateTime.local({ zone: data?.schedule.timeZone ?? 'UTC' })
+        start: DateTime.local({ zone: data.schedule.timeZone })
           .startOf('day')
           .toISO(),
-        end: DateTime.local({ zone: data?.schedule.timeZone ?? 'UTC' })
+        end: DateTime.local({ zone: data.schedule.timeZone })
           .plus({ day: 1 })
           .startOf('day')
           .toISO(),

--- a/web/src/app/schedules/ScheduleRuleCreateDialog.js
+++ b/web/src/app/schedules/ScheduleRuleCreateDialog.js
@@ -25,20 +25,27 @@ const query = gql`
 
 export default function ScheduleRuleCreateDialog(props) {
   const { scheduleID, targetType, onClose } = props
+
+  const { data, ...queryStatus } = useQuery(query, {
+    variables: { id: scheduleID },
+  })
+
   const [value, setValue] = useState({
     targetID: '',
     rules: [
       {
-        start: DateTime.local().startOf('day').toUTC().toISO(),
-        end: DateTime.local().plus({ day: 1 }).startOf('day').toUTC().toISO(),
+        start: DateTime.local({ zone: data?.schedule.timeZone ?? 'UTC' })
+          .startOf('day')
+          .toISO(),
+        end: DateTime.local({ zone: data?.schedule.timeZone ?? 'UTC' })
+          .plus({ day: 1 })
+          .startOf('day')
+          .toISO(),
         weekdayFilter: [true, true, true, true, true, true, true],
       },
     ],
   })
 
-  const { data, ...queryStatus } = useQuery(query, {
-    variables: { id: scheduleID },
-  })
   const [mutate, mutationStatus] = useMutation(mutation, {
     onCompleted: onClose,
     variables: {


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Fixed an issue with the ScheduleRuleCreateDialog where it was using the users timezone for the default start and end times rather than the schedules timezone.

**Which issue(s) this PR fixes:**
Fixes #2736 