### PR TITLE
admin/message-log: reflect sent time in sort order

### DIFF
--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -182,6 +182,8 @@ type ComplexityRoot struct {
 		Destination func(childComplexity int) int
 		ID          func(childComplexity int) int
 		ProviderID  func(childComplexity int) int
+		RetryCount  func(childComplexity int) int
+		SentAt      func(childComplexity int) int
 		ServiceID   func(childComplexity int) int
 		ServiceName func(childComplexity int) int
 		Source      func(childComplexity int) int
@@ -1212,6 +1214,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.DebugMessage.ProviderID(childComplexity), true
+
+	case "DebugMessage.retryCount":
+		if e.complexity.DebugMessage.RetryCount == nil {
+			break
+		}
+
+		return e.complexity.DebugMessage.RetryCount(childComplexity), true
+
+	case "DebugMessage.sentAt":
+		if e.complexity.DebugMessage.SentAt == nil {
+			break
+		}
+
+		return e.complexity.DebugMessage.SentAt(childComplexity), true
 
 	case "DebugMessage.serviceID":
 		if e.complexity.DebugMessage.ServiceID == nil {
@@ -7874,6 +7890,91 @@ func (ec *executionContext) fieldContext_DebugMessage_providerID(ctx context.Con
 	return fc, nil
 }
 
+func (ec *executionContext) _DebugMessage_sentAt(ctx context.Context, field graphql.CollectedField, obj *DebugMessage) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DebugMessage_sentAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SentAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOISOTimestamp2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DebugMessage_sentAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DebugMessage",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ISOTimestamp does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DebugMessage_retryCount(ctx context.Context, field graphql.CollectedField, obj *DebugMessage) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DebugMessage_retryCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RetryCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DebugMessage_retryCount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DebugMessage",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _DebugMessageStatusInfo_state(ctx context.Context, field graphql.CollectedField, obj *DebugMessageStatusInfo) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_DebugMessageStatusInfo_state(ctx, field)
 	if err != nil {
@@ -9803,6 +9904,10 @@ func (ec *executionContext) fieldContext_MessageLogConnection_nodes(ctx context.
 				return ec.fieldContext_DebugMessage_alertID(ctx, field)
 			case "providerID":
 				return ec.fieldContext_DebugMessage_providerID(ctx, field)
+			case "sentAt":
+				return ec.fieldContext_DebugMessage_sentAt(ctx, field)
+			case "retryCount":
+				return ec.fieldContext_DebugMessage_retryCount(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type DebugMessage", field.Name)
 		},
@@ -13822,6 +13927,10 @@ func (ec *executionContext) fieldContext_Query_debugMessages(ctx context.Context
 				return ec.fieldContext_DebugMessage_alertID(ctx, field)
 			case "providerID":
 				return ec.fieldContext_DebugMessage_providerID(ctx, field)
+			case "sentAt":
+				return ec.fieldContext_DebugMessage_sentAt(ctx, field)
+			case "retryCount":
+				return ec.fieldContext_DebugMessage_retryCount(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type DebugMessage", field.Name)
 		},
@@ -28902,6 +29011,17 @@ func (ec *executionContext) _DebugMessage(ctx context.Context, sel ast.Selection
 
 			out.Values[i] = ec._DebugMessage_providerID(ctx, field, obj)
 
+		case "sentAt":
+
+			out.Values[i] = ec._DebugMessage_sentAt(ctx, field, obj)
+
+		case "retryCount":
+
+			out.Values[i] = ec._DebugMessage_retryCount(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql2/graphqlapp/messagelog.go
+++ b/graphql2/graphqlapp/messagelog.go
@@ -173,12 +173,13 @@ func (q *Query) MessageLogs(ctx context.Context, opts *graphql2.MessageLogSearch
 		}
 
 		dm := graphql2.DebugMessage{
-			ID:        log.ID,
-			CreatedAt: log.CreatedAt,
-			UpdatedAt: log.LastStatusAt,
-			Type:      strings.TrimPrefix(log.MessageType.String(), "MessageType"),
-			Status:    msgStatus(notification.Status{State: log.LastStatus, Details: log.StatusDetails}),
-			AlertID:   &log.AlertID,
+			ID:         log.ID,
+			CreatedAt:  log.CreatedAt,
+			UpdatedAt:  log.LastStatusAt,
+			Type:       strings.TrimPrefix(log.MessageType.String(), "MessageType"),
+			Status:     msgStatus(notification.Status{State: log.LastStatus, Details: log.StatusDetails}),
+			AlertID:    &log.AlertID,
+			RetryCount: log.RetryCount,
 		}
 		if dest.ID != "" {
 			dm.Destination, err = q.formatDest(ctx, dest)
@@ -210,6 +211,9 @@ func (q *Query) MessageLogs(ctx context.Context, opts *graphql2.MessageLogSearch
 		}
 		if log.ProviderMsgID != nil {
 			dm.ProviderID = &log.ProviderMsgID.ExternalID
+		}
+		if log.SentAt != nil {
+			dm.SentAt = log.SentAt
 		}
 
 		conn.Nodes = append(conn.Nodes, dm)

--- a/graphql2/graphqlapp/messagelog.go
+++ b/graphql2/graphqlapp/messagelog.go
@@ -180,6 +180,7 @@ func (q *Query) MessageLogs(ctx context.Context, opts *graphql2.MessageLogSearch
 			Status:     msgStatus(notification.Status{State: log.LastStatus, Details: log.StatusDetails}),
 			AlertID:    &log.AlertID,
 			RetryCount: log.RetryCount,
+			SentAt:     log.SentAt,
 		}
 		if dest.ID != "" {
 			dm.Destination, err = q.formatDest(ctx, dest)
@@ -211,9 +212,6 @@ func (q *Query) MessageLogs(ctx context.Context, opts *graphql2.MessageLogSearch
 		}
 		if log.ProviderMsgID != nil {
 			dm.ProviderID = &log.ProviderMsgID.ExternalID
-		}
-		if log.SentAt != nil {
-			dm.SentAt = log.SentAt
 		}
 
 		conn.Nodes = append(conn.Nodes, dm)

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -218,19 +218,21 @@ type DebugCarrierInfoInput struct {
 }
 
 type DebugMessage struct {
-	ID          string    `json:"id"`
-	CreatedAt   time.Time `json:"createdAt"`
-	UpdatedAt   time.Time `json:"updatedAt"`
-	Type        string    `json:"type"`
-	Status      string    `json:"status"`
-	UserID      *string   `json:"userID"`
-	UserName    *string   `json:"userName"`
-	Source      *string   `json:"source"`
-	Destination string    `json:"destination"`
-	ServiceID   *string   `json:"serviceID"`
-	ServiceName *string   `json:"serviceName"`
-	AlertID     *int      `json:"alertID"`
-	ProviderID  *string   `json:"providerID"`
+	ID          string     `json:"id"`
+	CreatedAt   time.Time  `json:"createdAt"`
+	UpdatedAt   time.Time  `json:"updatedAt"`
+	Type        string     `json:"type"`
+	Status      string     `json:"status"`
+	UserID      *string    `json:"userID"`
+	UserName    *string    `json:"userName"`
+	Source      *string    `json:"source"`
+	Destination string     `json:"destination"`
+	ServiceID   *string    `json:"serviceID"`
+	ServiceName *string    `json:"serviceName"`
+	AlertID     *int       `json:"alertID"`
+	ProviderID  *string    `json:"providerID"`
+	SentAt      *time.Time `json:"sentAt"`
+	RetryCount  int        `json:"retryCount"`
 }
 
 type DebugMessageStatusInfo struct {

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -200,6 +200,8 @@ type DebugMessage {
   serviceName: String
   alertID: Int
   providerID: ID
+  sentAt: ISOTimestamp
+  retryCount: Int!
 }
 
 input MessageLogSearchOptions {
@@ -290,7 +292,6 @@ input UserOverrideSearchOptions {
   start: ISOTimestamp # start of the window to search for.
   end: ISOTimestamp # end of the window to search for.
 }
-
 
 type UserOverrideConnection {
   nodes: [UserOverride!]!

--- a/notification/search.go
+++ b/notification/search.go
@@ -102,7 +102,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		OR (om.created_at = :cursorCreatedAt AND om.id > :afterID)
 	{{end}}
 		AND om.last_status != 'bundled'
-	ORDER BY (CASE WHEN om.sent_at IS NULL THEN 1 ELSE 0 END) desc, om.created_at desc, om.id asc
+	ORDER BY om.last_status = 'pending' desc, coalesce(om.sent_at, om.last_status_at) desc, om.created_at desc, om.id asc
 	LIMIT {{.Limit}}
 `))
 

--- a/notification/search.go
+++ b/notification/search.go
@@ -66,7 +66,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		om.id, om.created_at, om.last_status_at, om.message_type, om.last_status, om.status_details,
 		om.src_value, om.alert_id, om.provider_msg_id,
 		om.user_id, u.name, om.contact_method_id, om.channel_id, om.service_id, s.name,
-    om.sent_at, om.retry_count
+		om.sent_at, om.retry_count
 	FROM outgoing_messages om
 	LEFT JOIN users u ON om.user_id = u.id
 	LEFT JOIN services s ON om.service_id = s.id
@@ -102,7 +102,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		OR (om.created_at = :cursorCreatedAt AND om.id > :afterID)
 	{{end}}
 		AND om.last_status != 'bundled'
-  ORDER BY (CASE WHEN om.sent_at IS NULL THEN 1 ELSE 0 END) desc, om.created_at desc, om.id asc
+	ORDER BY (CASE WHEN om.sent_at IS NULL THEN 1 ELSE 0 END) desc, om.created_at desc, om.id asc
 	LIMIT {{.Limit}}
 `))
 

--- a/test/smoke/graphqladminmessagelogs_test.go
+++ b/test/smoke/graphqladminmessagelogs_test.go
@@ -24,7 +24,7 @@ func TestGraphQLAdminMessageLogs(t *testing.T) {
 			({{uuid "om1"}}, 'test_notification', '2022-01-01 00:01:00', '2022-01-01 00:01:01', {{uuid "cm1"}}, 'delivered', {{uuid "user"}}),
 			({{uuid "om2"}}, 'test_notification', '2022-01-01 00:02:00', '2022-01-01 00:01:02', {{uuid "cm1"}}, 'delivered', {{uuid "user"}}),
 			({{uuid "om3"}}, 'test_notification', '2022-01-01 00:03:00', null, {{uuid "cm1"}}, 'failed', {{uuid "user"}}),
-			({{uuid "om4"}}, 'test_notification', '2022-01-01 00:05:00', '2022-01-01 00:01:05', {{uuid "cm1"}}, 'delivered', {{uuid "user"}}),
+			({{uuid "om4"}}, 'test_notification', '2022-01-01 00:05:00', null, {{uuid "cm1"}}, 'pending', {{uuid "user"}}),
 			({{uuid "om5"}}, 'test_notification', '2022-01-01 00:04:00', '2022-01-01 00:01:04', {{uuid "cm1"}}, 'delivered', {{uuid "user"}});
 	`
 
@@ -70,8 +70,8 @@ func TestGraphQLAdminMessageLogs(t *testing.T) {
 	// tests that the message logs are returned in the correct order
 	// of not sent then most recent to least recent
 	assert.Len(t, logs.MessageLogs.Nodes, 5, "messageLogs query")
-	assert.Equal(t, h.UUID("om3"), logs.MessageLogs.Nodes[0].ID)
-	assert.Equal(t, h.UUID("om4"), logs.MessageLogs.Nodes[1].ID)
+	assert.Equal(t, h.UUID("om4"), logs.MessageLogs.Nodes[0].ID)
+	assert.Equal(t, h.UUID("om3"), logs.MessageLogs.Nodes[1].ID)
 	assert.Equal(t, h.UUID("om5"), logs.MessageLogs.Nodes[2].ID)
 	assert.Equal(t, h.UUID("om2"), logs.MessageLogs.Nodes[3].ID)
 	assert.Equal(t, h.UUID("om1"), logs.MessageLogs.Nodes[4].ID)

--- a/test/smoke/graphqladminmessagelogs_test.go
+++ b/test/smoke/graphqladminmessagelogs_test.go
@@ -1,0 +1,79 @@
+package smoke
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/target/goalert/test/smoke/harness"
+)
+
+// TestGraphQLAdminMessageLogs tests that logs are properly generated for messages.
+func TestGraphQLAdminMessageLogs(t *testing.T) {
+	t.Parallel()
+
+	const sql = `
+		insert into users (id, name, email) 
+		values 
+			({{uuid "user"}}, 'bob', 'joe');
+		insert into user_contact_methods (id, user_id, name, type, value, disabled) 
+		values
+			({{uuid "cm1"}}, {{uuid "user"}}, 'personal', 'SMS', {{phone "1"}}, true);
+		insert into outgoing_messages (id, message_type, created_at, sent_at, contact_method_id, last_status, user_id)
+		values
+			({{uuid "om1"}}, 'test_notification', '2022-01-01 00:01:00', '2022-01-01 00:01:01', {{uuid "cm1"}}, 'delivered', {{uuid "user"}}),
+			({{uuid "om2"}}, 'test_notification', '2022-01-01 00:02:00', '2022-01-01 00:01:02', {{uuid "cm1"}}, 'delivered', {{uuid "user"}}),
+			({{uuid "om3"}}, 'test_notification', '2022-01-01 00:03:00', null, {{uuid "cm1"}}, 'failed', {{uuid "user"}}),
+			({{uuid "om4"}}, 'test_notification', '2022-01-01 00:05:00', '2022-01-01 00:01:05', {{uuid "cm1"}}, 'delivered', {{uuid "user"}}),
+			({{uuid "om5"}}, 'test_notification', '2022-01-01 00:04:00', '2022-01-01 00:01:04', {{uuid "cm1"}}, 'delivered', {{uuid "user"}});
+	`
+
+	h := harness.NewHarness(t, sql, "switchover-mk2")
+	defer h.Close()
+
+	doQL := func(query string, res interface{}) {
+		g := h.GraphQLQuery2(query)
+		for _, err := range g.Errors {
+			t.Error("GraphQL Error:", err.Message)
+		}
+		if len(g.Errors) > 0 {
+			t.Fatal("errors returned from GraphQL")
+		}
+		t.Log("Response:", string(g.Data))
+		if res == nil {
+			return
+		}
+		err := json.Unmarshal(g.Data, &res)
+		if err != nil {
+			t.Fatal("failed to parse response:", err)
+		}
+	}
+
+	type messageLogs struct {
+		MessageLogs struct {
+			Nodes []struct {
+				ID string `json:"id"`
+			} `json:"nodes"`
+		} `json:"messageLogs"`
+	}
+
+	var logs messageLogs
+
+	doQL(`query {
+		messageLogs(input: {}) {
+			nodes {
+				id
+			}
+		}
+	}`, &logs)
+
+	// tests that the message logs are returned in the correct order
+	// of not sent then most recent to least recent
+	assert.Len(t, logs.MessageLogs.Nodes, 5, "messageLogs query")
+	assert.Equal(t, h.UUID("om3"), logs.MessageLogs.Nodes[0].ID)
+	assert.Equal(t, h.UUID("om4"), logs.MessageLogs.Nodes[1].ID)
+	assert.Equal(t, h.UUID("om5"), logs.MessageLogs.Nodes[2].ID)
+	assert.Equal(t, h.UUID("om2"), logs.MessageLogs.Nodes[3].ID)
+	assert.Equal(t, h.UUID("om1"), logs.MessageLogs.Nodes[4].ID)
+
+}

--- a/web/src/app/admin/admin-message-logs/AdminDebugMessagesLayout.tsx
+++ b/web/src/app/admin/admin-message-logs/AdminDebugMessagesLayout.tsx
@@ -28,6 +28,8 @@ const query = gql`
         serviceName
         alertID
         providerID
+        retryCount
+        sentAt
       }
       pageInfo {
         hasNextPage

--- a/web/src/app/admin/admin-message-logs/DebugMessageDetails.tsx
+++ b/web/src/app/admin/admin-message-logs/DebugMessageDetails.tsx
@@ -38,6 +38,12 @@ export default function DebugMessageDetails(props: Props): JSX.Element {
 
   const isOpen = Boolean(log)
 
+  const sentAtText = (): string => {
+    return log?.sentAt
+      ? DateTime.fromISO(log.sentAt).toFormat('fff')
+      : 'Not Sent'
+  }
+
   return (
     <ClickAwayListener onClickAway={onClose} mouseEvent='onMouseUp'>
       <Drawer
@@ -53,12 +59,12 @@ export default function DebugMessageDetails(props: Props): JSX.Element {
           </Typography>
           <Divider />
           <List disablePadding>
-            {log?.id && (
+            {!!log?.id && (
               <ListItem divider>
                 <ListItemText primary='ID' secondary={log.id} />
               </ListItem>
             )}
-            {log?.createdAt && (
+            {!!log?.createdAt && (
               <ListItem divider>
                 <ListItemText
                   primary='Created At'
@@ -66,7 +72,7 @@ export default function DebugMessageDetails(props: Props): JSX.Element {
                 />
               </ListItem>
             )}
-            {log?.updatedAt && (
+            {!!log?.updatedAt && (
               <ListItem divider>
                 <ListItemText
                   primary='Updated At'
@@ -74,7 +80,19 @@ export default function DebugMessageDetails(props: Props): JSX.Element {
                 />
               </ListItem>
             )}
-            {log?.type && (
+            <ListItem divider>
+              <ListItemText primary='Sent At' secondary={sentAtText()} />
+            </ListItem>
+            {!!log?.retryCount && (
+              <ListItem divider>
+                <ListItemText
+                  primary='Retry Count'
+                  secondary={log.retryCount}
+                />
+              </ListItem>
+            )}
+
+            {!!log?.type && (
               <ListItem divider>
                 <ListItemText
                   primary='Notification Type'
@@ -82,13 +100,13 @@ export default function DebugMessageDetails(props: Props): JSX.Element {
                 />
               </ListItem>
             )}
-            {log?.status && (
+            {!!log?.status && (
               <ListItem divider>
                 <ListItemText primary='Current Status' secondary={log.status} />
               </ListItem>
             )}
 
-            {log?.userID && log?.userName && (
+            {!!log?.userID && !!log?.userName && (
               <ListItem divider>
                 <ListItemText
                   primary='User'
@@ -109,7 +127,7 @@ export default function DebugMessageDetails(props: Props): JSX.Element {
                 />
               </ListItem>
             )}
-            {log?.serviceID && log?.serviceName && (
+            {!!log?.serviceID && !!log?.serviceName && (
               <ListItem divider>
                 <ListItemText
                   primary='Service'
@@ -130,7 +148,7 @@ export default function DebugMessageDetails(props: Props): JSX.Element {
                 />
               </ListItem>
             )}
-            {log?.alertID && (
+            {!!log?.alertID && (
               <ListItem divider>
                 <ListItemText
                   primary='Alert'
@@ -152,12 +170,12 @@ export default function DebugMessageDetails(props: Props): JSX.Element {
               </ListItem>
             )}
 
-            {log?.source && (
+            {!!log?.source && (
               <ListItem divider>
                 <ListItemText primary='Source' secondary={log.source} />
               </ListItem>
             )}
-            {log?.destination && (
+            {!!log?.destination && (
               <ListItem divider>
                 <ListItemText
                   primary='Destination'
@@ -165,7 +183,7 @@ export default function DebugMessageDetails(props: Props): JSX.Element {
                 />
               </ListItem>
             )}
-            {log?.providerID && (
+            {!!log?.providerID && (
               <ListItem divider>
                 <ListItemText
                   primary='Provider ID'

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -111,6 +111,8 @@ export interface DebugMessage {
   serviceName?: null | string
   alertID?: null | number
   providerID?: null | string
+  sentAt?: null | ISOTimestamp
+  retryCount: number
 }
 
 export interface MessageLogSearchOptions {


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
The admin message log will now display messages that have not yet been sent at the top of the list and then sort by the created time thereafter. 

**Which issue(s) this PR fixes:**
Fixes #2650 

**Describe any introduced user-facing changes:**
- The sorting of the admin message logs was affected as described in the description above.
- Added the sent at time to the message details
- Added the retry count to the message details, if greater than 0

**Describe any introduced API changes:**
Added `sentAt` and `retryCount` to the `DebugMessage` type.

**Additional Info:**
- Updated the sql query and model to retrieve the `sent_at` and `retry_count` values from the database
- Updated the sql query to sort messages first by any messages where `sent_at` is null and then `created_at`
- Added a new smoke test to validate the sorting is being applied properly
