### PR TITLE
ui/profile: use title instead of aria-label for icon buttons

### DIFF
--- a/test/integration/email-cm.spec.ts
+++ b/test/integration/email-cm.spec.ts
@@ -17,7 +17,7 @@ test('EMAIL contact method', async ({ page, browser, isMobile }) => {
     await page.click('[aria-label="Add Items"]')
     await page.click('[aria-label="Add Contact Method"]')
   } else {
-    await page.click('[aria-label="Add contact method"]')
+    await page.click('[title="Add contact method"]')
   }
 
   await page.fill('input[name=name]', name)

--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -162,7 +162,7 @@ export default function UserContactMethodList(
           action={
             !mobile ? (
               <IconButton
-                aria-label='Add contact method'
+                title='Add contact method'
                 onClick={() => setShowAddDialog(true)}
                 size='large'
               >

--- a/web/src/app/users/UserNotificationRuleList.tsx
+++ b/web/src/app/users/UserNotificationRuleList.tsx
@@ -61,7 +61,7 @@ export default function UserNotificationRuleList(props: {
             action={
               !mobile ? (
                 <IconButton
-                  aria-label='Add notification rule'
+                  title='Add notification rule'
                   onClick={() => setShowAddDialog(true)}
                   disabled={user.contactMethods.length === 0}
                   size='large'

--- a/web/src/cypress/e2e/profile.cy.ts
+++ b/web/src/cypress/e2e/profile.cy.ts
@@ -17,7 +17,7 @@ function countryCodeCheck(
     if (screen === 'mobile') {
       cy.pageFab('Add Contact Method')
     } else {
-      cy.get('button[aria-label="Add contact method"]').click()
+      cy.get('button[title="Add contact method"]').click()
     }
 
     cy.get('input[name=name]').type(name)
@@ -160,7 +160,7 @@ function testProfile(screen: ScreenFormat): void {
       if (screen === 'mobile') {
         cy.pageFab('Add Contact Method')
       } else {
-        cy.get('button[aria-label="Add contact method"]').click()
+        cy.get('button[title="Add contact method"]').click()
       }
 
       cy.dialogTitle('Create New Contact Method')
@@ -234,7 +234,7 @@ function testProfile(screen: ScreenFormat): void {
           if (screen === 'mobile') {
             cy.pageFab('Add Contact Method')
           } else {
-            cy.get('button[aria-label="Add contact method"]').click()
+            cy.get('button[title="Add contact method"]').click()
           }
 
           cy.dialogTitle('Create New Contact Method')
@@ -304,9 +304,7 @@ function testProfile(screen: ScreenFormat): void {
           )}] button[role=menuitem]`,
         ).should('be.disabled')
       } else {
-        cy.get('button[aria-label="Add notification rule"]').should(
-          'be.disabled',
-        )
+        cy.get('button[title="Add notification rule"]').should('be.disabled')
       }
     })
 
@@ -322,7 +320,7 @@ function testProfile(screen: ScreenFormat): void {
       if (screen === 'mobile') {
         cy.pageFab('Add Contact Method')
       } else {
-        cy.get('button[aria-label="Add contact method"]').click()
+        cy.get('button[title="Add contact method"]').click()
       }
 
       cy.dialogTitle('New Contact Method')
@@ -338,7 +336,7 @@ function testProfile(screen: ScreenFormat): void {
       if (screen === 'mobile') {
         cy.pageFab('Add Contact Method')
       } else {
-        cy.get('button[aria-label="Add contact method"]').click()
+        cy.get('button[title="Add contact method"]').click()
       }
 
       cy.dialogTitle('New Contact Method')
@@ -356,7 +354,7 @@ function testProfile(screen: ScreenFormat): void {
       if (screen === 'mobile') {
         cy.pageFab('Add Contact Method')
       } else {
-        cy.get('button[aria-label="Add contact method"]').click()
+        cy.get('button[title="Add contact method"]').click()
       }
 
       cy.dialogTitle('New Contact Method')
@@ -404,7 +402,7 @@ function testProfile(screen: ScreenFormat): void {
       if (screen === 'mobile') {
         cy.pageFab('Add Notification Rule')
       } else {
-        cy.get('button[aria-label="Add notification rule"]').click()
+        cy.get('button[title="Add notification rule"]').click()
       }
 
       cy.dialogTitle('New Notification Rule')
@@ -436,7 +434,7 @@ function testProfile(screen: ScreenFormat): void {
       if (screen === 'mobile') {
         cy.pageFab('Add Notification Rule')
       } else {
-        cy.get('button[aria-label="Add notification rule"]').click()
+        cy.get('button[title="Add notification rule"]').click()
       }
 
       cy.dialogTitle('New Notification Rule')


### PR DESCRIPTION
**Description:**
Switch to `title` attribute for the icon-only `+` buttons on the profile page.

This will continue to work for screen readers, but also give information to mouse users on hover. 

**Describe any introduced user-facing changes:**
Hovering over the `+` buttons on your Profile page will now display information about what the button does.
