### PR TITLE
ui: update failing cypress tests

### DIFF
--- a/web/src/app/services/HeartbeatMonitorList.tsx
+++ b/web/src/app/services/HeartbeatMonitorList.tsx
@@ -128,6 +128,7 @@ export default function HeartbeatMonitorList(props: {
               variant='contained'
               onClick={() => setShowCreateDialog(true)}
               startIcon={<Add />}
+              data-testid='create-monitor'
             >
               Create Heartbeat Monitor
             </Button>

--- a/web/src/app/services/IntegrationKeyList.tsx
+++ b/web/src/app/services/IntegrationKeyList.tsx
@@ -157,6 +157,7 @@ export default function IntegrationKeyList(props: {
                     variant='contained'
                     onClick={(): void => setCreate(true)}
                     startIcon={<Add />}
+                    data-testid='create-key'
                   >
                     Create Integration Key
                   </Button>

--- a/web/src/app/services/ServiceLabelList.tsx
+++ b/web/src/app/services/ServiceLabelList.tsx
@@ -92,6 +92,7 @@ export default function ServiceLabelList(props: {
               variant='contained'
               onClick={() => setCreate(true)}
               startIcon={<Add />}
+              data-testid='create-label'
             >
               Create Label
             </Button>

--- a/web/src/cypress/e2e/services.cy.ts
+++ b/web/src/cypress/e2e/services.cy.ts
@@ -370,7 +370,11 @@ function testServices(screen: ScreenFormat): void {
       const timeoutMinutes = (Math.trunc(Math.random() * 10) + 5).toString()
       const invalidName = 'a'
 
-      cy.pageFab()
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button[data-testid="create-monitor"]').click()
+      }
 
       cy.dialogForm({ name: invalidName, timeoutMinutes })
       cy.dialogClick('Submit')
@@ -417,7 +421,11 @@ function testServices(screen: ScreenFormat): void {
 
     it('should handle canceling', () => {
       // cancel out of create
-      cy.pageFab()
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button[data-testid="create-monitor"]').click()
+      }
       cy.dialogTitle('Create New Heartbeat Monitor')
       cy.dialogFinish('Cancel')
 
@@ -449,7 +457,11 @@ function testServices(screen: ScreenFormat): void {
     )
 
     const createKey = (type: string, name: string): void => {
-      cy.pageFab()
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button[data-testid="create-key"]').click()
+      }
       cy.dialogForm({ name, type })
       cy.dialogFinish('Submit')
     }
@@ -506,7 +518,11 @@ function testServices(screen: ScreenFormat): void {
       )
 
       // check that dropdown type is hidden
-      cy.pageFab()
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button[data-testid="create-key"]').click()
+      }
       cy.get('input[name=type]').findByLabel('Email').should('not.exist')
     })
   })
@@ -570,7 +586,11 @@ function testServices(screen: ScreenFormat): void {
       const key = label.key
       const value = c.word({ length: 10 })
 
-      cy.pageFab()
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button[data-testid="create-label"]').click()
+      }
       cy.dialogForm({ key, value })
       cy.dialogFinish('Submit')
       cy.get('li').should('contain', key)
@@ -584,7 +604,11 @@ function testServices(screen: ScreenFormat): void {
         cy.visit(`/services/${svc.id}/labels`)
       })
 
-      cy.pageFab()
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button[data-testid="create-label"]').click()
+      }
       cy.dialogForm({ key, value })
       cy.dialogFinish('Submit')
 
@@ -644,7 +668,11 @@ function testServices(screen: ScreenFormat): void {
       const randomWord = c.word({
         length: 7,
       })
-      cy.pageFab()
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button[data-testid="create-label"]').click()
+      }
       cy.get('input[name=key]').findByLabel(`Create "${randomWord}"`)
 
       cy.updateConfig({
@@ -654,7 +682,11 @@ function testServices(screen: ScreenFormat): void {
       })
       cy.reload()
 
-      cy.pageFab()
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button[data-testid="create-label"]').click()
+      }
       cy.get('input[name=key]').type(`Create "${randomWord}"`)
       cy.get('[data-cy="select-dropdown"]').should('contain', 'No options')
     })


### PR DESCRIPTION
fixes a few tests that I missed updating in #2735

I opted to use the selector `data-testid` instead of `has-text()` or `.contains()` because the latter two were failing looking for the button before the page finished loading