### PR TITLE
ui: disable backdrop close for temp schedules

### DIFF
--- a/web/src/app/dialogs/FormDialog.js
+++ b/web/src/app/dialogs/FormDialog.js
@@ -61,6 +61,7 @@ function FormDialog(props) {
     onNext,
     onBack,
     fullHeight,
+    disableBackdropClose,
     ...dialogProps
   } = props
 
@@ -161,9 +162,11 @@ function FormDialog(props) {
       maxWidth={maxWidth}
       fullWidth
       open={open}
-      onClose={(event, reason) => {
-        if (reason === 'backdropClick' && (!isWideScreen || alert)) {
-          // disable backdrop for mobile and alerts
+      onClose={(_, reason) => {
+        if (
+          reason === 'backdropClick' &&
+          (!isWideScreen || alert || disableBackdropClose)
+        ) {
           return
         }
         handleOnClose()
@@ -246,6 +249,8 @@ FormDialog.propTypes = {
 
   // make dialog fill vertical space
   fullHeight: p.bool,
+
+  disableBackdropClose: p.bool,
 
   // gets spread to material-ui
   PaperProps: p.object,

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -244,6 +244,7 @@ export default function TempSchedDialog({
       onClose={onClose}
       loading={loading}
       errors={errs}
+      disableBackdropClose
       notices={
         !value.start ||
         DateTime.fromISO(value.start, { zone }) >


### PR DESCRIPTION
Fixes #2744

Adds the prop `disableBackdropClick` to `FormDialog` for more flexibility. Currently, this is only enabled if the form is of type `alert`.