### PR TITLE
feat: cleanup contact methods

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,10 +33,11 @@ type Config struct {
 	}
 
 	Maintenance struct {
-		AlertCleanupDays    int `public:"true" info:"Closed alerts will be deleted after this many days (0 means disable cleanup)."`
-		AlertAutoCloseDays  int `public:"true" info:"Unacknowledged alerts will automatically be closed after this many days of inactivity. (0 means disable auto-close)."`
-		APIKeyExpireDays    int `public:"true" info:"Unused calendar API keys will be disabled after this many days (0 means disable cleanup)."`
-		ScheduleCleanupDays int `public:"true" info:"Schedule on-call history will be deleted after this many days (0 means disable cleanup)."`
+		AlertCleanupDays         int `public:"true" info:"Closed alerts will be deleted after this many days (0 means disable cleanup)."`
+		AlertAutoCloseDays       int `public:"true" info:"Unacknowledged alerts will automatically be closed after this many days of inactivity. (0 means disable auto-close)."`
+		APIKeyExpireDays         int `public:"true" info:"Unused calendar API keys will be disabled after this many days (0 means disable cleanup)."`
+		ScheduleCleanupDays      int `public:"true" info:"Schedule on-call history will be deleted after this many days (0 means disable cleanup)."`
+		ContactMethodCleanupDays int `public:"true" info:"Unverified contact methods will be deleted after this many days (0 means disable cleanup)."`
 	}
 
 	Auth struct {
@@ -439,6 +440,7 @@ func (cfg Config) Validate() error {
 		validate.Range("Maintenance.AlertAutoCloseDays", cfg.Maintenance.AlertAutoCloseDays, 0, 9000),
 		validate.Range("Maintenance.APIKeyExpireDays", cfg.Maintenance.APIKeyExpireDays, 0, 9000),
 		validate.Range("Maintenance.ScheduleCleanupDays", cfg.Maintenance.ScheduleCleanupDays, 0, 9000),
+		validate.Range("Maintenance.ContactMethodCleanupDays", cfg.Maintenance.ContactMethodCleanupDays, 0, 9000),
 		validateScopes("OIDC.Scopes", cfg.OIDC.Scopes),
 		validatePath("OIDC.UserInfoEmailPath", cfg.OIDC.UserInfoEmailPath),
 		validatePath("OIDC.UserInfoEmailVerifiedPath", cfg.OIDC.UserInfoEmailVerifiedPath),

--- a/devtools/resetdb/datagen.go
+++ b/devtools/resetdb/datagen.go
@@ -142,11 +142,12 @@ func (d *datagen) NewUser() {
 // NewCM will generate a contact method for the given UserID.
 func (d *datagen) NewCM(userID string) {
 	cm := contactmethod.ContactMethod{
-		ID:       gofakeit.UUID(),
-		Type:     contactmethod.TypeSMS,
-		Name:     d.ids.Gen(gofakeit.FirstName, userID),
-		Disabled: true,
-		UserID:   userID,
+		ID:        gofakeit.UUID(),
+		Type:      contactmethod.TypeSMS,
+		Name:      d.ids.Gen(gofakeit.FirstName, userID),
+		Disabled:  true,
+		UserID:    userID,
+		CreatedAt: gofakeit.DateRange(time.Now().Add(-30*24*time.Hour), time.Now().Add(-1*time.Hour)),
 	}
 	if gofakeit.Bool() {
 		cm.Type = contactmethod.TypeVoice

--- a/devtools/resetdb/datagen.go
+++ b/devtools/resetdb/datagen.go
@@ -142,12 +142,13 @@ func (d *datagen) NewUser() {
 // NewCM will generate a contact method for the given UserID.
 func (d *datagen) NewCM(userID string) {
 	cm := contactmethod.ContactMethod{
-		ID:        gofakeit.UUID(),
-		Type:      contactmethod.TypeSMS,
-		Name:      d.ids.Gen(gofakeit.FirstName, userID),
-		Disabled:  true,
-		UserID:    userID,
-		CreatedAt: gofakeit.DateRange(time.Now().Add(-30*24*time.Hour), time.Now().Add(-1*time.Hour)),
+		ID:            gofakeit.UUID(),
+		Type:          contactmethod.TypeSMS,
+		Name:          d.ids.Gen(gofakeit.FirstName, userID),
+		Disabled:      true,
+		UserID:        userID,
+		CreatedAt:     gofakeit.DateRange(time.Now().Add(-30*24*time.Hour), time.Now().Add(-1*time.Hour)),
+		DisabledSince: gofakeit.DateRange(time.Now().Add(-30*24*time.Hour), time.Now().Add(-1*time.Hour)),
 	}
 	if gofakeit.Bool() {
 		cm.Type = contactmethod.TypeVoice

--- a/devtools/resetdb/main.go
+++ b/devtools/resetdb/main.go
@@ -138,9 +138,9 @@ func fillDB(ctx context.Context, dataCfg *datagenConfig, url string) error {
 		u := data.Users[n]
 		return []interface{}{asUUID(u.ID), u.Name, u.Role, u.Email}
 	})
-	copyFrom("user_contact_methods", []string{"id", "user_id", "name", "type", "value", "disabled"}, len(data.ContactMethods), func(n int) []interface{} {
+	copyFrom("user_contact_methods", []string{"id", "user_id", "name", "type", "value", "disabled", "created_at"}, len(data.ContactMethods), func(n int) []interface{} {
 		cm := data.ContactMethods[n]
-		return []interface{}{asUUID(cm.ID), asUUID(cm.UserID), cm.Name, cm.Type, cm.Value, cm.Disabled}
+		return []interface{}{asUUID(cm.ID), asUUID(cm.UserID), cm.Name, cm.Type, cm.Value, cm.Disabled, cm.CreatedAt}
 	}, "users")
 	copyFrom("user_notification_rules", []string{"id", "user_id", "contact_method_id", "delay_minutes"}, len(data.NotificationRules), func(n int) []interface{} {
 		nr := data.NotificationRules[n]

--- a/engine/cleanupmanager/db.go
+++ b/engine/cleanupmanager/db.go
@@ -68,7 +68,7 @@ func NewDB(ctx context.Context, db *sql.DB, alertstore *alert.Store) (*DB, error
 
 		cleanupContactMethods: p.P(`
 			DELETE FROM user_contact_methods 
-			WHERE id = any(SELECT id FROM user_contact_methods WHERE disabled = true AND created_at < (now() - $1::interval) LIMIT 100 FOR UPDATE SKIP LOCKED)
+			WHERE id = any(SELECT id FROM user_contact_methods WHERE disabled = true AND disabled_since < (now() - $1::interval) LIMIT 100 FOR UPDATE SKIP LOCKED)
 		`),
 
 		schedData: p.P(`

--- a/engine/cleanupmanager/update.go
+++ b/engine/cleanupmanager/update.go
@@ -96,6 +96,17 @@ func (db *DB) update(ctx context.Context) error {
 			return err
 		}
 	}
+
+	if cfg.Maintenance.ContactMethodCleanupDays > 0 {
+		var dur pgtype.Interval
+		dur.Days = int32(cfg.Maintenance.ContactMethodCleanupDays)
+		dur.Status = pgtype.Present
+		_, err = tx.StmtContext(ctx, db.cleanupContactMethods).ExecContext(ctx, &dur)
+		if err != nil {
+			return err
+		}
+	}
+
 	if cfg.Maintenance.ScheduleCleanupDays > 0 {
 		var dur pgtype.Interval
 		dur.Days = int32(cfg.Maintenance.ScheduleCleanupDays)

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -579,6 +579,7 @@ type ComplexityRoot struct {
 	}
 
 	UserContactMethod struct {
+		CleanupAt              func(childComplexity int) int
 		Disabled               func(childComplexity int) int
 		FormattedValue         func(childComplexity int) int
 		ID                     func(childComplexity int) int
@@ -816,6 +817,7 @@ type UserContactMethodResolver interface {
 
 	LastTestMessageState(ctx context.Context, obj *contactmethod.ContactMethod) (*NotificationState, error)
 	LastVerifyMessageState(ctx context.Context, obj *contactmethod.ContactMethod) (*NotificationState, error)
+	CleanupAt(ctx context.Context, obj *contactmethod.ContactMethod) (*time.Time, error)
 }
 type UserNotificationRuleResolver interface {
 	ContactMethod(ctx context.Context, obj *notificationrule.NotificationRule) (*contactmethod.ContactMethod, error)
@@ -3467,6 +3469,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.UserConnection.PageInfo(childComplexity), true
+
+	case "UserContactMethod.cleanupAt":
+		if e.complexity.UserContactMethod.CleanupAt == nil {
+			break
+		}
+
+		return e.complexity.UserContactMethod.CleanupAt(childComplexity), true
 
 	case "UserContactMethod.disabled":
 		if e.complexity.UserContactMethod.Disabled == nil {
@@ -12024,6 +12033,8 @@ func (ec *executionContext) fieldContext_Mutation_createUserContactMethod(ctx co
 				return ec.fieldContext_UserContactMethod_lastTestMessageState(ctx, field)
 			case "lastVerifyMessageState":
 				return ec.fieldContext_UserContactMethod_lastVerifyMessageState(ctx, field)
+			case "cleanupAt":
+				return ec.fieldContext_UserContactMethod_cleanupAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type UserContactMethod", field.Name)
 		},
@@ -15700,6 +15711,8 @@ func (ec *executionContext) fieldContext_Query_userContactMethod(ctx context.Con
 				return ec.fieldContext_UserContactMethod_lastTestMessageState(ctx, field)
 			case "lastVerifyMessageState":
 				return ec.fieldContext_UserContactMethod_lastVerifyMessageState(ctx, field)
+			case "cleanupAt":
+				return ec.fieldContext_UserContactMethod_cleanupAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type UserContactMethod", field.Name)
 		},
@@ -20586,6 +20599,8 @@ func (ec *executionContext) fieldContext_User_contactMethods(ctx context.Context
 				return ec.fieldContext_UserContactMethod_lastTestMessageState(ctx, field)
 			case "lastVerifyMessageState":
 				return ec.fieldContext_UserContactMethod_lastVerifyMessageState(ctx, field)
+			case "cleanupAt":
+				return ec.fieldContext_UserContactMethod_cleanupAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type UserContactMethod", field.Name)
 		},
@@ -21851,6 +21866,47 @@ func (ec *executionContext) fieldContext_UserContactMethod_lastVerifyMessageStat
 	return fc, nil
 }
 
+func (ec *executionContext) _UserContactMethod_cleanupAt(ctx context.Context, field graphql.CollectedField, obj *contactmethod.ContactMethod) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UserContactMethod_cleanupAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.UserContactMethod().CleanupAt(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOISOTimestamp2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UserContactMethod_cleanupAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserContactMethod",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ISOTimestamp does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UserNotificationRule_id(ctx context.Context, field graphql.CollectedField, obj *notificationrule.NotificationRule) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UserNotificationRule_id(ctx, field)
 	if err != nil {
@@ -22037,6 +22093,8 @@ func (ec *executionContext) fieldContext_UserNotificationRule_contactMethod(ctx 
 				return ec.fieldContext_UserContactMethod_lastTestMessageState(ctx, field)
 			case "lastVerifyMessageState":
 				return ec.fieldContext_UserContactMethod_lastVerifyMessageState(ctx, field)
+			case "cleanupAt":
+				return ec.fieldContext_UserContactMethod_cleanupAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type UserContactMethod", field.Name)
 		},
@@ -32899,6 +32957,23 @@ func (ec *executionContext) _UserContactMethod(ctx context.Context, sel ast.Sele
 					}
 				}()
 				res = ec._UserContactMethod_lastVerifyMessageState(ctx, field, obj)
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
+		case "cleanupAt":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UserContactMethod_cleanupAt(ctx, field, obj)
 				return res
 			}
 

--- a/graphql2/graphqlapp/contactmethod.go
+++ b/graphql2/graphqlapp/contactmethod.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"net/url"
+	"time"
 
 	"github.com/target/goalert/config"
 	"github.com/target/goalert/graphql2"
@@ -35,6 +36,15 @@ func (a *ContactMethod) Value(ctx context.Context, obj *contactmethod.ContactMet
 
 func (a *ContactMethod) FormattedValue(ctx context.Context, obj *contactmethod.ContactMethod) (string, error) {
 	return a.FormatDestFunc(ctx, notification.ScannableDestType{CM: obj.Type}.DestType(), obj.Value), nil
+}
+
+func (a *ContactMethod) CleanupAt(ctx context.Context, obj *contactmethod.ContactMethod) (*time.Time, error) {
+	if obj.Disabled {
+		cfg := config.FromContext(ctx)
+		endTime := obj.CreatedAt.Add(time.Duration(cfg.Maintenance.ContactMethodCleanupDays) * 24 * time.Hour)
+		return &endTime, nil
+	}
+	return nil, nil
 }
 
 func (a *ContactMethod) LastTestMessageState(ctx context.Context, obj *contactmethod.ContactMethod) (*graphql2.NotificationState, error) {

--- a/graphql2/mapconfig.go
+++ b/graphql2/mapconfig.go
@@ -38,6 +38,7 @@ func MapConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "Maintenance.AlertAutoCloseDays", Type: ConfigTypeInteger, Description: "Unacknowledged alerts will automatically be closed after this many days of inactivity. (0 means disable auto-close).", Value: fmt.Sprintf("%d", cfg.Maintenance.AlertAutoCloseDays)},
 		{ID: "Maintenance.APIKeyExpireDays", Type: ConfigTypeInteger, Description: "Unused calendar API keys will be disabled after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.APIKeyExpireDays)},
 		{ID: "Maintenance.ScheduleCleanupDays", Type: ConfigTypeInteger, Description: "Schedule on-call history will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.ScheduleCleanupDays)},
+		{ID: "Maintenance.ContactMethodCleanupDays", Type: ConfigTypeInteger, Description: "Unverified contact methods will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.ContactMethodCleanupDays)},
 		{ID: "Auth.RefererURLs", Type: ConfigTypeStringList, Description: "Allowed referer URLs for auth and redirects.", Value: strings.Join(cfg.Auth.RefererURLs, "\n"), Deprecated: "Use --public-url flag instead, which takes precedence."},
 		{ID: "Auth.DisableBasic", Type: ConfigTypeBoolean, Description: "Disallow username/password login.", Value: fmt.Sprintf("%t", cfg.Auth.DisableBasic)},
 		{ID: "GitHub.Enable", Type: ConfigTypeBoolean, Description: "Enable GitHub authentication.", Value: fmt.Sprintf("%t", cfg.GitHub.Enable)},
@@ -105,6 +106,7 @@ func MapPublicConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "Maintenance.AlertAutoCloseDays", Type: ConfigTypeInteger, Description: "Unacknowledged alerts will automatically be closed after this many days of inactivity. (0 means disable auto-close).", Value: fmt.Sprintf("%d", cfg.Maintenance.AlertAutoCloseDays)},
 		{ID: "Maintenance.APIKeyExpireDays", Type: ConfigTypeInteger, Description: "Unused calendar API keys will be disabled after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.APIKeyExpireDays)},
 		{ID: "Maintenance.ScheduleCleanupDays", Type: ConfigTypeInteger, Description: "Schedule on-call history will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.ScheduleCleanupDays)},
+		{ID: "Maintenance.ContactMethodCleanupDays", Type: ConfigTypeInteger, Description: "Unverified contact methods will be deleted after this many days (0 means disable cleanup).", Value: fmt.Sprintf("%d", cfg.Maintenance.ContactMethodCleanupDays)},
 		{ID: "Auth.DisableBasic", Type: ConfigTypeBoolean, Description: "Disallow username/password login.", Value: fmt.Sprintf("%t", cfg.Auth.DisableBasic)},
 		{ID: "GitHub.Enable", Type: ConfigTypeBoolean, Description: "Enable GitHub authentication.", Value: fmt.Sprintf("%t", cfg.GitHub.Enable)},
 		{ID: "OIDC.Enable", Type: ConfigTypeBoolean, Description: "Enable OpenID Connect authentication.", Value: fmt.Sprintf("%t", cfg.OIDC.Enable)},
@@ -210,6 +212,12 @@ func ApplyConfigValues(cfg config.Config, vals []ConfigValueInput) (config.Confi
 				return cfg, err
 			}
 			cfg.Maintenance.ScheduleCleanupDays = val
+		case "Maintenance.ContactMethodCleanupDays":
+			val, err := parseInt(v.ID, v.Value)
+			if err != nil {
+				return cfg, err
+			}
+			cfg.Maintenance.ContactMethodCleanupDays = val
 		case "Auth.RefererURLs":
 			cfg.Auth.RefererURLs = parseStringList(v.Value)
 		case "Auth.DisableBasic":

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -291,7 +291,6 @@ input UserOverrideSearchOptions {
   end: ISOTimestamp # end of the window to search for.
 }
 
-
 type UserOverrideConnection {
   nodes: [UserOverride!]!
   pageInfo: PageInfo!
@@ -1285,6 +1284,8 @@ type UserContactMethod {
   lastTestVerifyAt: ISOTimestamp
   lastTestMessageState: NotificationState
   lastVerifyMessageState: NotificationState
+
+  cleanupAt: ISOTimestamp
 }
 
 input CreateUserContactMethodInput {

--- a/migrate/migrations/20221219141706-add-timestamps-to-user-contact-methods.sql
+++ b/migrate/migrations/20221219141706-add-timestamps-to-user-contact-methods.sql
@@ -1,10 +1,10 @@
 -- +migrate Up
 ALTER TABLE user_contact_methods
     ADD COLUMN created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    ADD COLUMN disabled_at TIMESTAMP WITH TIME ZONE;
+    ADD COLUMN disabled_since TIMESTAMP WITH TIME ZONE DEFAULT NOW();
 
 -- +migrate Down
 ALTER TABLE user_contact_methods
     DROP COLUMN created_at,
-    DROP COLUMN disabled_at;
+    DROP COLUMN disabled_since;
 

--- a/migrate/migrations/20221219141706-add_timestamps_to_user_contact_methods.sql
+++ b/migrate/migrations/20221219141706-add_timestamps_to_user_contact_methods.sql
@@ -1,0 +1,10 @@
+-- +migrate Up
+ALTER TABLE user_contact_methods
+    ADD COLUMN created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    ADD COLUMN disabled_at TIMESTAMP WITH TIME ZONE;
+
+-- +migrate Down
+ALTER TABLE user_contact_methods
+    DROP COLUMN created_at,
+    DROP COLUMN disabled_at;
+

--- a/test/smoke/contactmethodcleanup_test.go
+++ b/test/smoke/contactmethodcleanup_test.go
@@ -1,0 +1,76 @@
+package smoke
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/target/goalert/test/smoke/harness"
+)
+
+// TestContactMethodCleanup verifies that stale contact methods are purged from the DB
+// when `Maintenance.ContactMethodCleanupDays` is set.
+func TestContactMethodCleanup(t *testing.T) {
+	t.Parallel()
+
+	sql := `
+		insert into users (id, name, email) 
+		values 
+			({{uuid "user"}}, 'bob', 'joe');
+		insert into user_contact_methods (id, user_id, name, type, value, disabled, disabled_since) 
+		values
+				({{uuid "cm1"}}, {{uuid "user"}}, 'personal1', 'SMS', {{phone "1"}}, true, now() - '2 days'::interval),
+				({{uuid "cm2"}}, {{uuid "user"}}, 'personal2', 'SMS', {{phone "2"}}, false, now());
+	`
+	h := harness.NewHarness(t, sql, "add-timestamps-to-user-contact-methods")
+	defer h.Close()
+
+	h.Trigger()
+
+	type data struct {
+		User struct {
+			ID             string `json:"id"`
+			ContactMethods []struct {
+				ID string `json:"id"`
+			} `json:"contactMethods"`
+		} `json:"user"`
+	}
+
+	doQL := func(res *data) {
+		g := h.GraphQLQuery2(fmt.Sprintf(`
+			query {
+				user(id: "%s") {
+					id
+					contactMethods {
+						id
+					}
+				}
+			}
+		`, h.UUID("user")))
+		for _, err := range g.Errors {
+			t.Error("GraphQL Error:", err.Message)
+		}
+		if len(g.Errors) > 0 {
+			t.Fatal("errors returned from GraphQL")
+		}
+		err := json.Unmarshal(g.Data, &res)
+		if err != nil {
+			t.Fatal("failed to parse response:", err)
+		}
+	}
+
+	var d data
+	doQL(&d)
+	assert.Len(t, d.User.ContactMethods, 2)
+	assert.Equal(t, h.UUID("cm1"), d.User.ContactMethods[0].ID)
+	assert.Equal(t, h.UUID("cm2"), d.User.ContactMethods[1].ID)
+
+	h.SetConfigValue("Maintenance.ContactMethodCleanupDays", "1")
+
+	h.Trigger()
+
+	doQL(&d)
+	assert.Len(t, d.User.ContactMethods, 1)
+	assert.Equal(t, h.UUID("cm2"), d.User.ContactMethods[0].ID)
+}

--- a/test/smoke/migrations_test.go
+++ b/test/smoke/migrations_test.go
@@ -84,6 +84,10 @@ var ignoreRules = []ignoreRule{
 
 	// Every DB must have a unique ID.
 	{MigrationName: "switchover-mk2", TableName: "switchover_state", ColumnName: "db_id"},
+
+	// Timestamp will change
+	{MigrationName: "add-timestamps-to-user-contact-methods", TableName: "user_contact_methods", ColumnName: "disabled_since"},
+	{MigrationName: "add-timestamps-to-user-contact-methods", TableName: "user_contact_methods", ColumnName: "created_at"},
 }
 
 const migrateInitData = `

--- a/user/contactmethod/contactmethod.go
+++ b/user/contactmethod/contactmethod.go
@@ -10,12 +10,13 @@ import (
 
 // ContactMethod stores the information for contacting a user.
 type ContactMethod struct {
-	ID       string
-	Name     string
-	Type     Type
-	Value    string
-	Disabled bool
-	UserID   string
+	ID        string
+	Name      string
+	Type      Type
+	Value     string
+	Disabled  bool
+	UserID    string
+	CreatedAt time.Time
 
 	lastTestVerifyAt sql.NullTime
 }

--- a/user/contactmethod/contactmethod.go
+++ b/user/contactmethod/contactmethod.go
@@ -10,13 +10,14 @@ import (
 
 // ContactMethod stores the information for contacting a user.
 type ContactMethod struct {
-	ID        string
-	Name      string
-	Type      Type
-	Value     string
-	Disabled  bool
-	UserID    string
-	CreatedAt time.Time
+	ID            string
+	Name          string
+	Type          Type
+	Value         string
+	Disabled      bool
+	UserID        string
+	CreatedAt     time.Time
+	DisabledSince time.Time
 
 	lastTestVerifyAt sql.NullTime
 }

--- a/user/contactmethod/store.go
+++ b/user/contactmethod/store.go
@@ -76,23 +76,23 @@ func NewStore(ctx context.Context, db *sql.DB) (*Store, error) {
 			VALUES ($1,$2,$3,$4,$5,$6)
 		`),
 		findOne: p.P(`
-			SELECT id,name,type,value,disabled,user_id,last_test_verify_at
+			SELECT id,name,type,value,disabled,user_id,last_test_verify_at,created_at
 			FROM user_contact_methods
 			WHERE id = $1
 		`),
 		findOneUpd: p.P(`
-			SELECT id,name,type,value,disabled,user_id,last_test_verify_at
+			SELECT id,name,type,value,disabled,user_id,last_test_verify_at,created_at
 			FROM user_contact_methods
 			WHERE id = $1
 			FOR UPDATE
 		`),
 		findMany: p.P(`
-			SELECT id,name,type,value,disabled,user_id,last_test_verify_at
+			SELECT id,name,type,value,disabled,user_id,last_test_verify_at,created_at
 			FROM user_contact_methods
 			WHERE id = any($1)
 		`),
 		findAll: p.P(`
-			SELECT id,name,type,value,disabled,user_id,last_test_verify_at
+			SELECT id,name,type,value,disabled,user_id,last_test_verify_at,created_at
 			FROM user_contact_methods
 			WHERE user_id = $1
 		`),
@@ -317,7 +317,7 @@ func (s *Store) FindOneTx(ctx context.Context, tx *sql.Tx, id string) (*ContactM
 
 	var c ContactMethod
 	row := wrapTx(ctx, tx, s.findOneUpd).QueryRowContext(ctx, id)
-	err = row.Scan(&c.ID, &c.Name, &c.Type, &c.Value, &c.Disabled, &c.UserID, &c.lastTestVerifyAt)
+	err = row.Scan(&c.ID, &c.Name, &c.Type, &c.Value, &c.Disabled, &c.UserID, &c.lastTestVerifyAt, &c.CreatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -338,7 +338,7 @@ func (s *Store) FindOne(ctx context.Context, id string) (*ContactMethod, error) 
 
 	var c ContactMethod
 	row := s.findOne.QueryRowContext(ctx, id)
-	err = row.Scan(&c.ID, &c.Name, &c.Type, &c.Value, &c.Disabled, &c.UserID, &c.lastTestVerifyAt)
+	err = row.Scan(&c.ID, &c.Name, &c.Type, &c.Value, &c.Disabled, &c.UserID, &c.lastTestVerifyAt, &c.CreatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -415,7 +415,7 @@ func scanAll(rows *sql.Rows) ([]ContactMethod, error) {
 	var contactMethods []ContactMethod
 	for rows.Next() {
 		var c ContactMethod
-		err := rows.Scan(&c.ID, &c.Name, &c.Type, &c.Value, &c.Disabled, &c.UserID, &c.lastTestVerifyAt)
+		err := rows.Scan(&c.ID, &c.Name, &c.Type, &c.Value, &c.Disabled, &c.UserID, &c.lastTestVerifyAt, &c.CreatedAt)
 		if err != nil {
 			return nil, err
 		}

--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -19,6 +19,7 @@ import AppLink from '../util/AppLink'
 import { styles as globalStyles } from '../styles/materialStyles'
 import { UserContactMethod } from '../../schema'
 import UserContactMethodCreateDialog from './UserContactMethodCreateDialog'
+import { relativeDate } from '../util/timeFormat'
 
 const query = gql`
   query cmList($id: ID!) {
@@ -31,6 +32,7 @@ const query = gql`
         value
         formattedValue
         disabled
+        cleanupAt
       }
     }
   }
@@ -79,6 +81,10 @@ export default function UserContactMethodList(
     if (props.readOnly) {
       return <Warning message='Contact method disabled' />
     }
+    let msg = 'Contact method disabled'
+    if (cm.cleanupAt) {
+      msg += ` (will be removed on ${relativeDate(cm.cleanupAt)})`
+    }
 
     return (
       <IconButton
@@ -88,7 +94,7 @@ export default function UserContactMethodList(
         disabled={props.readOnly}
         size='large'
       >
-        <Warning message='Contact method disabled' />
+        <Warning message={msg} />
       </IconButton>
     )
   }

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -1018,6 +1018,7 @@ export interface UserContactMethod {
   lastTestVerifyAt?: null | ISOTimestamp
   lastTestMessageState?: null | NotificationState
   lastVerifyMessageState?: null | NotificationState
+  cleanupAt?: null | ISOTimestamp
 }
 
 export interface CreateUserContactMethodInput {
@@ -1077,6 +1078,7 @@ type ConfigID =
   | 'Maintenance.AlertAutoCloseDays'
   | 'Maintenance.APIKeyExpireDays'
   | 'Maintenance.ScheduleCleanupDays'
+  | 'Maintenance.ContactMethodCleanupDays'
   | 'Auth.RefererURLs'
   | 'Auth.DisableBasic'
   | 'GitHub.Enable'


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Contact methods can now be cleaned up automatically if they have been disabled for a configured amount of time.

**Which issue(s) this PR fixes:**
#2757 

**Describe any introduced user-facing changes:**
Added a message to the tooltip on the contact method disabled icon that notifies the user of when a contact method will be removed by the system.

**Describe any introduced API changes:**
Added a new `cleanupAt` resolver too `ContactMethod`.
