### PR TITLE
Fix UI bugs on removing user from rotation

### DIFF
--- a/web/src/app/rotations/RotationUserDeleteDialog.tsx
+++ b/web/src/app/rotations/RotationUserDeleteDialog.tsx
@@ -13,7 +13,6 @@ const query = gql`
         id
         name
       }
-      activeUserIndex
     }
   }
 `
@@ -58,10 +57,6 @@ const RotationUserDeleteDialog = (props: {
           {
             input: {
               id: rotationID,
-              activeUserIndex:
-                activeUserIndex > userIndex
-                  ? activeUserIndex - 1
-                  : activeUserIndex,
               userIDs: userIDs.filter(
                 (_: string, index: number) => index !== userIndex,
               ),
@@ -69,8 +64,8 @@ const RotationUserDeleteDialog = (props: {
           },
           { additionalTypenames: ['Rotation'] },
         ).then((res) => {
-          if (res.error) console.log(res.error)
-          // onClose()
+          if (res.error) return
+          onClose()
         })
       }
     />

--- a/web/src/app/rotations/RotationUserDeleteDialog.tsx
+++ b/web/src/app/rotations/RotationUserDeleteDialog.tsx
@@ -39,7 +39,7 @@ const RotationUserDeleteDialog = (props: {
   if (fetching && !data) return <Spinner />
   if (error) return <GenericError error={error.message} />
 
-  const { userIDs, users, activeUserIndex } = data.rotation
+  const { userIDs, users } = data.rotation
 
   return (
     <FormDialog

--- a/web/src/app/rotations/RotationUserDeleteDialog.tsx
+++ b/web/src/app/rotations/RotationUserDeleteDialog.tsx
@@ -29,7 +29,7 @@ const RotationUserDeleteDialog = (props: {
   onClose: () => void
 }): JSX.Element => {
   const { rotationID, userIndex, onClose } = props
-  const [, deleteUserMutation] = useMutation(mutation)
+  const [deleteUserMutationStatus, deleteUserMutation] = useMutation(mutation)
   const [{ fetching, data, error }] = useQuery({
     query,
     variables: {
@@ -50,6 +50,9 @@ const RotationUserDeleteDialog = (props: {
         users[userIndex] ? users[userIndex].name : null
       } from this rotation.`}
       onClose={onClose}
+      errors={
+        deleteUserMutationStatus.error ? [deleteUserMutationStatus.error] : []
+      }
       onSubmit={() =>
         deleteUserMutation(
           {
@@ -66,8 +69,8 @@ const RotationUserDeleteDialog = (props: {
           },
           { additionalTypenames: ['Rotation'] },
         ).then((res) => {
-          if (res.error) return
-          onClose()
+          if (res.error) console.log(res.error)
+          // onClose()
         })
       }
     />


### PR DESCRIPTION
**Description:**
Following the previously [closed PR](https://github.com/target/goalert/pull/2707) on fixing the same issue, this PR fixes the operation when mutating rotation participants. The bug initially occurs because the code is trying to update the active user index on an out of bound index since the user is removed from the rotation. 

As suggested, I added the error props in the Dialog component so that the error is properly shown if there's any when submitting the mutation. I also omitted the `activeUserIndex` from the mutation and it immediately fixes this issue.

**Which issue(s) this PR fixes:**
Fixes https://github.com/target/goalert/issues/2543

**Screenshots:**
<img width="868" alt="Screen Shot 2022-12-23 at 13 43 59" src="https://user-images.githubusercontent.com/58095522/209287094-bc6693f6-f832-4cd7-9803-3ad4c27b75c2.png">