### PR TITLE
user/cm: cleanup unverified contact methods

### DIFF
--- a/devtools/resetdb/datagen.go
+++ b/devtools/resetdb/datagen.go
@@ -147,6 +147,7 @@ func (d *datagen) NewCM(userID string) {
 		Name:     d.ids.Gen(gofakeit.FirstName, userID),
 		Disabled: true,
 		UserID:   userID,
+		Pending:  false,
 	}
 	if gofakeit.Bool() {
 		cm.Type = contactmethod.TypeVoice

--- a/devtools/resetdb/main.go
+++ b/devtools/resetdb/main.go
@@ -138,9 +138,9 @@ func fillDB(ctx context.Context, dataCfg *datagenConfig, url string) error {
 		u := data.Users[n]
 		return []interface{}{asUUID(u.ID), u.Name, u.Role, u.Email}
 	})
-	copyFrom("user_contact_methods", []string{"id", "user_id", "name", "type", "value", "disabled"}, len(data.ContactMethods), func(n int) []interface{} {
+	copyFrom("user_contact_methods", []string{"id", "user_id", "name", "type", "value", "disabled", "pending"}, len(data.ContactMethods), func(n int) []interface{} {
 		cm := data.ContactMethods[n]
-		return []interface{}{asUUID(cm.ID), asUUID(cm.UserID), cm.Name, cm.Type, cm.Value, cm.Disabled}
+		return []interface{}{asUUID(cm.ID), asUUID(cm.UserID), cm.Name, cm.Type, cm.Value, cm.Disabled, cm.Pending}
 	}, "users")
 	copyFrom("user_notification_rules", []string{"id", "user_id", "contact_method_id", "delay_minutes"}, len(data.NotificationRules), func(n int) []interface{} {
 		nr := data.NotificationRules[n]

--- a/engine/verifymanager/db.go
+++ b/engine/verifymanager/db.go
@@ -3,6 +3,7 @@ package verifymanager
 import (
 	"context"
 	"database/sql"
+
 	"github.com/target/goalert/engine/processinglock"
 	"github.com/target/goalert/util"
 )
@@ -50,12 +51,16 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 
 		cleanupExpired: p.P(`
 			with rows as (
-				select id
+				select id, contact_method_id
 				from user_verification_codes
 				where now() >= expires_at
 				limit 100
 				for update skip locked
-			)
+			), _cms as (
+        delete from user_contact_methods cm
+        using rows
+        where cm.id = rows.contact_method_id and cm.pending = true
+      )
 			delete from user_verification_codes code
 			using rows
 			where code.id = rows.id

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -586,6 +586,7 @@ type ComplexityRoot struct {
 		LastTestVerifyAt       func(childComplexity int) int
 		LastVerifyMessageState func(childComplexity int) int
 		Name                   func(childComplexity int) int
+		Pending                func(childComplexity int) int
 		Type                   func(childComplexity int) int
 		Value                  func(childComplexity int) int
 	}
@@ -3516,6 +3517,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.UserContactMethod.Name(childComplexity), true
+
+	case "UserContactMethod.pending":
+		if e.complexity.UserContactMethod.Pending == nil {
+			break
+		}
+
+		return e.complexity.UserContactMethod.Pending(childComplexity), true
 
 	case "UserContactMethod.type":
 		if e.complexity.UserContactMethod.Type == nil {
@@ -12018,6 +12026,8 @@ func (ec *executionContext) fieldContext_Mutation_createUserContactMethod(ctx co
 				return ec.fieldContext_UserContactMethod_formattedValue(ctx, field)
 			case "disabled":
 				return ec.fieldContext_UserContactMethod_disabled(ctx, field)
+			case "pending":
+				return ec.fieldContext_UserContactMethod_pending(ctx, field)
 			case "lastTestVerifyAt":
 				return ec.fieldContext_UserContactMethod_lastTestVerifyAt(ctx, field)
 			case "lastTestMessageState":
@@ -15694,6 +15704,8 @@ func (ec *executionContext) fieldContext_Query_userContactMethod(ctx context.Con
 				return ec.fieldContext_UserContactMethod_formattedValue(ctx, field)
 			case "disabled":
 				return ec.fieldContext_UserContactMethod_disabled(ctx, field)
+			case "pending":
+				return ec.fieldContext_UserContactMethod_pending(ctx, field)
 			case "lastTestVerifyAt":
 				return ec.fieldContext_UserContactMethod_lastTestVerifyAt(ctx, field)
 			case "lastTestMessageState":
@@ -20580,6 +20592,8 @@ func (ec *executionContext) fieldContext_User_contactMethods(ctx context.Context
 				return ec.fieldContext_UserContactMethod_formattedValue(ctx, field)
 			case "disabled":
 				return ec.fieldContext_UserContactMethod_disabled(ctx, field)
+			case "pending":
+				return ec.fieldContext_UserContactMethod_pending(ctx, field)
 			case "lastTestVerifyAt":
 				return ec.fieldContext_UserContactMethod_lastTestVerifyAt(ctx, field)
 			case "lastTestMessageState":
@@ -21712,6 +21726,50 @@ func (ec *executionContext) fieldContext_UserContactMethod_disabled(ctx context.
 	return fc, nil
 }
 
+func (ec *executionContext) _UserContactMethod_pending(ctx context.Context, field graphql.CollectedField, obj *contactmethod.ContactMethod) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UserContactMethod_pending(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Pending, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UserContactMethod_pending(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserContactMethod",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UserContactMethod_lastTestVerifyAt(ctx context.Context, field graphql.CollectedField, obj *contactmethod.ContactMethod) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UserContactMethod_lastTestVerifyAt(ctx, field)
 	if err != nil {
@@ -22031,6 +22089,8 @@ func (ec *executionContext) fieldContext_UserNotificationRule_contactMethod(ctx 
 				return ec.fieldContext_UserContactMethod_formattedValue(ctx, field)
 			case "disabled":
 				return ec.fieldContext_UserContactMethod_disabled(ctx, field)
+			case "pending":
+				return ec.fieldContext_UserContactMethod_pending(ctx, field)
 			case "lastTestVerifyAt":
 				return ec.fieldContext_UserContactMethod_lastTestVerifyAt(ctx, field)
 			case "lastTestMessageState":
@@ -32864,6 +32924,13 @@ func (ec *executionContext) _UserContactMethod(ctx context.Context, sel ast.Sele
 		case "disabled":
 
 			out.Values[i] = ec._UserContactMethod_disabled(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "pending":
+
+			out.Values[i] = ec._UserContactMethod_pending(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -291,7 +291,6 @@ input UserOverrideSearchOptions {
   end: ISOTimestamp # end of the window to search for.
 }
 
-
 type UserOverrideConnection {
   nodes: [UserOverride!]!
   pageInfo: PageInfo!
@@ -1281,6 +1280,7 @@ type UserContactMethod {
   value: String!
   formattedValue: String!
   disabled: Boolean!
+  pending: Boolean!
 
   lastTestVerifyAt: ISOTimestamp
   lastTestMessageState: NotificationState

--- a/migrate/migrations/20221228092646-add-pending-to-contact-methods.sql
+++ b/migrate/migrations/20221228092646-add-pending-to-contact-methods.sql
@@ -1,0 +1,36 @@
+-- +migrate Up
+
+BEGIN;
+
+-- Add pending column with default to false for existing records and update default to true for new records later on
+ALTER TABLE user_contact_methods ADD COLUMN pending BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Update default to true for new records
+ALTER TABLE user_contact_methods ALTER COLUMN pending SET DEFAULT TRUE;
+
+-- Add a function to set pending to false when disabled is set to false
+-- +migrate StatementBegin
+CREATE OR REPLACE FUNCTION set_pending_to_false() RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.disabled = FALSE THEN
+    NEW.pending = FALSE;
+  END IF;
+  RETURN NEW;
+END;
+$$ language plpgsql;
+-- +migrate StatementEnd
+
+-- Bind the trigger function to user_contact_methods
+CREATE TRIGGER set_pending_to_false
+BEFORE UPDATE OF disabled ON user_contact_methods
+FOR EACH ROW EXECUTE PROCEDURE set_pending_to_false();
+
+COMMIT;
+
+-- +migrate Down
+
+-- Drop pending column
+ALTER TABLE user_contact_methods DROP COLUMN pending;
+
+-- Drop trigger
+DROP FUNCTION set_pending_to_false();

--- a/test/smoke/verifymanager_test.go
+++ b/test/smoke/verifymanager_test.go
@@ -1,0 +1,177 @@
+package smoke
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/permission"
+	"github.com/target/goalert/test/smoke/harness"
+)
+
+// TestUserVerificationCleanup tests that verification codes are cleaned up
+// when they are expired. Also tests that contact methods that are not verified
+// are cleaned up with the verification code.
+func TestUserVerificationCleanup(t *testing.T) {
+	t.Parallel()
+
+	type cm struct {
+		ID       string `json:"id"`
+		Disabled bool   `json:"disabled"`
+		Pending  bool   `json:"pending"`
+	}
+
+	type data struct {
+		User struct {
+			ID             string `json:"id"`
+			ContactMethods []cm   `json:"contactMethods"`
+		} `json:"user"`
+	}
+
+	doQL := func(t *testing.T, h *harness.Harness, query string, res interface{}) {
+		t.Helper()
+		g := h.GraphQLQuery2(query)
+		for _, err := range g.Errors {
+			t.Error("GraphQL Error:", err.Message)
+		}
+		if len(g.Errors) > 0 {
+			t.Fatal("errors returned from GraphQL")
+		}
+		t.Log("Response:", string(g.Data))
+		if res == nil {
+			return
+		}
+		err := json.Unmarshal(g.Data, &res)
+		if err != nil {
+			t.Fatal("failed to parse response:", err)
+		}
+	}
+	contactMethods := func(t *testing.T, h *harness.Harness) *data {
+		t.Helper()
+		var d data
+		doQL(t, h, fmt.Sprintf(`
+			query {
+				user(id: "%s") {
+					id
+					contactMethods {
+						id
+						disabled
+						pending
+					}
+				}
+			}
+		`, h.UUID("user")), &d)
+		return &d
+	}
+
+	checkCM := func(t *testing.T, h *harness.Harness, cm cm, id string, disabled, pending bool) {
+		t.Helper()
+		assert.Equal(t, id, cm.ID)
+		assert.Equal(t, disabled, cm.Disabled)
+		assert.Equal(t, pending, cm.Pending)
+	}
+
+	t.Run("existing unverified contact method is not deleted for compat", func(t *testing.T) {
+		sql := `
+			insert into users (id, name, email) 
+			values 
+				({{uuid "user"}}, 'bob', 'joe');
+			insert into user_contact_methods (id, user_id, name, type, value, disabled) 
+			values
+					({{uuid "cm1"}}, {{uuid "user"}}, 'personal1', 'SMS', {{phone "1"}}, true);
+			insert into user_verification_codes (id, contact_method_id, code, expires_at)
+			values
+				({{uuid "code"}}, {{uuid "cm1"}}, '1234', now() + '15 minutes'::interval);
+	`
+		h := harness.NewHarness(t, sql, "switchover-mk2")
+		defer h.Close()
+		h.Migrate("add-pending-to-contact-methods")
+		h.FastForward(20 * time.Minute)
+		h.Trigger()
+
+		// verify that a unverified contact method created before the migration is not deleted for compat
+		d := contactMethods(t, h)
+		assert.Len(t, d.User.ContactMethods, 1)
+		checkCM(t, h, d.User.ContactMethods[0], h.UUID("cm1"), true, false)
+	})
+
+	t.Run("database trigger on disabled field should set pending", func(t *testing.T) {
+		sql := `
+			insert into users (id, name, email) 
+			values 
+				({{uuid "user"}}, 'bob', 'joe');
+			insert into user_contact_methods (id, user_id, name, type, value, disabled, pending) 
+			values
+					({{uuid "cm1"}}, {{uuid "user"}}, 'personal1', 'SMS', {{phone "1"}}, true, true);
+	`
+		h := harness.NewHarness(t, sql, "add-pending-to-contact-methods")
+		defer h.Close()
+
+		permission.SudoContext(context.Background(), func(ctx context.Context) {
+			err := h.App().ContactMethodStore.EnableByValue(ctx, "SMS", h.Phone("1"))
+			require.NoError(t, err)
+		})
+
+		// verify that a unverified contact method created before the migration is not deleted for compat
+		d := contactMethods(t, h)
+		assert.Len(t, d.User.ContactMethods, 1)
+		checkCM(t, h, d.User.ContactMethods[0], h.UUID("cm1"), false, false)
+	})
+
+	t.Run("new contact methods are cleaned up properly", func(t *testing.T) {
+		sql := `
+			insert into users (id, name, email) 
+			values 
+				({{uuid "user"}}, 'bob', 'joe');
+			insert into user_contact_methods (id, user_id, name, type, value, disabled, pending) 
+			values
+					({{uuid "cm1"}}, {{uuid "user"}}, 'personal1', 'SMS', {{phone "1"}}, true, true),
+					({{uuid "cm2"}}, {{uuid "user"}}, 'personal2', 'SMS', {{phone "2"}}, false, false);
+			insert into user_verification_codes (id, contact_method_id, code, expires_at)
+			values
+				({{uuid "code"}}, {{uuid "cm1"}}, '1234', now() + '15 minutes'::interval);
+	`
+		h := harness.NewHarness(t, sql, "add-pending-to-contact-methods")
+		defer h.Close()
+		h.FastForward(20 * time.Minute)
+		h.Trigger()
+
+		d := contactMethods(t, h)
+		// cm1 should be deleted as the verification code is expired
+		// cm2 should still exist as it is not disabled and not pending
+		assert.Len(t, d.User.ContactMethods, 1)
+		checkCM(t, h, d.User.ContactMethods[0], h.UUID("cm2"), false, false)
+
+		// disable and re-verify cm2 and let it expire to make sure it is not deleted as it was previously verified
+		permission.SudoContext(context.Background(), func(ctx context.Context) {
+			err := h.App().ContactMethodStore.DisableByValue(ctx, "SMS", h.Phone("2"))
+			require.NoError(t, err)
+		})
+
+		d = contactMethods(t, h)
+		// cm2 should be disabled and not pending
+		assert.Len(t, d.User.ContactMethods, 1)
+		checkCM(t, h, d.User.ContactMethods[0], h.UUID("cm2"), true, false)
+
+		// re-verify cm2 and fast forward past the expiration
+		doQL(t, h, fmt.Sprintf(`
+			mutation {
+				sendContactMethodVerification(input: {
+					contactMethodID: "%s"
+				})
+			}
+		`, h.UUID("cm2")), nil)
+
+		h.FastForward(20 * time.Minute)
+		h.Trigger()
+
+		d = contactMethods(t, h)
+		// cm2 should exist, be disabled and not pending
+		assert.Len(t, d.User.ContactMethods, 1)
+		checkCM(t, h, d.User.ContactMethods[0], h.UUID("cm2"), true, false)
+	})
+}

--- a/user/contactmethod/contactmethod.go
+++ b/user/contactmethod/contactmethod.go
@@ -16,6 +16,7 @@ type ContactMethod struct {
 	Value    string
 	Disabled bool
 	UserID   string
+	Pending  bool
 
 	lastTestVerifyAt sql.NullTime
 }

--- a/user/contactmethod/store.go
+++ b/user/contactmethod/store.go
@@ -76,23 +76,23 @@ func NewStore(ctx context.Context, db *sql.DB) (*Store, error) {
 			VALUES ($1,$2,$3,$4,$5,$6)
 		`),
 		findOne: p.P(`
-			SELECT id,name,type,value,disabled,user_id,last_test_verify_at
+			SELECT id,name,type,value,disabled,user_id,last_test_verify_at,pending
 			FROM user_contact_methods
 			WHERE id = $1
 		`),
 		findOneUpd: p.P(`
-			SELECT id,name,type,value,disabled,user_id,last_test_verify_at
+			SELECT id,name,type,value,disabled,user_id,last_test_verify_at,pending
 			FROM user_contact_methods
 			WHERE id = $1
 			FOR UPDATE
 		`),
 		findMany: p.P(`
-			SELECT id,name,type,value,disabled,user_id,last_test_verify_at
+			SELECT id,name,type,value,disabled,user_id,last_test_verify_at,pending
 			FROM user_contact_methods
 			WHERE id = any($1)
 		`),
 		findAll: p.P(`
-			SELECT id,name,type,value,disabled,user_id,last_test_verify_at
+			SELECT id,name,type,value,disabled,user_id,last_test_verify_at,pending
 			FROM user_contact_methods
 			WHERE user_id = $1
 		`),
@@ -317,7 +317,7 @@ func (s *Store) FindOneTx(ctx context.Context, tx *sql.Tx, id string) (*ContactM
 
 	var c ContactMethod
 	row := wrapTx(ctx, tx, s.findOneUpd).QueryRowContext(ctx, id)
-	err = row.Scan(&c.ID, &c.Name, &c.Type, &c.Value, &c.Disabled, &c.UserID, &c.lastTestVerifyAt)
+	err = row.Scan(&c.ID, &c.Name, &c.Type, &c.Value, &c.Disabled, &c.UserID, &c.lastTestVerifyAt, &c.Pending)
 	if err != nil {
 		return nil, err
 	}
@@ -338,7 +338,7 @@ func (s *Store) FindOne(ctx context.Context, id string) (*ContactMethod, error) 
 
 	var c ContactMethod
 	row := s.findOne.QueryRowContext(ctx, id)
-	err = row.Scan(&c.ID, &c.Name, &c.Type, &c.Value, &c.Disabled, &c.UserID, &c.lastTestVerifyAt)
+	err = row.Scan(&c.ID, &c.Name, &c.Type, &c.Value, &c.Disabled, &c.UserID, &c.lastTestVerifyAt, &c.Pending)
 	if err != nil {
 		return nil, err
 	}
@@ -415,7 +415,7 @@ func scanAll(rows *sql.Rows) ([]ContactMethod, error) {
 	var contactMethods []ContactMethod
 	for rows.Next() {
 		var c ContactMethod
-		err := rows.Scan(&c.ID, &c.Name, &c.Type, &c.Value, &c.Disabled, &c.UserID, &c.lastTestVerifyAt)
+		err := rows.Scan(&c.ID, &c.Name, &c.Type, &c.Value, &c.Disabled, &c.UserID, &c.lastTestVerifyAt, &c.Pending)
 		if err != nil {
 			return nil, err
 		}

--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -31,6 +31,7 @@ const query = gql`
         value
         formattedValue
         disabled
+        pending
       }
     }
   }
@@ -147,6 +148,9 @@ export default function UserContactMethodList(
           <AppLink to='/docs'>docs</AppLink>)
         </React.Fragment>
       )
+    }
+    if (cm.pending) {
+      return `${cm.formattedValue} - this contact method will be automatically deleted if not verified`
     }
 
     return cm.formattedValue

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -1015,6 +1015,7 @@ export interface UserContactMethod {
   value: string
   formattedValue: string
   disabled: boolean
+  pending: boolean
   lastTestVerifyAt?: null | ISOTimestamp
   lastTestMessageState?: null | NotificationState
   lastVerifyMessageState?: null | NotificationState


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Unverified contact methods will be automatically removed when the verification code expires. This prevents contact methods that may have been created by mistake or were otherwise orphaned from hanging around in the system.

**Which issue(s) this PR fixes:**
Fixes #2727

**Screenshots:**
![Contact Methods](https://user-images.githubusercontent.com/16885612/210014582-6a263ef2-b5d3-4038-9d91-686a1d375e9b.png)

**Describe any introduced user-facing changes:**
A UI message is displayed on unverified contact methods.

**Describe any introduced API changes:**
Added a `pending` value to the `UserContactMethod`.
