### PR TITLE
notification/slack: refactor cache to use generics

### DIFF
--- a/notification/slack/cache.go
+++ b/notification/slack/cache.go
@@ -6,38 +6,40 @@ import (
 	"github.com/golang/groupcache/lru"
 )
 
-type ttlCache struct {
+type ttlCache[K comparable, V any] struct {
 	*lru.Cache
 	ttl time.Duration
 }
 
-func newTTLCache(maxEntries int, ttl time.Duration) *ttlCache {
-	return &ttlCache{
+func newTTLCache[K comparable, V any](maxEntries int, ttl time.Duration) *ttlCache[K, V] {
+	return &ttlCache[K, V]{
 		ttl:   ttl,
 		Cache: lru.New(maxEntries),
 	}
 }
 
-type cacheItem struct {
+type cacheItem[V any] struct {
 	expires time.Time
-	value   interface{}
+	value   V
 }
 
-func (c *ttlCache) Add(key lru.Key, value interface{}) {
-	c.Cache.Add(key, cacheItem{
+func (c *ttlCache[K, V]) Add(key lru.Key, value V) {
+	c.Cache.Add(key, cacheItem[V]{
 		value:   value,
 		expires: time.Now().Add(c.ttl),
 	})
 }
 
-func (c *ttlCache) Get(key lru.Key) (interface{}, bool) {
+func (c *ttlCache[K, V]) Get(key K) (val V, ok bool) {
 	item, ok := c.Cache.Get(key)
 	if !ok {
-		return nil, false
+		return val, false
 	}
-	cItem := item.(cacheItem)
+
+	cItem := item.(cacheItem[V])
 	if time.Until(cItem.expires) > 0 {
 		return cItem.value, true
 	}
-	return nil, false
+
+	return val, false
 }


### PR DESCRIPTION
**Description:**
Small PR to switch to generics for the slack in-memory cache.

**Additional Info:**
Part of #2712
