### PR TITLE
notification/slack: sort on-call users by name

### DIFF
--- a/notification/slack/oncallnotification.go
+++ b/notification/slack/oncallnotification.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/slack-go/slack/slackutilsx"
@@ -49,6 +50,15 @@ func (s *ChannelSender) onCallNotificationText(ctx context.Context, t notificati
 // If a user's ID is available in userSlackIDs, an `@` user mention will be used in place of a link to the GoAlert user's detail page.
 func renderOnCallNotificationMessage(msg notification.ScheduleOnCallUsers, userSlackIDs map[string]string) string {
 	suffix := fmt.Sprintf("on-call for <%s|%s>", slackutilsx.EscapeMessage(msg.ScheduleURL), slackutilsx.EscapeMessage(msg.ScheduleName))
+
+	sort.Slice(msg.Users, func(i, j int) bool {
+		ui, uj := msg.Users[i], msg.Users[j]
+		if ui.Name == uj.Name {
+			return ui.ID < uj.ID
+		}
+
+		return ui.Name < uj.Name
+	})
 
 	var userLinks []string
 	for _, u := range msg.Users {

--- a/notification/slack/oncallnotification_test.go
+++ b/notification/slack/oncallnotification_test.go
@@ -49,7 +49,7 @@ func TestRenderOnCallNotification(t *testing.T) {
 		[]string{"slack.1", "slack.2", "slack.3"})
 
 	check("3 users with fallback",
-		"<@slack.1.SLACKID>, <foo.url|foo.name>, and <@slack.3.SLACKID> are on-call for <schedule.url|schedule.name>",
+		"<foo.url|foo.name>, <@slack.1.SLACKID>, and <@slack.3.SLACKID> are on-call for <schedule.url|schedule.name>",
 		[]string{"slack.1", "foo", "slack.3"})
 
 	t.Run("no panic on nil map", func(t *testing.T) {
@@ -63,5 +63,4 @@ func TestRenderOnCallNotification(t *testing.T) {
 
 		assert.Equal(t, "<foo.url|foo.name> is on-call for <schedule.url|schedule.name>", renderOnCallNotificationMessage(msg, nil))
 	})
-
 }


### PR DESCRIPTION
**Description:**
This PR adds a missing Sort call to sort users by name in on-call messages.

**Which issue(s) this PR fixes:**
Fixes #2784 