### PR TITLE
app: add experimental feature flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ SIZE:=1
 PUBLIC_URL := http://localhost:3030$(HTTP_PREFIX)
 export GOALERT_PUBLIC_URL := $(PUBLIC_URL)
 
+EXPERIMENTAL :=
+export GOALERT_EXPERIMENTAL := $(EXPERIMENTAL)
+
 ifeq ($(CI), 1)
 PROD_CY_PROC = Procfile.cypress.ci
 endif

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ SIZE:=1
 PUBLIC_URL := http://localhost:3030$(HTTP_PREFIX)
 export GOALERT_PUBLIC_URL := $(PUBLIC_URL)
 
+# used to enable experimental features, use `goalert --list-experimental` to see available features or check the expflag package
 EXPERIMENTAL :=
 export GOALERT_EXPERIMENTAL := $(EXPERIMENTAL)
 

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ help: ## Show all valid options
 
 start: bin/goalert node_modules web/src/schema.d.ts $(BIN_DIR)/tools/prometheus ## Start the developer version of the application
 	go run ./devtools/waitfor -timeout 1s  "$(DB_URL)" || make postgres
-	GOALERT_VERSION=$(GIT_VERSION) go run ./devtools/runproc -f Procfile -l Procfile.local
+	GOALERT_VERSION=$(GIT_VERSION) GOALERT_STRICT_EXPERIMENTAL=1 go run ./devtools/runproc -f Procfile -l Procfile.local
 
 start-prod: web/src/build/static/app.js $(BIN_DIR)/tools/prometheus ## Start the production version of the application
 	# force rebuild to ensure build-flags are set

--- a/app/app.go
+++ b/app/app.go
@@ -245,7 +245,7 @@ func NewApp(c Config, db *sql.DB) (*App, error) {
 
 // WaitForStartup will wait until the startup sequence is completed or the context is expired.
 func (a *App) WaitForStartup(ctx context.Context) error {
-	return a.mgr.WaitForStartup(log.WithLogger(ctx, a.cfg.Logger))
+	return a.mgr.WaitForStartup(a.Context(ctx))
 }
 
 // DB returns the sql.DB instance used by the application.

--- a/app/cmd.go
+++ b/app/cmd.go
@@ -637,7 +637,11 @@ func getConfig(ctx context.Context) (Config, error) {
 
 	var fs expflag.FlagSet
 	strict := viper.GetBool("strict-experimental")
-	for _, f := range viper.GetStringSlice("experimental") {
+	s := viper.GetStringSlice("experimental")
+	if len(s) == 1 {
+		s = strings.Split(s[0], ",")
+	}
+	for _, f := range s {
 		if strict && expflag.Description(expflag.Flag(f)) == "" {
 			return cfg, errors.Errorf("unknown experimental flag: %s", f)
 		}

--- a/app/cmd.go
+++ b/app/cmd.go
@@ -68,16 +68,19 @@ var RootCmd = &cobra.Command{
 		}
 
 		if viper.GetBool("list-experimental") {
-			fmt.Print(`Experimental Flags:
+			fmt.Print(`Usage: goalert --experimental=<flag1>,<flag2> ...
 
-	These flags are not guaranteed to be stable and may change or be removed at 
-	any time. They are used to enable new features and are not intended for 
-	production use.
+These flags are not guaranteed to be stable and may change or be removed at any
+time. They are used to enable in-development features and are not intended for 
+production use.
+
+
+Available Flags:
 
 `)
 
 			for _, f := range expflag.AllFlags() {
-				fmt.Printf("\t%s: %s", f, expflag.Description(f))
+				fmt.Printf("\t%s\t\t%s", f, expflag.Description(f))
 			}
 
 			return nil

--- a/app/config.go
+++ b/app/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/target/goalert/config"
+	"github.com/target/goalert/expflag"
 	"github.com/target/goalert/keyring"
 	"github.com/target/goalert/swo"
 	"github.com/target/goalert/util/log"
@@ -12,6 +13,8 @@ import (
 
 type Config struct {
 	Logger *log.Logger
+
+	ExpFlags expflag.FlagSet
 
 	ListenAddr  string
 	Verbose     bool

--- a/app/context.go
+++ b/app/context.go
@@ -1,0 +1,24 @@
+package app
+
+import (
+	"context"
+
+	"github.com/target/goalert/expflag"
+	"github.com/target/goalert/util/log"
+)
+
+// Context returns a new context with the App's configuration for
+// experimental flags and logger.
+//
+// It should be used for calls from other packages to ensure that
+// the correct configuration is used.
+func (app *App) Context(ctx context.Context) context.Context {
+	ctx = expflag.Context(ctx, app.cfg.ExpFlags)
+	ctx = log.WithLogger(ctx, app.cfg.Logger)
+
+	if app.ConfigStore != nil {
+		ctx = app.ConfigStore.Config().Context(ctx)
+	}
+
+	return ctx
+}

--- a/app/pause.go
+++ b/app/pause.go
@@ -3,19 +3,17 @@ package app
 import (
 	"context"
 	"time"
-
-	"github.com/target/goalert/util/log"
 )
 
 // LogBackgroundContext returns a context.Background with the application logger configured.
 func (app *App) LogBackgroundContext() context.Context { return app.cfg.Logger.BackgroundContext() }
 
 func (app *App) Pause(ctx context.Context) error {
-	return app.mgr.Pause(log.WithLogger(ctx, app.cfg.Logger))
+	return app.mgr.Pause(app.Context(ctx))
 }
 
 func (app *App) Resume(ctx context.Context) error {
-	return app.mgr.Resume(log.WithLogger(ctx, app.cfg.Logger))
+	return app.mgr.Resume(app.Context(ctx))
 }
 
 func (app *App) _pause(ctx context.Context) error {

--- a/app/runapp.go
+++ b/app/runapp.go
@@ -14,7 +14,7 @@ var triggerSignals []os.Signal
 
 // Run will start the application and start serving traffic.
 func (app *App) Run(ctx context.Context) error {
-	return app.mgr.Run(log.WithLogger(ctx, app.cfg.Logger))
+	return app.mgr.Run(app.Context(ctx))
 }
 
 func (app *App) _Run(ctx context.Context) error {

--- a/app/shutdown.go
+++ b/app/shutdown.go
@@ -7,13 +7,12 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/target/goalert/util/log"
 )
 
 // Shutdown will cause the App to begin a graceful shutdown, using
 // the provided context for any cleanup operations.
 func (app *App) Shutdown(ctx context.Context) error {
-	return app.mgr.Shutdown(log.WithLogger(ctx, app.cfg.Logger))
+	return app.mgr.Shutdown(app.Context(ctx))
 }
 
 func (app *App) _Shutdown(ctx context.Context) error {

--- a/app/startup.go
+++ b/app/startup.go
@@ -2,9 +2,11 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/target/goalert/app/lifecycle"
+	"github.com/target/goalert/expflag"
 	"github.com/target/goalert/notification"
 	"github.com/target/goalert/notification/email"
 	"github.com/target/goalert/notification/webhook"
@@ -26,6 +28,14 @@ func (app *App) initStartup(ctx context.Context, label string, fn func(context.C
 }
 
 func (app *App) startup(ctx context.Context) error {
+	for _, f := range app.cfg.ExpFlags {
+		if expflag.Description(f) == "" {
+			log.Log(log.WithField(ctx, "flag", f), fmt.Errorf("unknown experimental flag"))
+		} else {
+			log.Logf(log.WithField(ctx, "flag", f), "Experimental flag enabled: %s", expflag.Description(f))
+		}
+	}
+
 	app.initStartup(ctx, "Startup.TestDBConn", func(ctx context.Context) error {
 		err := app.db.PingContext(ctx)
 		if err == nil {

--- a/expflag/context.go
+++ b/expflag/context.go
@@ -1,0 +1,22 @@
+package expflag
+
+import "context"
+
+type flagSetKeyT struct{}
+
+var flagSetKey flagSetKeyT
+
+// Context returns a new context with the given FlagSet.
+func Context(ctx context.Context, fs FlagSet) context.Context {
+	return context.WithValue(ctx, flagSetKey, fs)
+}
+
+// ContextHas returns true if the given context has the given flag.
+func ContextHas(ctx context.Context, flag Flag) bool {
+	fs, ok := ctx.Value(flagSetKey).(FlagSet)
+	if !ok {
+		return false
+	}
+
+	return fs.Has(flag)
+}

--- a/expflag/flags.go
+++ b/expflag/flags.go
@@ -1,0 +1,32 @@
+package expflag
+
+import "sort"
+
+type Flag string
+
+const (
+	Example Flag = "example"
+)
+
+var desc = map[Flag]string{
+	Example: "An example experimental flag to demonstrate usage.",
+}
+
+// AllFlags returns a slice of all experimental flags sorted by name.
+func AllFlags() []Flag {
+	var result []Flag
+	for k := range desc {
+		result = append(result, k)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i] < result[j]
+	})
+
+	return result
+}
+
+// Description returns the description of the given flag.
+func Description(f Flag) string {
+	return desc[f]
+}

--- a/expflag/flagset.go
+++ b/expflag/flagset.go
@@ -1,0 +1,18 @@
+package expflag
+
+type FlagSet []Flag
+
+// Has returns true if the given flag name is in the set.
+//
+// It will panic if the flag name is not known.
+func (f FlagSet) Has(flag Flag) bool {
+	for _, v := range f {
+		if v != flag {
+			continue
+		}
+
+		return true
+	}
+
+	return false
+}

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -228,6 +228,12 @@ type ComplexityRoot struct {
 		Targets          func(childComplexity int) int
 	}
 
+	ExperimentalFlag struct {
+		Description func(childComplexity int) int
+		Enabled     func(childComplexity int) int
+		ID          func(childComplexity int) int
+	}
+
 	HeartbeatMonitor struct {
 		Href           func(childComplexity int) int
 		ID             func(childComplexity int) int
@@ -372,6 +378,7 @@ type ComplexityRoot struct {
 		DebugMessages            func(childComplexity int, input *DebugMessagesInput) int
 		EscalationPolicies       func(childComplexity int, input *EscalationPolicySearchOptions) int
 		EscalationPolicy         func(childComplexity int, id string) int
+		ExperimentalFlags        func(childComplexity int, input *ExperimentalFlagsOptions) int
 		GenerateSlackAppManifest func(childComplexity int) int
 		HeartbeatMonitor         func(childComplexity int, id string) int
 		IntegrationKey           func(childComplexity int, id string) int
@@ -718,6 +725,7 @@ type OnCallShiftResolver interface {
 }
 type QueryResolver interface {
 	PhoneNumberInfo(ctx context.Context, number string) (*PhoneNumberInfo, error)
+	ExperimentalFlags(ctx context.Context, input *ExperimentalFlagsOptions) ([]ExperimentalFlag, error)
 	MessageLogs(ctx context.Context, input *MessageLogSearchOptions) (*MessageLogConnection, error)
 	DebugMessages(ctx context.Context, input *DebugMessagesInput) ([]DebugMessage, error)
 	User(ctx context.Context, id *string) (*user.User, error)
@@ -1417,6 +1425,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.EscalationPolicyStep.Targets(childComplexity), true
+
+	case "ExperimentalFlag.description":
+		if e.complexity.ExperimentalFlag.Description == nil {
+			break
+		}
+
+		return e.complexity.ExperimentalFlag.Description(childComplexity), true
+
+	case "ExperimentalFlag.enabled":
+		if e.complexity.ExperimentalFlag.Enabled == nil {
+			break
+		}
+
+		return e.complexity.ExperimentalFlag.Enabled(childComplexity), true
+
+	case "ExperimentalFlag.id":
+		if e.complexity.ExperimentalFlag.ID == nil {
+			break
+		}
+
+		return e.complexity.ExperimentalFlag.ID(childComplexity), true
 
 	case "HeartbeatMonitor.href":
 		if e.complexity.HeartbeatMonitor.Href == nil {
@@ -2389,6 +2418,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.EscalationPolicy(childComplexity, args["id"].(string)), true
+
+	case "Query.experimentalFlags":
+		if e.complexity.Query.ExperimentalFlags == nil {
+			break
+		}
+
+		args, err := ec.field_Query_experimentalFlags_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.ExperimentalFlags(childComplexity, args["input"].(*ExperimentalFlagsOptions)), true
 
 	case "Query.generateSlackAppManifest":
 		if e.complexity.Query.GenerateSlackAppManifest == nil {
@@ -3713,6 +3754,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDebugMessagesInput,
 		ec.unmarshalInputDebugSendSMSInput,
 		ec.unmarshalInputEscalationPolicySearchOptions,
+		ec.unmarshalInputExperimentalFlagsOptions,
 		ec.unmarshalInputIntegrationKeySearchOptions,
 		ec.unmarshalInputLabelKeySearchOptions,
 		ec.unmarshalInputLabelSearchOptions,
@@ -4668,6 +4710,21 @@ func (ec *executionContext) field_Query_escalationPolicy_args(ctx context.Contex
 		}
 	}
 	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_experimentalFlags_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *ExperimentalFlagsOptions
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalOExperimentalFlagsOptions2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐExperimentalFlagsOptions(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
 	return args, nil
 }
 
@@ -8889,6 +8946,138 @@ func (ec *executionContext) fieldContext_EscalationPolicyStep_escalationPolicy(c
 				return ec.fieldContext_EscalationPolicy_notices(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type EscalationPolicy", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ExperimentalFlag_id(ctx context.Context, field graphql.CollectedField, obj *ExperimentalFlag) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ExperimentalFlag_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ExperimentalFlag_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ExperimentalFlag",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ExperimentalFlag_description(ctx context.Context, field graphql.CollectedField, obj *ExperimentalFlag) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ExperimentalFlag_description(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Description, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ExperimentalFlag_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ExperimentalFlag",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ExperimentalFlag_enabled(ctx context.Context, field graphql.CollectedField, obj *ExperimentalFlag) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ExperimentalFlag_enabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Enabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ExperimentalFlag_enabled(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ExperimentalFlag",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -13795,6 +13984,69 @@ func (ec *executionContext) fieldContext_Query_phoneNumberInfo(ctx context.Conte
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_phoneNumberInfo_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_experimentalFlags(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_experimentalFlags(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ExperimentalFlags(rctx, fc.Args["input"].(*ExperimentalFlagsOptions))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]ExperimentalFlag)
+	fc.Result = res
+	return ec.marshalNExperimentalFlag2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐExperimentalFlagᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_experimentalFlags(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ExperimentalFlag_id(ctx, field)
+			case "description":
+				return ec.fieldContext_ExperimentalFlag_description(ctx, field)
+			case "enabled":
+				return ec.fieldContext_ExperimentalFlag_enabled(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ExperimentalFlag", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_experimentalFlags_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -26094,6 +26346,38 @@ func (ec *executionContext) unmarshalInputEscalationPolicySearchOptions(ctx cont
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputExperimentalFlagsOptions(ctx context.Context, obj interface{}) (ExperimentalFlagsOptions, error) {
+	var it ExperimentalFlagsOptions
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	if _, present := asMap["includeDisabled"]; !present {
+		asMap["includeDisabled"] = false
+	}
+
+	fieldsInOrder := [...]string{"includeDisabled"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "includeDisabled":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("includeDisabled"))
+			it.IncludeDisabled, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputIntegrationKeySearchOptions(ctx context.Context, obj interface{}) (IntegrationKeySearchOptions, error) {
 	var it IntegrationKeySearchOptions
 	asMap := map[string]interface{}{}
@@ -29346,6 +29630,48 @@ func (ec *executionContext) _EscalationPolicyStep(ctx context.Context, sel ast.S
 	return out
 }
 
+var experimentalFlagImplementors = []string{"ExperimentalFlag"}
+
+func (ec *executionContext) _ExperimentalFlag(ctx context.Context, sel ast.SelectionSet, obj *ExperimentalFlag) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, experimentalFlagImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ExperimentalFlag")
+		case "id":
+
+			out.Values[i] = ec._ExperimentalFlag_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "description":
+
+			out.Values[i] = ec._ExperimentalFlag_description(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "enabled":
+
+			out.Values[i] = ec._ExperimentalFlag_enabled(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var heartbeatMonitorImplementors = []string{"HeartbeatMonitor"}
 
 func (ec *executionContext) _HeartbeatMonitor(ctx context.Context, sel ast.SelectionSet, obj *heartbeat.Monitor) graphql.Marshaler {
@@ -30414,6 +30740,29 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_phoneNumberInfo(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "experimentalFlags":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_experimentalFlags(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
 				return res
 			}
 
@@ -34299,6 +34648,54 @@ func (ec *executionContext) marshalNEscalationPolicyStep2ᚕgithubᚗcomᚋtarge
 	return ret
 }
 
+func (ec *executionContext) marshalNExperimentalFlag2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐExperimentalFlag(ctx context.Context, sel ast.SelectionSet, v ExperimentalFlag) graphql.Marshaler {
+	return ec._ExperimentalFlag(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNExperimentalFlag2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐExperimentalFlagᚄ(ctx context.Context, sel ast.SelectionSet, v []ExperimentalFlag) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNExperimentalFlag2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐExperimentalFlag(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalNHeartbeatMonitor2githubᚗcomᚋtargetᚋgoalertᚋheartbeatᚐMonitor(ctx context.Context, sel ast.SelectionSet, v heartbeat.Monitor) graphql.Marshaler {
 	return ec._HeartbeatMonitor(ctx, sel, &v)
 }
@@ -36881,6 +37278,14 @@ func (ec *executionContext) marshalOEscalationPolicyStep2ᚖgithubᚗcomᚋtarge
 		return graphql.Null
 	}
 	return ec._EscalationPolicyStep(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOExperimentalFlagsOptions2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐExperimentalFlagsOptions(ctx context.Context, v interface{}) (*ExperimentalFlagsOptions, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputExperimentalFlagsOptions(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOHeartbeatMonitor2ᚖgithubᚗcomᚋtargetᚋgoalertᚋheartbeatᚐMonitor(ctx context.Context, sel ast.SelectionSet, v *heartbeat.Monitor) graphql.Marshaler {

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -228,12 +228,6 @@ type ComplexityRoot struct {
 		Targets          func(childComplexity int) int
 	}
 
-	ExperimentalFlag struct {
-		Description func(childComplexity int) int
-		Enabled     func(childComplexity int) int
-		ID          func(childComplexity int) int
-	}
-
 	HeartbeatMonitor struct {
 		Href           func(childComplexity int) int
 		ID             func(childComplexity int) int
@@ -378,7 +372,7 @@ type ComplexityRoot struct {
 		DebugMessages            func(childComplexity int, input *DebugMessagesInput) int
 		EscalationPolicies       func(childComplexity int, input *EscalationPolicySearchOptions) int
 		EscalationPolicy         func(childComplexity int, id string) int
-		ExperimentalFlags        func(childComplexity int, input *ExperimentalFlagsOptions) int
+		ExperimentalFlags        func(childComplexity int) int
 		GenerateSlackAppManifest func(childComplexity int) int
 		HeartbeatMonitor         func(childComplexity int, id string) int
 		IntegrationKey           func(childComplexity int, id string) int
@@ -725,7 +719,7 @@ type OnCallShiftResolver interface {
 }
 type QueryResolver interface {
 	PhoneNumberInfo(ctx context.Context, number string) (*PhoneNumberInfo, error)
-	ExperimentalFlags(ctx context.Context, input *ExperimentalFlagsOptions) ([]ExperimentalFlag, error)
+	ExperimentalFlags(ctx context.Context) ([]string, error)
 	MessageLogs(ctx context.Context, input *MessageLogSearchOptions) (*MessageLogConnection, error)
 	DebugMessages(ctx context.Context, input *DebugMessagesInput) ([]DebugMessage, error)
 	User(ctx context.Context, id *string) (*user.User, error)
@@ -1425,27 +1419,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.EscalationPolicyStep.Targets(childComplexity), true
-
-	case "ExperimentalFlag.description":
-		if e.complexity.ExperimentalFlag.Description == nil {
-			break
-		}
-
-		return e.complexity.ExperimentalFlag.Description(childComplexity), true
-
-	case "ExperimentalFlag.enabled":
-		if e.complexity.ExperimentalFlag.Enabled == nil {
-			break
-		}
-
-		return e.complexity.ExperimentalFlag.Enabled(childComplexity), true
-
-	case "ExperimentalFlag.id":
-		if e.complexity.ExperimentalFlag.ID == nil {
-			break
-		}
-
-		return e.complexity.ExperimentalFlag.ID(childComplexity), true
 
 	case "HeartbeatMonitor.href":
 		if e.complexity.HeartbeatMonitor.Href == nil {
@@ -2424,12 +2397,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		args, err := ec.field_Query_experimentalFlags_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.ExperimentalFlags(childComplexity, args["input"].(*ExperimentalFlagsOptions)), true
+		return e.complexity.Query.ExperimentalFlags(childComplexity), true
 
 	case "Query.generateSlackAppManifest":
 		if e.complexity.Query.GenerateSlackAppManifest == nil {
@@ -3754,7 +3722,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDebugMessagesInput,
 		ec.unmarshalInputDebugSendSMSInput,
 		ec.unmarshalInputEscalationPolicySearchOptions,
-		ec.unmarshalInputExperimentalFlagsOptions,
 		ec.unmarshalInputIntegrationKeySearchOptions,
 		ec.unmarshalInputLabelKeySearchOptions,
 		ec.unmarshalInputLabelSearchOptions,
@@ -4710,21 +4677,6 @@ func (ec *executionContext) field_Query_escalationPolicy_args(ctx context.Contex
 		}
 	}
 	args["id"] = arg0
-	return args, nil
-}
-
-func (ec *executionContext) field_Query_experimentalFlags_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 *ExperimentalFlagsOptions
-	if tmp, ok := rawArgs["input"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
-		arg0, err = ec.unmarshalOExperimentalFlagsOptions2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐExperimentalFlagsOptions(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["input"] = arg0
 	return args, nil
 }
 
@@ -8946,138 +8898,6 @@ func (ec *executionContext) fieldContext_EscalationPolicyStep_escalationPolicy(c
 				return ec.fieldContext_EscalationPolicy_notices(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type EscalationPolicy", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _ExperimentalFlag_id(ctx context.Context, field graphql.CollectedField, obj *ExperimentalFlag) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ExperimentalFlag_id(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.ID, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNID2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_ExperimentalFlag_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "ExperimentalFlag",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type ID does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _ExperimentalFlag_description(ctx context.Context, field graphql.CollectedField, obj *ExperimentalFlag) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ExperimentalFlag_description(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Description, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_ExperimentalFlag_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "ExperimentalFlag",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _ExperimentalFlag_enabled(ctx context.Context, field graphql.CollectedField, obj *ExperimentalFlag) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ExperimentalFlag_enabled(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Enabled, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(bool)
-	fc.Result = res
-	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_ExperimentalFlag_enabled(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "ExperimentalFlag",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -14004,7 +13824,7 @@ func (ec *executionContext) _Query_experimentalFlags(ctx context.Context, field 
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().ExperimentalFlags(rctx, fc.Args["input"].(*ExperimentalFlagsOptions))
+		return ec.resolvers.Query().ExperimentalFlags(rctx)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -14016,9 +13836,9 @@ func (ec *executionContext) _Query_experimentalFlags(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]ExperimentalFlag)
+	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalNExperimentalFlag2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐExperimentalFlagᚄ(ctx, field.Selections, res)
+	return ec.marshalNID2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Query_experimentalFlags(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -14028,27 +13848,8 @@ func (ec *executionContext) fieldContext_Query_experimentalFlags(ctx context.Con
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_ExperimentalFlag_id(ctx, field)
-			case "description":
-				return ec.fieldContext_ExperimentalFlag_description(ctx, field)
-			case "enabled":
-				return ec.fieldContext_ExperimentalFlag_enabled(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type ExperimentalFlag", field.Name)
+			return nil, errors.New("field of type ID does not have child fields")
 		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_experimentalFlags_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return
 	}
 	return fc, nil
 }
@@ -26346,38 +26147,6 @@ func (ec *executionContext) unmarshalInputEscalationPolicySearchOptions(ctx cont
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputExperimentalFlagsOptions(ctx context.Context, obj interface{}) (ExperimentalFlagsOptions, error) {
-	var it ExperimentalFlagsOptions
-	asMap := map[string]interface{}{}
-	for k, v := range obj.(map[string]interface{}) {
-		asMap[k] = v
-	}
-
-	if _, present := asMap["includeDisabled"]; !present {
-		asMap["includeDisabled"] = false
-	}
-
-	fieldsInOrder := [...]string{"includeDisabled"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "includeDisabled":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("includeDisabled"))
-			it.IncludeDisabled, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		}
-	}
-
-	return it, nil
-}
-
 func (ec *executionContext) unmarshalInputIntegrationKeySearchOptions(ctx context.Context, obj interface{}) (IntegrationKeySearchOptions, error) {
 	var it IntegrationKeySearchOptions
 	asMap := map[string]interface{}{}
@@ -29619,48 +29388,6 @@ func (ec *executionContext) _EscalationPolicyStep(ctx context.Context, sel ast.S
 				return innerFunc(ctx)
 
 			})
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var experimentalFlagImplementors = []string{"ExperimentalFlag"}
-
-func (ec *executionContext) _ExperimentalFlag(ctx context.Context, sel ast.SelectionSet, obj *ExperimentalFlag) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, experimentalFlagImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("ExperimentalFlag")
-		case "id":
-
-			out.Values[i] = ec._ExperimentalFlag_id(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "description":
-
-			out.Values[i] = ec._ExperimentalFlag_description(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "enabled":
-
-			out.Values[i] = ec._ExperimentalFlag_enabled(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -34648,54 +34375,6 @@ func (ec *executionContext) marshalNEscalationPolicyStep2ᚕgithubᚗcomᚋtarge
 	return ret
 }
 
-func (ec *executionContext) marshalNExperimentalFlag2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐExperimentalFlag(ctx context.Context, sel ast.SelectionSet, v ExperimentalFlag) graphql.Marshaler {
-	return ec._ExperimentalFlag(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNExperimentalFlag2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐExperimentalFlagᚄ(ctx context.Context, sel ast.SelectionSet, v []ExperimentalFlag) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNExperimentalFlag2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐExperimentalFlag(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
-}
-
 func (ec *executionContext) marshalNHeartbeatMonitor2githubᚗcomᚋtargetᚋgoalertᚋheartbeatᚐMonitor(ctx context.Context, sel ast.SelectionSet, v heartbeat.Monitor) graphql.Marshaler {
 	return ec._HeartbeatMonitor(ctx, sel, &v)
 }
@@ -37278,14 +36957,6 @@ func (ec *executionContext) marshalOEscalationPolicyStep2ᚖgithubᚗcomᚋtarge
 		return graphql.Null
 	}
 	return ec._EscalationPolicyStep(ctx, sel, v)
-}
-
-func (ec *executionContext) unmarshalOExperimentalFlagsOptions2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐExperimentalFlagsOptions(ctx context.Context, v interface{}) (*ExperimentalFlagsOptions, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalInputExperimentalFlagsOptions(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOHeartbeatMonitor2ᚖgithubᚗcomᚋtargetᚋgoalertᚋheartbeatᚐMonitor(ctx context.Context, sel ast.SelectionSet, v *heartbeat.Monitor) graphql.Marshaler {

--- a/graphql2/graphqlapp/query.go
+++ b/graphql2/graphqlapp/query.go
@@ -19,24 +19,14 @@ type (
 
 func (a *App) Query() graphql2.QueryResolver { return (*Query)(a) }
 
-func (a *Query) ExperimentalFlags(ctx context.Context, input *graphql2.ExperimentalFlagsOptions) ([]graphql2.ExperimentalFlag, error) {
-	if input == nil {
-		input = &graphql2.ExperimentalFlagsOptions{}
-	}
-	var flags []graphql2.ExperimentalFlag
+func (a *Query) ExperimentalFlags(ctx context.Context) ([]string, error) {
+	var flags []string
 	for _, f := range expflag.AllFlags() {
-		switch {
-		case input.IncludeDisabled != nil && *input.IncludeDisabled:
-		case expflag.ContextHas(ctx, f):
-		default:
+		if !expflag.ContextHas(ctx, f) {
 			continue
 		}
 
-		flags = append(flags, graphql2.ExperimentalFlag{
-			ID:          string(f),
-			Description: expflag.Description(f),
-			Enabled:     expflag.ContextHas(ctx, f),
-		})
+		flags = append(flags, string(f))
 	}
 
 	return flags, nil

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -275,16 +275,6 @@ type EscalationPolicySearchOptions struct {
 	FavoritesFirst *bool    `json:"favoritesFirst"`
 }
 
-type ExperimentalFlag struct {
-	ID          string `json:"id"`
-	Description string `json:"description"`
-	Enabled     bool   `json:"enabled"`
-}
-
-type ExperimentalFlagsOptions struct {
-	IncludeDisabled *bool `json:"includeDisabled"`
-}
-
 type IntegrationKeyConnection struct {
 	Nodes    []integrationkey.IntegrationKey `json:"nodes"`
 	PageInfo *PageInfo                       `json:"pageInfo"`

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -275,6 +275,16 @@ type EscalationPolicySearchOptions struct {
 	FavoritesFirst *bool    `json:"favoritesFirst"`
 }
 
+type ExperimentalFlag struct {
+	ID          string `json:"id"`
+	Description string `json:"description"`
+	Enabled     bool   `json:"enabled"`
+}
+
+type ExperimentalFlagsOptions struct {
+	IncludeDisabled *bool `json:"includeDisabled"`
+}
+
 type IntegrationKeyConnection struct {
 	Nodes    []integrationkey.IntegrationKey `json:"nodes"`
 	PageInfo *PageInfo                       `json:"pageInfo"`

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -1,6 +1,8 @@
 type Query {
   phoneNumberInfo(number: String!): PhoneNumberInfo
 
+  experimentalFlags(input: ExperimentalFlagsOptions): [ExperimentalFlag!]!
+
   # Returns the list of recent messages.
   messageLogs(input: MessageLogSearchOptions): MessageLogConnection!
   debugMessages(input: DebugMessagesInput): [DebugMessage!]!
@@ -118,6 +120,16 @@ type Query {
   linkAccountInfo(token: ID!): LinkAccountInfo
 
   swoStatus: SWOStatus!
+}
+
+input ExperimentalFlagsOptions {
+  includeDisabled: Boolean = false
+}
+
+type ExperimentalFlag {
+  id: ID!
+  description: String!
+  enabled: Boolean!
 }
 
 type SWOStatus {

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -1,7 +1,7 @@
 type Query {
   phoneNumberInfo(number: String!): PhoneNumberInfo
 
-  experimentalFlags(input: ExperimentalFlagsOptions): [ExperimentalFlag!]!
+  experimentalFlags: [ID!]!
 
   # Returns the list of recent messages.
   messageLogs(input: MessageLogSearchOptions): MessageLogConnection!
@@ -120,16 +120,6 @@ type Query {
   linkAccountInfo(token: ID!): LinkAccountInfo
 
   swoStatus: SWOStatus!
-}
-
-input ExperimentalFlagsOptions {
-  includeDisabled: Boolean = false
-}
-
-type ExperimentalFlag {
-  id: ID!
-  description: String!
-  enabled: Boolean!
 }
 
 type SWOStatus {

--- a/test/smoke/experimentalflags_test.go
+++ b/test/smoke/experimentalflags_test.go
@@ -1,0 +1,44 @@
+package smoke
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/expflag"
+	"github.com/target/goalert/test/smoke/harness"
+)
+
+// TestExperimentalFlag_None tests the GraphQL API when no experimental flags are set.
+func TestExperimentalFlag_None(t *testing.T) {
+	t.Parallel()
+
+	h := harness.NewHarness(t, "", "")
+	defer h.Close()
+
+	var resp struct {
+		ExperimentalFlags expflag.FlagSet
+	}
+
+	err := json.Unmarshal(h.GraphQLQuery2(`{experimentalFlags}`).Data, &resp)
+	require.NoError(t, err)
+	assert.Len(t, resp.ExperimentalFlags, 0)
+}
+
+// TestExperimentalFlag_Example tests the GraphQL API when the example experimental flag is set.
+func TestExperimentalFlag_Example(t *testing.T) {
+	t.Parallel()
+
+	h := harness.NewHarnessWithFlags(t, "", "", expflag.FlagSet{expflag.Example})
+	defer h.Close()
+
+	var resp struct {
+		ExperimentalFlags expflag.FlagSet
+	}
+
+	err := json.Unmarshal(h.GraphQLQuery2(`{experimentalFlags}`).Data, &resp)
+	require.NoError(t, err)
+	require.Len(t, resp.ExperimentalFlags, 1)
+	assert.True(t, resp.ExperimentalFlags.Has(expflag.Example))
+}

--- a/test/smoke/harness/harness.go
+++ b/test/smoke/harness/harness.go
@@ -159,7 +159,7 @@ func NewStoppedHarness(t *testing.T, initSQL string, sqlData interface{}, migrat
 
 // NewStoppedHarnessWithFlags is the same as NewStoppedHarness, but allows
 // passing in a set of experimental flags to be used for the test.
-func NewStoppedHarnessWithFlags(t *testing.T, initSQL string, sqlData interface{}, migrationName string, fs expflag.FlagSet) *Harness {
+func NewStoppedHarnessWithFlags(t *testing.T, initSQL string, sqlData interface{}, migrationName string, expFlags expflag.FlagSet) *Harness {
 	t.Helper()
 
 	if testing.Short() {

--- a/test/smoke/harness/harness.go
+++ b/test/smoke/harness/harness.go
@@ -118,7 +118,7 @@ func NewHarness(t *testing.T, initSQL, migrationName string) *Harness {
 func NewHarnessWithFlags(t *testing.T, initSQL, migrationName string, fs expflag.FlagSet) *Harness {
 	stdlog.SetOutput(io.Discard)
 	t.Helper()
-	h := NewStoppedHarness(t, initSQL, nil, migrationName)
+	h := NewStoppedHarnessWithFlags(t, initSQL, nil, migrationName, fs)
 	h.Start()
 	return h
 }

--- a/test/smoke/harness/harness.go
+++ b/test/smoke/harness/harness.go
@@ -152,7 +152,7 @@ const (
 )
 
 // NewStoppedHarness will create a NewHarness, but will not call Start.
-func NewStoppedHarness(t *testing.T, initSQL string, sqlData interface{}, migrationName string, expFlags ...expflag.Flag) *Harness {
+func NewStoppedHarness(t *testing.T, initSQL string, sqlData interface{}, migrationName string) *Harness {
 	t.Helper()
 	return NewStoppedHarnessWithFlags(t, initSQL, sqlData, migrationName, nil)
 }

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -2,6 +2,7 @@
 
 export interface Query {
   phoneNumberInfo?: null | PhoneNumberInfo
+  experimentalFlags: ExperimentalFlag[]
   messageLogs: MessageLogConnection
   debugMessages: DebugMessage[]
   user?: null | User
@@ -38,6 +39,16 @@ export interface Query {
   generateSlackAppManifest: string
   linkAccountInfo?: null | LinkAccountInfo
   swoStatus: SWOStatus
+}
+
+export interface ExperimentalFlagsOptions {
+  includeDisabled?: null | boolean
+}
+
+export interface ExperimentalFlag {
+  id: string
+  description: string
+  enabled: boolean
 }
 
 export interface SWOStatus {

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -2,7 +2,7 @@
 
 export interface Query {
   phoneNumberInfo?: null | PhoneNumberInfo
-  experimentalFlags: ExperimentalFlag[]
+  experimentalFlags: string[]
   messageLogs: MessageLogConnection
   debugMessages: DebugMessage[]
   user?: null | User
@@ -39,16 +39,6 @@ export interface Query {
   generateSlackAppManifest: string
   linkAccountInfo?: null | LinkAccountInfo
   swoStatus: SWOStatus
-}
-
-export interface ExperimentalFlagsOptions {
-  includeDisabled?: null | boolean
-}
-
-export interface ExperimentalFlag {
-  id: string
-  description: string
-  enabled: boolean
 }
 
 export interface SWOStatus {


### PR DESCRIPTION
**Description:**
This PR adds support for experimental feature flags.

**Which issue(s) this PR fixes:**
Part of #2788

**Out of Scope:**
- cypress support
- playwright support

**Additional Info:**
To keep size and complexity down for the first part, changes to support integration tests (Cypress/playwright) will be merged in subsequent PR(s) to close out the issue.

Functionality is validated by new smoketests in `experimentalflags_test.go`.

It can also be functionally tested by adding `EXPERIMENTAL=` to `make start`

```bash
make start EXPERIMENTAL=example
```

By default `make start` will set strict mode, so setting it to something invalid (e.g., `EXPERIMENTAL=foobar` will result in the application refusing to start.

The `experimentalFlags` query can be run in `/api/graphql/explore` to validate the flags are being set.