### PR TITLE
playwright: experimental feature flags support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ start-swo: bin/psql-lite bin/goalert bin/waitfor bin/runproc node_modules web/sr
 	./bin/goalert migrate --db-url=postgres://goalert@localhost/goalert2
 	GOALERT_VERSION=$(GIT_VERSION) ./bin/runproc -f Procfile.swo -l Procfile.local
 
-start-integration: web/src/build/static/app.js bin/goalert bin/psql-lite bin/waitfor bin/runproc $(BIN_DIR)/tools/prometheus
+start-integration: web/src/build/static/app.js bin/goalert bin/psql-lite bin/waitfor bin/runproc bin/procwrap $(BIN_DIR)/tools/prometheus
 	./bin/waitfor -timeout 1s  "$(DB_URL)" || make postgres
 	./bin/psql-lite -d "$(DB_URL)" -c 'DROP DATABASE IF EXISTS $(INT_DB); CREATE DATABASE $(INT_DB);'
 	./bin/goalert --db-url "$(INT_DB_URL)" migrate

--- a/Procfile.integration
+++ b/Procfile.integration
@@ -1,7 +1,7 @@
 build: while true; do make -qs bin/goalert BUNDLE=1 || make bin/goalert BUNDLE=1 || (echo '\033[0;31mBuild Failure'; sleep 3); sleep 0.1; done
 
 @watch-file=./bin/goalert
-goalert: ./bin/goalert -l=localhost:6130 --public-url=http://localhost:6130 --engine-cycle-time=50ms
+goalert: ./bin/procwrap -addr=localhost:6133 -test=localhost:6130 ./bin/goalert -l=localhost:6130 --public-url=http://localhost:6130 --engine-cycle-time=50ms --strict-experimental
 
 smtp: go run github.com/mailhog/MailHog -ui-bind-addr=localhost:6125 -api-bind-addr=localhost:6125 -smtp-bind-addr=localhost:6105 | grep -v KEEPALIVE
 

--- a/Procfile.integration.ci
+++ b/Procfile.integration.ci
@@ -1,3 +1,3 @@
-goalert: ./bin/goalert -l=localhost:6130 --public-url=http://localhost:6130 --engine-cycle-time=50ms
+goalert: ./bin/procwrap -addr=localhost:6133 -test=localhost:6130 ./bin/goalert -l=localhost:6130 --public-url=http://localhost:6130 --engine-cycle-time=50ms --strict-experimental
 
 smtp: go run github.com/mailhog/MailHog -ui-bind-addr=localhost:6125 -api-bind-addr=localhost:6125 -smtp-bind-addr=localhost:6105 | grep -v KEEPALIVE

--- a/test/integration/experimental-flags.spec.ts
+++ b/test/integration/experimental-flags.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test'
+import { configureExpFlags, userSessionFile } from './lib'
+
+test.use({ storageState: userSessionFile })
+
+test.describe(() => {
+  configureExpFlags(['example'])
+
+  // test a query for the current experimental flags (when example is set)
+  test('example experimental flag set', async ({ page, browser, isMobile }) => {
+    await page.goto('./api/graphql/explore')
+    await page.click('.graphiql-editor')
+    await page.keyboard.down('Control')
+    await page.keyboard.press('KeyA')
+    await page.keyboard.up('Control')
+    await page.keyboard.type(`{experimentalFlags`) // trailing curly brace will be added by the autocomplete
+
+    await page.keyboard.down('Control')
+    await page.keyboard.press('Enter')
+    await page.keyboard.up('Control')
+
+    expect(page.locator('.result-window')).toContainText('experimentalFlags')
+
+    const res = (await page.innerText('.result-window')).replace(/\s/g, '')
+    expect(res).toContain(`{"data":{"experimentalFlags":["example"]}}`)
+  })
+})
+
+// test a query for the current experimental flags (when none are set)
+test('no experimental flags set', async ({ page, browser, isMobile }) => {
+  await page.goto('./api/graphql/explore')
+  await page.click('.graphiql-editor')
+  await page.keyboard.down('Control')
+  await page.keyboard.press('KeyA')
+  await page.keyboard.up('Control')
+  await page.keyboard.type(`{experimentalFlags`) // trailing curly brace will be added by the autocomplete
+
+  await page.keyboard.down('Control')
+  await page.keyboard.press('Enter')
+  await page.keyboard.up('Control')
+
+  expect(page.locator('.result-window')).toContainText('experimentalFlags')
+
+  const res = (await page.innerText('.result-window')).replace(/\s/g, '')
+  expect(res).toContain(`{"data":{"experimentalFlags":[]}}`)
+})

--- a/test/integration/experimental-flags.spec.ts
+++ b/test/integration/experimental-flags.spec.ts
@@ -7,7 +7,7 @@ test.describe(() => {
   configureExpFlags(['example'])
 
   // test a query for the current experimental flags (when example is set)
-  test('example experimental flag set', async ({ page, browser, isMobile }) => {
+  test('example experimental flag set', async ({ page }) => {
     await page.goto('./api/graphql/explore')
     await page.click('.graphiql-editor')
     await page.keyboard.down('Control')
@@ -27,7 +27,7 @@ test.describe(() => {
 })
 
 // test a query for the current experimental flags (when none are set)
-test('no experimental flags set', async ({ page, browser, isMobile }) => {
+test('no experimental flags set', async ({ page }) => {
   await page.goto('./api/graphql/explore')
   await page.click('.graphiql-editor')
   await page.keyboard.down('Control')

--- a/test/integration/lib/flags.ts
+++ b/test/integration/lib/flags.ts
@@ -2,7 +2,7 @@ import { test } from '@playwright/test'
 import http from 'http'
 
 const base = 'http://127.0.0.1:6133'
-function fetch(path: string) {
+function fetch(path: string): Promise<string> {
   return new Promise((resolve, reject) => {
     http.get(base + path, (res) => {
       if (res.statusCode !== 200) {
@@ -26,7 +26,7 @@ function fetch(path: string) {
   })
 }
 
-export function configureExpFlags(flags: string[]) {
+export function configureExpFlags(flags: string[]): void {
   test.describe.configure({ mode: 'serial' })
 
   test.beforeAll(async () => {

--- a/test/integration/lib/flags.ts
+++ b/test/integration/lib/flags.ts
@@ -1,0 +1,40 @@
+import { test } from '@playwright/test'
+import http from 'http'
+
+const base = 'http://127.0.0.1:6133'
+function fetch(path: string) {
+  return new Promise((resolve, reject) => {
+    http.get(base + path, (res) => {
+      if (res.statusCode !== 200) {
+        reject(
+          new Error(`request failed: ${res.statusCode}; url=${base + path}`),
+        )
+        return
+      }
+      let data = ''
+      res.on('data', (chunk) => {
+        data += chunk
+      })
+      res.on('end', () => {
+        resolve(data)
+      })
+
+      res.on('error', (err) => {
+        reject(err)
+      })
+    })
+  })
+}
+
+export function configureExpFlags(flags: string[]) {
+  test.describe.configure({ mode: 'serial' })
+
+  test.beforeAll(async () => {
+    await fetch('/stop')
+    await fetch('/start?extra-arg=--experimental&extra-arg=' + flags.join(','))
+  })
+  test.afterAll(async () => {
+    await fetch('/stop')
+    await fetch('/start')
+  })
+}

--- a/test/integration/lib/index.ts
+++ b/test/integration/lib/index.ts
@@ -1,1 +1,2 @@
 export * from './login'
+export * from './flags'


### PR DESCRIPTION
**Description:**
This PR introduces support for experimental feature flags in Playwright tests by using the `configureExpFlags` function.

This function will mark the current test block (or file) as serial-only and set a beforeAll & afterAll hook to set/unset feature flags.

The added test validates the state of flags by using GraphiQL explorer UI.

**Which issue(s) this PR fixes:**
Resolves #2788 
