### PR TITLE
ui: upgrade cypress to v12.5.0

### DIFF
--- a/Procfile.cypress
+++ b/Procfile.cypress
@@ -1,7 +1,7 @@
 build: while true; do make -qs bin/goalert || make bin/goalert || (echo '\033[0;31mBuild Failure'; sleep 3); sleep 0.1; done
 
 @watch-file=./bin/goalert
-goalert: go run ./devtools/waitfor postgres://postgres@localhost:5433 && go run ./devtools/procwrap -test=localhost:3042 bin/goalert -l=localhost:3042 --ui-dir=web/src/build --db-url=postgres://postgres@localhost:5433 --slack-base-url=http://localhost:3040/slack --log-errors-only --public-url=http://localhost:3040$HTTP_PREFIX
+goalert: go run ./devtools/waitfor postgres://postgres@localhost:5433 && go run ./devtools/procwrap -test=localhost:3042 bin/goalert -l=localhost:3042 --ui-dir=web/src/build --db-url=postgres://postgres@localhost:5433 --slack-base-url=http://localhost:3040/slack --log-errors-only --public-url=http://127.0.0.1:3040$HTTP_PREFIX
 
 @watch-file=./web/src/esbuild.config.js
 ui: yarn workspace goalert-web run esbuild --watch

--- a/Procfile.cypress
+++ b/Procfile.cypress
@@ -1,7 +1,7 @@
 build: while true; do make -qs bin/goalert || make bin/goalert || (echo '\033[0;31mBuild Failure'; sleep 3); sleep 0.1; done
 
 @watch-file=./bin/goalert
-goalert: go run ./devtools/waitfor postgres://postgres@localhost:5433 && go run ./devtools/procwrap -test=localhost:3042 bin/goalert -l=localhost:3042 --ui-dir=web/src/build --db-url=postgres://postgres@localhost:5433 --slack-base-url=http://localhost:3040/slack --log-errors-only --public-url=http://127.0.0.1:3040$HTTP_PREFIX
+goalert: go run ./devtools/waitfor postgres://postgres@localhost:5433 && go run ./devtools/procwrap -test=localhost:3042 bin/goalert -l=localhost:3042 --ui-dir=web/src/build --db-url=postgres://postgres@localhost:5433 --slack-base-url=http://localhost:3040/slack --log-errors-only --public-url=http://localhost:3040$HTTP_PREFIX
 
 @watch-file=./web/src/esbuild.config.js
 ui: yarn workspace goalert-web run esbuild --watch

--- a/devtools/ci/dockerfiles/cypress-env/Dockerfile
+++ b/devtools/ci/dockerfiles/cypress-env/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cypress/included:11.2.0
+FROM docker.io/cypress/included:12.4.1
 ENTRYPOINT []
 RUN apt-get update && apt-get install -y --no-install-recommends postgresql postgresql-contrib && rm -rf /var/lib/apt/lists/*
 ENV PGDATA=/var/lib/postgresql/data PGUSER=postgres DB_URL=postgresql://postgres@

--- a/devtools/ci/dockerfiles/cypress-env/Dockerfile
+++ b/devtools/ci/dockerfiles/cypress-env/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cypress/included:12.4.1
+FROM docker.io/cypress/included:12.5.0
 ENTRYPOINT []
 RUN apt-get update && apt-get install -y --no-install-recommends postgresql postgresql-contrib && rm -rf /var/lib/apt/lists/*
 ENV PGDATA=/var/lib/postgresql/data PGUSER=postgres DB_URL=postgresql://postgres@

--- a/devtools/ci/tasks/test-integration.yml
+++ b/devtools/ci/tasks/test-integration.yml
@@ -7,7 +7,7 @@ outputs:
   - name: debug
 image_resource:
   type: registry-image
-  source: { repository: goalert/cypress-env, tag: '12.4.1' }
+  source: { repository: goalert/cypress-env, tag: '12.5.0' }
 run:
   path: sh
   dir: integration/goalert

--- a/devtools/ci/tasks/test-integration.yml
+++ b/devtools/ci/tasks/test-integration.yml
@@ -7,7 +7,7 @@ outputs:
   - name: debug
 image_resource:
   type: registry-image
-  source: { repository: goalert/cypress-env, tag: '11.2.0' }
+  source: { repository: goalert/cypress-env, tag: '12.4.1' }
 run:
   path: sh
   dir: integration/goalert

--- a/web/src/cypress/e2e/admin.cy.ts
+++ b/web/src/cypress/e2e/admin.cy.ts
@@ -231,9 +231,7 @@ function testAdmin(): void {
         minute: 'numeric',
       })
 
-      cy.get(`[data-cy="${svc1.name}-${now}"]`).trigger('mouseover', 0, 0, {
-        force: true,
-      })
+      cy.get(`.recharts-line-dots circle[r=3]`).last().trigger('mouseover')
       cy.get('[data-cy=alert-count-graph]')
         .should('contain', now)
         .should('contain', `${svc1.name}: 1`)

--- a/web/src/cypress/e2e/admin.cy.ts
+++ b/web/src/cypress/e2e/admin.cy.ts
@@ -249,10 +249,14 @@ function testAdmin(): void {
     let debugMessage: DebugMessage
 
     before(() => {
+      login() // required for before hooks
+
       cy.createOutgoingMessage().then((msg: DebugMessage) => {
         debugMessage = msg
-        cy.visit('/admin/message-logs')
       })
+    })
+    beforeEach(() => {
+      cy.visit('/admin/message-logs')
     })
 
     it('should view the logs list with one log', () => {
@@ -339,4 +343,4 @@ function testAdmin(): void {
   })
 }
 
-testScreen('Admin', testAdmin, false, true)
+const login = testScreen('Admin', testAdmin, false, true)

--- a/web/src/cypress/e2e/admin.cy.ts
+++ b/web/src/cypress/e2e/admin.cy.ts
@@ -1,7 +1,7 @@
 import { Chance } from 'chance'
 import { DateTime } from 'luxon'
 import { DebugMessage } from '../../schema'
-import { testScreen, Config, pathPrefix } from '../support/e2e'
+import { testScreen, login, Config, pathPrefix } from '../support/e2e'
 const c = new Chance()
 
 function testAdmin(): void {
@@ -343,4 +343,4 @@ function testAdmin(): void {
   })
 }
 
-const login = testScreen('Admin', testAdmin, false, true)
+testScreen('Admin', testAdmin, false, true)

--- a/web/src/cypress/e2e/pagination.cy.ts
+++ b/web/src/cypress/e2e/pagination.cy.ts
@@ -1,5 +1,5 @@
 import { Chance } from 'chance'
-import { testScreen } from '../support/e2e'
+import { testScreen, login } from '../support/e2e'
 const c = new Chance()
 
 const itemsPerPage = 15
@@ -122,4 +122,4 @@ function testPagination(): void {
   testPaginating('Users', 'users', cy.createManyUsers)
 }
 
-const login = testScreen('Pagination', testPagination)
+testScreen('Pagination', testPagination)

--- a/web/src/cypress/e2e/pagination.cy.ts
+++ b/web/src/cypress/e2e/pagination.cy.ts
@@ -25,6 +25,8 @@ function testPaginating(
 
   describe(label, () => {
     before(() => {
+      login()
+
       names = []
       nameSubstr = c.word({ length: 12 })
       for (let i = 0; i < 45; i++) {
@@ -120,4 +122,4 @@ function testPagination(): void {
   testPaginating('Users', 'users', cy.createManyUsers)
 }
 
-testScreen('Pagination', testPagination)
+const login = testScreen('Pagination', testPagination)

--- a/web/src/cypress/e2e/services.cy.ts
+++ b/web/src/cypress/e2e/services.cy.ts
@@ -692,7 +692,7 @@ function testServices(screen: ScreenFormat): void {
     })
   })
 
-  describe('Metrics', () => {
+  describe.only('Metrics', () => {
     let closedAlert: Alert
     let openAlert: Alert
     beforeEach(() =>

--- a/web/src/cypress/e2e/services.cy.ts
+++ b/web/src/cypress/e2e/services.cy.ts
@@ -692,7 +692,7 @@ function testServices(screen: ScreenFormat): void {
     })
   })
 
-  describe.only('Metrics', () => {
+  describe('Metrics', () => {
     let closedAlert: Alert
     let openAlert: Alert
     beforeEach(() =>

--- a/web/src/cypress/e2e/services.cy.ts
+++ b/web/src/cypress/e2e/services.cy.ts
@@ -736,7 +736,7 @@ function testServices(screen: ScreenFormat): void {
         .should('contain', 'Alert Count: 1')
         .should('contain', 'Escalated: 0') // no ep steps
 
-      cy.get(`.recharts-line-dots circle`).last().trigger('mouseover')
+      cy.get(`.recharts-line-dots circle[r=3]`).last().trigger('mouseover')
       cy.get('[data-cy=metrics-averages-graph]')
         .should('contain', now)
         .should('contain', 'Avg. Ack: 1 min')

--- a/web/src/cypress/e2e/services.cy.ts
+++ b/web/src/cypress/e2e/services.cy.ts
@@ -736,9 +736,7 @@ function testServices(screen: ScreenFormat): void {
         .should('contain', 'Alert Count: 1')
         .should('contain', 'Escalated: 0') // no ep steps
 
-      cy.get(`[data-cy="avgTimeToClose-${now}"]`).trigger('mouseover', 0, 0, {
-        force: true,
-      })
+      cy.get(`.recharts-line-dots circle`).last().trigger('mouseover')
       cy.get('[data-cy=metrics-averages-graph]')
         .should('contain', now)
         .should('contain', 'Avg. Ack: 1 min')

--- a/web/src/cypress/support/e2e.ts
+++ b/web/src/cypress/support/e2e.ts
@@ -39,13 +39,9 @@ import './form'
 import './dialog'
 import './limits'
 
-Cypress.Cookies.defaults({
-  preserve: 'goalert_session.2',
-})
 Cypress.Keyboard.defaults({
   keystrokeDelay: 0,
 })
-Cypress.Cookies.debug(true)
 
 export * from './config'
 export * from './util'

--- a/web/src/cypress/support/login.ts
+++ b/web/src/cypress/support/login.ts
@@ -48,8 +48,6 @@ function login(
       })
   }
 
-  cy.clearCookie('goalert_session.2')
-
   return cy
     .request({
       url: '/api/v2/identity/providers/basic',

--- a/web/src/cypress/support/util.ts
+++ b/web/src/cypress/support/util.ts
@@ -153,8 +153,13 @@ export function testScreen(
     })
     it('reset db', () => {}) // required due to mocha skip bug
 
+    const loginType = adminLogin ? 'adminLogin' : 'login'
     if (!skipLogin) {
-      before(() => cy.resetConfig()[adminLogin ? 'adminLogin' : 'login']())
+      beforeEach(() => {
+        cy.session(loginType, () => {
+          cy.resetConfig()[loginType]()
+        })
+      })
       it(adminLogin ? 'admin login' : 'login', () => {}) // required due to mocha skip bug
     }
 

--- a/web/src/cypress/support/util.ts
+++ b/web/src/cypress/support/util.ts
@@ -124,6 +124,8 @@ export function screenName(): string {
   return 'Wide'
 }
 
+let testN = 0
+
 export function testScreen(
   label: string,
   fn: (screen: ScreenFormat) => void,
@@ -153,11 +155,10 @@ export function testScreen(
     })
     it('reset db', () => {}) // required due to mocha skip bug
 
-    const loginType = adminLogin ? 'adminLogin' : 'login'
     if (!skipLogin) {
       beforeEach(() => {
-        cy.session(loginType, () => {
-          cy.resetConfig()[loginType]()
+        cy.session('testScreen_' + ++testN, () => {
+          cy.resetConfig()[adminLogin ? 'adminLogin' : 'login']()
         })
       })
       it(adminLogin ? 'admin login' : 'login', () => {}) // required due to mocha skip bug

--- a/web/src/cypress/support/util.ts
+++ b/web/src/cypress/support/util.ts
@@ -146,7 +146,6 @@ export function testScreen(
       cy.intercept('/_cy_test_reset', '<html></html>')
       cy.visit('/_cy_test_reset')
 
-      cy.clearCookie('goalert_session.2')
       cy.task('engine:stop')
         .sql(resetQuery)
         .task('db:resettime')
@@ -161,7 +160,6 @@ export function testScreen(
           cy.resetConfig()[adminLogin ? 'adminLogin' : 'login']()
         })
       })
-      it(adminLogin ? 'admin login' : 'login', () => {}) // required due to mocha skip bug
     }
 
     describe(screenName(), () => fn(screen()))

--- a/web/src/cypress/support/util.ts
+++ b/web/src/cypress/support/util.ts
@@ -157,7 +157,7 @@ export function testScreen(
 
     if (!skipLogin) {
       beforeEach(() => {
-        cy.session('testScreen_' + ++testN, () => {
+        cy.session({ n: testN++, ts: new Date() }, () => {
           cy.resetConfig()[adminLogin ? 'adminLogin' : 'login']()
         })
       })

--- a/web/src/cypress/support/util.ts
+++ b/web/src/cypress/support/util.ts
@@ -141,6 +141,10 @@ export function testScreen(
   adminLogin = false,
   expFlags: string[] = [],
 ): void {
+  after(() => {
+    loginFn = null
+  })
+
   if (!skipLogin) {
     const sessID = { n: testN++, ts: new Date() }
     loginFn = () => {
@@ -148,6 +152,8 @@ export function testScreen(
         cy.resetConfig()[adminLogin ? 'adminLogin' : 'login']()
       })
     }
+  } else {
+    loginFn = null
   }
 
   describe(label, () => {
@@ -178,8 +184,6 @@ export function testScreen(
 
     describe(screenName(), () => fn(screen()))
   })
-
-  loginFn = null
 }
 
 // testScreenWithFlags is a convenience function for testing a screen with

--- a/web/src/package.json
+++ b/web/src/package.json
@@ -75,7 +75,7 @@
     "@types/react-dom": "18.0.1",
     "@types/react-virtualized-auto-sizer": "1.0.1",
     "chance": "1.1.7",
-    "cypress": "12.4.1",
+    "cypress": "12.5.0",
     "esbuild-jest": "0.5.0",
     "jest": "29.4.0",
     "prop-types": "15.8.0",

--- a/web/src/package.json
+++ b/web/src/package.json
@@ -75,7 +75,7 @@
     "@types/react-dom": "18.0.1",
     "@types/react-virtualized-auto-sizer": "1.0.1",
     "chance": "1.1.7",
-    "cypress": "11.2.0",
+    "cypress": "12.4.1",
     "esbuild-jest": "0.5.0",
     "jest": "29.4.0",
     "prop-types": "15.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2943,10 +2943,10 @@ csstype@^3.0.2, csstype@^3.1.0, csstype@^3.1.1:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
   integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
 
-cypress@11.2.0:
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-11.2.0.tgz#63edef8c387b687066c5493f6f0ad7b9ced4b2b7"
-  integrity sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==
+cypress@12.4.1:
+  version "12.4.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.4.1.tgz#6121b49fd7d833d1f4a0f486034f063467f433af"
+  integrity sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2943,10 +2943,10 @@ csstype@^3.0.2, csstype@^3.1.0, csstype@^3.1.1:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
   integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
 
-cypress@12.4.1:
-  version "12.4.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.4.1.tgz#6121b49fd7d833d1f4a0f486034f063467f433af"
-  integrity sha512-IFMPzc1RJ22Fac+YbdqywtpcuqZXqQJh+JqZDXn+A15zG/dw99njfv8f0bTvD+WAHhP118+xWG/VwilkFg1rnA==
+cypress@12.5.0:
+  version "12.5.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.5.0.tgz#e2070d9351944f79fd8688fc7ec0bfdf91c30e1e"
+  integrity sha512-CRo1DIr0LoCE3SNb/kJ0TZM9dIdiy7fNlRp/YoPfAv+XOKZV27LQ7zZUi4lMmHIEo3K0dAN5+tJ/8eZc/Jmbyg==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
upgrade Cypress to v12.4.1

includes changes to how the session cookies are stored. each test now runs with its own isolated cookie rather than one session preserved once at the top level