### PR TITLE
slack: add UI for Slack DM contact method type (experimental)

### DIFF
--- a/web/src/app/users/UserContactMethodCreateDialog.tsx
+++ b/web/src/app/users/UserContactMethodCreateDialog.tsx
@@ -8,6 +8,7 @@ import { useConfigValue } from '../util/RequireConfig'
 import { Dialog, DialogTitle, DialogActions, Button } from '@mui/material'
 import DialogContentError from '../dialogs/components/DialogContentError'
 import { ContactMethodType } from '../../schema'
+import { useExpFlag } from '../util/useExpFlag'
 
 type Value = {
   name: string
@@ -40,11 +41,14 @@ export default function UserContactMethodCreateDialog(props: {
   title?: string
   subtitle?: string
 }): JSX.Element {
-  const [allowSV, allowE, allowW] = useConfigValue(
+  const [allowSV, allowE, allowW, allowS] = useConfigValue(
     'Twilio.Enable',
     'SMTP.Enable',
     'Webhook.Enable',
+    'Slack.Enable',
   )
+  const allowSFlag = useExpFlag('slack-dm')
+
   let typeVal: ContactMethodType = 'VOICE'
   if (allowSV) {
     typeVal = 'SMS'
@@ -52,7 +56,10 @@ export default function UserContactMethodCreateDialog(props: {
     typeVal = 'EMAIL'
   } else if (allowW) {
     typeVal = 'WEBHOOK'
+  } else if (allowS && allowSFlag) {
+    typeVal = 'SLACK_DM'
   }
+
   // values for contact method form
   const [CMValue, setCMValue] = useState<Value>({
     name: '',

--- a/web/src/app/users/UserContactMethodForm.tsx
+++ b/web/src/app/users/UserContactMethodForm.tsx
@@ -7,6 +7,7 @@ import { MenuItem, Typography } from '@mui/material'
 import { ContactMethodType } from '../../schema'
 import { useConfigValue } from '../util/RequireConfig'
 import { FieldError } from '../util/errutil'
+import { useExpFlag } from '../util/useExpFlag'
 
 type Value = {
   name: string
@@ -72,6 +73,21 @@ function renderURLField(edit: boolean): JSX.Element {
   )
 }
 
+function renderSlackField(edit: boolean): JSX.Element {
+  return (
+    <FormField
+      fullWidth
+      name='value'
+      required
+      label='Slack Member ID'
+      placeholder='member ID'
+      component={TextField}
+      disabled={edit}
+      helperText='Go to your Slack profile, click the three dots, and select "Copy member ID".'
+    />
+  )
+}
+
 function renderTypeField(type: ContactMethodType, edit: boolean): JSX.Element {
   switch (type) {
     case 'SMS':
@@ -81,6 +97,8 @@ function renderTypeField(type: ContactMethodType, edit: boolean): JSX.Element {
       return renderEmailField(edit)
     case 'WEBHOOK':
       return renderURLField(edit)
+    case 'SLACK_DM':
+      return renderSlackField(edit)
     default:
   }
 
@@ -105,13 +123,21 @@ export default function UserContactMethodForm(
 ): JSX.Element {
   const { value, edit = false, ...other } = props
 
-  const [smsVoiceEnabled, emailEnabled, webhookEnabled, disclaimer] =
-    useConfigValue(
-      'Twilio.Enable',
-      'SMTP.Enable',
-      'Webhook.Enable',
-      'General.NotificationDisclaimer',
-    )
+  const [
+    smsVoiceEnabled,
+    emailEnabled,
+    webhookEnabled,
+    slackEnabled,
+    disclaimer,
+  ] = useConfigValue(
+    'Twilio.Enable',
+    'SMTP.Enable',
+    'Webhook.Enable',
+    'Slack.Enable',
+    'General.NotificationDisclaimer',
+  )
+
+  const slackDMEnabled = useExpFlag('slack-dm')
 
   return (
     <FormContainer
@@ -148,11 +174,14 @@ export default function UserContactMethodForm(
           >
             {(edit || smsVoiceEnabled) && <MenuItem value='SMS'>SMS</MenuItem>}
             {(edit || smsVoiceEnabled) && (
-              <MenuItem value='VOICE'>VOICE</MenuItem>
+              <MenuItem value='VOICE'>Voice</MenuItem>
             )}
-            {(edit || emailEnabled) && <MenuItem value='EMAIL'>EMAIL</MenuItem>}
+            {(edit || emailEnabled) && <MenuItem value='EMAIL'>Email</MenuItem>}
             {(edit || webhookEnabled) && (
-              <MenuItem value='WEBHOOK'>WEBHOOK</MenuItem>
+              <MenuItem value='WEBHOOK'>Webhook</MenuItem>
+            )}
+            {(edit || (slackEnabled && slackDMEnabled)) && (
+              <MenuItem value='SLACK_DM'>Slack DM</MenuItem>
             )}
           </FormField>
         </Grid>

--- a/web/src/app/users/UserContactMethodForm.tsx
+++ b/web/src/app/users/UserContactMethodForm.tsx
@@ -175,14 +175,14 @@ export default function UserContactMethodForm(
           >
             {(edit || smsVoiceEnabled) && <MenuItem value='SMS'>SMS</MenuItem>}
             {(edit || smsVoiceEnabled) && (
-              <MenuItem value='VOICE'>Voice</MenuItem>
+              <MenuItem value='VOICE'>VOICE</MenuItem>
             )}
-            {(edit || emailEnabled) && <MenuItem value='EMAIL'>Email</MenuItem>}
+            {(edit || emailEnabled) && <MenuItem value='EMAIL'>EMAIL</MenuItem>}
             {(edit || webhookEnabled) && (
-              <MenuItem value='WEBHOOK'>Webhook</MenuItem>
+              <MenuItem value='WEBHOOK'>WEBHOOK</MenuItem>
             )}
             {(edit || (slackEnabled && slackDMEnabled)) && (
-              <MenuItem value='SLACK_DM'>Slack DM</MenuItem>
+              <MenuItem value='SLACK_DM'>SLACK DM</MenuItem>
             )}
           </FormField>
         </Grid>

--- a/web/src/app/users/UserContactMethodForm.tsx
+++ b/web/src/app/users/UserContactMethodForm.tsx
@@ -83,6 +83,7 @@ function renderSlackField(edit: boolean): JSX.Element {
       placeholder='member ID'
       component={TextField}
       disabled={edit}
+      // @ts-expect-error TS2322 -- FormField has not been converted to ts, and inferred type is incorrect.
       helperText='Go to your Slack profile, click the three dots, and select "Copy member ID".'
     />
   )

--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -19,6 +19,7 @@ import AppLink from '../util/AppLink'
 import { styles as globalStyles } from '../styles/materialStyles'
 import { UserContactMethod } from '../../schema'
 import UserContactMethodCreateDialog from './UserContactMethodCreateDialog'
+import { useExpFlag } from '../util/useExpFlag'
 
 const query = gql`
   query cmList($id: ID!) {
@@ -61,6 +62,7 @@ export default function UserContactMethodList(
   const [showEditDialogByID, setShowEditDialogByID] = useState('')
   const [showDeleteDialogByID, setShowDeleteDialogByID] = useState('')
   const [showSendTestByID, setShowSendTestByID] = useState('')
+  const hasSlackDM = useExpFlag('slack-dm')
 
   const { loading, error, data } = useQuery(query, {
     variables: {
@@ -101,6 +103,9 @@ export default function UserContactMethodList(
         onClick: () => setShowDeleteDialogByID(cm.id),
       },
     ]
+
+    // don't show send test for slack DMs if disabled
+    if (cm.type === 'SLACK_DM' && !hasSlackDM) return actions
 
     if (!cm.disabled) {
       actions.push({


### PR DESCRIPTION
**Description:**
This PR adds UI support for Slack DMs as a contact method type.

**Which issue(s) this PR fixes:**
Part of #2712
This is a follow-up to #2805 

**Out of Scope:**
It only adds support in the UI for creating & deleting the new contact method type.

**Additional Info:**
Start with `make start EXPERIMENTAL=slack-dm` to create a Slack DM contact method.

![image](https://user-images.githubusercontent.com/595010/218177589-6b81c895-caa0-4199-8eb4-197516a0ce59.png)

