### PR TITLE
ui: add Time component

### DIFF
--- a/web/src/app/alerts/AlertDetailLogs.js
+++ b/web/src/app/alerts/AlertDetailLogs.js
@@ -6,10 +6,9 @@ import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
 import ListItemText from '@mui/material/ListItemText'
 import makeStyles from '@mui/styles/makeStyles'
-import { DateTime } from 'luxon'
 import _ from 'lodash'
-import { formatTimeSince } from '../util/timeFormat'
 import { POLL_INTERVAL } from '../config'
+import { Time } from '../util/Time'
 
 const FETCH_LIMIT = 149
 const QUERY_LIMIT = 35
@@ -120,13 +119,6 @@ export default function AlertDetailLogs(props) {
     const details = _.upperFirst(event?.state?.details ?? '')
     const status = event?.state?.status ?? ''
 
-    let timestamp = formatTimeSince(event.timestamp)
-    if (props.showExactTimes) {
-      timestamp = DateTime.fromISO(event.timestamp).toLocaleString(
-        DateTime.DATETIME_FULL,
-      )
-    }
-
     return (
       <ListItem key={idx} divider>
         <ListItemText
@@ -137,7 +129,12 @@ export default function AlertDetailLogs(props) {
         <div>
           <ListItemText
             className={classes.logTimeContainer}
-            secondary={timestamp}
+            secondary={
+              <Time
+                time={event.timestamp}
+                format={props.showExactTimes ? 'default' : 'relative'}
+              />
+            }
           />
         </div>
       </ListItem>

--- a/web/src/app/alerts/AlertsList.tsx
+++ b/web/src/app/alerts/AlertsList.tsx
@@ -9,11 +9,9 @@ import {
   Check as AcknowledgeIcon,
   Close as CloseIcon,
 } from '@mui/icons-material'
-import { DateTime } from 'luxon'
 
 import AlertsListFilter from './components/AlertsListFilter'
 import AlertsListControls from './components/AlertsListControls'
-import { formatTimeSince } from '../util/timeFormat'
 import QueryList from '../lists/QueryList'
 import { useIsWidthDown } from '../util/useWidth'
 import CreateFAB from '../lists/CreateFAB'
@@ -21,6 +19,7 @@ import CreateAlertDialog from './CreateAlertDialog/CreateAlertDialog'
 import { useURLParam } from '../actions'
 import { ControlledPaginatedListAction } from '../lists/ControlledPaginatedList'
 import ServiceMaintenanceNotice from '../services/ServiceMaintenanceNotice'
+import { Time } from '../util/Time'
 
 interface AlertsListProps {
   serviceID: string
@@ -281,11 +280,10 @@ export default function AlertsList(props: AlertsListProps): JSX.Element {
                 <ListItemText
                   className={classes.alertTimeContainer}
                   secondary={
-                    fullTime
-                      ? DateTime.fromISO(a.createdAt).toLocaleString(
-                          DateTime.DATETIME_MED,
-                        )
-                      : formatTimeSince(a.createdAt)
+                    <Time
+                      time={a.createdAt}
+                      format={fullTime ? 'default' : 'relative'}
+                    />
                   }
                 />
               ),

--- a/web/src/app/services/HeartbeatMonitorList.tsx
+++ b/web/src/app/services/HeartbeatMonitorList.tsx
@@ -18,6 +18,7 @@ import { GenericError } from '../error-pages'
 import { HeartbeatMonitor } from '../../schema'
 import { useIsWidthDown } from '../util/useWidth'
 import { Add } from '@mui/icons-material'
+import { Time } from '../util/Time'
 
 // generates a single alert if a POST is not received before the timeout
 const HEARTBEAT_MONITOR_DESCRIPTION =
@@ -93,9 +94,10 @@ export default function HeartbeatMonitorList(props: {
         title: monitor.name,
         subText: (
           <React.Fragment>
-            {`Timeout: ${monitor.timeoutMinutes} minute${
-              monitor.timeoutMinutes > 1 ? 's' : ''
-            }`}
+            <Time
+              prefix='Timeout: '
+              duration={{ minutes: monitor.timeoutMinutes }}
+            />
             <br />
             <CopyText title='Copy URL' value={monitor.href} asURL />
           </React.Fragment>

--- a/web/src/app/services/HeartbeatMonitorList.tsx
+++ b/web/src/app/services/HeartbeatMonitorList.tsx
@@ -98,6 +98,7 @@ export default function HeartbeatMonitorList(props: {
               prefix='Timeout: '
               duration={{ minutes: monitor.timeoutMinutes }}
               precise
+              units={['hours', 'minutes']}
             />
             <br />
             <CopyText title='Copy URL' value={monitor.href} asURL />

--- a/web/src/app/services/HeartbeatMonitorList.tsx
+++ b/web/src/app/services/HeartbeatMonitorList.tsx
@@ -97,6 +97,7 @@ export default function HeartbeatMonitorList(props: {
             <Time
               prefix='Timeout: '
               duration={{ minutes: monitor.timeoutMinutes }}
+              precise
             />
             <br />
             <CopyText title='Copy URL' value={monitor.href} asURL />

--- a/web/src/app/services/HeartbeatMonitorStatus.tsx
+++ b/web/src/app/services/HeartbeatMonitorStatus.tsx
@@ -7,9 +7,9 @@ import HealthyIcon from '@mui/icons-material/Check'
 import UnhealthyIcon from '@mui/icons-material/Clear'
 import InactiveIcon from '@mui/icons-material/Remove'
 import makeStyles from '@mui/styles/makeStyles'
-import { formatTimeSince } from '../util/timeFormat'
 import useStatusColors from '../theme/useStatusColors'
 import { ISOTimestamp } from '../../schema'
+import { Time } from '../util/Time'
 
 const useStyles = makeStyles({
   gridContainer: {
@@ -72,8 +72,7 @@ export default function HeartbeatMonitorStatus(props: {
       </Grid>
       <Grid item xs={12} className={classes.durationText}>
         <Typography variant='caption'>
-          {formatTimeSince(props.lastHeartbeat ? props.lastHeartbeat : '') ||
-            'Inactive'}
+          <Time time={props.lastHeartbeat} format='relative' zero='Inactive' />
         </Typography>
       </Grid>
     </Grid>

--- a/web/src/app/users/UserSessionList.tsx
+++ b/web/src/app/users/UserSessionList.tsx
@@ -11,10 +11,10 @@ import { Button, Card, Grid, IconButton } from '@mui/material'
 import DeleteIcon from '@mui/icons-material/Delete'
 import { UserSession } from '../../schema'
 import Bowser from 'bowser'
-import { formatTimeSince } from '../util/timeFormat'
 import _ from 'lodash'
 import FormDialog from '../dialogs/FormDialog'
 import { nonFieldErrors } from '../util/errutil'
+import { Time } from '../util/Time'
 
 const profileQuery = gql`
   query {
@@ -149,7 +149,13 @@ export default function UserSessionList({
                     <DeleteIcon />
                   </IconButton>
                 ),
-                subText: `Last access: ${formatTimeSince(s.lastAccessAt)}`,
+                subText: (
+                  <Time
+                    format='relative'
+                    time={s.lastAccessAt}
+                    prefix='Last access: '
+                  />
+                ),
               }))}
             />
           </Card>

--- a/web/src/app/users/UserSessionList.tsx
+++ b/web/src/app/users/UserSessionList.tsx
@@ -154,6 +154,7 @@ export default function UserSessionList({
                     format='relative'
                     time={s.lastAccessAt}
                     prefix='Last access: '
+                    min={{ minutes: 2 }}
                   />
                 ),
               }))}

--- a/web/src/app/util/Time.tsx
+++ b/web/src/app/util/Time.tsx
@@ -67,6 +67,7 @@ const TimeTimestamp: React.FC<TimeTimestampProps> = (props) => {
 type TimeDurationProps = TimeBaseProps & {
   precise?: boolean
   duration: DurationLikeObject | string | Duration
+  units?: readonly (keyof DurationLikeObject)[]
 }
 
 const TimeDuration: React.FC<TimeDurationProps> = (props) => {
@@ -79,7 +80,9 @@ const TimeDuration: React.FC<TimeDurationProps> = (props) => {
     <React.Fragment>
       {props.prefix}
       <time dateTime={dur.toISO()}>
-        {props.precise ? toRelativePrecise(dur, true) : dur.toHuman()}
+        {props.precise
+          ? toRelativePrecise(dur, true, props.units)
+          : dur.toHuman()}
       </time>
       {props.suffix}
     </React.Fragment>

--- a/web/src/app/util/Time.tsx
+++ b/web/src/app/util/Time.tsx
@@ -79,7 +79,7 @@ const TimeDuration: React.FC<TimeDurationProps> = (props) => {
     <React.Fragment>
       {props.prefix}
       <time dateTime={dur.toISO()}>
-        {props.precise ? toRelativePrecise(dur) : dur.toHuman()}
+        {props.precise ? toRelativePrecise(dur, true) : dur.toHuman()}
       </time>
       {props.suffix}
     </React.Fragment>

--- a/web/src/app/util/Time.tsx
+++ b/web/src/app/util/Time.tsx
@@ -40,10 +40,14 @@ const TimeTimestamp: React.FC<TimeTimestampProps> = (props) => {
 
   const time = getDT(props.time, props.zone)
   const display = formatTimestamp({ ...props, time })
-  const local = formatTimestamp({ ...props, time, zone: 'local' })
+  const local = formatTimestamp({
+    ...props,
+    time,
+    zone: 'local',
+    format: props.format === 'relative' ? 'default' : props.format,
+  })
 
-  const title =
-    formatTimestamp({ ...props, time, zone: 'local' }) + ' in local time'
+  const title = local + ' local time'
   const zoneStr = ' ' + time.toFormat('ZZZZ')
 
   return (
@@ -58,7 +62,7 @@ const TimeTimestamp: React.FC<TimeTimestampProps> = (props) => {
         }}
       >
         {display}
-        {display !== local && zoneStr}
+        {display !== local && props.format !== 'relative' && zoneStr}
       </time>
       {suffix}
     </React.Fragment>

--- a/web/src/app/util/Time.tsx
+++ b/web/src/app/util/Time.tsx
@@ -3,8 +3,9 @@ import React, { useEffect, useState } from 'react'
 import {
   formatTimestamp,
   getDT,
+  getDur,
   TimeFormatOpts,
-  toRelativePrecise,
+  toRelative,
 } from './timeFormat'
 
 type TimeBaseProps = {
@@ -68,6 +69,7 @@ type TimeDurationProps = TimeBaseProps & {
   precise?: boolean
   duration: DurationLikeObject | string | Duration
   units?: readonly (keyof DurationLikeObject)[]
+  min?: DurationLikeObject | string | Duration
 }
 
 const TimeDuration: React.FC<TimeDurationProps> = (props) => {
@@ -75,14 +77,19 @@ const TimeDuration: React.FC<TimeDurationProps> = (props) => {
     typeof props.duration === 'string'
       ? Duration.fromISO(props.duration)
       : Duration.fromObject(props.duration)
+  const min = props.min ? getDur(props.min) : undefined
 
   return (
     <React.Fragment>
       {props.prefix}
       <time dateTime={dur.toISO()}>
-        {props.precise
-          ? toRelativePrecise(dur, true, props.units)
-          : dur.toHuman()}
+        {toRelative({
+          dur,
+          noQualifier: true,
+          units: props.units,
+          min,
+          precise: props.precise,
+        })}
       </time>
       {props.suffix}
     </React.Fragment>

--- a/web/src/app/util/Time.tsx
+++ b/web/src/app/util/Time.tsx
@@ -53,7 +53,7 @@ const TimeTimestamp: React.FC<TimeTimestampProps> = (props) => {
         title={display !== local ? title : undefined}
         style={{
           textDecorationStyle: 'dotted',
-          textDecorationLine: title ? 'underline' : 'none',
+          textDecorationLine: display !== local ? 'underline' : 'none',
         }}
       >
         {display}

--- a/web/src/app/util/Time.tsx
+++ b/web/src/app/util/Time.tsx
@@ -4,8 +4,8 @@ import {
   formatTimestamp,
   getDT,
   getDur,
-  TimeFormatOpts,
-  toRelative,
+  FormatTimestampArg,
+  formatRelative,
 } from './timeFormat'
 
 type TimeBaseProps = {
@@ -14,7 +14,7 @@ type TimeBaseProps = {
 }
 
 type TimeTimestampProps = TimeBaseProps &
-  Omit<TimeFormatOpts, 'time'> & {
+  Omit<FormatTimestampArg, 'time'> & {
     time: string | null | undefined
     zero?: string
   }
@@ -83,7 +83,7 @@ const TimeDuration: React.FC<TimeDurationProps> = (props) => {
     <React.Fragment>
       {props.prefix}
       <time dateTime={dur.toISO()}>
-        {toRelative({
+        {formatRelative({
           dur,
           noQualifier: true,
           units: props.units,

--- a/web/src/app/util/Time.tsx
+++ b/web/src/app/util/Time.tsx
@@ -1,0 +1,95 @@
+import { DateTime, Duration, DurationLikeObject } from 'luxon'
+import React, { useEffect, useState } from 'react'
+import {
+  formatTimestamp,
+  getDT,
+  TimeFormatOpts,
+  toRelativePrecise,
+} from './timeFormat'
+
+type TimeBaseProps = {
+  prefix?: string
+  suffix?: string
+}
+
+type TimeTimestampProps = TimeBaseProps &
+  Omit<TimeFormatOpts, 'time'> & {
+    time: string | null | undefined
+    zero?: string
+  }
+
+const TimeTimestamp: React.FC<TimeTimestampProps> = (props) => {
+  const [, setTS] = useState('') // force re-render
+  useEffect(() => {
+    if (!['relative', 'relative-date'].includes(props.format || '')) return
+    const interval = setInterval(() => setTS(DateTime.utc().toISO()), 1000)
+    return () => clearInterval(interval)
+  }, [props.format])
+
+  const { prefix, zero, suffix } = props
+  if (!props.time && !zero) return null
+  if (!props.time)
+    return (
+      <React.Fragment>
+        {prefix}
+        {zero}
+        {suffix}
+      </React.Fragment>
+    )
+
+  const time = getDT(props.time, props.zone)
+  const display = formatTimestamp({ ...props, time })
+  const local = formatTimestamp({ ...props, time, zone: 'local' })
+
+  const title =
+    formatTimestamp({ ...props, time, zone: 'local' }) + ' in local time'
+  const zoneStr = ' ' + time.toFormat('ZZZZ')
+
+  return (
+    <React.Fragment>
+      {prefix}
+      <time
+        dateTime={props.time}
+        title={display !== local ? title : undefined}
+        style={{
+          textDecorationStyle: 'dotted',
+          textDecorationLine: title ? 'underline' : 'none',
+        }}
+      >
+        {display}
+        {display !== local && zoneStr}
+      </time>
+      {suffix}
+    </React.Fragment>
+  )
+}
+
+type TimeDurationProps = TimeBaseProps & {
+  precise?: boolean
+  duration: DurationLikeObject | string | Duration
+}
+
+const TimeDuration: React.FC<TimeDurationProps> = (props) => {
+  const dur =
+    typeof props.duration === 'string'
+      ? Duration.fromISO(props.duration)
+      : Duration.fromObject(props.duration)
+
+  return (
+    <React.Fragment>
+      {props.prefix}
+      <time dateTime={dur.toISO()}>
+        {props.precise ? toRelativePrecise(dur) : dur.toHuman()}
+      </time>
+      {props.suffix}
+    </React.Fragment>
+  )
+}
+
+export type TimeProps = TimeTimestampProps | TimeDurationProps
+
+// Time will render a <time> element using Luxon to format the time.
+export const Time: React.FC<TimeProps> = (props) => {
+  if ('time' in props) return <TimeTimestamp {...props} />
+  return <TimeDuration {...props} />
+}

--- a/web/src/app/util/timeFormat.test.ts
+++ b/web/src/app/util/timeFormat.test.ts
@@ -4,7 +4,6 @@ import {
   FormatTimestampArg,
   formatRelative,
 } from './timeFormat'
-import { Duration } from 'luxon'
 
 describe('formatTimestamp', () => {
   const check = (opts: FormatTimestampArg, exp: string): void => {

--- a/web/src/app/util/timeFormat.test.ts
+++ b/web/src/app/util/timeFormat.test.ts
@@ -1,12 +1,13 @@
 import {
   formatTimestamp,
-  TimeFormatOpts,
-  toRelativePrecise,
+  FormatRelativeArg,
+  FormatTimestampArg,
+  formatRelative,
 } from './timeFormat'
 import { Duration } from 'luxon'
 
 describe('formatTimestamp', () => {
-  const check = (opts: TimeFormatOpts, exp: string): void => {
+  const check = (opts: FormatTimestampArg, exp: string): void => {
     it(`${opts.time} === ${exp}`, () => {
       expect(formatTimestamp(opts)).toBe(exp)
     })
@@ -56,14 +57,20 @@ describe('formatTimestamp', () => {
   )
 })
 
-describe('toRelativePrecise', () => {
-  const check = (dur: Duration, exp: string): void => {
-    it(`${dur.toFormat('dDays h:m:s')} === ${exp}`, () => {
-      expect(toRelativePrecise(dur)).toBe(exp)
+describe('toRelative', () => {
+  const check = (arg: FormatRelativeArg, exp: string): void => {
+    it(exp, () => {
+      expect(formatRelative(arg)).toBe(exp)
     })
   }
 
-  check(Duration.fromObject({ minutes: -1 }), '1 minute ago')
-  check(Duration.fromObject({ minutes: 1 }), 'in 1 minute')
-  check(Duration.fromObject({ hours: 1.5 }), 'in 1 hour 30 minutes')
+  check({ dur: { minute: -1 } }, '1 min ago')
+  check({ dur: { minute: 1 } }, 'in 1 min')
+  check({ dur: { hour: 1.5 }, precise: true }, 'in 1 hr, 30 min')
+  check({ dur: { seconds: -5 }, precise: true }, '< 1 min ago') // default
+  check({ dur: { seconds: -5 }, units: ['hour'], precise: true }, '< 1 hr ago') // default min
+  check(
+    { dur: { seconds: -5 }, min: { minute: 2 }, precise: true },
+    '< 2 min ago',
+  )
 })

--- a/web/src/app/util/timeFormat.test.ts
+++ b/web/src/app/util/timeFormat.test.ts
@@ -1,25 +1,69 @@
-import { formatTimeSince } from './timeFormat'
-import { DateTime, Duration, DurationLikeObject } from 'luxon'
+import {
+  formatTimestamp,
+  TimeFormatOpts,
+  toRelativePrecise,
+} from './timeFormat'
+import { Duration } from 'luxon'
 
-describe('formatTimeSince', () => {
-  const check = (time: DurationLikeObject, exp: string): void => {
-    const dur = Duration.fromObject(time)
-    it(`${dur.toFormat('dDays h:m:s')} === ${exp}`, () => {
-      const since = DateTime.utc()
-      expect(formatTimeSince(since, since.plus(dur))).toBe(exp)
+describe('formatTimestamp', () => {
+  const check = (opts: TimeFormatOpts, exp: string): void => {
+    it(`${opts.time} === ${exp}`, () => {
+      expect(formatTimestamp(opts)).toBe(exp)
     })
   }
-  check({ seconds: -1 }, '< 1m ago')
-  check({ seconds: 1 }, '< 1m ago')
-  check({ seconds: 59 }, '< 1m ago')
-  check({ minutes: 1 }, '1m ago')
-  check({ minutes: 1, seconds: 1 }, '1m ago')
-  check({ hours: 1 }, '1h ago')
-  check({ hours: 1, seconds: 1 }, '1h ago')
-  check({ hours: 3, seconds: 1 }, '3h ago')
-  check({ days: 1, seconds: 1 }, '1d ago')
-  check({ days: 20, seconds: 1 }, '20d ago')
-  check({ months: 3, days: 5 }, '> 3mo ago')
-  check({ months: 20, seconds: 1 }, '> 1y ago')
-  check({ months: 200, seconds: 1 }, '> 16y ago')
+
+  check({ time: '2020-01-01T00:00:00Z', zone: 'UTC' }, 'Jan 1, 2020, 12:00 AM')
+  check(
+    { time: '2020-01-01T00:00:00Z', zone: 'UTC', format: 'default' },
+    'Jan 1, 2020, 12:00 AM',
+  )
+  check(
+    { time: '2020-01-01T00:00:00Z', zone: 'UTC', format: 'clock' },
+    '12:00 AM',
+  )
+  check(
+    { time: '2020-01-01T00:00:00Z', zone: 'UTC', format: 'weekday-clock' },
+    'Wed 12:00 AM',
+  )
+  check(
+    {
+      time: '2020-01-01T00:00:00Z',
+      zone: 'UTC',
+      format: 'relative-date',
+      from: '2020-01-02T00:00:00Z',
+    },
+    'Yesterday, January 1',
+  )
+
+  check(
+    {
+      time: '2020-01-01T00:00:00Z',
+      zone: 'UTC',
+      format: 'relative',
+      from: '2020-01-02T00:00:00Z',
+    },
+    '1 day ago',
+  )
+
+  check(
+    {
+      time: '2020-01-02T00:00:00Z',
+      zone: 'UTC',
+      format: 'relative',
+      from: '2020-01-01T00:00:00Z',
+    },
+    'in 1 day',
+  )
+})
+
+describe('toRelativePrecise', () => {
+  const check = (dur: Duration, exp: string): void => {
+    it(`${dur.toFormat('dDays h:m:s')} === ${exp}`, () => {
+      expect(toRelativePrecise(dur)).toBe(exp)
+    })
+  }
+
+  check(Duration.fromObject({ minutes: -1 }), '1 minute ago')
+  check(Duration.fromObject({ minutes: 1 }), 'in 1 minute')
+  check(Duration.fromObject({ hours: 1.5 }), 'in 1 hour 30 minutes')
 })

--- a/web/src/app/util/timeFormat.ts
+++ b/web/src/app/util/timeFormat.ts
@@ -7,6 +7,38 @@ import {
 } from 'luxon'
 import { ExplicitZone } from './luxon-helpers'
 
+export function formatTimeSince(
+  _since: DateTime | string,
+  _now = DateTime.utc(),
+): string {
+  if (!_since) return ''
+  const since = _since instanceof DateTime ? _since : DateTime.fromISO(_since)
+  const now = _now instanceof DateTime ? _now : DateTime.fromISO(_now)
+  const diff = now.diff(since)
+
+  if (diff.as('minutes') < 1) {
+    return `< 1m ago`
+  }
+
+  if (diff.as('hours') < 1) {
+    return `${Math.floor(diff.as('minutes'))}m ago`
+  }
+
+  if (diff.as('days') < 1) {
+    return `${Math.floor(diff.as('hours'))}h ago`
+  }
+
+  if (diff.as('months') < 1) {
+    return `${Math.floor(diff.as('days'))}d ago`
+  }
+
+  if (diff.as('years') < 1) {
+    return `> ${Math.floor(diff.as('months'))}mo ago`
+  }
+
+  return `> ${Math.floor(diff.as('years'))}y ago`
+}
+
 export type TimeFormatOpts = {
   time: string | DateTime
   zone?: string

--- a/web/src/app/util/timeFormat.ts
+++ b/web/src/app/util/timeFormat.ts
@@ -7,6 +7,17 @@ import {
 } from 'luxon'
 import { ExplicitZone } from './luxon-helpers'
 
+export const getDT = (t: string | DateTime, z?: ExplicitZone): DateTime =>
+  DateTime.isDateTime(t)
+    ? t.setZone(z || 'local')
+    : DateTime.fromISO(t, { zone: z })
+
+export const getDur = (d: string | DurationLikeObject | Duration): Duration => {
+  if (typeof d === 'string') return Duration.fromISO(d)
+  if (Duration.isDuration(d)) return d
+  return Duration.fromObject(d)
+}
+
 export function formatTimeSince(
   _since: DateTime | string,
   _now = DateTime.utc(),
@@ -118,16 +129,6 @@ export function formatRelative({
 
 function formatGuard(fmt: never): never {
   throw new Error('invalid time format ' + fmt)
-}
-export const getDT = (t: string | DateTime, z?: ExplicitZone): DateTime =>
-  DateTime.isDateTime(t)
-    ? t.setZone(z || 'local')
-    : DateTime.fromISO(t, { zone: z })
-
-export const getDur = (d: string | DurationLikeObject | Duration): Duration => {
-  if (typeof d === 'string') return Duration.fromISO(d)
-  if (Duration.isDuration(d)) return d
-  return Duration.fromObject(d)
 }
 
 export type FormatTimestampArg = {

--- a/web/src/app/util/timeFormat.ts
+++ b/web/src/app/util/timeFormat.ts
@@ -94,11 +94,12 @@ export function relativeDate(
 
 export function toRelativePrecise(
   dur: Duration,
+  noQualifier: boolean = false,
   units: ReadonlyArray<keyof DurationLikeObject> = ['days', 'hours', 'minutes'],
 ): string {
   const parts = []
-  const prefix = dur.valueOf() > 0 ? 'in ' : ''
-  const suffix = dur.valueOf() > 0 ? '' : ' ago'
+  const prefix = noQualifier || dur.valueOf() < 0 ? '' : 'in '
+  const suffix = noQualifier || dur.valueOf() > 0 ? '' : ' ago'
   if (dur.valueOf() < 0) dur = dur.negate()
 
   for (const unit of units) {


### PR DESCRIPTION
**Description:**
This PR adds a new `<Time>` component to render various timestamps and durations throughout the application.

**Out of Scope:**
Only a few call sites have been updated to keep the PR focused on the new component.

**Screenshots**
An example of the rendered times (this change to rotations is **_not_** in this PR)
![image](https://user-images.githubusercontent.com/595010/221988557-9103aaa0-b688-4ac0-946e-e05884f3b2c5.png)

**Describe any introduced user-facing changes:**
Experience should be the same, with minor changes due to the added consistency of using a single formatting function and the browsers configured locale instead of our custom logic.

**Additional Context**
Places updated to use the new component for validating this PR:
- Alert details event log timestamps
- Alert list timestamps
- Heartbeat monitor timeout display
- Heartbeat monitor status display
- User session list