### PR TITLE
ui/time: use Time for services and alert details

### DIFF
--- a/web/src/app/alerts/components/AlertDetails.tsx
+++ b/web/src/app/alerts/components/AlertDetails.tsx
@@ -18,7 +18,6 @@ import {
   Check as AcknowledgeIcon,
   Close as CloseIcon,
 } from '@mui/icons-material'
-import Countdown from 'react-countdown'
 import { gql, useMutation } from '@apollo/client'
 import { DateTime } from 'luxon'
 import _ from 'lodash'
@@ -41,6 +40,7 @@ import {
   AlertStatus,
 } from '../../../schema'
 import ServiceMaintenanceNotice from '../../services/ServiceMaintenanceNotice'
+import { Time } from '../../util/Time'
 
 interface AlertDetailsProps {
   data: Alert
@@ -191,38 +191,21 @@ export default function AlertDetails(props: AlertDetailsProps): JSX.Element {
 
   function getNextEscalation(): JSX.Element | string {
     const { currentLevel, lastEscalation, steps } = epsHelper()
-    const prevEscalation = new Date(lastEscalation ?? '')
+    if (!canAutoEscalate()) return 'None'
 
-    if (canAutoEscalate()) {
-      return (
-        <Countdown
-          date={
-            new Date(
-              prevEscalation.getTime() +
-                (steps ? steps[currentLevel ?? 0].delayMinutes : 0) * 60000,
-            )
-          }
-          overtime
-          renderer={(props) => {
-            const { hours, minutes, seconds, completed } = props
+    const prevEscalation = DateTime.fromISO(lastEscalation ?? '')
+    const nextEsclation = prevEscalation.plus({
+      minutes: steps ? steps[currentLevel ?? 0].delayMinutes : 0,
+    })
 
-            if (completed) return 'Escalating...'
-
-            const hourTxt = hours
-              ? `${hours} hour${hours === 1 ? '' : 's'} `
-              : ''
-            const minTxt = minutes
-              ? `${minutes} minute${minutes === 1 ? '' : 's'} `
-              : ''
-            const secTxt = `${seconds} second${seconds === 1 ? '' : 's'}`
-
-            return hourTxt + minTxt + secTxt
-          }}
-        />
-      )
-    }
-
-    return 'None'
+    return (
+      <Time
+        time={nextEsclation}
+        format='relative'
+        units={['hours', 'minutes', 'seconds']}
+        precise
+      />
+    )
   }
 
   function renderEscalationPolicySteps(): JSX.Element[] | JSX.Element {
@@ -426,8 +409,7 @@ export default function AlertDetails(props: AlertDetailsProps): JSX.Element {
             {alert?.state?.lastEscalation && (
               <React.Fragment>
                 <Typography color='textSecondary' variant='caption'>
-                  Last Escalated:{' '}
-                  {DateTime.fromISO(alert.state.lastEscalation).toFormat('fff')}
+                  Last Escalated: <Time time={alert.state.lastEscalation} />
                 </Typography>
                 <br />
                 <Typography color='textSecondary' variant='caption'>

--- a/web/src/app/services/ServiceMaintenanceDialog.tsx
+++ b/web/src/app/services/ServiceMaintenanceDialog.tsx
@@ -7,6 +7,7 @@ import FormControl from '@mui/material/FormControl'
 import FormDialog from '../dialogs/FormDialog'
 import { nonFieldErrors } from '../util/errutil'
 import { DateTime } from 'luxon'
+import { Time } from '../util/Time'
 
 interface Props {
   serviceID: string
@@ -14,14 +15,13 @@ interface Props {
   onClose: () => void
 }
 
-function calcExp(hours: number): string {
-  return DateTime.now().plus({ hours }).toISO()
-}
-
-function label(hours: number): string {
-  return `Until ${DateTime.fromISO(calcExp(hours)).toLocaleString(
-    DateTime.DATETIME_MED,
-  )}`
+function label(hours: number): JSX.Element {
+  return (
+    <span>
+      For <Time duration={{ hours }} /> (
+      <Time prefix='ends ' time={DateTime.local().plus({ hours }).toISO()} />)
+    </span>
+  )
 }
 
 function ServiceMaintenanceForm(props: {
@@ -32,7 +32,7 @@ function ServiceMaintenanceForm(props: {
     <FormControl>
       <RadioGroup
         value={props.selectedIndex}
-        onChange={(e) => props.onChange(parseInt(e.target.value))}
+        onChange={(e) => props.onChange(parseInt(e.target.value, 10))}
       >
         <FormControlLabel value={1} control={<Radio />} label={label(1)} />
         <FormControlLabel value={2} control={<Radio />} label={label(2)} />
@@ -63,11 +63,14 @@ export default function ServiceMaintenanceModeDialog(
     <FormDialog
       maxWidth='sm'
       title='Set Maintenance Mode'
-      subTitle={`Pause all outgoing notifications and escalations for${' '}
-      ${selectedHours} hour${
-        selectedHours > 1 ? 's' : ''
-      }. Incoming alerts will still be created
-      and will continue as normal after maintenance mode ends.`}
+      subTitle={
+        <React.Fragment>
+          Pause all outgoing notifications and escalations for{' '}
+          <Time duration={{ hours: selectedHours }} />. Incoming alerts will
+          still be created and will continue as normal after maintenance mode
+          ends.
+        </React.Fragment>
+      }
       loading={updateServiceStatus.fetching}
       errors={nonFieldErrors(updateServiceStatus.error)}
       onClose={props.onClose}
@@ -76,7 +79,9 @@ export default function ServiceMaintenanceModeDialog(
           {
             input: {
               id: props.serviceID,
-              maintenanceExpiresAt: calcExp(selectedHours),
+              maintenanceExpiresAt: DateTime.local()
+                .plus({ hours: selectedHours })
+                .toISO(),
             },
           },
           {

--- a/web/src/app/services/ServiceMaintenanceNotice.tsx
+++ b/web/src/app/services/ServiceMaintenanceNotice.tsx
@@ -3,7 +3,7 @@ import { gql, useQuery, useMutation } from 'urql'
 import { Button, Grid } from '@mui/material'
 import { DateTime } from 'luxon'
 import Notices, { Notice } from '../details/Notices'
-import CountDown from '../util/CountDown'
+import { Time } from '../util/Time'
 
 const query = gql`
   query serviceMaintenanceQuery($serviceID: ID!) {
@@ -50,14 +50,7 @@ export default function ServiceMaintenanceNotice({
             message: 'In Maintenance Mode',
             details: (
               <React.Fragment>
-                Ends at {DateTime.fromISO(maintMode).toFormat('FFF')} (
-                <CountDown
-                  end={maintMode}
-                  hours
-                  minutes
-                  expiredMessage='less than 1 minute'
-                />{' '}
-                remaining)
+                Ends <Time format='relative' time={maintMode} precise />
               </React.Fragment>
             ),
             action: (

--- a/web/src/app/util/Time.tsx
+++ b/web/src/app/util/Time.tsx
@@ -15,7 +15,7 @@ type TimeBaseProps = {
 
 type TimeTimestampProps = TimeBaseProps &
   Omit<FormatTimestampArg, 'time'> & {
-    time: string | null | undefined
+    time: string | DateTime | null | undefined
     zero?: string
   }
 
@@ -54,7 +54,7 @@ const TimeTimestamp: React.FC<TimeTimestampProps> = (props) => {
     <React.Fragment>
       {prefix}
       <time
-        dateTime={props.time}
+        dateTime={time.toISO()}
         title={display !== local ? title : undefined}
         style={{
           textDecorationStyle: 'dotted',

--- a/web/src/app/util/timeFormat.test.ts
+++ b/web/src/app/util/timeFormat.test.ts
@@ -54,6 +54,18 @@ describe('formatTimestamp', () => {
     },
     'in 1 day',
   )
+
+  check(
+    {
+      time: '2020-01-02T00:00:10Z',
+      zone: 'UTC',
+      format: 'relative',
+      from: '2020-01-01T00:00:00Z',
+      units: ['hour', 'minute', 'seconds'],
+      precise: true,
+    },
+    'in 24 hr, 10 sec',
+  )
 })
 
 describe('toRelative', () => {
@@ -71,5 +83,14 @@ describe('toRelative', () => {
   check(
     { dur: { seconds: -5 }, min: { minute: 2 }, precise: true },
     '< 2 min ago',
+  )
+
+  check(
+    {
+      dur: { minutes: -1, seconds: -5 },
+      units: ['minutes', 'seconds'],
+      precise: true,
+    },
+    '1 min, 5 sec ago',
   )
 })

--- a/web/src/app/util/timeFormat.ts
+++ b/web/src/app/util/timeFormat.ts
@@ -142,6 +142,7 @@ export type FormatTimestampArg = {
       // If true, the 'relative' format will include multiple units.
       precise?: boolean
       min?: string | DurationLikeObject | Duration
+      units?: ReadonlyArray<keyof DurationLikeObject>
     }
   | {
       format: 'relative-date'
@@ -174,6 +175,7 @@ export function formatTimestamp(arg: FormatTimestampArg): string {
       dur: dt.diff(from),
       precise: arg.precise,
       min: arg.min,
+      units: arg.units,
     })
 
   // Create a type error if we add a new format and forget to handle it.


### PR DESCRIPTION
**Description:**
Updates services and alert details to use the new `<Time>` component.

**Screenshots:**
![image](https://user-images.githubusercontent.com/595010/222482367-ab3c1330-3c00-4433-a4ef-2d16997e9b41.png)
![image](https://user-images.githubusercontent.com/595010/222482426-e37010ef-044b-456b-9e0f-98113234bf83.png)

**Describe any introduced user-facing changes:**
- Svc. Maint. Dialog
- Svc. Maint. Notice
- Alert details EP summary
