### PR TITLE
prs: add labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,36 @@
+name: labeler
+
+on: [pull_request]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    name: Label the PR size
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: 'size/xs'
+          xs_max_size: '15'
+          s_label: 'size/s'
+          s_max_size: '100'
+          m_label: 'size/m'
+          m_max_size: '250'
+          l_label: 'size/l'
+          l_max_size: '500'
+          xl_label: 'size/xl'
+          fail_if_xl: 'false'
+          message_if_xl: >
+            This PR exceeds the recommended size of 500 lines.
+            Please make sure you are NOT addressing multiple issues with one PR.
+            Note this PR might be rejected due to its size.
+          files_to_ignore: |
+            "*.lock"
+            "graphql2/generated.go"
+            "graphql2/maplimit.go"
+            "graphql2/mapconfig.go"
+            "pkg/sysapi/*.pb.go"
+            "swo/swodb/*.go"
+            "web/src/*.d.ts"
+            "Makefile.binaries.mk"


### PR DESCRIPTION
**Description:**
Adds a workflow to add size labels to PRs https://github.com/marketplace/actions/pull-request-size-labeler

The goal is to help review smaller PRs quicker by helping them stand out.
