### PR TITLE
ui/ISOPickers: Remove fallback code

### DIFF
--- a/web/src/app/util/ISOPickers.tsx
+++ b/web/src/app/util/ISOPickers.tsx
@@ -1,14 +1,9 @@
 import React, { useState, useEffect } from 'react'
 import { DateTime, DateTimeUnit } from 'luxon'
 import { TextField, TextFieldProps } from '@mui/material'
-import DatePicker from '@mui/lab/DatePicker'
-import DateTimePicker from '@mui/lab/DateTimePicker'
-import TimePicker from '@mui/lab/TimePicker'
-import { inputtypes } from 'modernizr-esm/feature/inputtypes'
 import { useURLParam } from '../actions'
 
 interface ISOPickerProps extends ISOTextFieldProps {
-  Fallback: typeof TimePicker | typeof DatePicker | typeof DateTimePicker
   format: string
   timeZone?: string
   truncateTo: DateTimeUnit
@@ -25,17 +20,8 @@ type ISOTextFieldProps = Partial<Omit<TextFieldProps, 'value'>> & {
   onChange: (value: string) => void
 }
 
-function hasInputSupport(name: string): boolean {
-  if (new URLSearchParams(location.search).get('nativeInput') === '0') {
-    return false
-  }
-
-  return inputtypes[name]
-}
-
 function ISOPicker(props: ISOPickerProps): JSX.Element {
   const {
-    Fallback,
     format,
     timeZone,
     truncateTo,
@@ -49,7 +35,6 @@ function ISOPicker(props: ISOPickerProps): JSX.Element {
     ...textFieldProps
   } = props
 
-  const native = hasInputSupport(type)
   const [_zone] = useURLParam('tz', 'local')
   const zone = timeZone || _zone
   let valueAsDT = props.value ? DateTime.fromISO(props.value, { zone }) : null
@@ -95,7 +80,7 @@ function ISOPicker(props: ISOPickerProps): JSX.Element {
     return ''
   }
 
-  function handleNativeChange(e: React.ChangeEvent<HTMLInputElement>): void {
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>): void {
     setInputValue(e.target.value)
     const newVal = parseInputToISO(e.target.value)
 
@@ -106,92 +91,32 @@ function ISOPicker(props: ISOPickerProps): JSX.Element {
     }
   }
 
-  function handleFallbackChange(
-    date: DateTime | null,
-    keyboardInputValue = '',
-  ): void {
-    // attempt to set value from DateTime object first
-    if (date?.isValid) {
-      setInputValue(date.toFormat(format))
-      onChange(dtToISO(date))
-    } else {
-      setInputValue(keyboardInputValue)
-      // likely invalid, but validate keyboard input just to be sure
-      const dt = DateTime.fromFormat(keyboardInputValue, format, { zone })
-      if (dt.isValid) onChange(dtToISO(dt))
-      else onChange(keyboardInputValue) // set invalid input for form validation
-    }
-  }
-
   const defaultLabel = type === 'time' ? 'Select a time...' : 'Select a date...'
-  if (native) {
-    return (
-      <TextField
-        label={defaultLabel}
-        {...textFieldProps}
-        type={type}
-        value={valueAsDT ? valueAsDT.toFormat(format) : inputValue}
-        onChange={handleNativeChange}
-        InputLabelProps={{ shrink: true, ...textFieldProps?.InputLabelProps }}
-        inputProps={{
-          min: min
-            ? DateTime.fromISO(min, { zone }).toFormat(format)
-            : undefined,
-          max: max
-            ? DateTime.fromISO(max, { zone }).toFormat(format)
-            : undefined,
-          ...textFieldProps?.inputProps,
-        }}
-      />
-    )
-  }
 
   return (
-    <Fallback
-      value={valueAsDT}
-      onChange={handleFallbackChange}
-      showTodayButton
-      minDate={min ? DateTime.fromISO(min, { zone }) : undefined}
-      maxDate={max ? DateTime.fromISO(max, { zone }) : undefined}
-      disabled={textFieldProps?.disabled}
-      renderInput={(params) => (
-        <TextField
-          data-cy-fallback-type={type}
-          {...params}
-          label={defaultLabel}
-          {...textFieldProps}
-        />
-      )}
-      PopperProps={{
-        // @ts-expect-error DOM attribute for testing
-        'data-cy': props.name + '-picker-fallback',
+    <TextField
+      label={defaultLabel}
+      {...textFieldProps}
+      type={type}
+      value={valueAsDT ? valueAsDT.toFormat(format) : inputValue}
+      onChange={handleChange}
+      InputLabelProps={{ shrink: true, ...textFieldProps?.InputLabelProps }}
+      inputProps={{
+        min: min ? DateTime.fromISO(min, { zone }).toFormat(format) : undefined,
+        max: max ? DateTime.fromISO(max, { zone }).toFormat(format) : undefined,
+        ...textFieldProps?.inputProps,
       }}
-      style={{ width: 'fit-container' }}
     />
   )
 }
 
 export function ISOTimePicker(props: ISOTextFieldProps): JSX.Element {
-  return (
-    <ISOPicker
-      {...props}
-      format='HH:mm'
-      truncateTo='minute'
-      type='time'
-      Fallback={TimePicker}
-    />
-  )
+  return <ISOPicker {...props} format='HH:mm' truncateTo='minute' type='time' />
 }
 
 export function ISODatePicker(props: ISOTextFieldProps): JSX.Element {
   return (
-    <ISOPicker
-      {...props}
-      format='yyyy-MM-dd'
-      truncateTo='day'
-      type='date'
-      Fallback={DatePicker}
-    />
+    <ISOPicker {...props} format='yyyy-MM-dd' truncateTo='day' type='date' />
   )
 }
 
@@ -202,7 +127,6 @@ export function ISODateTimePicker(props: ISOTextFieldProps): JSX.Element {
       format={`yyyy-MM-dd'T'HH:mm`}
       truncateTo='minute'
       type='datetime-local'
-      Fallback={DateTimePicker}
     />
   )
 }

--- a/web/src/cypress/e2e/timepickers.cy.ts
+++ b/web/src/cypress/e2e/timepickers.cy.ts
@@ -42,13 +42,11 @@ function testTimePickers(screen: ScreenFormat): void {
         cy.get('body').contains('Sun from 2:05 PM to 5:56 PM')
       })
 
-    describe('Native', () => {
-      check(
-        'should handle selecting time values when displaying the same time zone',
-        '?tz=America/New_York',
-        'Sun from 3:04 PM to 4:23 AM',
-      )
-    })
+    check(
+      'should handle selecting time values when displaying the same time zone',
+      '?tz=America/New_York',
+      'Sun from 3:04 PM to 4:23 AM',
+    )
   })
 
   describe('Date (schedule shifts)', () => {
@@ -67,18 +65,16 @@ function testTimePickers(screen: ScreenFormat): void {
         cy.get('body').contains('2/3/2007')
       })
 
-    describe('Native', () => {
-      check(
-        'should handle selecting date values when displaying the same time zone',
-        '?tz=America/New_York&start=2006-01-02T06%3A00%3A00.000Z',
-        '1/2/2006',
-      )
-      check(
-        'should handle selecting date values when displaying an alternate time zone',
-        '?tz=America/Boise&start=2006-01-02T06%3A00%3A00.000Z',
-        '1/1/2006',
-      )
-    })
+    check(
+      'should handle selecting date values when displaying the same time zone',
+      '?tz=America/New_York&start=2006-01-02T06%3A00%3A00.000Z',
+      '1/2/2006',
+    )
+    check(
+      'should handle selecting date values when displaying an alternate time zone',
+      '?tz=America/Boise&start=2006-01-02T06%3A00%3A00.000Z',
+      '1/1/2006',
+    )
   })
 
   describe('DateTime (schedule overrides)', () => {
@@ -121,12 +117,10 @@ function testTimePickers(screen: ScreenFormat): void {
         cy.get('body').contains(start.toLocaleString(DateTime.DATETIME_MED))
       })
 
-    describe('Native', () => {
-      check(
-        'should handle selecting date values when displaying the same time zone',
-        '?tz=America/New_York',
-      )
-    })
+    check(
+      'should handle selecting date values when displaying the same time zone',
+      '?tz=America/New_York',
+    )
   })
 }
 

--- a/web/src/cypress/e2e/timepickers.cy.ts
+++ b/web/src/cypress/e2e/timepickers.cy.ts
@@ -49,14 +49,6 @@ function testTimePickers(screen: ScreenFormat): void {
         'Sun from 3:04 PM to 4:23 AM',
       )
     })
-
-    describe('Fallback', () => {
-      check(
-        'should handle selecting time values when displaying the same time zone',
-        '?tz=America/New_York&nativeInput=0',
-        'Sun from 3:04 PM to 4:23 AM',
-      )
-    })
   })
 
   describe('Date (schedule shifts)', () => {
@@ -84,19 +76,6 @@ function testTimePickers(screen: ScreenFormat): void {
       check(
         'should handle selecting date values when displaying an alternate time zone',
         '?tz=America/Boise&start=2006-01-02T06%3A00%3A00.000Z',
-        '1/1/2006',
-      )
-    })
-
-    describe('Fallback', () => {
-      check(
-        'should handle selecting date values when displaying the same time zone',
-        '?tz=America/New_York&start=2006-01-02T06%3A00%3A00.000Z&nativeInput=0',
-        '1/2/2006',
-      )
-      check(
-        'should handle selecting date values when displaying an alternate time zone',
-        '?tz=America/Boise&start=2006-01-02T06%3A00%3A00.000Z&nativeInput=0',
         '1/1/2006',
       )
     })
@@ -146,13 +125,6 @@ function testTimePickers(screen: ScreenFormat): void {
       check(
         'should handle selecting date values when displaying the same time zone',
         '?tz=America/New_York',
-      )
-    })
-
-    describe('Fallback', () => {
-      check(
-        'should handle selecting date values when displaying the same time zone',
-        '?tz=America/New_York&start=2006-01-02T06%3A00%3A00.000Z&nativeInput=0',
       )
     })
   })

--- a/web/src/cypress/support/form.ts
+++ b/web/src/cypress/support/form.ts
@@ -9,110 +9,6 @@ declare global {
   }
 }
 
-const clickArc = (pct: number) => (el: JQuery) => {
-  const height = el.height() || 0
-  const radius = height / 2
-  const angle = (-1 + pct) * Math.PI * 2 - Math.PI / 2
-
-  const x = radius * Math.cos(angle) * 0.9 + radius
-  const y = radius * Math.sin(angle) * 0.9 + radius
-
-  return cy.wrap(el).click(x, y)
-}
-
-const openPicker = (selector: string, name: string): void => {
-  cy.get(selector).parent().find('button').click() // open clock/calendar popper
-  cy.get(`[role=dialog][data-cy="${name}-picker-fallback"]`).should(
-    'be.visible',
-  )
-}
-
-// materialClock will control a material time-picker from an input field
-function materialClock(
-  time: string | DateTime,
-  fieldName: string,
-): Cypress.Chainable<JQuery<HTMLElement>> {
-  const dt = DateTime.isDateTime(time)
-    ? time
-    : DateTime.fromFormat(time, 'HH:mm')
-
-  let hour = dt.hour
-
-  const isAM = hour < 12
-  if (!isAM) hour -= 12
-
-  return cy
-    .get(`[role=dialog][data-cy="${fieldName}-picker-fallback"]`)
-    .contains('button', isAM ? 'AM' : 'PM')
-    .click() // select AM or PM
-    .get(`[role=dialog][data-cy="${fieldName}-picker-fallback"] [role=listbox]`)
-    .parent()
-    .children()
-    .eq(0)
-    .then(clickArc(hour / 12)) // select the hour
-    .get(`[role=dialog][data-cy="${fieldName}-picker-fallback"] [role=listbox]`)
-    .parent()
-    .children()
-    .eq(0)
-    .then(clickArc(dt.minute / 60)) // minutes
-}
-
-// materialCalendar will control a material date-picker from an input field
-function materialCalendar(date: string | DateTime, fieldName: string): void {
-  const dt = DateTime.isDateTime(date)
-    ? date
-    : DateTime.fromFormat(date, 'yyyy-MM-dd')
-
-  cy.get(`[role=dialog][data-cy="${fieldName}-picker-fallback"]`)
-    .find('button[aria-label="calendar view is open, switch to year view"]')
-    .click() // open year selection
-
-  cy.get(`[role=dialog][data-cy="${fieldName}-picker-fallback"]`)
-    .contains('[type=button]', dt.year)
-    .click() // click on correct year
-
-  cy.get(
-    `[role=dialog][data-cy="${fieldName}-picker-fallback"] button[aria-label="Previous month"]`,
-  )
-    .parent()
-    .siblings()
-    .should((el) => {
-      expect(DateTime.fromFormat(el.text(), 'MMMMyyyy').isValid).to.equal(true)
-    })
-    .then((el) => {
-      const displayedDT = DateTime.fromFormat(el.text(), 'MMMMyyyy')
-      const diff = dt.startOf('month').diff(displayedDT, 'months').months
-
-      // navigate to correct month
-      for (let i = 0; i < Math.abs(diff); i++) {
-        cy.get(
-          `button[aria-label="${diff < 0 ? 'Previous' : 'Next'} month"]`,
-        ).click()
-
-        cy.get(`[role=dialog][data-cy="${fieldName}-picker-fallback"]`)
-          .should(
-            'contain',
-            displayedDT
-              .plus({ months: (diff < 0 ? -1 : 1) * (i + 1) })
-              .toFormat('MMMM'),
-          )
-          .should(
-            'not.contain',
-            displayedDT
-              .plus({ months: (diff < 0 ? -1 : 1) * i })
-              .toFormat('MMMM'),
-          )
-      }
-
-      // click on the day
-      cy.get(
-        `[role=dialog][data-cy="${fieldName}-picker-fallback"] button[aria-label="${dt.toFormat(
-          'MMM d, y',
-        )}"]`,
-      ).click({ force: true })
-    })
-}
-
 function fillFormField(
   selPrefix: string,
   name: string,
@@ -150,10 +46,6 @@ function fillFormField(
           'material-select' ||
         el.siblings('[role=button]').attr('aria-haspopup') === 'listbox'
 
-      const pickerFallback = el
-        .parents('[data-cy-fallback-type]')
-        .data('cyFallbackType')
-
       if (isSelect) {
         if (value === '') {
           cy.get(selector).clear()
@@ -187,30 +79,6 @@ function fillFormField(
       }
 
       if (value === '') return cy.get(selector).clear()
-
-      if (pickerFallback) {
-        switch (pickerFallback) {
-          case 'time':
-            openPicker(selector, name)
-            materialClock(value, name)
-            return
-          case 'date':
-            openPicker(selector, name)
-            materialCalendar(value, name)
-            return
-          case 'datetime-local':
-            openPicker(selector, name)
-            materialCalendar(value, name)
-            materialClock(value, name)
-            return
-          default:
-            if (DateTime.isDateTime(value)) {
-              throw new TypeError(
-                'DateTime only supported for time, date, or datetime-local types',
-              )
-            }
-        }
-      }
 
       return cy.get(selector).then((el) => {
         if (!DateTime.isDateTime(value)) {

--- a/web/src/global.d.ts
+++ b/web/src/global.d.ts
@@ -11,8 +11,3 @@ var pathPrefix: string
 var applicationName: string
 var GOALERT_VERSION: string
 var Cypress: any
-
-declare module 'modernizr-esm/feature/inputtypes' {
-  import * as m from 'modernizr'
-  export const inputtypes = m.inputtypes
-}

--- a/web/src/package.json
+++ b/web/src/package.json
@@ -45,7 +45,6 @@
     "lodash": "4.17.21",
     "luxon": "3.3.0",
     "mdi-material-ui": "7.6.0",
-    "modernizr-esm": "2.0.0",
     "react": "18.1.0",
     "react-beautiful-dnd": "13.1.0",
     "react-big-calendar": "1.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6271,11 +6271,6 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-modernizr-esm@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/modernizr-esm/-/modernizr-esm-2.0.0.tgz#de44ebcd768fdcb2d38fb286cfd77c721c2432cf"
-  integrity sha512-tSxxQ/PU90EBs9q6SOgWOYatnjnBvFvkSDVKfqeMbkF8igjPDA8yAmJaAIJbbrNDvtxhzyyqYCa5XxYbW/9/tg==
-
 moment-timezone@^0.5.40:
   version "0.5.41"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.41.tgz#a7ad3285fd24aaf5f93b8119a9d749c8039c64c5"


### PR DESCRIPTION
**Description:**
This PR removes the fallback code for date/time pickers.

**Describe any introduced user-facing changes:**
None expected, all supported browsers have had native controls for a couple of years now.

Worst case a user will have a text field to enter time and/or date info.

**Additional Info:**
We only use `time`, `date`, and `datetime-local`
https://caniuse.com/input-datetime
