### PR TITLE
slack-dm: fix dm message updates

### DIFF
--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -337,6 +338,20 @@ func alertMsgOption(ctx context.Context, callbackID string, id int, summary, log
 	)
 }
 
+func chanTS(origChannelID, externalID string) (channelID, ts string) {
+	ts = externalID
+	if strings.Contains(ts, ":") {
+		// DMs have a channel ID and timestamp separated by a colon,
+		// so we need to split them out. Trying to update a message
+		// with a user ID will fail.
+		channelID, ts, _ = strings.Cut(ts, ":")
+	} else {
+		channelID = origChannelID
+	}
+
+	return channelID, ts
+}
+
 func (s *ChannelSender) Send(ctx context.Context, msg notification.Message) (*notification.SentMessage, error) {
 	cfg := config.FromContext(ctx)
 
@@ -344,6 +359,7 @@ func (s *ChannelSender) Send(ctx context.Context, msg notification.Message) (*no
 
 	var opts []slack.MsgOption
 	var isUpdate bool
+	channelID := msg.Destination().Value
 	switch t := msg.(type) {
 	case notification.Test:
 		opts = append(opts, slack.MsgOptionText("This is a test message.", false))
@@ -351,9 +367,12 @@ func (s *ChannelSender) Send(ctx context.Context, msg notification.Message) (*no
 		opts = append(opts, slack.MsgOptionText(fmt.Sprintf("Your verification code is: %06d", t.Code), false))
 	case notification.Alert:
 		if t.OriginalStatus != nil {
+			var ts string
+			channelID, ts = chanTS(channelID, t.OriginalStatus.ProviderMessageID.ExternalID)
+
 			// Reply in thread if we already sent a message for this alert.
 			opts = append(opts,
-				slack.MsgOptionTS(t.OriginalStatus.ProviderMessageID.ExternalID),
+				slack.MsgOptionTS(ts),
 				slack.MsgOptionBroadcast(),
 				slack.MsgOptionText(alertLink(ctx, t.AlertID, t.Summary), false),
 			)
@@ -363,8 +382,10 @@ func (s *ChannelSender) Send(ctx context.Context, msg notification.Message) (*no
 		opts = append(opts, alertMsgOption(ctx, t.CallbackID, t.AlertID, t.Summary, "Unacknowledged", notification.AlertStateUnacknowledged))
 	case notification.AlertStatus:
 		isUpdate = true
+		var ts string
+		channelID, ts = chanTS(channelID, t.OriginalStatus.ProviderMessageID.ExternalID)
 		opts = append(opts,
-			slack.MsgOptionUpdate(t.OriginalStatus.ProviderMessageID.ExternalID),
+			slack.MsgOptionUpdate(ts),
 			alertMsgOption(ctx, t.OriginalStatus.ID, t.AlertID, t.Summary, t.LogEntry, t.NewAlertState),
 		)
 	case notification.AlertBundle:
@@ -377,13 +398,22 @@ func (s *ChannelSender) Send(ctx context.Context, msg notification.Message) (*no
 		return nil, errors.Errorf("unsupported message type: %T", t)
 	}
 
-	var msgTS string
+	var externalID string
 	err := s.withClient(ctx, func(c *slack.Client) error {
-		_, _msgTS, err := c.PostMessageContext(ctx, msg.Destination().Value, opts...)
+		msgChan, msgTS, err := c.PostMessageContext(ctx, channelID, opts...)
 		if err != nil {
 			return err
 		}
-		msgTS = _msgTS
+		if msgChan != channelID {
+			// DMs have a generated channel ID that we need to store
+			// along with the timestamp that does not match the original
+			// in order to update the message.
+			externalID = fmt.Sprintf("%s:%s", msgChan, msgTS)
+		} else {
+			// For other channels, we can just store the timestamp,
+			// to preserve compatibility with older versions of GoAlert.
+			externalID = msgTS
+		}
 		return nil
 	})
 	if err != nil {
@@ -391,11 +421,11 @@ func (s *ChannelSender) Send(ctx context.Context, msg notification.Message) (*no
 	}
 
 	if isUpdate {
-		msgTS = ""
+		externalID = ""
 	}
 
 	return &notification.SentMessage{
-		ExternalID: msgTS,
+		ExternalID: externalID,
 		State:      notification.StateDelivered,
 	}, nil
 }


### PR DESCRIPTION
**Description:**
This PR fixes the update issue with slack DMs.

**Additional Info:**
When sending a DM, a new channel ID is generated that must be preserved to update the message. This differs from channel messages that use the original channel ID for updates.

Start with `make start EXPERIMENTAL=slack-dm` to validate dm messages and message updates.
