### PR TITLE
ui: fix snackbar not showing latest alert notification

### DIFF
--- a/web/src/app/main/App.tsx
+++ b/web/src/app/main/App.tsx
@@ -25,6 +25,7 @@ import { useURLKey } from '../actions'
 import NavBar from './NavBar'
 import AuthLink from './components/AuthLink'
 import { useExpFlag } from '../util/useExpFlag'
+import { NotificationProvider } from './SnackbarNotification'
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -79,65 +80,67 @@ export default function App(): JSX.Element {
     <div className={classes.root} id='app-root'>
       <PageActionProvider>
         <SearchProvider>
-          <AppBar
-            position='fixed'
-            className={classes.appBar}
-            data-cy='app-bar'
-            data-cy-format={cyFormat}
-          >
-            <SkipToContentLink />
-            <Toolbar>
-              <ToolbarAction
-                showMobileSidebar={showMobile}
-                openMobileSidebar={() => setShowMobile(true)}
-              />
-              <ToolbarPageTitle />
-              <div style={{ flex: 1 }} />
-              <PageActionContainer />
-              <SearchContainer />
-              <UserSettingsPopover />
-            </Toolbar>
-          </AppBar>
-
-          <Hidden mdDown>
-            <LazyWideSideBar>
-              <NavBar />
-            </LazyWideSideBar>
-          </Hidden>
-          <Hidden mdUp>
-            <SwipeableDrawer
-              disableDiscovery={isIOS}
-              open={showMobile}
-              onOpen={() => setShowMobile(true)}
-              onClose={() => setShowMobile(false)}
-              SlideProps={{
-                unmountOnExit: true,
-              }}
+          <NotificationProvider>
+            <AppBar
+              position='fixed'
+              className={classes.appBar}
+              data-cy='app-bar'
+              data-cy-format={cyFormat}
             >
-              <NavBar />
-            </SwipeableDrawer>
-          </Hidden>
+              <SkipToContentLink />
+              <Toolbar>
+                <ToolbarAction
+                  showMobileSidebar={showMobile}
+                  openMobileSidebar={() => setShowMobile(true)}
+                />
+                <ToolbarPageTitle />
+                <div style={{ flex: 1 }} />
+                <PageActionContainer />
+                <SearchContainer />
+                <UserSettingsPopover />
+              </Toolbar>
+            </AppBar>
 
-          <main
-            id='content'
-            className={classes.main}
-            style={{ marginLeft }}
-            data-exp-flag-example={String(hasExampleFlag)}
-          >
-            <ErrorBoundary>
-              <LazyNewUserSetup />
-              <AuthLink />
-              <Grid
-                container
-                justifyContent='center'
-                className={classes.mainContainer}
+            <Hidden mdDown>
+              <LazyWideSideBar>
+                <NavBar />
+              </LazyWideSideBar>
+            </Hidden>
+            <Hidden mdUp>
+              <SwipeableDrawer
+                disableDiscovery={isIOS}
+                open={showMobile}
+                onOpen={() => setShowMobile(true)}
+                onClose={() => setShowMobile(false)}
+                SlideProps={{
+                  unmountOnExit: true,
+                }}
               >
-                <Grid className={classes.containerClass} item>
-                  <AppRoutes />
+                <NavBar />
+              </SwipeableDrawer>
+            </Hidden>
+
+            <main
+              id='content'
+              className={classes.main}
+              style={{ marginLeft }}
+              data-exp-flag-example={String(hasExampleFlag)}
+            >
+              <ErrorBoundary>
+                <LazyNewUserSetup />
+                <AuthLink />
+                <Grid
+                  container
+                  justifyContent='center'
+                  className={classes.mainContainer}
+                >
+                  <Grid className={classes.containerClass} item>
+                    <AppRoutes />
+                  </Grid>
                 </Grid>
-              </Grid>
-            </ErrorBoundary>
-          </main>
+              </ErrorBoundary>
+            </main>
+          </NotificationProvider>
         </SearchProvider>
       </PageActionProvider>
     </div>

--- a/web/src/app/main/SnackbarNotification.tsx
+++ b/web/src/app/main/SnackbarNotification.tsx
@@ -43,6 +43,7 @@ export const NotificationProvider = (
       <Snackbar
         action={notification?.action}
         open={open}
+        onClose={() => setOpen(false)}
         autoHideDuration={notification?.severity === 'error' ? null : 6000}
         TransitionProps={{ onExited: () => setNotification(undefined) }}
       >

--- a/web/src/app/main/SnackbarNotification.tsx
+++ b/web/src/app/main/SnackbarNotification.tsx
@@ -43,6 +43,7 @@ export const NotificationProvider = (
       <Snackbar
         action={notification?.action}
         open={open}
+        autoHideDuration={notification?.severity === 'error' ? null : 6000}
         TransitionProps={{ onExited: () => setNotification(undefined) }}
       >
         <Alert

--- a/web/src/app/main/SnackbarNotification.tsx
+++ b/web/src/app/main/SnackbarNotification.tsx
@@ -1,0 +1,58 @@
+import { Alert, Snackbar } from '@mui/material'
+import React, { ReactNode, useState } from 'react'
+
+type Notification = {
+  message: string
+  severity: 'info' | 'error'
+  action?: ReactNode
+}
+
+interface NotificationContextParams {
+  notification?: Notification
+  setNotification: (n: Notification) => void
+}
+
+export const NotificationContext =
+  React.createContext<NotificationContextParams>({
+    notification: undefined,
+    setNotification: () => {},
+  })
+NotificationContext.displayName = 'NotificationContext'
+
+interface NotificationProviderProps {
+  children: ReactNode
+}
+
+export const NotificationProvider = (
+  props: NotificationProviderProps,
+): JSX.Element => {
+  const [notification, setNotification] = useState<Notification>()
+  const [open, setOpen] = useState(false)
+
+  return (
+    <NotificationContext.Provider
+      value={{
+        notification,
+        setNotification: (n) => {
+          setNotification(n)
+          setOpen(true)
+        },
+      }}
+    >
+      {props.children}
+      <Snackbar
+        action={notification?.action}
+        open={open}
+        TransitionProps={{ onExited: () => setNotification(undefined) }}
+      >
+        <Alert
+          severity={notification?.severity}
+          onClose={() => setOpen(false)}
+          variant='filled'
+        >
+          {notification?.message}
+        </Alert>
+      </Snackbar>
+    </NotificationContext.Provider>
+  )
+}


### PR DESCRIPTION
On the alerts list, if multiple updates are made, only the first snackbar notification appears then it glitches out.

This change uses context at the top level in `App.js` to always shows the latest notification, pushing new notification data to the context on mutation `onComplete`s/`onError`s.

the bug:
https://youtu.be/CEMMgKroCQg