### PR TITLE
slack: fix DM display and pending state

### DIFF
--- a/engine/compatmanager/db.go
+++ b/engine/compatmanager/db.go
@@ -62,8 +62,8 @@ func NewDB(ctx context.Context, db *sql.DB, cs *slack.ChannelSender) (*DB, error
 		`),
 
 		insertCM: p.P(`
-			insert into user_contact_methods (id, name, type, value, user_id)
-			values ($1, $2, $3, $4, $5)
+			insert into user_contact_methods (id, name, type, value, user_id, pending)
+			values ($1, $2, $3, $4, $5, false)
 			on conflict (type, value) do nothing
 		`),
 

--- a/notification/slack/user.go
+++ b/notification/slack/user.go
@@ -17,9 +17,14 @@ func (s *ChannelSender) User(ctx context.Context, id string) (*User, error) {
 
 	usr, ok := s.userInfoCache.Get(id)
 	if ok {
+
+		name := usr.Profile.DisplayName
+		if name == "" {
+			name = usr.Name
+		}
 		return &User{
 			ID:     usr.ID,
-			Name:   usr.Name,
+			Name:   name,
 			TeamID: usr.TeamID,
 		}, nil
 	}


### PR DESCRIPTION
**Description:**
This PR fixes 2 issues with the `slack-dm` feature
- On the profile page, we should be using `Profile.DisplayName` instead of `Name`
- Contact methods created from the compat module should have `pending` set to `FALSE` as they are considered verified through the linking process.
