### PR TITLE
mocktwilio/twiml: add initial doc.go, Say verb and NullInt types

### DIFF
--- a/devtools/mocktwilio/twiml/doc.go
+++ b/devtools/mocktwilio/twiml/doc.go
@@ -1,0 +1,45 @@
+// Package twiml provides a type-safe way of building and parsing the TwiML markup language in Go.
+//
+// TwiML is an XML-based language used by Twilio to control phone calls and SMS messages. The package provides
+// Go structs that can be used to generate TwiML documents or parse incoming TwiML messages.
+//
+// The `Response` struct is the root element of a TwiML document. It can contain a sequence of `Verb`s, such as
+// `Say`, `Gather`, `Pause`, `Redirect`, or `Hangup`. Each `Verb` is represented by a Go struct that contains
+// the corresponding TwiML attributes and child elements.
+//
+// Example usage:
+//
+//	r := &twiml.Response{
+//	    Verbs: []twiml.Verb{
+//	        &twiml.Say{
+//	            Content: "Hello, world!",
+//	        },
+//	        &twiml.Gather{
+//	            Action: "/process_gather",
+//	            NumDigitsCount: 1,
+//	            Verbs: []twiml.GatherVerb{
+//	                &twiml.Say{
+//	                    Content: "Press 1 to confirm, or any other key to try again.",
+//	                },
+//	            },
+//	        },
+//	    },
+//	}
+//	b, _ := xml.MarshalIndent(r, "", "  ")
+//	fmt.Println(string(b))
+//
+// Output:
+//
+// <Response>
+//
+//	<Say>Hello, world!</Say>
+//	<Gather action="/process_gather">
+//	  <Say>Press 1 to confirm, or any other key to try again.</Say>
+//	</Gather>
+//
+// </Response>
+//
+// Incoming TwiML messages can be parsed using the `Interpreter` struct, which reads a sequence of bytes and
+// returns the next `Verb` in the message until the end is reached. The `Interpreter` can be used to implement
+// server-side TwiML applications that respond to user input.
+package twiml

--- a/devtools/mocktwilio/twiml/nullint.go
+++ b/devtools/mocktwilio/twiml/nullint.go
@@ -1,0 +1,41 @@
+package twiml
+
+import (
+	"encoding/xml"
+	"strconv"
+)
+
+type NullInt struct {
+	Valid bool
+	Value int
+}
+
+var (
+	_ xml.MarshalerAttr   = (*NullInt)(nil)
+	_ xml.UnmarshalerAttr = (*NullInt)(nil)
+)
+
+func (n *NullInt) UnmarshalXMLAttr(attr xml.Attr) error {
+	if attr.Value == "" {
+		n.Valid = false
+		n.Value = 0
+		return nil
+	}
+
+	val, err := strconv.Atoi(attr.Value)
+	if err != nil {
+		return err
+	}
+
+	n.Valid = true
+	n.Value = val
+	return nil
+}
+
+func (n *NullInt) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	if n == nil || !n.Valid {
+		return xml.Attr{}, nil
+	}
+
+	return xml.Attr{Name: name, Value: strconv.Itoa(n.Value)}, nil
+}

--- a/devtools/mocktwilio/twiml/nullint.go
+++ b/devtools/mocktwilio/twiml/nullint.go
@@ -5,6 +5,9 @@ import (
 	"strconv"
 )
 
+// NullInt is a nullable int that can be used to marshal/unmarshal
+// XML attributes that are optional but have special meaning when
+// they are present vs. when they are not.
 type NullInt struct {
 	Valid bool
 	Value int

--- a/devtools/mocktwilio/twiml/nullint_test.go
+++ b/devtools/mocktwilio/twiml/nullint_test.go
@@ -1,0 +1,32 @@
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNullInt(t *testing.T) {
+	type testDoc struct {
+		XMLName   xml.Name `xml:"Test"`
+		HasValue  NullInt  `xml:",attr"`
+		HasValue2 NullInt  `xml:",attr"`
+		NoValue   NullInt  `xml:",attr"`
+	}
+	var doc testDoc
+	doc.HasValue = NullInt{Valid: true}
+	doc.HasValue2 = NullInt{Valid: true, Value: 2}
+
+	data, err := xml.Marshal(&doc)
+	assert.NoError(t, err)
+	assert.Equal(t, `<Test HasValue="0" HasValue2="2"></Test>`, string(data))
+
+	var doc2 testDoc
+	err = xml.Unmarshal(data, &doc2)
+	assert.NoError(t, err)
+	assert.True(t, doc2.HasValue.Valid)
+	assert.NotNil(t, doc2.HasValue2)
+	assert.False(t, doc2.NoValue.Valid)
+	assert.Equal(t, 2, doc2.HasValue2.Value)
+}

--- a/devtools/mocktwilio/twiml/verbs.go
+++ b/devtools/mocktwilio/twiml/verbs.go
@@ -1,0 +1,59 @@
+package twiml
+
+import (
+	"encoding/xml"
+	"time"
+)
+
+type Say struct {
+	Content  string `xml:",innerxml"`
+	Language string `xml:"language,attr,omitempty"`
+	Voice    string `xml:"voice,attr,omitempty"`
+
+	// LoopCount is derived from the `loop` attribute, taking into account the default value
+	// and the special value of 0.
+	//
+	// If LoopCount is below zero, the message is not played.
+	//
+	// https://www.twilio.com/docs/voice/twiml/say#attributes-loop
+	LoopCount int `xml:"-"`
+}
+
+var (
+	_ xml.Unmarshaler = (*Say)(nil)
+	_ xml.Marshaler   = Say{}
+)
+
+func (s *Say) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type SayRaw Say
+	var ss struct {
+		SayRaw
+		Loop NullInt `xml:"loop,attr"`
+	}
+	if err := d.DecodeElement(&ss, &start); err != nil {
+		return err
+	}
+	*s = Say(ss.SayRaw)
+	if ss.Loop.Valid {
+		s.LoopCount = ss.Loop.Value
+		if s.LoopCount == 0 {
+			s.LoopCount = 1000
+		}
+	}
+	return nil
+}
+
+func (s Say) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type SayRaw Say
+	var ss struct {
+		SayRaw
+		Content string `xml:",innerxml"`
+		Loop    *int   `xml:"loop,attr"`
+	}
+	ss.Content = s.Content
+	if s.LoopCount != 0 {
+		ss.Loop = &s.LoopCount
+	}
+	ss.SayRaw = SayRaw(s)
+	return e.EncodeElement(ss, start)
+}

--- a/devtools/mocktwilio/twiml/verbs.go
+++ b/devtools/mocktwilio/twiml/verbs.go
@@ -2,7 +2,6 @@ package twiml
 
 import (
 	"encoding/xml"
-	"time"
 )
 
 type Say struct {

--- a/devtools/mocktwilio/twiml/verbs.go
+++ b/devtools/mocktwilio/twiml/verbs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 )
 
+// Say is a TwiML verb that plays back a message to the caller.
 type Say struct {
 	Content  string `xml:",innerxml"`
 	Language string `xml:"language,attr,omitempty"`

--- a/devtools/mocktwilio/twiml/verbs_test.go
+++ b/devtools/mocktwilio/twiml/verbs_test.go
@@ -1,0 +1,36 @@
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSay(t *testing.T) {
+	checkExp := func(exp Say, doc, expDoc string) {
+		t.Helper()
+		var s Say
+		err := xml.Unmarshal([]byte(doc), &s)
+		require.NoError(t, err)
+		assert.Equal(t, exp, s)
+
+		data, err := xml.Marshal(s)
+		require.NoError(t, err)
+		assert.Equal(t, expDoc, string(data))
+	}
+	check := func(exp Say, doc string) {
+		t.Helper()
+		checkExp(exp, doc, doc)
+	}
+
+	check(Say{Content: "hi"}, `<Say>hi</Say>`)
+	checkExp(Say{Content: "hi"}, `<Say loop="">hi</Say>`, `<Say>hi</Say>`)
+	checkExp(Say{Content: "hi", LoopCount: 1000}, `<Say loop="0">hi</Say>`, `<Say loop="1000">hi</Say>`)
+	check(Say{Content: "hi", LoopCount: 1}, `<Say loop="1">hi</Say>`)
+	check(Say{Content: "hi", LoopCount: 1000}, `<Say loop="1000">hi</Say>`)
+	check(Say{Content: "hi", Voice: "foo"}, `<Say voice="foo">hi</Say>`)
+}
+

--- a/devtools/mocktwilio/twiml/verbs_test.go
+++ b/devtools/mocktwilio/twiml/verbs_test.go
@@ -3,7 +3,6 @@ package twiml
 import (
 	"encoding/xml"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,4 +32,3 @@ func TestSay(t *testing.T) {
 	check(Say{Content: "hi", LoopCount: 1000}, `<Say loop="1000">hi</Say>`)
 	check(Say{Content: "hi", Voice: "foo"}, `<Say voice="foo">hi</Say>`)
 }
-


### PR DESCRIPTION
**Description:**
Adds a new `twiml` package for interacting with TwiML markup. First of a few PRs to break apart #2602 
