### PR TITLE
mocktwilio/twiml: add Response, Gather, and Hangup

### DIFF
--- a/devtools/mocktwilio/twiml/anyverb.go
+++ b/devtools/mocktwilio/twiml/anyverb.go
@@ -16,10 +16,13 @@ type (
 		isVerb() v
 	}
 )
-func (*Say) isGatherVerb() v   { return v{} }
 
-func (*Say) isVerb() v      { return v{} }
-func (*Gather) isVerb() v   { return v{} }
+func (*Say) isGatherVerb() v { return v{} }
+
+func (*Say) isVerb() v    { return v{} }
+func (*Gather) isVerb() v { return v{} }
+func (*Hangup) isVerb() v { return v{} }
+
 type anyVerb struct {
 	verb Verb
 }
@@ -29,6 +32,9 @@ func decodeVerb(d *xml.Decoder, start xml.StartElement) (Verb, error) {
 	case "Gather":
 		g := new(Gather)
 		return g, d.DecodeElement(&g, &start)
+	case "Hangup":
+		h := new(Hangup)
+		return h, d.DecodeElement(&h, &start)
 	case "Say":
 		s := new(Say)
 		return s, d.DecodeElement(&s, &start)
@@ -42,6 +48,8 @@ func encodeVerb(e *xml.Encoder, v Verb) error {
 	switch v.(type) {
 	case *Gather:
 		name = "Gather"
+	case *Hangup:
+		name = "Hangup"
 	case *Say:
 		name = "Say"
 	default:

--- a/devtools/mocktwilio/twiml/anyverb.go
+++ b/devtools/mocktwilio/twiml/anyverb.go
@@ -1,0 +1,65 @@
+package twiml
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+)
+
+type (
+	v          struct{}
+	GatherVerb interface {
+		Verb
+		isGatherVerb() v
+	}
+	Verb interface {
+		isVerb() v
+	}
+)
+func (*Say) isGatherVerb() v   { return v{} }
+
+func (*Say) isVerb() v      { return v{} }
+func (*Gather) isVerb() v   { return v{} }
+type anyVerb struct {
+	verb Verb
+}
+
+func decodeVerb(d *xml.Decoder, start xml.StartElement) (Verb, error) {
+	switch start.Name.Local {
+	case "Gather":
+		g := new(Gather)
+		return g, d.DecodeElement(&g, &start)
+	case "Say":
+		s := new(Say)
+		return s, d.DecodeElement(&s, &start)
+	}
+
+	return nil, errors.New("unsupported verb: " + start.Name.Local)
+}
+
+func encodeVerb(e *xml.Encoder, v Verb) error {
+	var name string
+	switch v.(type) {
+	case *Gather:
+		name = "Gather"
+	case *Say:
+		name = "Say"
+	default:
+		return fmt.Errorf("unsupported verb: %T", v)
+	}
+
+	if err := e.EncodeElement(v, xml.StartElement{Name: xml.Name{Local: name}}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (v *anyVerb) UnmarshalXML(d *xml.Decoder, start xml.StartElement) (err error) {
+	v.verb, err = decodeVerb(d, start)
+	return err
+}
+
+func (v anyVerb) MarshalXML(e *xml.Encoder, start xml.StartElement) (err error) {
+	return encodeVerb(e, v.verb)
+}

--- a/devtools/mocktwilio/twiml/gather.go
+++ b/devtools/mocktwilio/twiml/gather.go
@@ -1,0 +1,181 @@
+package twiml
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+type Gather struct {
+	XMLName xml.Name `xml:"Gather"`
+
+	// Action defaults to the current request URL and can be relative or absolute.
+	Action string `xml:"action,attr,omitempty"`
+
+	// FinishOnKey defaults to "#".
+	FinishOnKey string `xml:"finishOnKey,attr,omitempty"`
+
+	Hints string `xml:"hints,attr,omitempty"`
+
+	// Input defaults to dtmf.
+	Input string `xml:"input,attr,omitempty"`
+
+	// Language defaults to en-US.
+	Language string `xml:"language,attr,omitempty"`
+
+	// Method defaults to POST.
+	Method string `xml:"method,attr,omitempty"`
+
+	// NumDigitsCount is the normalized version of `numDigits`. A zero value indicates no limit and is the default.
+	NumDigitsCount int `xml:"-"`
+
+	// PartialResultCallback defaults to the current request URL and can be relative or absolute.
+	//
+	// https://www.twilio.com/docs/voice/twiml/gather#partialresultcallback
+	PartialResultCallback string `xml:"partialResultCallback,attr,omitempty"`
+
+	PartialResultCallbackMethod string `xml:"partialResultCallbackMethod,attr,omitempty"`
+
+	// DisableProfanityFilter disables the profanity filter.
+	DisableProfanityFilter bool `xml:"-"`
+
+	// TimeoutDur defaults to 5 seconds.
+	TimeoutDur time.Duration `xml:"-"`
+
+	// SpeechTimeoutDur is the speechTimeout attribute.
+	//
+	// It should be ignored if SpeechTimeoutAuto is true. Defaults to TimeoutDur.
+	SpeechTimeoutDur time.Duration `xml:"-"`
+
+	// SpeechTimeoutAuto will be ture if the `speechTimeout` value is set to true.
+	SpeechTimeoutAuto bool `xml:"-"`
+
+	SpeechModel string `xml:"speechModel,attr,omitempty"`
+
+	Enhanced bool `xml:"enhanced,attr,omitempty"`
+
+	ActionOnEmptyResult bool `xml:"actionOnEmptyResult,attr,omitempty"`
+
+	Verbs []GatherVerb `xml:"-"`
+}
+
+func defStr(s *string, defaultValue string) {
+	if *s == "" {
+		*s = defaultValue
+	}
+}
+
+func (g *Gather) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type RawGather Gather
+	var gg struct {
+		RawGather
+		NumDigits       NullInt `xml:"numDigits,attr"`
+		SpeechTimeout   string  `xml:"speechTimeout,attr"`
+		Timeout         NullInt `xml:"timeout,attr"`
+		ProfanityFilter *bool   `xml:"profanityFilter,attr"`
+
+		Content []anyVerb `xml:",any"`
+	}
+
+	if err := d.DecodeElement(&gg, &start); err != nil {
+		return err
+	}
+	*g = Gather(gg.RawGather)
+	for _, v := range gg.Content {
+		switch t := v.verb.(type) {
+		case *Say:
+			g.Verbs = append(g.Verbs, t)
+		default:
+			return fmt.Errorf("unexpected verb in Gather: %T", t)
+		}
+	}
+
+	defStr(&g.FinishOnKey, "#")
+	defStr(&g.Method, "POST")
+	defStr(&g.Input, "dtmf")
+	defStr(&g.Language, "en-US")
+	defStr(&g.PartialResultCallbackMethod, "POST")
+	defStr(&g.SpeechModel, "default")
+	if gg.NumDigits.Valid {
+		g.NumDigitsCount = gg.NumDigits.Value
+		if g.NumDigitsCount < 1 {
+			g.NumDigitsCount = 1
+		}
+	}
+	if gg.ProfanityFilter != nil {
+		g.DisableProfanityFilter = !*gg.ProfanityFilter
+	}
+	if gg.Timeout.Valid {
+		g.TimeoutDur = time.Duration(gg.Timeout.Value) * time.Second
+	} else {
+		g.TimeoutDur = 5 * time.Second
+	}
+	switch gg.SpeechTimeout {
+	case "auto":
+		g.SpeechTimeoutAuto = true
+	case "":
+		g.SpeechTimeoutDur = g.TimeoutDur
+	default:
+		v, err := strconv.Atoi(gg.SpeechTimeout)
+		if err != nil {
+			return err
+		}
+		g.SpeechTimeoutDur = time.Duration(v) * time.Second
+	}
+
+	return nil
+}
+
+func (g Gather) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type RawGather Gather
+	var gg struct {
+		RawGather
+		NumDigits       int    `xml:"numDigits,attr,omitempty"`
+		SpeechTimeout   string `xml:"speechTimeout,attr,omitempty"`
+		Timeout         int    `xml:"timeout,attr,omitempty"`
+		ProfanityFilter *bool  `xml:"profanityFilter,attr,omitempty"`
+		Verbs           []any  `xml:",any"`
+	}
+	gg.RawGather = RawGather(g)
+	for _, v := range g.Verbs {
+		switch t := v.(type) {
+		case *Say:
+			gg.Verbs = append(gg.Verbs, anyVerb{verb: t})
+		default:
+			return fmt.Errorf("unexpected verb in Gather: %T", v)
+		}
+	}
+	if g.NumDigitsCount > 1 {
+		gg.NumDigits = g.NumDigitsCount
+	}
+	if g.SpeechTimeoutAuto {
+		gg.SpeechTimeout = "auto"
+	} else if g.SpeechTimeoutDur != gg.TimeoutDur {
+		gg.SpeechTimeout = strconv.Itoa(int(g.SpeechTimeoutDur / time.Second))
+	}
+	if gg.Input == "dtmf" {
+		gg.Input = ""
+	}
+	if gg.FinishOnKey == "#" {
+		gg.FinishOnKey = ""
+	}
+	if gg.Language == "en-US" {
+		gg.Language = ""
+	}
+	if gg.PartialResultCallback == "" || gg.PartialResultCallbackMethod == "POST" {
+		gg.PartialResultCallbackMethod = ""
+	}
+	if gg.Method == "POST" {
+		gg.Method = ""
+	}
+	if g.DisableProfanityFilter {
+		gg.ProfanityFilter = new(bool)
+		*gg.ProfanityFilter = false
+	}
+	if gg.SpeechModel == "default" {
+		gg.SpeechModel = ""
+	}
+	gg.Timeout = int(g.TimeoutDur / time.Second)
+	return e.EncodeElement(gg, start)
+}

--- a/devtools/mocktwilio/twiml/gather_test.go
+++ b/devtools/mocktwilio/twiml/gather_test.go
@@ -1,0 +1,25 @@
+package twiml_test
+
+import (
+	"encoding/xml"
+	"os"
+
+	"github.com/target/goalert/devtools/mocktwilio/twiml"
+)
+
+func ExampleGather() {
+	var resp twiml.Response
+	resp.Verbs = append(resp.Verbs, &twiml.Gather{
+		Action:         "/gather",
+		NumDigitsCount: 5,
+		Verbs: []twiml.GatherVerb{
+			&twiml.Say{
+				Content: "Please enter your 5-digit zip code.",
+			},
+		},
+	})
+
+	xml.NewEncoder(os.Stdout).Encode(resp)
+	// Output:
+	// <Response><Gather action="/gather" numDigits="5"><Say>Please enter your 5-digit zip code.</Say></Gather></Response>
+}

--- a/devtools/mocktwilio/twiml/response.go
+++ b/devtools/mocktwilio/twiml/response.go
@@ -1,0 +1,51 @@
+package twiml
+
+import (
+	"encoding/xml"
+	"errors"
+	"io"
+)
+
+type Response struct {
+	Verbs []Verb `xml:"-"`
+}
+
+func (r *Response) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	for {
+		t, err := d.Token()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return err
+		}
+		if t == nil {
+			break
+		}
+
+		if t, ok := t.(xml.StartElement); ok {
+			v, err := decodeVerb(d, t)
+			if err != nil {
+				return err
+			}
+			r.Verbs = append(r.Verbs, v)
+		}
+	}
+
+	return nil
+}
+
+func (r Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+
+	for _, v := range r.Verbs {
+		if err := encodeVerb(e, v); err != nil {
+			return err
+		}
+	}
+
+	return e.EncodeToken(start.End())
+}

--- a/devtools/mocktwilio/twiml/response_test.go
+++ b/devtools/mocktwilio/twiml/response_test.go
@@ -1,0 +1,40 @@
+package twiml
+
+import (
+	"encoding/xml"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponse_UnmarshalXML(t *testing.T) {
+	const doc = `<Response><Say>hi</Say><Gather timeout="13"><Say>there</Say></Gather><Hangup></Hangup></Response>`
+
+	var r Response
+	err := xml.Unmarshal([]byte(doc), &r)
+	require.NoError(t, err)
+
+	assert.Equal(t, Response{Verbs: []Verb{
+		&Say{Content: "hi"},
+		&Gather{
+			TimeoutDur: 13 * time.Second,
+			Verbs:      []GatherVerb{&Say{Content: "there"}},
+
+			// defaults should be set
+			FinishOnKey:                 "#",
+			Input:                       "dtmf",
+			Language:                    "en-US",
+			Method:                      "POST",
+			PartialResultCallbackMethod: "POST",
+			SpeechTimeoutDur:            13 * time.Second, // defaults to TimeoutDur
+			SpeechModel:                 "default",
+		},
+		&Hangup{},
+	}}, r)
+
+	data, err := xml.Marshal(r)
+	require.NoError(t, err)
+	assert.Equal(t, doc, string(data))
+}

--- a/devtools/mocktwilio/twiml/verbs.go
+++ b/devtools/mocktwilio/twiml/verbs.go
@@ -4,6 +4,9 @@ import (
 	"encoding/xml"
 )
 
+// Hangup is a verb that hangs up the call.
+type Hangup struct{}
+
 // Say is a TwiML verb that plays back a message to the caller.
 type Say struct {
 	Content  string `xml:",innerxml"`


### PR DESCRIPTION
**Description:**
This PR adds the `Response` struct and the `Gather` and `Hangup` verbs.

Some type interfaces with unexported fields are used to create type safety when building a TwiML document.

**Which issue(s) this PR fixes:**
Part 2 of #2602 

**Additional Info**
This PR has a bit more than the last because of the new type information added to ensure `Gather` works correctly.
