### PR TITLE
calsub: add app and schedule name to shifts

### DIFF
--- a/calsub/http.go
+++ b/calsub/http.go
@@ -1,12 +1,15 @@
 package calsub
 
 import (
+	"encoding/json"
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/target/goalert/config"
 	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/util/errutil"
+	"github.com/target/goalert/version"
 )
 
 // ServeICalData will return an iCal file for the subscription associated with the current request.
@@ -19,17 +22,12 @@ func (s *Store) ServeICalData(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	cs, err := s.FindOne(ctx, src.ID)
+	info, err := gadb.New(s.db).CalSubRenderInfo(ctx, uuid.MustParse(src.ID))
 	if errutil.HTTPError(ctx, w, err) {
 		return
 	}
 
-	n, err := gadb.New(s.db).Now(ctx)
-	if errutil.HTTPError(ctx, w, err) {
-		return
-	}
-
-	shifts, err := s.oc.HistoryBySchedule(ctx, cs.ScheduleID, n, n.AddDate(1, 0, 0))
+	shifts, err := s.oc.HistoryBySchedule(ctx, info.ScheduleID.String(), info.Now, info.Now.AddDate(1, 0, 0))
 	if errutil.HTTPError(ctx, w, err) {
 		return
 	}
@@ -37,13 +35,29 @@ func (s *Store) ServeICalData(w http.ResponseWriter, req *http.Request) {
 	// filter out other users
 	filtered := shifts[:0]
 	for _, s := range shifts {
-		if s.UserID != cs.UserID {
+		if s.UserID != info.UserID.String() {
 			continue
 		}
 		filtered = append(filtered, s)
 	}
 
-	calData, err := cs.renderICalFromShifts(cfg.ApplicationName(), filtered, n)
+	var subCfg SubscriptionConfig
+	err = json.Unmarshal(info.Config, &subCfg)
+	if errutil.HTTPError(ctx, w, err) {
+		return
+	}
+
+	data := renderData{
+		ApplicationName: cfg.ApplicationName(),
+		ScheduleID:      info.ScheduleID,
+		ScheduleName:    info.ScheduleName,
+		Shifts:          filtered,
+		ReminderMinutes: subCfg.ReminderMinutes,
+		Version:         version.GitVersion(),
+		GeneratedAt:     info.Now,
+	}
+
+	calData, err := data.renderICal()
 	if errutil.HTTPError(ctx, w, err) {
 		return
 	}

--- a/calsub/queries.sql
+++ b/calsub/queries.sql
@@ -9,6 +9,19 @@ SELECT id,
 FROM user_calendar_subscriptions
 WHERE id = $1;
 
+-- name: CalSubRenderInfo :one
+SELECT
+    now()::timestamptz AS now,
+    sub.schedule_id,
+    sched.name AS schedule_name,
+    sub.config,
+    sub.user_id
+FROM
+    user_calendar_subscriptions sub
+    JOIN schedules sched ON sched.id = schedule_id
+WHERE
+    sub.id = $1;
+
 -- name: FindOneCalSubForUpdate :one
 SELECT id,
     NAME,

--- a/calsub/renderdata.go
+++ b/calsub/renderdata.go
@@ -1,0 +1,18 @@
+package calsub
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/target/goalert/oncall"
+)
+
+type renderData struct {
+	ApplicationName string
+	ScheduleID      uuid.UUID
+	ScheduleName    string
+	Shifts          []oncall.Shift
+	ReminderMinutes []int
+	Version         string
+	GeneratedAt     time.Time
+}

--- a/calsub/renderical_test.go
+++ b/calsub/renderical_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/target/goalert/oncall"
 )
 
-func TestSubscription_RenderICalFromShifts(t *testing.T) {
-	var cs Subscription
-	cs.Config.ReminderMinutes = []int{5, 10}
+func TestRenderData_RenderICal(t *testing.T) {
 	shifts := []oncall.Shift{{
 		UserID: "01020304-0506-0708-090a-0b0c0d0e0f10",
 		Start:  time.Date(2020, 1, 1, 8, 0, 0, 0, time.UTC),
@@ -23,9 +23,17 @@ func TestSubscription_RenderICalFromShifts(t *testing.T) {
 		Truncated: true,
 	}}
 	generatedAt := time.Date(2020, 1, 1, 5, 0, 0, 0, time.UTC)
-	cs.ScheduleID = "100f0e0d-0c0b-0a09-0807-060504030201"
-	iCal, err := cs.renderICalFromShifts("GoAlert", shifts, generatedAt)
-	assert.NoError(t, err)
+	r := renderData{
+		ApplicationName: "GoAlert",
+		ScheduleID:      uuid.MustParse("100f0e0d-0c0b-0a09-0807-060504030201"),
+		ScheduleName:    "Sched",
+		Shifts:          shifts,
+		ReminderMinutes: []int{5, 10},
+		Version:         "dev",
+		GeneratedAt:     generatedAt,
+	}
+	iCal, err := r.renderICal()
+	require.NoError(t, err)
 	expected := strings.Join([]string{
 		"BEGIN:VCALENDAR",
 		"PRODID:-//GoAlert//dev//EN",
@@ -34,7 +42,7 @@ func TestSubscription_RenderICalFromShifts(t *testing.T) {
 		"METHOD:PUBLISH",
 		"BEGIN:VEVENT",
 		"UID:4c7d37bf28d64eccc1e74a3889cfc97f6839a00fa781c91721058df915de27ce",
-		"SUMMARY:On-Call Shift",
+		"SUMMARY:On-Call (GoAlert: Sched)",
 		"DTSTAMP:20200101T050000Z",
 		"DTSTART:20200101T080000Z",
 		"DTEND:20200115T080000Z",
@@ -51,7 +59,7 @@ func TestSubscription_RenderICalFromShifts(t *testing.T) {
 		"END:VEVENT",
 		"BEGIN:VEVENT",
 		"UID:39514a8d78cada01fe7b66e1f9e511799cae36420a4b86a1d909c0bbbb99b747",
-		"SUMMARY:On-Call Shift Begins*",
+		"SUMMARY:On-Call (GoAlert: Sched) Begins*",
 		"DESCRIPTION:The end time of this shift is unknown and will continue beyond what is displayed.",
 		"DTSTAMP:20200101T050000Z",
 		"DTSTART:20200201T080000Z",


### PR DESCRIPTION
**Description:**
This PR changes the calendar event name from `On-Call Shift` to `On-Call (GoAlert: Schedule)` where "GoAlert" is the configured application name, and "Schedule" is the name of the schedule.

This is to make it more obvious on various calendar applications what the upcoming shift is for, especially when there are multiple schedules involved.
