### PR TITLE
mocktwilio/twiml: Add Iterator for processing TwiML documents

### DIFF
--- a/devtools/mocktwilio/twiml/iterator.go
+++ b/devtools/mocktwilio/twiml/iterator.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// Iterator will iterate over the Verbs in a TwiML document,
+// Iterator will iterate over the verbs in a TwiML document,
 // in the order they should be processed.
 //
 // A Say verb within a Gather verb will be processed before

--- a/devtools/mocktwilio/twiml/iterator.go
+++ b/devtools/mocktwilio/twiml/iterator.go
@@ -1,0 +1,77 @@
+package twiml
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// Iterator will iterate over the Verbs in a TwiML document,
+// in the order they should be processed.
+//
+// A Say verb within a Gather verb will be processed before
+// the Gather verb itself.
+type Iterator struct {
+	state Verb
+
+	verbs []Verb
+}
+
+// NewIterator returns a new Iterator.
+func NewIterator() *Iterator {
+	return &Iterator{}
+}
+
+// SetResponse sets the response to interpret, and resets the state.
+//
+// This method will return an error if the response is not valid TwiML.
+func (i *Iterator) SetResponse(data []byte) error {
+	var rsp Response
+	if err := xml.Unmarshal(data, &rsp); err != nil {
+		return err
+	}
+
+	i.verbs = append(i.verbs[:0], rsp.Verbs...)
+	i.state = nil
+	return nil
+}
+
+// Verb returns the current verb.
+func (i *Iterator) Verb() Verb { return i.state }
+
+// Next advances the iterator to the next verb
+// and returns true if there is another verb.
+func (i *Iterator) Next() bool {
+	if len(i.verbs) == 0 {
+		return false
+	}
+
+	switch t := i.verbs[0].(type) {
+	case *Hangup, *Redirect, *Reject:
+		// end the call
+		i.state = t
+		i.verbs = nil
+	case *Gather:
+		if len(t.Verbs) == 0 {
+			i.state = t
+			i.verbs = i.verbs[1:]
+			break
+		}
+
+		newVerbs := make([]Verb, 0, len(t.Verbs)+len(i.verbs))
+		i.state = t.Verbs[0]
+		for _, v := range t.Verbs[1:] {
+			newVerbs = append(newVerbs, v)
+		}
+		t.Verbs = nil
+		newVerbs = append(newVerbs, t)
+		newVerbs = append(newVerbs, i.verbs[1:]...)
+		i.verbs = newVerbs
+	case *Pause, *Say:
+		i.state = t
+		i.verbs = i.verbs[1:]
+	default:
+		panic(fmt.Sprintf("unhandled verb: %T", t))
+	}
+
+	return true
+}

--- a/devtools/mocktwilio/twiml/iterator_test.go
+++ b/devtools/mocktwilio/twiml/iterator_test.go
@@ -1,0 +1,67 @@
+package twiml
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIterator(t *testing.T) {
+	const doc = `<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+	<Gather numDigits="1" timeout="10" action="http://127.0.0.1:39111/api/v2/twilio/call?msgBody=VGhpcyBpcyBHb0FsZXJ0IHdpdGggYW4gYWxlcnQgbm90aWZpY2F0aW9uLiB0ZXN0aW5nLg&amp;msgID=62b6e835-e086-4cc2-9030-b0b230fdd2b2&amp;msgSubjectID=1&amp;type=alert">
+		<Say>
+			<prosody rate="slow">This is GoAlert with an alert notification. testing.</prosody>
+		</Say>
+		<Say>
+			<prosody rate="slow">To acknowledge, press 4.</prosody>
+		</Say>
+		<Say>
+			<prosody rate="slow">To close, press 6.</prosody>
+		</Say>
+		<Say>
+			<prosody rate="slow">To disable voice notifications to this number, press 1.</prosody>
+		</Say>
+		<Say>
+			<prosody rate="slow">To repeat this message, press star.</prosody>
+		</Say>
+	</Gather>
+</Response>`
+
+	i := NewIterator()
+	err := i.SetResponse([]byte(doc))
+	require.NoError(t, err)
+
+	assert.True(t, i.Next())
+	assert.Equal(t, &Say{Content: "\n\t\t\t<prosody rate=\"slow\">This is GoAlert with an alert notification. testing.</prosody>\n\t\t"}, i.Verb())
+
+	assert.True(t, i.Next())
+	assert.Equal(t, &Say{Content: "\n\t\t\t<prosody rate=\"slow\">To acknowledge, press 4.</prosody>\n\t\t"}, i.Verb())
+
+	assert.True(t, i.Next())
+	assert.Equal(t, &Say{Content: "\n\t\t\t<prosody rate=\"slow\">To close, press 6.</prosody>\n\t\t"}, i.Verb())
+
+	assert.True(t, i.Next())
+	assert.Equal(t, &Say{Content: "\n\t\t\t<prosody rate=\"slow\">To disable voice notifications to this number, press 1.</prosody>\n\t\t"}, i.Verb())
+
+	assert.True(t, i.Next())
+	assert.Equal(t, &Say{Content: "\n\t\t\t<prosody rate=\"slow\">To repeat this message, press star.</prosody>\n\t\t"}, i.Verb())
+
+	assert.True(t, i.Next())
+	assert.Equal(t, &Gather{
+		Action:                      "http://127.0.0.1:39111/api/v2/twilio/call?msgBody=VGhpcyBpcyBHb0FsZXJ0IHdpdGggYW4gYWxlcnQgbm90aWZpY2F0aW9uLiB0ZXN0aW5nLg&msgID=62b6e835-e086-4cc2-9030-b0b230fdd2b2&msgSubjectID=1&type=alert",
+		FinishOnKey:                 "#",
+		Input:                       "dtmf",
+		Language:                    "en-US",
+		Method:                      "POST",
+		NumDigitsCount:              1,
+		PartialResultCallbackMethod: "POST",
+		TimeoutDur:                  10 * time.Second,
+		SpeechTimeoutDur:            10 * time.Second,
+		SpeechModel:                 "default",
+	}, i.Verb())
+
+	assert.False(t, i.Next())
+}


### PR DESCRIPTION
**Description:**
Adding an `Iterator` to be used in processing TwiML verbs from a `Response` document.

**Which issue(s) this PR fixes:**
Part of https://github.com/target/goalert/pull/2602
