### PR TITLE
twilio: move version to api path instead of base

### DIFF
--- a/devtools/mocktwilio/server.go
+++ b/devtools/mocktwilio/server.go
@@ -19,7 +19,6 @@ import (
 
 // Config is used to configure the mock server.
 type Config struct {
-
 	// The SID and token should match values given to the backend
 	// as the mock server will send and validate signatures.
 	AccountSID string
@@ -83,7 +82,7 @@ func NewServer(cfg Config) *Server {
 		carrierInfo: make(map[string]twilio.CarrierInfo),
 	}
 
-	base := "/Accounts/" + cfg.AccountSID
+	base := "/2010-04-01/Accounts/" + cfg.AccountSID
 
 	s.mux.HandleFunc(base+"/Calls.json", s.serveNewCall)
 	s.mux.HandleFunc(base+"/Messages.json", s.serveNewMessage)

--- a/notification/twilio/client.go
+++ b/notification/twilio/client.go
@@ -17,7 +17,7 @@ import (
 )
 
 // DefaultTwilioAPIURL is the value that will be used for API calls if Config.BaseURL is empty.
-const DefaultTwilioAPIURL = "https://api.twilio.com/2010-04-01"
+const DefaultTwilioAPIURL = "https://api.twilio.com"
 
 // SMSOptions allows configuring outgoing SMS messages.
 type SMSOptions struct {
@@ -71,13 +71,15 @@ func urlJoin(base string, parts ...string) string {
 	}
 	return base + "/" + strings.Join(parts, "/")
 }
+
 func (c *Config) url(parts ...string) string {
 	base := c.BaseURL
 	if base == "" {
 		base = DefaultTwilioAPIURL
 	}
-	return urlJoin(base, parts...)
+	return urlJoin(urlJoin(base, "2010-04-01"), parts...)
 }
+
 func (c *Config) httpClient() *http.Client {
 	if c.Client != nil {
 		return c.Client
@@ -85,6 +87,7 @@ func (c *Config) httpClient() *http.Client {
 
 	return http.DefaultClient
 }
+
 func (c *Config) get(ctx context.Context, urlStr string) (*http.Response, error) {
 	req, err := http.NewRequest("GET", urlStr, nil)
 	if err != nil {
@@ -98,6 +101,7 @@ func (c *Config) get(ctx context.Context, urlStr string) (*http.Response, error)
 
 	return c.httpClient().Do(req)
 }
+
 func (c *Config) post(ctx context.Context, urlStr string, v url.Values) (*http.Response, error) {
 	req, err := http.NewRequest("POST", urlStr, bytes.NewBufferString(v.Encode()))
 	if err != nil {


### PR DESCRIPTION
**Description:**
Small change to move the API version to the path instead of the base URL to keep things clean if using the same domain (e.g., test servers).
