### PR TITLE
ctxlock: add IDLocker and tests

### DIFF
--- a/ctxlock/config.go
+++ b/ctxlock/config.go
@@ -1,0 +1,24 @@
+package ctxlock
+
+import "time"
+
+// Config is the configuration for an IDLocker.
+type Config struct {
+	// MaxHeld indicates the maximum number of locks that can be held at once,
+	// per ID.
+	//
+	// If MaxHeld is not set, it defaults to 1.
+	MaxHeld int
+
+	// MaxWait indicates the maximum number of pending locks that can be
+	// queued for a given ID.
+	//
+	// If MaxWait is -1, no limit is enforced.
+	MaxWait int
+
+	// Timeout indicates the maximum amount of time to wait for a lock to be
+	// aquired.
+	//
+	// If Timeout is 0, no timeout is enforced.
+	Timeout time.Duration
+}

--- a/ctxlock/idlocker.go
+++ b/ctxlock/idlocker.go
@@ -1,0 +1,50 @@
+package ctxlock
+
+import (
+	"errors"
+	"sync"
+)
+
+var (
+	// ErrQueueFull is returned when the queue is full and a lock is requested.
+	ErrQueueFull = errors.New("queue full")
+
+	// ErrTimeout is returned when the lock request times out while waiting in
+	// the queue.
+	ErrTimeout = errors.New("timeout")
+)
+
+// IDLocker allows multiple locks to be held at once, but only up to a certain
+// number of locks per ID.
+//
+// If the number of locks for an ID exceeds the maximum, the lock will be
+// queued until a lock is released.
+//
+// It is safe to use IDLocker from multiple goroutines and is used to manage
+// concurency.
+type IDLocker[K comparable] struct {
+	cfg   Config
+	count map[K]int
+	queue map[K][]chan struct{}
+	mx    sync.Mutex
+}
+
+// NewIDLocker creates a new IDLocker with the given config.
+//
+// An empty config will result in a locker that allows only one lock to be held
+// at a time, with no queue (i.e., ErrQueueFull will be returned if a lock is
+// requested while another is held).
+func NewIDLocker[K comparable](cfg Config) *IDLocker[K] {
+	if cfg.MaxHeld == 0 {
+		cfg.MaxHeld = 1
+	}
+	if cfg.MaxHeld < 0 {
+		panic("MaxHeld must be >= 0")
+	}
+
+	return &IDLocker[K]{
+		count: make(map[K]int),
+		queue: make(map[K][]chan struct{}),
+		cfg:   cfg,
+	}
+}

--- a/ctxlock/idlocker_test.go
+++ b/ctxlock/idlocker_test.go
@@ -124,7 +124,7 @@ func TestIDLocker_CancelQueue(t *testing.T) {
 	go func() { ch <- l.Lock(ctx, "foo") }()
 	require.ErrorIs(t, <-ch, ctxlock.ErrQueueFull) // queue overflow on the last
 	// Queue now should look like this:
-	// [nnn, nnn, nnn, nnn, nnn, nnn, nnn, nnn, nnn, ctx]
+	// [nnn, nnn, nnn, nnn, nnn, nnn, nnn, nnn, ctx, ctx]
 
 	// Make one space, push two nnn items.
 	// One of them will randomly end up in the last spot, and the other

--- a/ctxlock/idlocker_test.go
+++ b/ctxlock/idlocker_test.go
@@ -1,0 +1,214 @@
+package ctxlock_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/ctxlock"
+)
+
+func TestIDLocker_NoQueue(t *testing.T) {
+	assert.Panics(t, func() {
+		ctxlock.NewIDLocker[string](ctxlock.Config{MaxHeld: -1})
+	}, "MaxHeld must be >= 0")
+
+	l := ctxlock.NewIDLocker[string](ctxlock.Config{})
+
+	ctx := context.Background()
+
+	err := l.Lock(ctx, "foo")
+	require.NoError(t, err, "first lock should work")
+
+	err = l.Lock(ctx, "foo")
+	require.ErrorIs(t, err, ctxlock.ErrQueueFull, "second lock should fail with ErrQueueFull")
+
+	err = l.Lock(ctx, "bar")
+	require.NoError(t, err, "lock for different id should work")
+
+	l.Unlock("foo")
+	err = l.Lock(ctx, "foo")
+	require.NoError(t, err, "third lock should work")
+
+	l.Unlock("foo")
+	require.Panics(t, func() {
+		l.Unlock("foo") // too many unlocks
+	})
+}
+
+func TestIDLocker_Context(t *testing.T) {
+	l := ctxlock.NewIDLocker[string](ctxlock.Config{MaxWait: 1})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := l.Lock(ctx, "foo")
+	require.NoError(t, err, "first lock should work")
+
+	ch := make(chan error, 2)
+	go func() { ch <- l.Lock(ctx, "foo") }()
+	go func() { ch <- l.Lock(ctx, "foo") }()
+
+	err = <-ch
+	require.ErrorIs(t, err, ctxlock.ErrQueueFull, "second lock should fail with ErrQueueFull")
+	l.Unlock("foo")
+
+	err = <-ch
+	require.NoError(t, err, "third lock should work")
+
+	cancel()
+	err = l.Lock(ctx, "foo")
+	require.ErrorIs(t, err, context.Canceled, "lock should fail with context canceled")
+}
+
+func TestIDLocker_Timeout(t *testing.T) {
+	l := ctxlock.NewIDLocker[string](ctxlock.Config{MaxWait: 1, Timeout: time.Millisecond})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := l.Lock(ctx, "foo")
+	require.NoError(t, err, "first lock should work")
+
+	ch := make(chan error, 1)
+	go func() { ch <- l.Lock(ctx, "foo") }()
+
+	err = <-ch
+	require.ErrorIs(t, err, ctxlock.ErrTimeout, "third lock should fail with ErrTimeout")
+}
+
+func TestIDLocker_CancelQueue(t *testing.T) {
+	l := ctxlock.NewIDLocker[string](ctxlock.Config{MaxWait: 10, Timeout: time.Millisecond})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := l.Lock(ctx, "foo")
+	require.NoError(t, err, "first lock should work")
+
+	ch := make(chan error)
+	nnn, nCancel := context.WithCancel(ctx)
+	// We need to test that canceling items in the queue works.
+	// Our nnn will be the one we cancel. We're going to fill the queue
+	// with these, then Unlock a few times to make new space, fill it with
+	// ones waiting on ctx, then do again, then cancel nnn.
+	//
+	// Our queue will look like this:
+	// [nnn, nnn, nnn, ctx, ctx, nnn, ctx, ctx, ctx, ctx]
+	//
+	// The only way we can be sure the queue is full, is to push items until
+	// we get ErrQueueFull. Doing so will allow us to test the logic of the
+	// concurrent queue, without relying on timing.
+	//
+	// Note: all the `go func() { ... }` calls can run in any order, so we
+	// use the ErrQueueFull to guarantee that we've filled/processed all the
+	// items we want to test before pushing more.
+	for i := 0; i < 11; i++ {
+		go func() { ch <- l.Lock(nnn, "foo") }()
+	}
+	require.ErrorIs(t, <-ch, ctxlock.ErrQueueFull) // queue overflow
+	// Queue now looks like this (all nnn):
+	// [nnn, nnn, nnn, nnn, nnn, nnn, nnn, nnn, nnn, nnn, nnn]
+
+	// We need to make space for the two ctx items (position 3 and 4).
+	l.Unlock("foo")
+	l.Unlock("foo")
+	require.NoError(t, <-ch)
+	require.NoError(t, <-ch)
+
+	// Attempt to push 3 ctx items.
+	go func() { ch <- l.Lock(ctx, "foo") }()
+	go func() { ch <- l.Lock(ctx, "foo") }()
+	go func() { ch <- l.Lock(ctx, "foo") }()
+	require.ErrorIs(t, <-ch, ctxlock.ErrQueueFull) // queue overflow on the last
+	// Queue now should look like this:
+	// [nnn, nnn, nnn, nnn, nnn, nnn, nnn, nnn, nnn, ctx]
+
+	// Make one space, push two nnn items.
+	// One of them will randomly end up in the last spot, and the other
+	// will be rejected with ErrQueueFull.
+	l.Unlock("foo")
+	require.NoError(t, <-ch)
+	go func() { ch <- l.Lock(nnn, "foo") }()
+	go func() { ch <- l.Lock(nnn, "foo") }()
+	require.ErrorIs(t, <-ch, ctxlock.ErrQueueFull) // queue overflow
+	// Queue now looks like this:
+	// [nnn, nnn, nnn, nnn, nnn, nnn, nnn, ctx, ctx, nnn]
+
+	// We want that last nnn to move from position 9 to position 5.
+
+	l.Unlock("foo")
+	l.Unlock("foo")
+	l.Unlock("foo")
+	l.Unlock("foo")
+	require.NoError(t, <-ch)
+	require.NoError(t, <-ch)
+	require.NoError(t, <-ch)
+	require.NoError(t, <-ch)
+
+	// Queue now looks like this:
+	// [nnn, nnn, nnn, ctx, ctx, nnn]
+	for i := 0; i < 5; i++ {
+		go func() { ch <- l.Lock(ctx, "foo") }()
+	}
+	require.ErrorIs(t, <-ch, ctxlock.ErrQueueFull) // queue overflow
+	// Queue now looks like this:
+	// [nnn, nnn, nnn, ctx, ctx, nnn, ctx, ctx, ctx, ctx]
+
+	// Now we can cancel nnn, and ensure we get our 4 canceled items.
+	nCancel()
+	for i := 0; i < 4; i++ {
+		require.ErrorIs(t, <-ch, context.Canceled)
+	}
+
+	// At this point, we should have 6 items in the queue.
+	// We can now unlock 6 times, and ensure we get 6 items.
+	for i := 0; i < 6; i++ {
+		l.Unlock("foo")
+		require.NoError(t, <-ch)
+	}
+
+	l.Unlock("foo") // original lock
+
+	// We should now have an empty queue, and no held lock.
+	require.Panics(t, func() { l.Unlock("foo") }, "unlocking an empty queue should panic")
+}
+
+func TestIDLocker_Unlock_Abandoned(t *testing.T) {
+	l := ctxlock.NewIDLocker[string](ctxlock.Config{
+		MaxWait: 1,
+		Timeout: time.Second, // in case of bug, we don't want to wait forever
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := l.Lock(ctx, "foo")
+	require.NoError(t, err, "first lock should work")
+
+	test := func() {
+		nnn, cancel := context.WithCancel(ctx)
+		ch := make(chan error, 1)
+		go func() { ch <- l.Lock(nnn, "foo") }()
+		go func() { ch <- l.Lock(nnn, "foo") }()
+		require.ErrorIs(t, <-ch, ctxlock.ErrQueueFull, "queue should be full")
+
+		cancel()
+		l.Unlock("foo")
+
+		if <-ch != nil {
+			// lost the race, re-lock foo
+			err := l.Lock(ctx, "foo")
+			require.NoError(t, err, "re-lock should work")
+		}
+	}
+
+	for i := 0; i < 1000; i++ {
+		test()
+	}
+
+	l.Unlock("foo") // original lock
+	assert.Panics(t, func() { l.Unlock("foo") }, "unlocking an empty queue should panic")
+}

--- a/ctxlock/lock.go
+++ b/ctxlock/lock.go
@@ -1,0 +1,63 @@
+package ctxlock
+
+import (
+	"context"
+	"time"
+)
+
+// Lock will attempt to acquire a lock for the given ID.
+//
+// If Lock returns nil, Unlock must be called to release the lock,
+// even if the context is canceled.
+func (l *IDLocker[K]) Lock(ctx context.Context, id K) error {
+	l.mx.Lock()
+	if l.count[id] < l.cfg.MaxHeld {
+		// fast path, no queue
+		l.count[id]++
+		l.mx.Unlock()
+		return nil
+	}
+
+	if l.cfg.MaxWait != -1 && len(l.queue[id]) >= l.cfg.MaxWait {
+		l.mx.Unlock()
+		return ErrQueueFull
+	}
+
+	if l.cfg.Timeout > 0 {
+		var cancel func(error)
+		ctx, cancel = context.WithCancelCause(ctx)
+		t := time.AfterFunc(l.cfg.Timeout, func() { cancel(ErrTimeout) })
+		defer t.Stop()
+		defer cancel(nil)
+	}
+
+	// slow path, queue to hold our spot
+	ch := make(chan struct{})
+	l.queue[id] = append(l.queue[id], ch)
+	l.mx.Unlock()
+
+	select {
+	case <-ctx.Done():
+		close(ch) // Ensure Unlock knows we are abandoning our spot.
+
+		l.mx.Lock()
+		defer l.mx.Unlock()
+		for i, c := range l.queue[id] {
+			if c != ch {
+				continue
+			}
+
+			l.queue[id] = append(l.queue[id][:i], l.queue[id][i+1:]...)
+			break
+		}
+		if len(l.queue[id]) == 0 {
+			delete(l.queue, id) // cleanup so the map doesn't grow forever
+		}
+
+		return context.Cause(ctx)
+	case ch <- struct{}{}:
+		// we have the lock, queue and count have been updated by Unlock
+	}
+
+	return nil
+}

--- a/ctxlock/unlock.go
+++ b/ctxlock/unlock.go
@@ -1,0 +1,49 @@
+package ctxlock
+
+//	Unlock will release a lock for the given ID.
+//
+//	If there are any pending locks, the next one will be granted.
+//
+// Note: Unlock will panic if called more times than Lock.
+func (l *IDLocker[K]) Unlock(id K) {
+	l.mx.Lock()
+	defer l.mx.Unlock()
+
+	for {
+		if len(l.queue[id]) == 0 {
+			// since there is nobody waiting, we can just decrement the count
+			l.count[id]--
+			if l.count[id] < 0 {
+				panic("count < 0")
+			}
+			if l.count[id] == 0 {
+				delete(l.count, id) // cleanup so the map doesn't grow forever
+			}
+			return
+		}
+
+		ch := l.queue[id][0]
+		l.queue[id] = l.queue[id][1:]
+		if len(l.queue[id]) == 0 {
+			delete(l.queue, id)
+		}
+
+		_, ok := <-ch
+		// Use the negative flow so that code coverage can detect both the
+		// continue and return case.
+		if !ok {
+			// The channel was closed and we need to try again.
+			//
+			// This is rare but can happen if Unlock is called
+			// after a Lock context has been canceled but beats
+			// the Lock's cleanup code to the Mutex.
+			//
+			// Commenting out the continue will cause the test
+			// TestIDLocker_Unlock_Abandoned to fail.
+			continue
+		}
+
+		// If the channel is still open, someone got the lock.
+		return
+	}
+}


### PR DESCRIPTION
**Description:**
This is a replacement for the concurrency limiter code with full test coverage and _hopefully_ easier-to-validate code. This implementation has better guarantees than the original and uses simple slices instead of linked lists.

**Out of Scope**
- This just adds the new package and implementation, future PRs will replace the old code.
- Benchmark/memory analysis -- this will be done in a future PR before replacing old code.
