### PR TITLE
feat: add markdown supported hint, increased description size to 6KiB for service form

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -17,6 +17,8 @@ type Service struct {
 	isUserFavorite bool
 }
 
+const MaxDetailsLength = 6 * 1024 // 6KiB
+
 func (s Service) EscalationPolicyName() string {
 	return s.epName
 }
@@ -38,7 +40,7 @@ func (s Service) Normalize() (*Service, error) {
 
 	err := validate.Many(
 		validate.IDName("Name", s.Name),
-		validate.Text("Description", s.Description, 1, 255),
+		validate.Text("Description", s.Description, 1, MaxDetailsLength),
 		validate.UUID("EscalationPolicyID", s.EscalationPolicyID),
 		validate.Duration("MaintenanceExpiresAt", dur, 0, 8*time.Hour),
 	)

--- a/web/src/app/forms/FormField.js
+++ b/web/src/app/forms/FormField.js
@@ -109,6 +109,7 @@ export function FormField(props) {
     onChange(fieldName, mapOnChangeValue(newValue, value))
   }
 
+  // wraps hints/errors within a grid containing character counter to align horizontally
   function charCountWrapper(component, count) {
     return (
       <Grid container spacing={2}>
@@ -125,6 +126,7 @@ export function FormField(props) {
   }
 
   function renderFormHelperText(error, hint, count) {
+    // handle optional count parameter
     if (count === undefined) {
       count = 0
     }

--- a/web/src/app/forms/FormField.js
+++ b/web/src/app/forms/FormField.js
@@ -7,6 +7,7 @@ import { get, isEmpty, startCase } from 'lodash'
 import shrinkWorkaround from '../util/shrinkWorkaround'
 import AppLink from '../util/AppLink'
 import { FormContainerContext } from './context'
+import { Grid } from '@mui/material'
 
 export function FormField(props) {
   const {
@@ -38,6 +39,7 @@ export function FormField(props) {
     max,
     checkbox,
     float,
+    charCount,
     ...otherFieldProps
   } = props
 
@@ -107,7 +109,25 @@ export function FormField(props) {
     onChange(fieldName, mapOnChangeValue(newValue, value))
   }
 
-  function renderFormHelperText(error, hint) {
+  function charCountWrapper(component, count) {
+    return (
+      <Grid container spacing={2}>
+        <Grid item xs={10}>
+          {component}
+        </Grid>
+        <Grid item xs={2}>
+          <FormHelperText style={{ textAlign: 'right' }}>
+            {value.description.length}/{count}
+          </FormHelperText>
+        </Grid>
+      </Grid>
+    )
+  }
+
+  function renderFormHelperText(error, hint, count) {
+    if (count === undefined) {
+      count = 0
+    }
     if (!noError) {
       if (error?.helpLink) {
         return (
@@ -120,15 +140,22 @@ export function FormField(props) {
       }
 
       if (error?.message) {
-        return (
+        const errorText = (
           <FormHelperText>
             {error.message.replace(/^./, (str) => str.toUpperCase())}
           </FormHelperText>
         )
+        if (count) {
+          return charCountWrapper(errorText, count)
+        }
+        return errorText
       }
     }
 
     if (hint) {
+      if (count) {
+        return charCountWrapper(<FormHelperText>{hint}</FormHelperText>, count)
+      }
       return <FormHelperText>{hint}</FormHelperText>
     }
 
@@ -152,7 +179,7 @@ export function FormField(props) {
       >
         {fieldProps.children}
       </Component>
-      {renderFormHelperText(fieldProps.error, fieldProps.hint)}
+      {renderFormHelperText(fieldProps.error, fieldProps.hint, charCount)}
     </FormControl>
   )
 }
@@ -217,7 +244,10 @@ FormField.propTypes = {
   disabled: p.bool,
 
   multiline: p.bool,
+  rows: p.string,
   autoComplete: p.string,
+
+  charCount: p.number,
 
   fullWidth: p.bool,
 

--- a/web/src/app/services/ServiceForm.tsx
+++ b/web/src/app/services/ServiceForm.tsx
@@ -5,6 +5,8 @@ import { EscalationPolicySelect } from '../selection/EscalationPolicySelect'
 import { FormContainer, FormField } from '../forms'
 import { FieldError } from '../util/errutil'
 
+const MaxDetailsLength = 6 * 1024 // 6KiB
+
 export interface Value {
   name: string
   description: string
@@ -43,7 +45,10 @@ export default function ServiceForm(props: ServiceFormProps): JSX.Element {
             label='Description'
             name='description'
             multiline
+            rows='4'
             component={TextField}
+            charCount={MaxDetailsLength}
+            hint='Markdown Supported'
           />
         </Grid>
         <Grid item xs={12}>


### PR DESCRIPTION
…ervice form

<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Added hint indicating markdown support for create/edit service form description text box. Also increased description size to 6KiB supporting up to 6144 chars. Added a char count to indicate this capacity.

**Which issue(s) this PR fixes:**
Fixes #2803

**Screenshots:**
Before:
<img width="599" alt="Screenshot 2023-04-05 at 2 21 08 PM" src="https://user-images.githubusercontent.com/59105963/230183352-d64f846b-814a-4359-bc3d-7767fc01d907.png">

After:
<img width="548" alt="Screenshot 2023-04-05 at 2 20 49 PM" src="https://user-images.githubusercontent.com/59105963/230183408-adac1047-1ff3-4b58-b7bd-b2a3978c7669.png">

**Describe any introduced user-facing changes:**
New UI elements for user facing service form. Allows larger services description, adds hints.
