### PR TITLE
Converting remaining service tests from Cypress to Playwright

### DIFF
--- a/test/integration/service.spec.ts
+++ b/test/integration/service.spec.ts
@@ -42,6 +42,138 @@ test('Service', async ({ page, isMobile }) => {
 
   await expect(page.getByRole('heading', { name, level: 1 })).toBeVisible()
 
+  // Navigate to the heartbeat monitors
+  await page.getByRole('link', { name: 'Heartbeat Monitors' }).click()
+
+  // Cancel out of create
+  if (isMobile) {
+    await page.getByRole('button', { name: 'Create Heartbeat Monitor' }).click()
+  } else {
+    await page.getByTestId('create-monitor').click()
+  }
+  await page.getByRole('button', { name: 'Cancel' }).click()
+
+  // Create a heartbeat monitor using invalid name
+  let timeoutMinutes = (Math.trunc(Math.random() * 10) + 5).toString()
+  const invalidHMName = 'a'
+  if (isMobile) {
+    await page.getByRole('button', { name: 'Create Heartbeat Monitor' }).click()
+  } else {
+    await page.getByTestId('create-monitor').click()
+  }
+  await page.getByLabel('Name').fill(invalidHMName)
+  await page.getByLabel('Timeout (minutes)').fill(timeoutMinutes)
+  await page.getByRole('button', { name: 'Submit' }).click()
+
+  // Should see error message
+  await expect(page.getByText('Must be at least 2 characters')).toBeVisible()
+
+  // Use valid name instead
+  let hmName = c.word({ length: 5 }) + ' Monitor'
+  await page.getByLabel('Name').fill(hmName)
+  await page.getByRole('button', { name: 'Retry' }).click()
+
+  // Should see the heartbeat monitor created
+  await expect(page.getByText(hmName)).toBeVisible()
+  await expect(page.getByText(timeoutMinutes)).toBeVisible()
+
+  // Cancel out of edit
+  await page.getByRole('button', { name: 'Other Actions' }).click()
+  await page.getByRole('menuitem', { name: 'Edit' }).click()
+  await page.getByRole('button', { name: 'Cancel' }).click()
+
+  // Edit the heartbeat monitor
+  hmName = c.word({ length: 5 })
+  timeoutMinutes = (Math.trunc(Math.random() * 10) + 5).toString()
+  await page.getByRole('button', { name: 'Other Actions' }).click()
+  await page.getByRole('menuitem', { name: 'Edit' }).click()
+  await page.getByLabel('Name').fill(hmName)
+  await page.getByLabel('Timeout (minutes)').fill(timeoutMinutes)
+  await page.getByRole('button', { name: 'Submit' }).click()
+
+  // Should see the edited heartbeat monitor
+  await expect(page.getByText(hmName)).toBeVisible()
+  await expect(page.getByText(timeoutMinutes)).toBeVisible()
+
+  // Cancel out of delete
+  await page.getByRole('button', { name: 'Other Actions' }).click()
+  await page.getByRole('menuitem', { name: 'Delete' }).click()
+  await page.getByRole('button', { name: 'Cancel' }).click()
+
+  // Delete the heartbeat monitor
+  await page.getByRole('button', { name: 'Other Actions' }).click()
+  await page.getByRole('menuitem', { name: 'Delete' }).click()
+  await page.getByRole('button', { name: 'Confirm' }).click()
+  await page.getByText('No heartbeat monitors exist for this service.').click()
+
+  // Return to the service
+  if (isMobile) {
+    await page.getByRole('button', { name: 'Back' }).click()
+  } else {
+    await page.getByRole('link', { name, exact: true }).click()
+  }
+
+  // Go to the alerts page
+  await page
+    .getByRole('link', {
+      name: 'Alerts Manage alerts specific to this service',
+    })
+    .click()
+
+  // Create an alert
+  const summary = c.sentence({ words: 3 })
+  const details = c.word({ length: 10 })
+  await page.getByRole('button', { name: 'Create Alert' }).click()
+  await page.getByLabel('Alert Summary').fill(summary)
+  await page.getByLabel('Details (optional)').fill(details)
+  await page.getByRole('button', { name: 'Next' }).click()
+  if (isMobile) {
+    await expect(page.getByText('Selected Services (1)' + name)).toBeVisible()
+  } else {
+    await expect(
+      page.getByRole('dialog', { name: 'Create New Alert' }).getByText(name),
+    ).toBeVisible()
+  }
+  await page.getByRole('button', { name: 'Submit' }).click()
+  await page.getByRole('button', { name: 'Done' }).click()
+
+  // Alert should be unacknowledged
+  await expect(
+    page.getByRole('link', { name: ' UNACKNOWLEDGED ' + summary }),
+  ).toBeVisible()
+
+  // Acknowledge the alert
+  await page.getByRole('button', { name: 'Acknowledge All' }).click()
+  await page.getByRole('button', { name: 'Confirm' }).click()
+  await expect(
+    page.getByRole('link', { name: ' ACKNOWLEDGED ' + summary }),
+  ).toBeVisible()
+  await expect(
+    page.getByRole('link', { name: ' UNACKNOWLEDGED ' + summary }),
+  ).toBeHidden()
+
+  // Close the alert
+  await page.getByRole('button', { name: 'Close All' }).click()
+  await page.getByRole('button', { name: 'Confirm' }).click()
+  await expect(page.getByText('No results')).toBeVisible()
+
+  // Return to the service
+  if (isMobile) {
+    await page.getByRole('button', { name: 'Back' }).click()
+  } else {
+    await page.getByRole('link', { name, exact: true }).click()
+  }
+
+  // Navigate to the metrics
+  await page.getByRole('link', { name: 'Metrics' }).click()
+
+  // Return to the service
+  if (isMobile) {
+    await page.getByRole('button', { name: 'Back' }).click()
+  } else {
+    await page.getByRole('link', { name, exact: true }).click()
+  }
+
   // Create a label for the service
   await page.getByRole('link', { name: 'Labels' }).click()
   const key = `${c.word({ length: 4 })}/${c.word({ length: 3 })}`
@@ -137,77 +269,6 @@ test('Service', async ({ page, isMobile }) => {
 
   await expect(page.getByText(intKey, { exact: true })).toBeVisible()
   await expect(page.getByText(grafanaKey, { exact: true })).toBeHidden()
-
-  // Return to the service
-  if (isMobile) {
-    await page.getByRole('button', { name: 'Back' }).click()
-  } else {
-    await page.getByRole('link', { name, exact: true }).click()
-  }
-
-  // Navigate to the heartbeat monitors
-  await page.getByRole('link', { name: 'Heartbeat Monitors' }).click()
-
-  // Cancel out of create
-  if (isMobile) {
-    await page.getByRole('button', { name: 'Create Heartbeat Monitor' }).click()
-  } else {
-    await page.getByTestId('create-monitor').click()
-  }
-  await page.getByRole('button', { name: 'Cancel' }).click()
-
-  // Create a heartbeat monitor using invalid name
-  let timeoutMinutes = (Math.trunc(Math.random() * 10) + 5).toString()
-  const invalidHMName = 'a'
-  if (isMobile) {
-    await page.getByRole('button', { name: 'Create Heartbeat Monitor' }).click()
-  } else {
-    await page.getByTestId('create-monitor').click()
-  }
-  await page.getByLabel('Name').fill(invalidHMName)
-  await page.getByLabel('Timeout (minutes)').fill(timeoutMinutes)
-  await page.getByRole('button', { name: 'Submit' }).click()
-
-  // Should see error message
-  await expect(page.getByText('Must be at least 2 characters')).toBeVisible()
-
-  // Use valid name instead
-  let hmName = c.word({ length: 5 }) + ' Monitor'
-  await page.getByLabel('Name').fill(hmName)
-  await page.getByRole('button', { name: 'Retry' }).click()
-
-  // Should see the heartbeat monitor created
-  await expect(page.getByText(hmName)).toBeVisible()
-  await expect(page.getByText(timeoutMinutes)).toBeVisible()
-
-  // Cancel out of edit
-  await page.getByRole('button', { name: 'Other Actions' }).click()
-  await page.getByRole('menuitem', { name: 'Edit' }).click()
-  await page.getByRole('button', { name: 'Cancel' }).click()
-
-  // Edit the heartbeat monitor
-  hmName = c.word({ length: 5 })
-  timeoutMinutes = (Math.trunc(Math.random() * 10) + 5).toString()
-  await page.getByRole('button', { name: 'Other Actions' }).click()
-  await page.getByRole('menuitem', { name: 'Edit' }).click()
-  await page.getByLabel('Name').fill(hmName)
-  await page.getByLabel('Timeout (minutes)').fill(timeoutMinutes)
-  await page.getByRole('button', { name: 'Submit' }).click()
-
-  // Should see the edited heartbeat monitor
-  await expect(page.getByText(hmName)).toBeVisible()
-  await expect(page.getByText(timeoutMinutes)).toBeVisible()
-
-  // Cancel out of delete
-  await page.getByRole('button', { name: 'Other Actions' }).click()
-  await page.getByRole('menuitem', { name: 'Delete' }).click()
-  await page.getByRole('button', { name: 'Cancel' }).click()
-
-  // Delete the heartbeat monitor
-  await page.getByRole('button', { name: 'Other Actions' }).click()
-  await page.getByRole('menuitem', { name: 'Delete' }).click()
-  await page.getByRole('button', { name: 'Confirm' }).click()
-  await page.getByText('No heartbeat monitors exist for this service.').click()
 
   // Make another service
   const diffName = 'pw-service ' + c.name()

--- a/web/src/cypress/e2e/services.cy.ts
+++ b/web/src/cypress/e2e/services.cy.ts
@@ -8,36 +8,6 @@ function testServices(screen: ScreenFormat): void {
     window.localStorage.setItem('show_services_new_feature_popup', 'false')
   })
 
-  describe('Details Page', () => {
-    let svc: Service
-    beforeEach(() =>
-      cy.createService().then((s: Service) => {
-        svc = s
-        return cy.visit(`/services/${s.id}`)
-      }),
-    )
-
-    it('should navigate to and from metrics', () => {
-      cy.navigateToAndFrom(
-        screen,
-        'Services',
-        svc.name,
-        'Metrics',
-        `${svc.id}/alert-metrics`,
-      )
-    })
-
-    it('should navigate to and from alerts', () => {
-      cy.navigateToAndFrom(
-        screen,
-        'Services',
-        svc.name,
-        'Alerts',
-        `${svc.id}/alerts`,
-      )
-    })
-  })
-
   describe('Integration Keys', () => {
     let svc: Service
     beforeEach(() =>
@@ -96,52 +66,6 @@ function testServices(screen: ScreenFormat): void {
         cy.get('button[data-testid="create-key"]').click()
       }
       cy.get('input[name=type]').findByLabel('Email').should('not.exist')
-    })
-  })
-
-  describe('Alerts', () => {
-    let svc: Service
-    beforeEach(() =>
-      cy.createService().then((s: Service) => {
-        svc = s
-        return cy.visit(`/services/${s.id}/alerts`)
-      }),
-    )
-
-    it('should create alert with prepopulated service', () => {
-      const summary = c.sentence({ words: 3 })
-      const details = c.word({ length: 10 })
-
-      cy.pageFab()
-      cy.dialogForm({ summary, details })
-      cy.dialogClick('Next')
-      cy.dialogContains(svc.name)
-      cy.dialogClick('Submit')
-      cy.dialogFinish('Done')
-    })
-
-    it('should allow ack/close all alerts', () => {
-      cy.createAlert({ serviceID: svc.id })
-      cy.createAlert({ serviceID: svc.id })
-      cy.createAlert({ serviceID: svc.id })
-
-      cy.reload()
-
-      cy.get('ul[data-cy=paginated-list]').should('contain', 'UNACKNOWLEDGED')
-
-      cy.get('button').contains('Acknowledge All').click()
-      cy.dialogFinish('Confirm')
-
-      cy.get('ul[data-cy=paginated-list]').should('contain', 'ACKNOWLEDGED')
-      cy.get('ul[data-cy=paginated-list]').should(
-        'not.contain',
-        'UNACKNOWLEDGED',
-      )
-
-      cy.get('button').contains('Close All').click()
-      cy.dialogFinish('Confirm')
-
-      cy.get('body').should('contain', 'No results')
     })
   })
 

--- a/web/src/cypress/e2e/services.cy.ts
+++ b/web/src/cypress/e2e/services.cy.ts
@@ -27,7 +27,7 @@ function testServices(screen: ScreenFormat): void {
       )
     })
 
-    it('should navigate to and from metrics', () => {
+    it('should navigate to and from alerts', () => {
       cy.navigateToAndFrom(
         screen,
         'Services',
@@ -35,115 +35,6 @@ function testServices(screen: ScreenFormat): void {
         'Alerts',
         `${svc.id}/alerts`,
       )
-    })
-
-    it('should navigate to and from heartbeat monitors', () => {
-      cy.navigateToAndFrom(
-        screen,
-        'Services',
-        svc.name,
-        'Heartbeat Monitors',
-        `${svc.id}/heartbeat-monitors`,
-      )
-    })
-  })
-
-  describe('Heartbeat Monitors', () => {
-    let monitor: HeartbeatMonitor
-    beforeEach(() => {
-      cy.createService().then((s: Service) =>
-        cy
-          .createHeartbeatMonitor({
-            svcID: s.id,
-            name: c.word({ length: 5 }) + ' Monitor',
-            timeoutMinutes: Math.trunc(Math.random() * 10) + 5,
-          })
-          .then((m: HeartbeatMonitor) => {
-            monitor = m
-          })
-          .visit(`/services/${s.id}/heartbeat-monitors`),
-      )
-    })
-
-    it('should create a monitor', () => {
-      const name = c.word({ length: 5 }) + ' Monitor'
-      const timeoutMinutes = (Math.trunc(Math.random() * 10) + 5).toString()
-      const invalidName = 'a'
-
-      if (screen === 'mobile') {
-        cy.pageFab()
-      } else {
-        cy.get('button[data-testid="create-monitor"]').click()
-      }
-
-      cy.dialogForm({ name: invalidName, timeoutMinutes })
-      cy.dialogClick('Submit')
-      cy.get('body').should('contain', 'Must be at least 2 characters')
-
-      cy.dialogForm({ name, timeoutMinutes })
-      cy.dialogFinish('Retry')
-
-      cy.get('li').should('contain', name).should('contain', timeoutMinutes)
-    })
-
-    it('should edit a monitor', () => {
-      const name = c.word({ length: 5 })
-      const timeoutMinutes = (Math.trunc(Math.random() * 10) + 5).toString()
-
-      cy.get('li')
-        .should('contain', monitor.name)
-        .find('div')
-        .find('button[data-cy=other-actions]')
-        .menu('Edit')
-
-      cy.dialogForm({ name, timeoutMinutes })
-      cy.dialogFinish('Submit')
-
-      cy.get('li').should('contain', name)
-      cy.get('li').should('contain', timeoutMinutes)
-    })
-
-    it('should delete a monitor', () => {
-      cy.get('li')
-        .should('contain', monitor.name)
-        .find('div')
-        .find('button[data-cy=other-actions]')
-        .menu('Delete')
-
-      cy.dialogFinish('Confirm')
-
-      cy.get('li').should('not.contain', monitor.name)
-      cy.get('li').should(
-        'contain',
-        'No heartbeat monitors exist for this service.',
-      )
-    })
-
-    it('should handle canceling', () => {
-      // cancel out of create
-      if (screen === 'mobile') {
-        cy.pageFab()
-      } else {
-        cy.get('button[data-testid="create-monitor"]').click()
-      }
-      cy.dialogTitle('Create New Heartbeat Monitor')
-      cy.dialogFinish('Cancel')
-
-      // cancel out of edit
-      cy.get('li')
-        .should('contain', monitor.name)
-        .find('div')
-        .find('button[data-cy=other-actions]')
-        .menu('Edit')
-      cy.dialogFinish('Cancel')
-
-      // cancel out of delete
-      cy.get('li')
-        .should('contain', monitor.name)
-        .find('div')
-        .find('button[data-cy=other-actions]')
-        .menu('Delete')
-      cy.dialogFinish('Cancel')
     })
   })
 

--- a/web/src/cypress/e2e/services.cy.ts
+++ b/web/src/cypress/e2e/services.cy.ts
@@ -166,25 +166,6 @@ function testServices(screen: ScreenFormat): void {
       cy.dialogFinish('Submit')
     }
 
-    it('should allow managing integration keys', () => {
-      const name = 'SM Int ' + c.word({ length: 8 })
-
-      cy.get('body').should('contain', 'No integration keys')
-      ;['Generic API', 'Grafana'].forEach((type) => {
-        createKey(type, name)
-
-        cy.get('ul[data-cy=int-keys]').should('contain', name)
-
-        // delete
-        cy.get('ul[data-cy=int-keys')
-          .contains('li', name)
-          .find('button')
-          .click()
-
-        cy.dialogFinish('Confirm')
-      })
-    })
-
     it('should manage integration keys with mailgun disabled', () => {
       const domain = c.domain()
       const name = 'SM Int ' + c.word({ length: 8 })
@@ -274,61 +255,11 @@ function testServices(screen: ScreenFormat): void {
   })
 
   describe('Labels', () => {
-    let label: Label
     beforeEach(() =>
       cy.createLabel().then((l: Label) => {
-        label = l
         return cy.visit(`/services/${l.svcID}/labels`)
       }),
     )
-
-    it('should edit a label', () => {
-      const key = label.key
-      const value = c.word({ length: 10 })
-
-      cy.get('li')
-        .should('contain', key)
-        .find('div')
-        .find('button[data-cy=other-actions]')
-        .menu('Edit')
-
-      cy.dialogForm({ value })
-      cy.dialogFinish('Submit')
-
-      cy.get('li').should('contain', key)
-      cy.get('li').should('contain', value)
-    })
-
-    it('should delete a label', () => {
-      cy.get('li')
-        .should('contain', label.key)
-        .find('div')
-        .find('button[data-cy=other-actions]')
-        .menu('Delete')
-
-      cy.dialogFinish('Confirm')
-
-      cy.get('li').should('not.contain', label.key)
-      cy.get('li').should('not.contain', label.value)
-    })
-
-    it('should search for a specific service with label', () => {
-      cy.visit(`/services`)
-      cy.get('ul[data-cy=paginated-list]').should('exist')
-      cy.pageSearch(`${label.key}=${label.value}`)
-      cy.get('body')
-        .should('contain', label.svc.name)
-        .should('contain', label.svc.description)
-    })
-
-    it('should search for a services without label', () => {
-      cy.visit(`/services`)
-      cy.get('ul[data-cy=paginated-list]').should('exist')
-      cy.pageSearch(`${label.key}!=${label.value}`)
-      cy.get('body')
-        .should('not.contain', label.svc.name)
-        .should('not.contain', label.svc.description)
-    })
 
     it('should not be able to create a label when DisableLabelCreation is true', () => {
       const randomWord = c.word({


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR converts the rest of the service test previously written for Cypress to Playwright.
Specifically covers:

- Creating a new type and deleting an integration key
- Creating, editing and deleting a heartbeat monitor
- Navigating to the metrics
- Creating, acknowledging, and closing an alert
- Editing and deleting a label
- Searching for a service by label key and value 

**Which issue(s) this PR fixes:**
Part of #2847 
Follow-up to #2913 and #2922 

**Out of Scope:**
There are three tests remaining in the services file that are still only written for Cypress:
- Two (one for labels and one for integration keys) tests that rely on admin access to manipulate the config. These will be converted in a separate test suite dedicated to turning off admin features and testing that they no longer appear in the UI
- One (metrics) test that relies on the harness and fast forwarding to acknowledge and close alerts after a certain amount of time.