### PR TITLE
feat: clarify permissions around contact methods

### DIFF
--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -127,14 +127,14 @@ export default function UserContactMethodList(
         label: 'Send Test',
         onClick: () => setShowSendTestByID(cm.id),
         disabled: !isCurrentUser,
-        tooltip: 'Send Test only available for your own contract methods',
+        tooltip: 'Send Test only available for your own contact methods',
       })
     } else {
       actions.push({
         label: 'Reactivate',
         onClick: () => setShowVerifyDialogByID(cm.id),
         disabled: !isCurrentUser,
-        tooltip: 'Reactivate only available for your own contract methods',
+        tooltip: 'Reactivate only available for your own contact methods',
       })
     }
     return actions

--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -20,6 +20,7 @@ import { styles as globalStyles } from '../styles/materialStyles'
 import { UserContactMethod } from '../../schema'
 import UserContactMethodCreateDialog from './UserContactMethodCreateDialog'
 import { useExpFlag } from '../util/useExpFlag'
+import { useSessionInfo } from '../util/RequireConfig'
 
 const query = gql`
   query cmList($id: ID!) {
@@ -41,6 +42,8 @@ const query = gql`
 interface ListItemAction {
   label: string
   onClick: () => void
+  disabled?: boolean
+  tooltip?: string
 }
 
 interface UserContactMethodListProps {
@@ -71,6 +74,9 @@ export default function UserContactMethodList(
     },
   })
 
+  const { userID: currentUserID } = useSessionInfo()
+  const isCurrentUser = props.userID === currentUserID
+
   if (loading && !data) return <Spinner />
   if (data && !data.user) return <ObjectNotFound type='user' />
   if (error) return <GenericError error={error.message} />
@@ -98,25 +104,37 @@ export default function UserContactMethodList(
 
   function getActionMenuItems(cm: UserContactMethod): ListItemAction[] {
     const actions = [
-      { label: 'Edit', onClick: () => setShowEditDialogByID(cm.id) },
+      {
+        label: 'Edit',
+        onClick: () => setShowEditDialogByID(cm.id),
+        disabled: false,
+        tooltip: '',
+      },
       {
         label: 'Delete',
         onClick: () => setShowDeleteDialogByID(cm.id),
+        disabled: false,
+        tooltip: '',
       },
     ]
 
     // don't show send test for slack DMs if disabled
     if (cm.type === 'SLACK_DM' && !hasSlackDM) return actions
 
+    // disable send test and reactivate if not current user
     if (!cm.disabled) {
       actions.push({
         label: 'Send Test',
         onClick: () => setShowSendTestByID(cm.id),
+        disabled: !isCurrentUser,
+        tooltip: 'Send Test only available for your own contract methods',
       })
     } else {
       actions.push({
         label: 'Reactivate',
         onClick: () => setShowVerifyDialogByID(cm.id),
+        disabled: !isCurrentUser,
+        tooltip: 'Reactivate only available for your own contract methods',
       })
     }
     return actions
@@ -125,7 +143,7 @@ export default function UserContactMethodList(
   function getSecondaryAction(cm: UserContactMethod): JSX.Element {
     return (
       <Grid container spacing={2} alignItems='center' wrap='nowrap'>
-        {cm.disabled && !props.readOnly && !mobile && (
+        {cm.disabled && !props.readOnly && !mobile && isCurrentUser && (
           <Grid item>
             <Button
               aria-label='Reactivate contact method'

--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -127,14 +127,18 @@ export default function UserContactMethodList(
         label: 'Send Test',
         onClick: () => setShowSendTestByID(cm.id),
         disabled: !isCurrentUser,
-        tooltip: 'Send Test only available for your own contact methods',
+        tooltip: !isCurrentUser
+          ? 'Send Test only available for your own contact methods'
+          : '',
       })
     } else {
       actions.push({
         label: 'Reactivate',
         onClick: () => setShowVerifyDialogByID(cm.id),
         disabled: !isCurrentUser,
-        tooltip: 'Reactivate only available for your own contact methods',
+        tooltip: !isCurrentUser
+          ? 'Reactivate only available for your own contact methods'
+          : '',
       })
     }
     return actions

--- a/web/src/app/util/OtherActions.js
+++ b/web/src/app/util/OtherActions.js
@@ -67,6 +67,8 @@ OtherActions.propTypes = {
     p.shape({
       label: p.string.isRequired,
       onClick: p.func.isRequired,
+      disabled: p.bool,
+      tooltip: p.string,
     }),
   ).isRequired,
   disabled: p.bool,

--- a/web/src/app/util/OtherActionsDesktop.js
+++ b/web/src/app/util/OtherActionsDesktop.js
@@ -3,6 +3,7 @@ import p from 'prop-types'
 
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
+import { Tooltip } from '@mui/material'
 
 export default function OtherActionsMenuDesktop({
   placement,
@@ -34,15 +35,22 @@ export default function OtherActionsMenuDesktop({
       }}
     >
       {actions.map((o, idx) => (
-        <MenuItem
-          key={idx}
-          onClick={() => {
-            onClose()
-            o.onClick()
-          }}
-        >
-          {o.label}
-        </MenuItem>
+        // tooltip for alt text on menuitem hover
+        // wrapped with div to allow tooltip to work on disabled menuitem
+        <Tooltip key={idx} title={o.tooltip}>
+          <div>
+            <MenuItem
+              key={idx}
+              onClick={() => {
+                onClose()
+                o.onClick()
+              }}
+              disabled={o.disabled}
+            >
+              {o.label}
+            </MenuItem>
+          </div>
+        </Tooltip>
       ))}
     </Menu>
   )
@@ -57,6 +65,8 @@ OtherActionsMenuDesktop.propTypes = {
     p.shape({
       label: p.string.isRequired,
       onClick: p.func.isRequired,
+      disabled: p.bool,
+      tooltip: p.string,
     }),
   ),
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Make test and verification options available only to the current user to send to their contact methods.
- Hide reactivate button if userid does not match current user
- Disable "send to test" and "reactivate" dropdown options if not the current user
- Show tooltip for disabled options explaining why options are disable when hovering over those options

**Which issue(s) this PR fixes:**
Fixes #2823 

**Screenshots:**
<img width="990" alt="Screenshot 2023-04-11 at 4 08 47 PM" src="https://user-images.githubusercontent.com/59105963/231288799-3b832c73-ea78-45be-8832-b096c607efc2.png">

