### PR TITLE
ui/alerts: Convert CreateAlertConfirm to typescript

### DIFF
--- a/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertConfirm.tsx
+++ b/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertConfirm.tsx
@@ -14,10 +14,20 @@ const useStyles = makeStyles({
   },
 })
 
-export function CreateAlertConfirm() {
+export function CreateAlertConfirm(): JSX.Element {
   const classes = useStyles()
 
-  const renderItem = ({ name, label, value, children }) => (
+  const renderItem = ({
+    name,
+    label,
+    value,
+    children,
+  }: {
+    name: string
+    label: string
+    value: string
+    children: JSX.Element
+  }): JSX.Element => (
     <Grid item xs={12}>
       <Typography
         variant='subtitle1'
@@ -56,7 +66,7 @@ export function CreateAlertConfirm() {
           renderItem({
             ...otherProps,
             label: `Selected Services (${value.length})`,
-            children: value.map((id) => (
+            children: value.map((id: string) => (
               <ServiceChip
                 key={id}
                 clickable={false}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Convert component to typescript.
Part of #2318