### PR TITLE
dev: use ipv4-only addresses for Cypress

### DIFF
--- a/Procfile.cypress
+++ b/Procfile.cypress
@@ -1,7 +1,7 @@
 build: while true; do make -qs bin/goalert || make bin/goalert || (echo '\033[0;31mBuild Failure'; sleep 3); sleep 0.1; done
 
 @watch-file=./bin/goalert
-goalert: go run ./devtools/waitfor postgres://postgres@localhost:5433 && go run ./devtools/procwrap -test=localhost:3042 bin/goalert -l=localhost:3042 --ui-dir=web/src/build --db-url=postgres://postgres@localhost:5433 --slack-base-url=http://localhost:3040/slack --log-errors-only --public-url=http://localhost:3040$HTTP_PREFIX
+goalert: go run ./devtools/waitfor postgres://postgres@127.0.0.1:5433 && go run ./devtools/procwrap -test=127.0.0.1:3042 bin/goalert -l=127.0.0.1:3042 --ui-dir=web/src/build --db-url=postgres://postgres@127.0.0.1:5433 --slack-base-url=http://127.0.0.1:3040/slack --log-errors-only --public-url=http://127.0.0.1:3040$HTTP_PREFIX
 
 @watch-file=./web/src/esbuild.config.js
 ui: yarn workspace goalert-web run esbuild --watch
@@ -9,11 +9,11 @@ ui: yarn workspace goalert-web run esbuild --watch
 @watch-file=./web/src/esbuild.cypress.js
 build-cy: yarn workspace goalert-web run esbuild-cy --watch
 
-slack: go run ./devtools/mockslack/cmd/mockslack -client-id=000000000000.000000000000 -client-secret=00000000000000000000000000000000 -access-token=xoxp-000000000000-000000000000-000000000000-00000000000000000000000000000000 -prefix=/slack -single-user=bob -addr=localhost:3046
+slack: go run ./devtools/mockslack/cmd/mockslack -client-id=000000000000.000000000000 -client-secret=00000000000000000000000000000000 -access-token=xoxp-000000000000-000000000000-000000000000-00000000000000000000000000000000 -prefix=/slack -single-user=bob -addr=127.0.0.1:3046
 
-proxy: go run ./devtools/simpleproxy -addr=localhost:3040 /slack/=http://localhost:3046 http://localhost:3042
+proxy: go run ./devtools/simpleproxy -addr=127.0.0.1:3040 /slack/=http://127.0.0.1:3046 http://127.0.0.1:3042
 
 @oneshot
-cypress: go run ./devtools/waitfor http://localhost:3042 && CYPRESS_DB_URL=postgres://postgres@localhost:5433 yarn workspace goalert-web --cwd=bin/build/integration cypress open --config baseUrl=http://localhost:3040$HTTP_PREFIX
+cypress: go run ./devtools/waitfor http://127.0.0.1:3042 && CYPRESS_DB_URL=postgres://postgres@127.0.0.1:5433 yarn workspace goalert-web --cwd=bin/build/integration cypress open --config baseUrl=http://127.0.0.1:3040$HTTP_PREFIX
 
 db: $CONTAINER_TOOL rm -f smoketest-postgres || true; $CONTAINER_TOOL run -it --rm --name smoketest-postgres -p5433:5432 -e=POSTGRES_HOST_AUTH_METHOD=trust postgres:13-alpine

--- a/Procfile.cypress.ci
+++ b/Procfile.cypress.ci
@@ -1,10 +1,10 @@
 @oneshot
-cypress: go run ./devtools/waitfor http://localhost:3042 && CYPRESS_DB_URL=$DB_URL yarn workspace goalert-web --cwd=bin/build/integration cypress $CY_ACTION --config baseUrl=http://localhost:3040$HTTP_PREFIX
+cypress: go run ./devtools/waitfor http://127.0.0.1:3042 && CYPRESS_DB_URL=$DB_URL yarn workspace goalert-web --cwd=bin/build/integration cypress $CY_ACTION --config baseUrl=http://127.0.0.1:3040$HTTP_PREFIX
 
-goalert: go run ./devtools/waitfor $DB_URL && go run ./devtools/procwrap -test=localhost:3042 bin/goalert -l=localhost:3042 --db-url=$DB_URL --slack-base-url=http://localhost:3040/slack --log-errors-only --public-url=http://localhost:3040$HTTP_PREFIX
+goalert: go run ./devtools/waitfor $DB_URL && go run ./devtools/procwrap -test=127.0.0.1:3042 bin/goalert -l=127.0.0.1:3042 --db-url=$DB_URL --slack-base-url=http://127.0.0.1:3040/slack --log-errors-only --public-url=http://127.0.0.1:3040$HTTP_PREFIX
 
-slack: go run ./devtools/mockslack/cmd/mockslack -client-id=000000000000.000000000000 -client-secret=00000000000000000000000000000000 -access-token=xoxp-000000000000-000000000000-000000000000-00000000000000000000000000000000 -prefix=/slack -single-user=bob -addr=localhost:3046
+slack: go run ./devtools/mockslack/cmd/mockslack -client-id=000000000000.000000000000 -client-secret=00000000000000000000000000000000 -access-token=xoxp-000000000000-000000000000-000000000000-00000000000000000000000000000000 -prefix=/slack -single-user=bob -addr=127.0.0.1:3046
 
-proxy: go run ./devtools/simpleproxy -addr=localhost:3040 /slack/=http://localhost:3046 http://localhost:3042
+proxy: go run ./devtools/simpleproxy -addr=127.0.0.1:3040 /slack/=http://127.0.0.1:3046 http://127.0.0.1:3042
 
 db: tail -f /var/log/postgresql/server.log

--- a/Procfile.cypress.prod
+++ b/Procfile.cypress.prod
@@ -1,14 +1,14 @@
 build: while true; do make -qs bin/goalert BUNDLE=1 >/dev/null || make bin/goalert BUNDLE=1 || (echo '\033[0;31mBuild Failure'; sleep 3); sleep 0.1; done
 
 @watch-file=./bin/goalert
-goalert: go run ./devtools/waitfor postgres://postgres@localhost:5433 && go run ./devtools/procwrap -test=localhost:3042 bin/goalert -l=localhost:3042 --db-url=postgres://postgres@localhost:5433 --slack-base-url=http://localhost:3040/slack --log-errors-only --public-url=http://localhost:3040$HTTP_PREFIX
+goalert: go run ./devtools/waitfor postgres://postgres@127.0.0.1:5433 && go run ./devtools/procwrap -test=127.0.0.1:3042 bin/goalert -l=127.0.0.1:3042 --db-url=postgres://postgres@127.0.0.1:5433 --slack-base-url=http://127.0.0.1:3040/slack --log-errors-only --public-url=http://127.0.0.1:3040$HTTP_PREFIX
 
-slack: go run ./devtools/mockslack/cmd/mockslack -client-id=000000000000.000000000000 -client-secret=00000000000000000000000000000000 -access-token=xoxp-000000000000-000000000000-000000000000-00000000000000000000000000000000 -prefix=/slack -single-user=bob -addr=localhost:3046
+slack: go run ./devtools/mockslack/cmd/mockslack -client-id=000000000000.000000000000 -client-secret=00000000000000000000000000000000 -access-token=xoxp-000000000000-000000000000-000000000000-00000000000000000000000000000000 -prefix=/slack -single-user=bob -addr=127.0.0.1:3046
 
-proxy: go run ./devtools/simpleproxy -addr=localhost:3040 /slack/=http://localhost:3046 http://localhost:3042
+proxy: go run ./devtools/simpleproxy -addr=127.0.0.1:3040 /slack/=http://127.0.0.1:3046 http://127.0.0.1:3042
 
 @oneshot
-cypress: go run ./devtools/waitfor http://localhost:3042 && CYPRESS_DB_URL=postgres://postgres@localhost:5433 yarn workspace goalert-web --cwd=bin/build/integration cypress $CY_ACTION --config baseUrl=http://localhost:3040$HTTP_PREFIX
+cypress: go run ./devtools/waitfor http://127.0.0.1:3042 && CYPRESS_DB_URL=postgres://postgres@127.0.0.1:5433 yarn workspace goalert-web --cwd=bin/build/integration cypress $CY_ACTION --config baseUrl=http://127.0.0.1:3040$HTTP_PREFIX
 
 db: $CONTAINER_TOOL rm -f smoketest-postgres || true; $CONTAINER_TOOL run -it --rm --name smoketest-postgres -p5433:5432 -e=POSTGRES_HOST_AUTH_METHOD=trust postgres:13-alpine
 


### PR DESCRIPTION
**Description:**
Node 17+ changed the default of localhost to ipv6, with no fallback for ipv4. This means something listening on `localhost` that defaults to ipv4-only will result in nodejs breaking with connection refused.

To resolve this without the need for version detection/flags we can just update the Procfiles for Cypress to use `127.0.0.1` to force the compatible option.
