### PR TITLE
slack: add team:read scope to Slack

### DIFF
--- a/graphql2/graphqlapp/slack.manifest.yaml
+++ b/graphql2/graphqlapp/slack.manifest.yaml
@@ -25,5 +25,6 @@ oauth_config:
       - users:read.email
       - usergroups:read
       - usergroups:write
+      - team:read
   redirect_urls:
     - '{{.CallbackURL "/api/v2/identity/providers/oidc/callback"}}'


### PR DESCRIPTION
**Description:**
Add missing `team:read` scope (needed for team.info endpoint) to manifest.
