### PR TITLE
auth/basic: separate password hashing from DB insert

### DIFF
--- a/app/cmd.go
+++ b/app/cmd.go
@@ -569,7 +569,12 @@ Migration: %s (#%d)
 				fmt.Fprintln(os.Stderr)
 			}
 
-			err = basicStore.CreateTx(ctx, tx, id, username, pass)
+			pw, err := basicStore.NewHashedPassword(pass)
+			if err != nil {
+				return errors.Wrap(err, "hash password")
+			}
+
+			err = basicStore.CreateTx(ctx, tx, id, username, pw)
 			if err != nil {
 				return errors.Wrap(err, "add basic auth entry")
 			}

--- a/auth/basic/db.go
+++ b/auth/basic/db.go
@@ -34,8 +34,8 @@ func NewStore(ctx context.Context, db *sql.DB) (*Store, error) {
 	}, p.Err
 }
 
-// Password is an interface that can be used to store a password.
-type Password interface {
+// HashedPassword is an interface that can be used to store a password.
+type HashedPassword interface {
 	String() string
 
 	_private() // prevent external implementations
@@ -47,7 +47,7 @@ func (h hashed) String() string { return string(h) }
 func (h hashed) _private()      {}
 
 // NewHashedPassword will hash the given password and return a Password object.
-func (b *Store) NewHashedPassword(password string) (Password, error) {
+func (b *Store) NewHashedPassword(password string) (HashedPassword, error) {
 	err := validate.Text("Password", password, 8, 200)
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func (b *Store) NewHashedPassword(password string) (Password, error) {
 // CreateTx should add a new entry for the username/password combination linking to userID.
 // An error is returned if the username is not unique or the userID is invalid.
 // Must have same user or admin role.
-func (b *Store) CreateTx(ctx context.Context, tx *sql.Tx, userID, username string, password Password) error {
+func (b *Store) CreateTx(ctx context.Context, tx *sql.Tx, userID, username string, password HashedPassword) error {
 	err := permission.LimitCheckAny(ctx, permission.System, permission.Admin, permission.MatchUser(userID))
 	if err != nil {
 		return err

--- a/auth/basic/db.go
+++ b/auth/basic/db.go
@@ -36,15 +36,15 @@ func NewStore(ctx context.Context, db *sql.DB) (*Store, error) {
 
 // HashedPassword is an interface that can be used to store a password.
 type HashedPassword interface {
-	String() string
+	Hash() string
 
 	_private() // prevent external implementations
 }
 
 type hashed []byte
 
-func (h hashed) String() string { return string(h) }
-func (h hashed) _private()      {}
+func (h hashed) Hash() string { return string(h) }
+func (h hashed) _private()    {}
 
 // NewHashedPassword will hash the given password and return a Password object.
 func (b *Store) NewHashedPassword(password string) (HashedPassword, error) {
@@ -80,7 +80,7 @@ func (b *Store) CreateTx(ctx context.Context, tx *sql.Tx, userID, username strin
 		return err
 	}
 
-	_, err = tx.StmtContext(ctx, b.insert).ExecContext(ctx, userID, username, password.String())
+	_, err = tx.StmtContext(ctx, b.insert).ExecContext(ctx, userID, username, password.Hash())
 	return err
 }
 

--- a/graphql2/graphqlapp/user.go
+++ b/graphql2/graphqlapp/user.go
@@ -78,6 +78,11 @@ func (a *Mutation) CreateUser(ctx context.Context, input graphql2.CreateUserInpu
 		return nil, err
 	}
 
+	pass, err := a.AuthBasicStore.NewHashedPassword(input.Password)
+	if err != nil {
+		return nil, err
+	}
+
 	// user default values
 	usr := &user.User{
 		Name: input.Username,
@@ -108,7 +113,7 @@ func (a *Mutation) CreateUser(ctx context.Context, input graphql2.CreateUserInpu
 				return err
 			}
 		}
-		err = a.AuthBasicStore.CreateTx(ctx, tx, newUser.ID, input.Username, input.Password)
+		err = a.AuthBasicStore.CreateTx(ctx, tx, newUser.ID, input.Username, pass)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**Description:**
- Moves bcrypt hashing out of the `CreateTx` method of the basic store
- Uses type system to ensure only hashed passwords are accepted by `CreateTx`

**Which issue(s) this PR fixes:**
Fixes #2985 
