### PR TITLE
dev: switch to wait for page vs time

### DIFF
--- a/test/integration/timepickers.spec.ts
+++ b/test/integration/timepickers.spec.ts
@@ -11,14 +11,13 @@ let scheduleID: string
 
 test.beforeEach(async ({ page }) => {
   // create schedule
-  const name = c.name() + ' Service'
+  const name = 'time-picker ' + c.string({ length: 10, alpha: true })
   await page.goto(`${baseURL}/schedules`)
   await page.getByRole('button', { name: 'Create Schedule' }).click()
   await page.fill('input[name=name]', name)
   await page.locator('button[type=submit]').click()
-  await page.waitForTimeout(1000)
-  const p = page.url().split('/')
-  scheduleID = p[p.length - 1]
+  await page.waitForURL(/\/schedules\/.{36}/)
+  scheduleID = page.url().split('/schedules/')[1]
 })
 
 test.afterEach(async ({ page }) => {


### PR DESCRIPTION
**Description:**
Does some cleanup on playwright tests to reduce flakiness
- Removed all use of `waitForTimeout`
- Use random strings for generated schedules
- Removed loops for double key presses in favor of flat calls
- Use `li` qualifier for search-select items
