### PR TITLE
Fix smtp default port

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -119,7 +119,7 @@ type Config struct {
 
 		From string `public:"true" info:"The email address messages should be sent from."`
 
-		Address    string `info:"The server address to use for sending email. Port is optional."`
+		Address    string `info:"The server address to use for sending email. Port is optional and defaults to 465, or 25 if Disable TLS is set. Common ports are: 25 or 587 for STARTTLS (or unencrypted) and 465 for TLS."`
 		DisableTLS bool   `info:"Disables TLS on the connection (STARTTLS will still be used if supported)."`
 		SkipVerify bool   `info:"Disables certificate validation for TLS/STARTTLS (insecure)."`
 

--- a/graphql2/mapconfig.go
+++ b/graphql2/mapconfig.go
@@ -79,7 +79,7 @@ func MapConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "Twilio.SMSFromNumberOverride", Type: ConfigTypeStringList, Description: "List of 'carrier=number' pairs, SMS messages to numbers of the provided carrier string (exact match) will use the alternate From Number.", Value: strings.Join(cfg.Twilio.SMSFromNumberOverride, "\n")},
 		{ID: "SMTP.Enable", Type: ConfigTypeBoolean, Description: "Enables email as a contact method.", Value: fmt.Sprintf("%t", cfg.SMTP.Enable)},
 		{ID: "SMTP.From", Type: ConfigTypeString, Description: "The email address messages should be sent from.", Value: cfg.SMTP.From},
-		{ID: "SMTP.Address", Type: ConfigTypeString, Description: "The server address to use for sending email. Port is optional.", Value: cfg.SMTP.Address},
+		{ID: "SMTP.Address", Type: ConfigTypeString, Description: "The server address to use for sending email. Port is optional and defaults to 465, or 25 if Disable TLS is set. Common ports are: 25 or 587 for STARTTLS (or unencrypted) and 465 for TLS.", Value: cfg.SMTP.Address},
 		{ID: "SMTP.DisableTLS", Type: ConfigTypeBoolean, Description: "Disables TLS on the connection (STARTTLS will still be used if supported).", Value: fmt.Sprintf("%t", cfg.SMTP.DisableTLS)},
 		{ID: "SMTP.SkipVerify", Type: ConfigTypeBoolean, Description: "Disables certificate validation for TLS/STARTTLS (insecure).", Value: fmt.Sprintf("%t", cfg.SMTP.SkipVerify)},
 		{ID: "SMTP.Username", Type: ConfigTypeString, Description: "Username for authentication.", Value: cfg.SMTP.Username},

--- a/notification/email/sender.go
+++ b/notification/email/sender.go
@@ -137,7 +137,7 @@ func (s *Sender) Send(ctx context.Context, msg notification.Message) (*notificat
 			port = "25"
 		}
 	} else if port == "" {
-		port = "587"
+		port = "465"
 	}
 
 	var authFn NegotiateAuth


### PR DESCRIPTION
**Description:**
- Update `SMTP.Address` description to document default port numbers and add more information
- Fix the default port for TLS mode to be `465` (instead of `587`)
