### PR TITLE
slack: lower slack cache time

### DIFF
--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -259,12 +259,14 @@ func (s *ChannelSender) loadChannels(ctx context.Context) ([]Channel, error) {
 
 			cursor = nextCursor
 
-			for _, ch := range respChan {
-				channels = append(channels, Channel{
-					ID:     ch.ID,
-					Name:   "#" + ch.Name,
+			for _, rCh := range respChan {
+				ch := Channel{
+					ID:     rCh.ID,
+					Name:   "#" + rCh.Name,
 					TeamID: teamID,
-				})
+				}
+				channels = append(channels, ch)
+				s.chanCache.Add(ch.ID, &ch)
 			}
 
 			return nil

--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -57,11 +57,11 @@ func NewChannelSender(ctx context.Context, cfg Config) (*ChannelSender, error) {
 
 		listCache: newTTLCache[string, []Channel](250, time.Minute),
 		chanCache: newTTLCache[string, *Channel](1000, 15*time.Minute),
-		ugCache:   newTTLCache[string, []slack.UserGroup](1000, 15*time.Minute),
+		ugCache:   newTTLCache[string, []slack.UserGroup](1000, time.Minute),
 
-		teamInfoCache: newTTLCache[string, *slack.TeamInfo](1, 24*time.Hour),
-		userInfoCache: newTTLCache[string, *slack.User](1000, 24*time.Hour),
-		ugInfoCache:   newTTLCache[string, UserGroup](1000, 24*time.Hour),
+		teamInfoCache: newTTLCache[string, *slack.TeamInfo](1, 15*time.Minute),
+		userInfoCache: newTTLCache[string, *slack.User](1000, 15*time.Minute),
+		ugInfoCache:   newTTLCache[string, UserGroup](1000, 15*time.Minute),
 	}, nil
 }
 

--- a/notification/slack/usergroup.go
+++ b/notification/slack/usergroup.go
@@ -68,11 +68,13 @@ func (s *ChannelSender) ListUserGroups(ctx context.Context) ([]UserGroup, error)
 
 	res := make([]UserGroup, 0, len(groups))
 	for _, g := range groups {
-		res = append(res, UserGroup{
+		grp := UserGroup{
 			ID:     g.ID,
 			Name:   g.Name,
 			Handle: g.Handle,
-		})
+		}
+		res = append(res, grp)
+		s.ugInfoCache.Add(g.ID, grp)
 	}
 
 	return res, nil


### PR DESCRIPTION
**Description:**
Fixes some stale data issues by making cache times consistent:
- Listed resources used for searching (i.e., channels & user groups) are set to 1m
- Individual resources are cached for 15m
- When listing resources, individual records are now updated
