### PR TITLE
slack: use usergroup handle instead of name

### DIFF
--- a/graphql2/graphqlapp/mutation.go
+++ b/graphql2/graphqlapp/mutation.go
@@ -77,7 +77,7 @@ func (a *Mutation) SetScheduleOnCallNotificationRules(ctx context.Context, input
 
 				nfyChan = &notificationchannel.Channel{
 					Type:  notificationchannel.TypeSlackUG,
-					Name:  fmt.Sprintf("@%s (%s)", grp.Handle, ch.Name),
+					Name:  fmt.Sprintf("%s (%s)", grp.Handle, ch.Name),
 					Value: r.Target.ID,
 				}
 			case assignment.TargetTypeSlackChannel:

--- a/graphql2/graphqlapp/slack.go
+++ b/graphql2/graphqlapp/slack.go
@@ -65,14 +65,14 @@ func (q *Query) SlackUserGroups(ctx context.Context, input *graphql2.SlackUserGr
 	if err != nil {
 		return nil, err
 	}
-	// Sort by name, case-insensitive, then sensitive.
+	// Sort by handle, case-insensitive, then sensitive.
 	sort.Slice(groups, func(i, j int) bool {
-		iName, jName := strings.ToLower(groups[i].Name), strings.ToLower(groups[j].Name)
+		iName, jName := strings.ToLower(groups[i].Handle), strings.ToLower(groups[j].Handle)
 
 		if iName != jName {
 			return iName < jName
 		}
-		return groups[i].Name < groups[j].Name
+		return groups[i].Handle < groups[j].Handle
 	})
 
 	// No DB search, so we manually filter for the cursor and search strings.
@@ -80,7 +80,7 @@ func (q *Query) SlackUserGroups(ctx context.Context, input *graphql2.SlackUserGr
 	n := strings.ToLower(searchOpts.After.Name)
 	filtered := groups[:0]
 	for _, ch := range groups {
-		grpName := strings.ToLower(ch.Name)
+		grpName := strings.ToLower(ch.Handle)
 		if !strings.Contains(grpName, s) {
 			continue
 		}

--- a/notification/slack/usergroup.go
+++ b/notification/slack/usergroup.go
@@ -71,7 +71,7 @@ func (s *ChannelSender) ListUserGroups(ctx context.Context) ([]UserGroup, error)
 		res = append(res, UserGroup{
 			ID:     g.ID,
 			Name:   g.Name,
-			Handle: g.Handle,
+			Handle: "@" + g.Handle,
 		})
 	}
 

--- a/web/src/app/selection/SlackUserGroupSelect.tsx
+++ b/web/src/app/selection/SlackUserGroupSelect.tsx
@@ -6,8 +6,7 @@ const query = gql`
     slackUserGroups(input: $input) {
       nodes {
         id
-        name
-        handle
+        name: handle
       }
     }
   }
@@ -17,8 +16,7 @@ const valueQuery = gql`
   query ($id: ID!) {
     slackUserGroup(id: $id) {
       id
-      name
-      handle
+      name: handle
     }
   }
 `


### PR DESCRIPTION
**Description:**
This PR updates the Slack user group feature to use the handle for user group display and searching rather than the name field.

Within Slack users use, and are shown, the handle and not the name, so this aims to make that consistent with what is shown in GoAlert.

![image](https://github.com/target/goalert/assets/595010/946e8dcc-26e8-45b2-b8d2-b4343eb09573)
