### PR TITLE
logs: don't log context canceled errors (e.g., closed browser tab)

### DIFF
--- a/graphql2/graphqlapp/app.go
+++ b/graphql2/graphqlapp/app.go
@@ -195,6 +195,7 @@ func (a *App) Handler() http.Handler {
 		}
 
 		if isUnsafe && !isGQLValidation(gqlErr) {
+			// context.Canceled is caused by normal things like closing a browser tab.
 			if !errors.Is(err, context.Canceled) {
 				log.Log(ctx, err)
 			}

--- a/graphql2/graphqlapp/app.go
+++ b/graphql2/graphqlapp/app.go
@@ -195,7 +195,9 @@ func (a *App) Handler() http.Handler {
 		}
 
 		if isUnsafe && !isGQLValidation(gqlErr) {
-			log.Log(ctx, err)
+			if !errors.Is(err, context.Canceled) {
+				log.Log(ctx, err)
+			}
 			gqlErr.Message = safeErr.Error()
 		}
 


### PR DESCRIPTION
**Description:**
Fixes a noise regression/issue where context canceled errors were being logged. Should also cleanup test output as well.