### PR TITLE
fix: webhook check on edit escalation policy step

### DIFF
--- a/graphql2/graphqlapp/escalationpolicy.go
+++ b/graphql2/graphqlapp/escalationpolicy.go
@@ -59,6 +59,7 @@ func (m *Mutation) CreateEscalationPolicyStep(ctx context.Context, input graphql
 
 	for _, tgt := range input.Targets {
 		if tgt.Type == assignment.TargetTypeChanWebhook && !cfg.ValidWebhookURL(tgt.ID) {
+			// UI code expects targets to be un-indexed
 			return nil, validation.NewFieldError("targets", "URL not allowed by administrator")
 		}
 	}
@@ -248,7 +249,8 @@ func (m *Mutation) UpdateEscalationPolicyStep(ctx context.Context, input graphql
 			step.Targets = make([]assignment.Target, len(input.Targets))
 			for i, tgt := range input.Targets {
 				if tgt.Type == assignment.TargetTypeChanWebhook && !cfg.ValidWebhookURL(tgt.ID) {
-					return validation.NewFieldError("webhook-targets", "URL not allowed by administrator")
+					// UI code expects targets to be un-indexed
+					return validation.NewFieldError("targets", "URL not allowed by administrator")
 				}
 				step.Targets[i] = tgt
 			}

--- a/graphql2/graphqlapp/escalationpolicy.go
+++ b/graphql2/graphqlapp/escalationpolicy.go
@@ -226,8 +226,8 @@ func (m *Mutation) UpdateEscalationPolicy(ctx context.Context, input graphql2.Up
 }
 
 func (m *Mutation) UpdateEscalationPolicyStep(ctx context.Context, input graphql2.UpdateEscalationPolicyStepInput) (bool, error) {
-	cfg := config.FromContext(ctx)
 	err := withContextTx(ctx, m.DB, func(ctx context.Context, tx *sql.Tx) error {
+		cfg := config.FromContext(ctx)
 		step, err := m.PolicyStore.FindOneStepForUpdateTx(ctx, tx, input.ID) // get delay
 		if err != nil {
 			return err
@@ -248,7 +248,7 @@ func (m *Mutation) UpdateEscalationPolicyStep(ctx context.Context, input graphql
 			step.Targets = make([]assignment.Target, len(input.Targets))
 			for i, tgt := range input.Targets {
 				if tgt.Type == assignment.TargetTypeChanWebhook && !cfg.ValidWebhookURL(tgt.ID) {
-					return validation.NewFieldError("targets", "URL not allowed by administrator")
+					return validation.NewFieldError("webhook-targets", "URL not allowed by administrator")
 				}
 				step.Targets[i] = tgt
 			}


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Adding backend check for webhooks added to existing escalation steps.
Uses the same validation logic as creating a new step.

**Which issue(s) this PR fixes:**
Fixes #3039 

**Attachments**
This error will appear when editing a step to include a forbidden webhook:
<img width="634" alt="Screenshot 2023-05-30 at 3 00 52 PM" src="https://github.com/target/goalert/assets/42848290/b29bd70b-0399-4964-ae52-570bdeb5884f">
