### PR TITLE
datetime: don't pass invalid strings to `fromISO`

### DIFF
--- a/web/src/app/schedules/ScheduleDetails.tsx
+++ b/web/src/app/schedules/ScheduleDetails.tsx
@@ -17,8 +17,9 @@ import { ScheduleAvatar } from '../util/avatars'
 import { useConfigValue } from '../util/RequireConfig'
 import ScheduleOverrideDialog from './ScheduleOverrideDialog'
 import { useIsWidthDown } from '../util/useWidth'
-import { TempSchedValue } from './temp-sched/sharedUtils'
+import { TempSchedValue, defaultTempSchedValue } from './temp-sched/sharedUtils'
 import { Redirect } from 'wouter'
+import { useScheduleTZ } from './useScheduleTZ'
 
 const query = gql`
   fragment ScheduleTitleQuery on Schedule {
@@ -76,8 +77,12 @@ export default function ScheduleDetails({
   const [slackEnabled] = useConfigValue('Slack.Enable')
 
   const [configTempSchedule, setConfigTempSchedule] =
-    useState<Partial<TempSchedValue> | null>(null)
-  const onNewTempSched = useCallback(() => setConfigTempSchedule({}), [])
+    useState<TempSchedValue | null>(null)
+  const { zone } = useScheduleTZ(scheduleID)
+  const onNewTempSched = useCallback(
+    () => setConfigTempSchedule(defaultTempSchedValue(zone)),
+    [],
+  )
   const onEditTempSched = useCallback(
     (v: TempSchedValue) => setConfigTempSchedule(v),
     [],

--- a/web/src/app/schedules/ScheduleOverrideForm.tsx
+++ b/web/src/app/schedules/ScheduleOverrideForm.tsx
@@ -11,6 +11,7 @@ import { ISODateTimePicker } from '../util/ISOPickers'
 import { useScheduleTZ } from './useScheduleTZ'
 import { fmtLocal } from '../util/timeFormat'
 import { FieldError } from '../util/errutil'
+import { ensureInterval } from './timeUtil'
 
 const query = gql`
   query ($id: ID!) {
@@ -91,6 +92,9 @@ export default function ScheduleOverrideForm(
       errors={errors.concat(userConflictErrors)}
       value={value}
       {...formProps}
+      onChange={(newValue: ScheduleOverrideFormValue) => {
+        formProps.onChange(ensureInterval(value, newValue))
+      }}
     >
       <Grid container spacing={2}>
         {remove && (

--- a/web/src/app/schedules/ScheduleShiftList.tsx
+++ b/web/src/app/schedules/ScheduleShiftList.tsx
@@ -25,7 +25,11 @@ import { relativeDate } from '../util/timeFormat'
 import { useIsWidthDown } from '../util/useWidth'
 import { OverrideDialog, OverrideDialogContext } from './ScheduleDetails'
 import ScheduleOverrideDialog from './ScheduleOverrideDialog'
-import { Shift, TempSchedValue } from './temp-sched/sharedUtils'
+import {
+  Shift,
+  TempSchedValue,
+  defaultTempSchedValue,
+} from './temp-sched/sharedUtils'
 import TempSchedDialog from './temp-sched/TempSchedDialog'
 
 // query name is important, as it's used for refetching data after mutations
@@ -79,11 +83,14 @@ function ScheduleShiftList({
   const [overrideDialog, setOverrideDialog] = useState<OverrideDialog | null>(
     null,
   )
-  const [configTempSchedule, setConfigTempSchedule] =
-    useState<Partial<TempSchedValue> | null>(null)
-  const onNewTempSched = useCallback(() => setConfigTempSchedule({}), [])
-  const [duration, setDuration] = useURLParam<string>('duration', 'P14D')
   const { zone, isLocalZone } = useScheduleTZ(scheduleID)
+  const [configTempSchedule, setConfigTempSchedule] =
+    useState<TempSchedValue | null>(null)
+  const onNewTempSched = useCallback(
+    () => setConfigTempSchedule(defaultTempSchedValue(zone)),
+    [],
+  )
+  const [duration, setDuration] = useURLParam<string>('duration', 'P14D')
   const [userFilter, setUserFilter] = useURLParam<string[]>('userFilter', [])
   const [activeOnly, setActiveOnly] = useURLParam<boolean>('activeOnly', false)
 

--- a/web/src/app/schedules/temp-sched/sharedUtils.tsx
+++ b/web/src/app/schedules/temp-sched/sharedUtils.tsx
@@ -20,6 +20,24 @@ export type Shift = {
   }
 }
 
+// defaultTempScheduleValue returns a timespan, with no shifts,
+// of the following week.
+export function defaultTempSchedValue(zone: string): TempSchedValue {
+  // We want the start to be the _next_ start-of-week for the current locale.
+  // For example, if today is Sunday, we want the start to be next Sunday.
+  // If today is Saturday, we want the start to be tomorrow.
+  const startDT = DateTime.local()
+    .setZone(zone)
+    .startOf('week')
+    .plus({ weeks: 1 })
+
+  return {
+    start: startDT.toISO(),
+    end: startDT.plus({ days: 7 }).toISO(),
+    shifts: [],
+  }
+}
+
 // removes bottom margin from content text so form fields
 // don't have a bunch of whitespace above them
 export const contentText = {

--- a/web/src/app/schedules/timeUtil.test.ts
+++ b/web/src/app/schedules/timeUtil.test.ts
@@ -1,0 +1,67 @@
+import { DateTime } from 'luxon'
+import { ensureInterval } from './timeUtil'
+
+describe('ensureInterval', () => {
+  it('should preserve additional properties', () => {
+    const val = {
+      start: DateTime.utc().toISO(),
+      end: DateTime.utc().plus({ minutes: 15 }).toISO(),
+      extra: 1,
+    }
+
+    const newVal = ensureInterval(val, val)
+
+    expect(newVal.extra).toEqual(1)
+  })
+
+  it('should not change start or end if it is a valid interval', () => {
+    const n = DateTime.utc()
+    const oldVal = {
+      start: n.toISO(),
+      end: n.plus({ minutes: 1 }).toISO(),
+    }
+    const newVal = {
+      start: n.plus({ minutes: 2 }).toISO(),
+      end: n.plus({ minutes: 3 }).toISO(),
+    }
+
+    const res = ensureInterval(oldVal, newVal)
+
+    expect(res.start).toEqual(newVal.start)
+    expect(res.end).toEqual(newVal.end)
+  })
+
+  it('should jump forward if start is past the new end time, and end is unchanged', () => {
+    const n = DateTime.utc()
+    const oldVal = {
+      start: n.toISO(),
+      end: n.plus({ minutes: 1 }).toISO(),
+    }
+    const newVal = {
+      start: n.plus({ minutes: 2 }).toISO(),
+      end: oldVal.end, // unchanged
+    }
+
+    const res = ensureInterval(oldVal, newVal)
+
+    expect(res.start).toEqual(newVal.start)
+    expect(res.end).toEqual(n.plus({ minutes: 3 }).toISO())
+  })
+
+  it('should jump backward if end is before the new start time', () => {
+    const n = DateTime.utc()
+    const oldVal = {
+      start: n.toISO(),
+      end: n.plus({ minutes: 1 }).toISO(),
+    }
+    const newVal = {
+      start: oldVal.start, // unchanged
+      end: n.minus({ minutes: 1 }).toISO(),
+    }
+
+    const res = ensureInterval(oldVal, newVal)
+
+    expect(res.start).toEqual(n.minus({ minutes: 2 }).toISO())
+    expect(res.end).toEqual(newVal.end)
+  })
+})

--- a/web/src/app/schedules/timeUtil.ts
+++ b/web/src/app/schedules/timeUtil.ts
@@ -1,0 +1,30 @@
+import { DateTime } from 'luxon'
+
+export interface Spanable {
+  start: string
+  end: string
+}
+
+export function ensureInterval<T extends Spanable, N extends Spanable>(
+  value: T,
+  newValue: N,
+): N {
+  const oldDur = DateTime.fromISO(value.end).diff(DateTime.fromISO(value.start))
+  if (value.start !== newValue.start) {
+    const oldEnd = DateTime.fromISO(value.end)
+    const newStart = DateTime.fromISO(newValue.start)
+    if (newStart >= oldEnd) {
+      // if start time is put after end time, move end time forward
+      newValue.end = newStart.plus(oldDur).toUTC().toISO()
+    }
+  } else if (value.end !== newValue.end) {
+    const newEnd = DateTime.fromISO(newValue.end)
+    const start = DateTime.fromISO(newValue.start)
+    if (newEnd <= start) {
+      // if end time is put before start time, move start time back
+      newValue.start = newEnd.minus(oldDur).toUTC().toISO()
+    }
+  }
+
+  return newValue
+}

--- a/web/src/cypress/support/schedule.ts
+++ b/web/src/cypress/support/schedule.ts
@@ -264,22 +264,19 @@ function genShifts(
 
 function shiftRange(
   shifts?: Partial<SetScheduleShiftInput>[],
-): [DateTime, DateTime] {
-  if (!shifts || !shifts.length)
-    return [DateTime.fromISO(''), DateTime.fromISO('')]
+): [DateTime | null, DateTime | null] {
+  if (!shifts || !shifts.length) return [null, null]
 
-  let min = DateTime.fromISO('')
-  let max = DateTime.fromISO('')
+  let min: DateTime | null = null
+  let max: DateTime | null = null
   shifts.forEach((s) => {
-    const start = DateTime.fromISO(s.start || '')
-    const end = DateTime.fromISO(s.end || '')
-
-    if ((start.isValid && !min.isValid) || start < min) {
-      min = start
+    if (s.start) {
+      const start = DateTime.fromISO(s.start)
+      if (!min || start < min) min = start
     }
-
-    if ((end.isValid && !max.isValid) || end > max) {
-      max = end
+    if (s.end) {
+      const end = DateTime.fromISO(s.end)
+      if (!max || end > max) max = end
     }
   })
 
@@ -303,6 +300,9 @@ function createTemporarySchedule(
     }
   `
 
+  if (!opts.start) opts.start = randDT({ max: opts.end }).toISO()
+  if (!opts.end) opts.end = randDT({ min: opts.start }).toISO()
+
   // create schedule if necessary
   if (!opts.scheduleID) {
     return cy
@@ -319,13 +319,13 @@ function createTemporarySchedule(
   let start = DateTime.fromISO(opts.start || '')
   let end = DateTime.fromISO(opts.end || '')
   if (start.isValid && !end.isValid) {
-    if (shiftEnd.isValid) {
+    if (shiftEnd) {
       end = randDT({ min: shiftEnd })
     } else {
       end = randDT({ min: start.plus({ day: 1 }) })
     }
   } else if (end.isValid && !start.isValid) {
-    if (shiftStart.isValid) {
+    if (shiftStart) {
       start = randDT({ min: now, max: shiftStart })
     } else {
       start = randDT({

--- a/web/src/cypress/support/util.ts
+++ b/web/src/cypress/support/util.ts
@@ -66,9 +66,13 @@ export function randDT({
   min,
   max,
 }: {
-  min?: DateTime
-  max?: DateTime
+  min?: DateTime | string | null
+  max?: DateTime | string | null
 }): DateTime {
+  if (typeof min === 'string') min = DateTime.fromISO(min)
+  if (typeof max === 'string') max = DateTime.fromISO(max)
+
+  if (!min && max) min = max.minus({ days: 7 })
   if (!min) min = DateTime.utc().plus({ minutes: 15 })
   if (!max) max = min.plus({ days: 7 })
 


### PR DESCRIPTION
**Description:**
This PR updates places in the application that rely on `DateTime.fromISO` returning a struct with `isValid` as false with code that operates on valid strings or explicitly null.

In #2957 these calls will be updated to throw an exception if invalid data is passed in. This PR fixes the invalid data issues.

**Which issue(s) this PR fixes:**
- Required for #2957 

**Additional Context**
- Temp schedule code now starts with a Value with defaults, instead of an empty object with "default" scattered elsewhere via if-checks
- Interval inputs, like shifts and overrides, will now move instead of going to an invalid state (e.g., if you put a 1 day override 3 weeks in the future, the end time will update to be 1 day past the start)
- A bunch of code in the temp schedule dialog was simplified by removing the use of "maybe" types
- Cypress helper was updated to use explicit checks instead of relying on `fromISO` parse failures
- Cypress helper was also updated to handle the Interval issue (ensuring always-valid data)