### PR TITLE
slack: Add smoketest for Slack DM notificaitons

### DIFF
--- a/devtools/mockslack/server.go
+++ b/devtools/mockslack/server.go
@@ -34,6 +34,7 @@ func NewServer() *Server {
 	srv.mux.HandleFunc("/api/conversations.info", srv.ServeConversationsInfo)
 	srv.mux.HandleFunc("/api/conversations.list", srv.ServeConversationsList)
 	srv.mux.HandleFunc("/api/users.conversations", srv.ServeConversationsList) // same data
+	srv.mux.HandleFunc("/api/users.info", srv.ServeUsersInfo)
 	srv.mux.HandleFunc("/api/oauth.access", srv.ServeOAuthAccess)
 	srv.mux.HandleFunc("/api/auth.revoke", srv.ServeAuthRevoke)
 	srv.mux.HandleFunc("/api/auth.test", srv.ServeAuthTest)

--- a/devtools/mockslack/user.go
+++ b/devtools/mockslack/user.go
@@ -1,8 +1,9 @@
 package mockslack
 
 type User struct {
-	ID   string
-	Name string
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	TeamID string `json:"team_id"`
 }
 type userState struct {
 	User
@@ -21,6 +22,9 @@ func (st *state) newUser(u User) User {
 
 	if u.ID == "" {
 		u.ID = st.gen.UserID()
+	}
+	if u.TeamID == "" {
+		u.TeamID = st.teamID
 	}
 	st.users[u.ID] = &userState{User: u, appTokens: make(map[string]*AuthToken)}
 

--- a/devtools/mockslack/usersinfo.go
+++ b/devtools/mockslack/usersinfo.go
@@ -1,0 +1,47 @@
+package mockslack
+
+import (
+	"context"
+	"net/http"
+)
+
+// UsersInfoOpts contains parameters for the UsersInfo API call.
+type UsersInfoOpts struct {
+	User string
+}
+
+func (st *API) UsersInfo(ctx context.Context, id string) (*User, error) {
+	err := checkPermission(ctx, "bot", "users:read")
+	if err != nil {
+		return nil, err
+	}
+
+	st.mx.Lock()
+	defer st.mx.Unlock()
+
+	u := st.users[id]
+	if u == nil {
+		return nil, &response{Err: "user_not_found"}
+	}
+
+	return &u.User, nil
+}
+
+// ServeUsersInfo serves a request to the `users.info` API call.
+//
+// https://api.slack.com/methods/users.info
+func (s *Server) ServeUsersInfo(w http.ResponseWriter, req *http.Request) {
+	u, err := s.API().UsersInfo(req.Context(), req.FormValue("user"))
+	if respondErr(w, err) {
+		return
+	}
+
+	var resp struct {
+		response
+		User *User `json:"user"`
+	}
+	resp.OK = true
+	resp.User = u
+
+	respondWith(w, resp)
+}

--- a/engine/compatmanager/update.go
+++ b/engine/compatmanager/update.go
@@ -63,7 +63,7 @@ func (db *DB) updateAuthSubjects(ctx context.Context) error {
 
 		u, err := db.cs.User(ctx, c.SlackUserID)
 		if err != nil {
-			log.Log(ctx, err)
+			log.Log(ctx, fmt.Errorf("update auth subjects: lookup Slack user (%s): %w", c.SlackUserID, err))
 			continue
 		}
 

--- a/test/smoke/harness/harness.go
+++ b/test/smoke/harness/harness.go
@@ -593,6 +593,7 @@ func (h *Harness) Close() error {
 	if recErr := recover(); recErr != nil {
 		defer panic(recErr)
 	}
+	h.dumpDB() // early as possible
 
 	h.tw.WaitAndAssert(h.t)
 	h.slack.WaitAndAssert()
@@ -614,7 +615,6 @@ func (h *Harness) Close() error {
 	h.twS.Close()
 
 	h.tw.Close()
-	h.dumpDB()
 
 	h.pgTime.Close()
 

--- a/test/smoke/harness/harness.go
+++ b/test/smoke/harness/harness.go
@@ -365,6 +365,7 @@ func (h *Harness) execQuery(sql string, data interface{}) {
 		"email":          func(id string) string { return fmt.Sprintf("'%s'", h.emailG.Get(id)) },
 		"phoneCC":        func(cc, id string) string { return fmt.Sprintf("'%s'", h.phoneCCG.GetWithArg(cc, id)) },
 		"slackChannelID": func(name string) string { return fmt.Sprintf("'%s'", h.Slack().Channel(name).ID()) },
+		"slackUserID":    func(name string) string { return fmt.Sprintf("'%s'", h.Slack().User(name).ID()) },
 	})
 	_, err := t.Parse(sql)
 	if err != nil {

--- a/test/smoke/harness/slack.go
+++ b/test/smoke/harness/slack.go
@@ -139,7 +139,12 @@ func (a *slackAction) Click() {
 	a.h.t.Helper()
 
 	a.h.t.Logf("clicking action: %s", a.Text)
-	err := a.h.slack.PerformActionAs(a.h.slackUser.ID, a.Action)
+	asID := a.h.slackUser.ID
+	if strings.HasPrefix(a.ChannelID, "W") {
+		// Perform actions in DMs as the user who received the DM.
+		asID = a.ChannelID
+	}
+	err := a.h.slack.PerformActionAs(asID, a.Action)
 	require.NoError(a.h.t, err, "perform Slack action")
 }
 

--- a/test/smoke/slackdm_test.go
+++ b/test/smoke/slackdm_test.go
@@ -1,0 +1,54 @@
+package smoke
+
+import (
+	"testing"
+
+	"github.com/target/goalert/expflag"
+	"github.com/target/goalert/test/smoke/harness"
+)
+
+// TestSlackDM tests that slack DMs are sent when configured.
+func TestSlackDM(t *testing.T) {
+	t.Parallel()
+
+	sql := `
+	insert into users (id, name, email, role) 
+	values 
+		({{uuid "user"}}, 'bob', 'joe', 'user');
+	insert into user_contact_methods (id, user_id, name, type, value)
+	values
+		({{uuid "cm1"}}, {{uuid "user"}}, 'personal', 'SLACK_DM', {{slackUserID "bob"}});
+
+	insert into user_notification_rules (user_id, contact_method_id, delay_minutes) 
+	values
+		({{uuid "user"}}, {{uuid "cm1"}}, 0),
+		({{uuid "user"}}, {{uuid "cm1"}}, 30);
+
+	insert into escalation_policies (id, name) 
+	values
+		({{uuid "eid"}}, 'esc policy');
+	insert into escalation_policy_steps (id, escalation_policy_id) 
+	values
+		({{uuid "esid"}}, {{uuid "eid"}});
+	insert into escalation_policy_actions (escalation_policy_step_id, user_id) 
+	values 
+		({{uuid "esid"}}, {{uuid "user"}});
+
+	insert into services (id, escalation_policy_id, name) 
+	values
+		({{uuid "sid"}}, {{uuid "eid"}}, 'service');
+
+`
+	h := harness.NewHarnessWithFlags(t, sql, "slack-dm-cm-type", expflag.FlagSet{expflag.SlackDM})
+	defer h.Close()
+	h.SetConfigValue("Slack.InteractiveMessages", "true")
+	h.Trigger() // the user's account should get "linked" via compat mgr
+
+	h.CreateAlert(h.UUID("sid"), "testing")
+	msg := h.Slack().User("bob").ExpectMessage("testing")
+	msg.Action("Close").Click()
+
+	updated := msg.ExpectUpdate()
+	updated.AssertText("Closed", "testing")
+	updated.AssertActions()
+}


### PR DESCRIPTION
**Description:**
Adds a smoke test validating Slack DM functionality:
- interactivity
- compat manager linking
- message status updates
