### PR TITLE
ui: move button for adding user to rotation

### DIFF
--- a/web/src/app/rotations/RotationDetails.tsx
+++ b/web/src/app/rotations/RotationDetails.tsx
@@ -3,13 +3,10 @@ import { gql, useQuery } from 'urql'
 import _ from 'lodash'
 import { Redirect } from 'wouter'
 import { Edit, Delete } from '@mui/icons-material'
-
-import CreateFAB from '../lists/CreateFAB'
 import DetailsPage from '../details/DetailsPage'
 import RotationEditDialog from './RotationEditDialog'
 import RotationDeleteDialog from './RotationDeleteDialog'
 import RotationUserList from './RotationUserList'
-import RotationAddUserDialog from './RotationAddUserDialog'
 import { QuerySetFavoriteButton } from '../util/QuerySetFavoriteButton'
 import Spinner from '../loading/components/Spinner'
 import { ObjectNotFound, GenericError } from '../error-pages'
@@ -42,7 +39,6 @@ export default function RotationDetails(props: {
 }): JSX.Element {
   const [showEdit, setShowEdit] = useState(false)
   const [showDelete, setShowDelete] = useState(false)
-  const [showAddUser, setShowAddUser] = useState(false)
 
   const [{ data: _data, fetching, error }] = useQuery({
     query,
@@ -63,14 +59,6 @@ export default function RotationDetails(props: {
 
   return (
     <React.Fragment>
-      <CreateFAB title='Add User' onClick={() => setShowAddUser(true)} />
-      {showAddUser && (
-        <RotationAddUserDialog
-          rotationID={props.rotationID}
-          userIDs={data.userIDs}
-          onClose={() => setShowAddUser(false)}
-        />
-      )}
       {showEdit && (
         <RotationEditDialog
           rotationID={props.rotationID}

--- a/web/src/app/rotations/RotationUserList.tsx
+++ b/web/src/app/rotations/RotationUserList.tsx
@@ -1,8 +1,11 @@
 import React, { useEffect, useState } from 'react'
 import { gql, useMutation, useQuery } from '@apollo/client'
+import Button from '@mui/material/Button'
 import Card from '@mui/material/Card'
 import makeStyles from '@mui/styles/makeStyles'
 import CardHeader from '@mui/material/CardHeader'
+import { Theme } from '@mui/material/styles'
+import { Add } from '@mui/icons-material'
 import FlatList from '../lists/FlatList'
 import { reorderList, calcNewActiveIndex } from './util'
 import OtherActions from '../util/OtherActions'
@@ -12,9 +15,11 @@ import { UserAvatar } from '../util/avatars'
 import { styles as globalStyles } from '../styles/materialStyles'
 import Spinner from '../loading/components/Spinner'
 import { GenericError, ObjectNotFound } from '../error-pages'
-import { Theme } from '@mui/material/styles'
 import { User, Rotation } from '../../schema'
 import { Time } from '../util/Time'
+import CreateFAB from '../lists/CreateFAB'
+import RotationAddUserDialog from './RotationAddUserDialog'
+import { useIsWidthDown } from '../util/useWidth'
 
 const query = gql`
   query rotationUsers($id: ID!) {
@@ -27,6 +32,7 @@ const query = gql`
       timeZone
       activeUserIndex
       nextHandoffTimes
+      userIDs
     }
   }
 `
@@ -59,7 +65,9 @@ function RotationUserList(props: RotationUserListProps): JSX.Element {
   const { rotationID } = props
   const [deleteIndex, setDeleteIndex] = useState<number | null>(null)
   const [setActiveIndex, setSetActiveIndex] = useState<number | null>(null)
+  const [showAddUser, setShowAddUser] = useState(false)
   const [lastSwap, setLastSwap] = useState<SwapType[]>([])
+  const isMobile = useIsWidthDown('md')
 
   const {
     data,
@@ -81,7 +89,7 @@ function RotationUserList(props: RotationUserListProps): JSX.Element {
   if (qError || mError)
     return <GenericError error={qError?.message || mError?.message} />
 
-  const { users, activeUserIndex, nextHandoffTimes } = data.rotation
+  const { users, userIDs, activeUserIndex, nextHandoffTimes } = data.rotation
 
   // duplicate first entry
   const _nextHandoffTimes = (nextHandoffTimes || [])
@@ -130,6 +138,9 @@ function RotationUserList(props: RotationUserListProps): JSX.Element {
 
   return (
     <React.Fragment>
+      {isMobile && (
+        <CreateFAB title='Add User' onClick={() => setShowAddUser(true)} />
+      )}
       {deleteIndex !== null && (
         <RotationUserDeleteDialog
           rotationID={rotationID}
@@ -144,11 +155,29 @@ function RotationUserList(props: RotationUserListProps): JSX.Element {
           onClose={() => setSetActiveIndex(null)}
         />
       )}
+      {showAddUser && (
+        <RotationAddUserDialog
+          rotationID={rotationID}
+          userIDs={userIDs ?? []}
+          onClose={() => setShowAddUser(false)}
+        />
+      )}
       <Card>
         <CardHeader
           className={classes.cardHeader}
           component='h3'
           title='Users'
+          action={
+            !isMobile ? (
+              <Button
+                variant='contained'
+                onClick={() => setShowAddUser(true)}
+                startIcon={<Add />}
+              >
+                Add User
+              </Button>
+            ) : null
+          }
         />
 
         <FlatList

--- a/web/src/cypress/e2e/materialSelect.cy.ts
+++ b/web/src/cypress/e2e/materialSelect.cy.ts
@@ -8,7 +8,11 @@ function testMaterialSelect(screen: ScreenFormat): void {
     cy.createRotation().then((r) => {
       const u = users[3]
       cy.visit(`rotations/${r.id}`)
-      cy.pageFab()
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button').contains('Add User').click()
+      }
       cy.dialogTitle('Add User')
       cy.get('input[name=users]').click()
       cy.focused().type(u.name.replace('.', ' '))

--- a/web/src/cypress/e2e/rotations.cy.ts
+++ b/web/src/cypress/e2e/rotations.cy.ts
@@ -97,7 +97,11 @@ function testRotations(screen: ScreenFormat): void {
       cy.get('@parts').should('not.contain', rot.users[1].name)
 
       // add again
-      cy.pageFab()
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button').contains('Add User').click()
+      }
       cy.dialogTitle('Add User')
       cy.dialogForm({ users: rot.users[1].name })
       cy.dialogFinish('Submit')
@@ -114,7 +118,11 @@ function testRotations(screen: ScreenFormat): void {
       cy.createUser({ name, email })
       cy.createUser({ name, email: dupEmail })
 
-      cy.pageFab()
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button').contains('Add User').click()
+      }
       cy.dialogTitle('Add User')
       cy.get('input').click()
       cy.focused().type(name)


### PR DESCRIPTION
**Description:**
- Moves the rotation add user button to top right of card when on lg or xl screen sizes

**Which issue(s) this PR fixes:**
Part of #2693

**Out of Scope:**
- EP add step button
- User profile buttons

**Old:**

![screencapture-dev-target-goalert-me-rotations-35b96fa5-2232-415a-a191-fa56c4574861-2023-06-15-11_06_43](https://github.com/target/goalert/assets/11381794/31f1ca72-1b83-43bf-b372-1b8e714ef7d9)

**New:**

![screencapture-localhost-3030-rotations-cb79aad3-1095-4dc8-be0b-db0da0a99bf3-2023-06-15-11_05_10](https://github.com/target/goalert/assets/11381794/ffa54b7e-387b-4627-a25e-aaeaa83d2a1a)