### PR TITLE
ui: move button creating a step on an EP

### DIFF
--- a/web/src/app/escalation-policies/PolicyDetails.tsx
+++ b/web/src/app/escalation-policies/PolicyDetails.tsx
@@ -2,15 +2,11 @@ import React, { useState } from 'react'
 import { useQuery, gql } from 'urql'
 import _ from 'lodash'
 import { Edit, Delete } from '@mui/icons-material'
-
 import PolicyStepsQuery from './PolicyStepsQuery'
 import PolicyDeleteDialog from './PolicyDeleteDialog'
 import { QuerySetFavoriteButton } from '../util/QuerySetFavoriteButton'
-import CreateFAB from '../lists/CreateFAB'
-import PolicyStepCreateDialog from './PolicyStepCreateDialog'
 import DetailsPage from '../details/DetailsPage'
 import PolicyEditDialog from './PolicyEditDialog'
-import { useResetURLParams, useURLParam } from '../actions'
 import { GenericError, ObjectNotFound } from '../error-pages'
 import Spinner from '../loading/components/Spinner'
 import { EPAvatar } from '../util/avatars'
@@ -35,10 +31,6 @@ const query = gql`
 export default function PolicyDetails(props: {
   policyID: string
 }): JSX.Element {
-  const stepNumParam = 'createStep'
-  const [createStep, setCreateStep] = useURLParam<boolean>(stepNumParam, false)
-  const resetCreateStep = useResetURLParams(stepNumParam)
-
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [showEditDialog, setShowEditDialog] = useState(false)
 
@@ -95,13 +87,6 @@ export default function PolicyDetails(props: {
           },
         ]}
       />
-      <CreateFAB onClick={() => setCreateStep(true)} title='Create Step' />
-      {createStep && (
-        <PolicyStepCreateDialog
-          escalationPolicyID={data.id}
-          onClose={resetCreateStep}
-        />
-      )}
       {showEditDialog && (
         <PolicyEditDialog
           escalationPolicyID={data.id}

--- a/web/src/app/escalation-policies/PolicyStepsCard.js
+++ b/web/src/app/escalation-policies/PolicyStepsCard.js
@@ -1,13 +1,19 @@
 import React, { useRef, useState } from 'react'
 import { PropTypes as p } from 'prop-types'
+import Button from '@mui/material/Button'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
+import CardHeader from '@mui/material/CardHeader'
 import Dialog from '@mui/material/Dialog'
 import List from '@mui/material/List'
 import Typography from '@mui/material/Typography'
 import makeStyles from '@mui/styles/makeStyles'
+import { Add } from '@mui/icons-material'
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd'
 import { gql, useMutation } from '@apollo/client'
+import CreateFAB from '../lists/CreateFAB'
+import PolicyStepCreateDialog from './PolicyStepCreateDialog'
+import { useResetURLParams, useURLParam } from '../actions'
 import PolicyStep from './PolicyStep'
 import DialogTitleWrapper from '../dialogs/components/DialogTitleWrapper'
 import DialogContentError from '../dialogs/components/DialogContentError'
@@ -34,6 +40,11 @@ const mutation = gql`
 function PolicyStepsCard(props) {
   const classes = useStyles()
   const { escalationPolicyID, repeat, steps } = props
+
+  const isMobile = useIsWidthDown('md')
+  const stepNumParam = 'createStep'
+  const [createStep, setCreateStep] = useURLParam(stepNumParam, false)
+  const resetCreateStep = useResetURLParams(stepNumParam)
 
   const oldID = useRef(null)
   const oldIdx = useRef(null)
@@ -231,11 +242,33 @@ function PolicyStepsCard(props) {
 
   return (
     <React.Fragment>
+      {isMobile && (
+        <CreateFAB onClick={() => setCreateStep(true)} title='Create Step' />
+      )}
+      {createStep && (
+        <PolicyStepCreateDialog
+          escalationPolicyID={escalationPolicyID}
+          onClose={resetCreateStep}
+        />
+      )}
       <Card>
         <CardContent>
-          <Typography variant='h5' component='h3'>
-            Escalation Steps
-          </Typography>
+          <CardHeader
+            title='Escalation Steps'
+            component='h3'
+            sx={{ padding: 0, margin: 0 }}
+            action={
+              !isMobile && (
+                <Button
+                  variant='contained'
+                  onClick={() => setCreateStep(true)}
+                  startIcon={<Add />}
+                >
+                  Create Step
+                </Button>
+              )
+            }
+          />
           {renderStepsList()}
           {renderRepeatText()}
         </CardContent>

--- a/web/src/cypress/e2e/escalationPolicySteps.cy.ts
+++ b/web/src/cypress/e2e/escalationPolicySteps.cy.ts
@@ -5,7 +5,7 @@ import users from '../fixtures/users.json'
 
 const c = new Chance()
 
-function testSteps(): void {
+function testSteps(screen: ScreenFormat): void {
   describe('Steps', () => {
     let ep: EP
     let r1: Rotation
@@ -38,7 +38,11 @@ function testSteps(): void {
       const u2 = users[1]
       const delay = c.integer({ min: 1, max: 9000 })
 
-      cy.pageFab()
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button').contains('Create Step').click()
+      }
       cy.dialogTitle('Create Step')
       cy.dialogForm({ schedules: [s1.name, s2.name] })
 
@@ -72,7 +76,11 @@ function testSteps(): void {
       const u1 = users[0]
       const u2 = users[1]
 
-      cy.pageFab()
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button').contains('Create Step').click()
+      }
       cy.dialogTitle('Create Step')
       cy.get('button[data-cy="users-step"]').click()
       cy.dialogForm({ users: [u1.name, u2.name] })
@@ -114,7 +122,11 @@ function testSteps(): void {
       cy.updateConfig({ Slack: { Enable: true } })
       cy.reload()
 
-      cy.pageFab()
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button').contains('Create Step').click()
+      }
       cy.dialogTitle('Create Step')
 
       // expand slack channels section
@@ -246,7 +258,7 @@ testScreen('Escalation Policy Steps', testSteps)
 
 testScreenWithFlags(
   'Webhook Support',
-  () => {
+  (screen: ScreenFormat) => {
     let ep: EP
     beforeEach(() => {
       cy.createEP().then((e: EP) => {
@@ -259,7 +271,11 @@ testScreenWithFlags(
       cy.updateConfig({ Webhook: { Enable: true } })
       cy.reload()
 
-      cy.pageFab()
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button').contains('Create Step').click()
+      }
       cy.dialogTitle('Create Step')
 
       // expand webhook section

--- a/web/src/cypress/e2e/favorites.cy.ts
+++ b/web/src/cypress/e2e/favorites.cy.ts
@@ -104,11 +104,16 @@ function testFavorites(screen: ScreenFormat): void {
     (name: string, favorite: boolean) =>
       cy.createRotation({ name, favorite }).then((r: Rotation) => r.id),
     () => {
-      cy.createEP()
-        .then((e: EP) => {
-          return cy.visit(`/escalation-policies/${e.id}`)
-        })
-        .pageFab()
+      cy.createEP().then((e: EP) => {
+        return cy.visit(`/escalation-policies/${e.id}`)
+      })
+
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button').contains('Create Step').click()
+      }
+
       cy.get('[data-cy="rotations-step"]').click()
       return cy.get('input[name=rotations]')
     },
@@ -121,14 +126,17 @@ function testFavorites(screen: ScreenFormat): void {
       cy
         .createSchedule({ name, isFavorite })
         .then((sched: Schedule) => sched.id),
-    () =>
-      cy
-        .createEP()
-        .then((e: EP) => {
-          return cy.visit(`/escalation-policies/${e.id}`)
-        })
-        .pageFab()
-        .get('input[name=schedules]'),
+    () => {
+      cy.createEP().then((e: EP) => {
+        return cy.visit(`/escalation-policies/${e.id}`)
+      })
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button').contains('Create Step').click()
+      }
+      return cy.get('input[name=schedules]')
+    },
   )
 
   check(
@@ -150,11 +158,14 @@ function testFavorites(screen: ScreenFormat): void {
     (name: string, favorite: boolean) =>
       cy.createUser({ name, favorite }).then((user: Profile) => user.id),
     () => {
-      cy.createEP()
-        .then((e: EP) => {
-          return cy.visit(`/escalation-policies/${e.id}`)
-        })
-        .pageFab()
+      cy.createEP().then((e: EP) => {
+        return cy.visit(`/escalation-policies/${e.id}`)
+      })
+      if (screen === 'mobile') {
+        cy.pageFab()
+      } else {
+        cy.get('button').contains('Create Step').click()
+      }
       cy.get('[data-cy="users-step"]').click()
       return cy.get('input[name=users]')
     },

--- a/web/src/cypress/e2e/materialSelect.cy.ts
+++ b/web/src/cypress/e2e/materialSelect.cy.ts
@@ -30,7 +30,11 @@ function testMaterialSelect(screen: ScreenFormat): void {
         const u1 = users[0]
         const u2 = users[1]
 
-        cy.pageFab()
+        if (screen === 'mobile') {
+          cy.pageFab()
+        } else {
+          cy.get('button').contains('Create Step').click()
+        }
         cy.dialogTitle('Create Step')
 
         // populate users


### PR DESCRIPTION
**Description:**
- Moves the escalation policy create step button to top right of card when on lg or xl screen sizes

**Which issue(s) this PR fixes:**
Part of #2693

**Out of Scope:**
- User profile buttons

**Old:**

![before](https://github.com/target/goalert/assets/11381794/5851cad4-a00e-4afb-ae16-ab75707a3d27)

**New:**

![after](https://github.com/target/goalert/assets/11381794/7d520808-d4aa-4715-8e7d-da2bf4565dc7)
