### PR TITLE
auth: set SameSite to strict on session cookie

### DIFF
--- a/auth/cookies.go
+++ b/auth/cookies.go
@@ -37,6 +37,8 @@ func SetCookieAge(w http.ResponseWriter, req *http.Request, name, value string, 
 		Path:   cookiePath,
 		Value:  value,
 		MaxAge: int(age.Seconds()),
+
+		SameSite: http.SameSiteStrictMode,
 	})
 }
 


### PR DESCRIPTION
**Description:**
Sets the `SameSite` parameter to strict mode when setting session cookies as they are intended to only be used from the application itself.

https://pkg.go.dev/net/http#SameSite
