### PR TITLE
auth: Validate redir on return from auth

### DIFF
--- a/auth/handler.go
+++ b/auth/handler.go
@@ -320,23 +320,13 @@ func (h *Handler) IdentityProviderHandler(id string) http.HandlerFunc {
 				errutil.HTTPError(ctx, w, validation.NewFieldError("login_redir", err.Error()))
 				return
 			}
-			if cfg.ShouldUsePublicURL() {
-				refU, _ = url.Parse(c.Value)
-				if refU == nil || !cfg.ValidReferer("", c.Value) {
-					// redirect with err
-					q := make(url.Values)
-					q.Set("login_error", "invalid referer")
-					http.Redirect(w, req, cfg.CallbackURL("", q), http.StatusTemporaryRedirect)
-					return
-				}
-			} else {
-				// fallback to old method
-				var ok bool
-				refU, ok = h.refererURL(w, req)
-				if !ok {
-					errutil.HTTPError(ctx, w, validation.NewFieldError("referer", "failed to resolve referer"))
-					return
-				}
+			refU, _ = url.Parse(c.Value)
+			if refU == nil || !cfg.ValidReferer(req.URL.String(), c.Value) {
+				// redirect with err
+				q := make(url.Values)
+				q.Set("login_error", "invalid referer")
+				http.Redirect(w, req, cfg.CallbackURL("", q), http.StatusTemporaryRedirect)
+				return
 			}
 		}
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,6 +53,11 @@ const config = {
       port: 9997,
     },
     {
+      command: './bin/goalert -l=localhost:6120', // no public url (fallback code)
+      env: { ...wsEnv, GOALERT_PUBLIC_URL: '' },
+      url: 'http://localhost:6120/health',
+    },
+    {
       command:
         './bin/goalert -l=localhost:6130 --public-url=http://localhost:6130',
       env: wsEnv,

--- a/test/integration/oidc.spec.ts
+++ b/test/integration/oidc.spec.ts
@@ -11,3 +11,12 @@ test('OIDC Login', async ({ page }) => {
   // ensure we have an h1 with jane.doe
   await page.waitForSelector('h1 >> "jane.doe"')
 })
+// test loging in with OIDC
+test('OIDC Login (fallback public url)', async ({ page }) => {
+  await page.goto('http://127.0.0.1:6120/profile')
+
+  await page.click('button[type=submit] >> "Login with OIDC"')
+
+  // ensure we have an h1 with jane.doe
+  await page.waitForSelector('h1 >> "jane.doe"')
+})


### PR DESCRIPTION
**Description:**
This PR adds additional validation on the `login_redir` cookie before issuing a redirect on successful login. The added validation is identical to the validation performed before setting the cookie value initially.

**Describe any introduced user-facing changes:**
There are no changes in behavior: in user flows, the validation happens before the cookie is set. However, invalid cookie values will now be rejected.

**Additional Context**
- A recent integration test (oidc) validates that authentication works as it did before.