### PR TITLE
sending alert object as create alert response body

### DIFF
--- a/genericapi/handler.go
+++ b/genericapi/handler.go
@@ -150,12 +150,14 @@ func (h *Handler) ServeCreateAlert(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, _ := json.MarshalIndent(*a, "", " ")
-
-	w.WriteHeader(200)
-	_, err = w.Write(resp)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	if r.Header.Get("Accept") == "application/json" {
+		resp, _ := json.MarshalIndent(*a, "", " ")
+		w.WriteHeader(200)
+		_, err = w.Write(resp)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	} else {
+		w.WriteHeader(204)
 	}
-
 }

--- a/genericapi/handler.go
+++ b/genericapi/handler.go
@@ -139,7 +139,7 @@ func (h *Handler) ServeCreateAlert(w http.ResponseWriter, r *http.Request) {
 	}
 
 	err = retry.DoTemporaryError(func(int) error {
-		_, err = h.c.AlertStore.CreateOrUpdate(ctx, a)
+		a, err = h.c.AlertStore.CreateOrUpdate(ctx, a)
 		return err
 	},
 		retry.Log(ctx),
@@ -150,5 +150,12 @@ func (h *Handler) ServeCreateAlert(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(204)
+	resp, _ := json.MarshalIndent(*a, "", " ")
+
+	w.WriteHeader(200)
+	_, err = w.Write(resp)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+
 }

--- a/genericapi/handler.go
+++ b/genericapi/handler.go
@@ -150,7 +150,10 @@ func (h *Handler) ServeCreateAlert(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.Header.Get("Accept") == "application/json" {
+	if r.Header.Get("Accept") != "application/json" {
+		w.WriteHeader(204)
+		return
+	}
 		resp, _ := json.MarshalIndent(*a, "", " ")
 		w.WriteHeader(200)
 		_, err = w.Write(resp)

--- a/grafana/grafana.go
+++ b/grafana/grafana.go
@@ -220,7 +220,7 @@ func GrafanaToEventsAPI(aDB *alert.Store, intDB *integrationkey.Store) http.Hand
 		var hasFailures bool
 		for _, a := range alerts {
 			err = retry.DoTemporaryError(func(int) error {
-				_, err = aDB.CreateOrUpdate(ctx, &a)
+				_, _, err = aDB.CreateOrUpdate(ctx, &a)
 				return err
 			},
 				retry.Log(ctx),

--- a/mailgun/mailgun.go
+++ b/mailgun/mailgun.go
@@ -185,7 +185,7 @@ func (h *ingressHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			return err
 		}
-		_, err = h.alerts.CreateOrUpdate(ctx, newAlert)
+		_, _, err = h.alerts.CreateOrUpdate(ctx, newAlert)
 		err = errors.Wrap(err, "create/update alert")
 		err = errutil.MapDBError(err)
 		return err

--- a/prometheusalertmanager/prometheusalertmanager.go
+++ b/prometheusalertmanager/prometheusalertmanager.go
@@ -231,7 +231,7 @@ func PrometheusAlertmanagerEventsAPI(aDB *alert.Store, intDB *integrationkey.Sto
 		}
 
 		err = retry.DoTemporaryError(func(int) error {
-			_, err = aDB.CreateOrUpdate(ctx, msg)
+			_, _, err = aDB.CreateOrUpdate(ctx, msg)
 			return err
 		},
 			retry.Log(ctx),

--- a/site24x7/site24x7.go
+++ b/site24x7/site24x7.go
@@ -84,7 +84,7 @@ func Site24x7ToEventsAPI(aDB *alert.Store, intDB *integrationkey.Store) http.Han
 		}
 
 		err = retry.DoTemporaryError(func(int) error {
-			_, err = aDB.CreateOrUpdate(ctx, msg)
+			_, _, err = aDB.CreateOrUpdate(ctx, msg)
 			return err
 		},
 			retry.Log(ctx),

--- a/web/src/app/documentation/sections/IntegrationKeys.md
+++ b/web/src/app/documentation/sections/IntegrationKeys.md
@@ -12,6 +12,22 @@
 | `action`  | _optional_   | If set to `close`, it will close any matching alerts.                                                                                                               |
 | `dedup`   | _optional_   | All calls for the same service with the same `dedup` string will update the same alert (if open) or create a new one. Defaults to using summary & details together. |
 
+### Response:
+
+Default response is a `204` with no content. Set the `Accept` header to `application/json` for information on the created alert.
+
+Example:
+
+```json
+{
+  "AlertID": 10,
+  "ServiceID": "00000000-0000-0000-0000-000000000001",
+  "IsNew": true
+}
+```
+
+`IsNew` will be false if the call was de-duplicated.
+
 ### Examples:
 
 ```bash
@@ -86,13 +102,13 @@ To trigger an alert using Prometheus Alertmanager, follow these steps:
 
 2. In Prometheus Alertmanager, enable a webhook by adding a webhook receiver in the alertmanager configuration file:
 
-    ```yaml
-    receivers:
-    - name: 'service'
-      webhook_configs:
-      - url: '<prometheus_alertmanager_webhook_url_from_previous_step>'
-        send_resolved: true
-    ```
+   ```yaml
+   receivers:
+     - name: 'service'
+       webhook_configs:
+         - url: '<prometheus_alertmanager_webhook_url_from_previous_step>'
+           send_resolved: true
+   ```
 
 ---
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [ ] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adds the sends the created alert as response body in create alert generic API.

**Which issue(s) this PR fixes:**
Fixes https://github.com/target/goalert/issues/3123

**Screenshots:**
<img width="1624" alt="Screenshot 2023-06-26 at 12 41 54 PM" src="https://github.com/target/goalert/assets/137173845/d25890d4-e013-4a35-907f-1425b3382ab1">


**Describe any introduced API changes:**
This PR changes the response of the createAlert API  (`POST /api/v2/generic/incoming`) from 204 to 200 with the alert object as the payload.
