### PR TITLE
auth: use samesite=lax for oauth cookies

### DIFF
--- a/auth/github/identityprovider.go
+++ b/auth/github/identityprovider.go
@@ -95,7 +95,7 @@ func (p *Provider) ExtractIdentity(route *auth.RouteInfo, w http.ResponseWriter,
 			return nil, auth.Error("Failed to generate state token.")
 		}
 
-		auth.SetCookie(w, req, stateCookieName, tok)
+		auth.SetCookie(w, req, stateCookieName, tok, false)
 		u := authConfig(ctx).AuthCodeURL(tok, oauth2.ApprovalForce)
 
 		return nil, auth.RedirectURL(u)
@@ -110,7 +110,7 @@ func (p *Provider) ExtractIdentity(route *auth.RouteInfo, w http.ResponseWriter,
 	if err != nil || stateCookie.Value != tokStr {
 		return nil, auth.Error("Invalid state token.")
 	}
-	auth.ClearCookie(w, req, stateCookieName)
+	auth.ClearCookie(w, req, stateCookieName, false)
 
 	valid, err := p.validateStateToken(req.Context(), tokStr)
 	if err != nil {

--- a/auth/handler.go
+++ b/auth/handler.go
@@ -212,7 +212,7 @@ func (h *Handler) FindAllUserSessions(ctx context.Context, userID string) ([]Use
 
 // ServeLogout will clear the current session cookie and end the session(s) (if any).
 func (h *Handler) ServeLogout(w http.ResponseWriter, req *http.Request) {
-	ClearCookie(w, req, CookieName)
+	ClearCookie(w, req, CookieName, true)
 	var sessionIDs []string
 	for _, c := range req.Cookies() {
 		switch c.Name {
@@ -539,7 +539,7 @@ func (h *Handler) CreateSession(ctx context.Context, userAgent, userID string) (
 }
 
 func (h *Handler) setSessionCookie(w http.ResponseWriter, req *http.Request, val string) {
-	SetCookieAge(w, req, CookieName, val, 30*24*time.Hour)
+	SetCookieAge(w, req, CookieName, val, 30*24*time.Hour, true)
 }
 
 func (h *Handler) authWithToken(w http.ResponseWriter, req *http.Request, next http.Handler) bool {
@@ -717,7 +717,7 @@ func (h *Handler) refererURL(w http.ResponseWriter, req *http.Request) (*url.URL
 }
 
 func (h *Handler) serveProviderPost(id string, p IdentityProvider, refU *url.URL, w http.ResponseWriter, req *http.Request) {
-	SetCookie(w, req, "login_redir", refU.String())
+	SetCookie(w, req, "login_redir", refU.String(), false)
 
 	h.handleProvider(id, p, refU, w, req)
 }

--- a/auth/oidc/identityprovider.go
+++ b/auth/oidc/identityprovider.go
@@ -194,7 +194,7 @@ func (p *Provider) ExtractIdentity(route *auth.RouteInfo, w http.ResponseWriter,
 			return nil, auth.Error("Failed to generate state token.")
 		}
 		nonceStr := b64enc.EncodeToString(nonce[:])
-		auth.SetCookie(w, req, nonceCookieName, nonceStr)
+		auth.SetCookie(w, req, nonceCookieName, nonceStr, false)
 
 		oaCfg, _, err := p.oaConfig(ctx)
 		if err != nil {
@@ -215,7 +215,7 @@ func (p *Provider) ExtractIdentity(route *auth.RouteInfo, w http.ResponseWriter,
 	if err != nil {
 		return nil, auth.Error("There was a problem recognizing this browser. You can try again")
 	}
-	auth.ClearCookie(w, req, nonceCookieName)
+	auth.ClearCookie(w, req, nonceCookieName, false)
 
 	nonce, err := b64enc.DecodeString(nonceC.Value)
 	if err != nil || len(nonce) != 16 {


### PR DESCRIPTION
**Description:**
Fixes a regression that prevents login when redirecting from an OIDC server by setting `SameSite=Lax` for OAuth cookies, and retaining `SameSite=Strict` for the session cookie.

**Additional Info:**
1. `SameSite=None`: Cookies will be sent in all contexts. This was how cookies worked by default prior to the SameSite attribute implementation.

2. `SameSite=Lax`: Cookies are not sent on normal cross-site subrequests (for example, to load images or frames into a third-party site), but __are sent when a user is navigating to the origin site__. This is the default value in modern browsers if the attribute is not specified.

3. `SameSite=Strict`: Cookies will only be sent in a first-party context and not be sent along with requests initiated by third-party websites. This means that the cookies won't be sent if the user is not already on your site.
