### PR TITLE
feat: extending maintenance allowance through API

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -28,8 +28,7 @@ func (s Service) IsUserFavorite() bool {
 	return s.isUserFavorite
 }
 
-// Normalize will validate and 'normalize' the ContactMethod -- such as making email lower-case
-// and setting carrier to "" (for non-phone types).
+// Normalize will validate and 'normalize' the Service -- such as setting the minimum duration to 0.
 func (s Service) Normalize() (*Service, error) {
 	dur := time.Until(s.MaintenanceExpiresAt)
 

--- a/service/service.go
+++ b/service/service.go
@@ -42,7 +42,7 @@ func (s Service) Normalize() (*Service, error) {
 		validate.IDName("Name", s.Name),
 		validate.Text("Description", s.Description, 1, MaxDetailsLength),
 		validate.UUID("EscalationPolicyID", s.EscalationPolicyID),
-		validate.Duration("MaintenanceExpiresAt", dur, 0, 8*time.Hour),
+		validate.Duration("MaintenanceExpiresAt", dur, 0, 24*time.Hour+5*time.Minute),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Extending maximum maintenance mode from 8 hours to 24 hours. We also want to allow a 5 minute grace period for clock drift.

**Which issue(s) this PR fixes:**
N/A

**Out of Scope:**
N/A

**Screenshots:**
N/A

**Describe any introduced user-facing changes:**
N/A

**Describe any introduced API changes:**
Nothing new introduced, but this does alter the maximum amount of time a service can be added to maintenance mode

**Additional Info:**
none
