### PR TITLE
feat: add smoke test for on call notification webhooks

### DIFF
--- a/test/smoke/webhook_test.go
+++ b/test/smoke/webhook_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/target/goalert/test/smoke/harness"
 )
 
@@ -22,16 +21,20 @@ type WebhookTestingAlert struct {
 func TestWebhookAlert(t *testing.T) {
 	t.Parallel()
 
-	ch := make(chan WebhookTestingAlert)
+	ch := make(chan WebhookTestingAlert, 1)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var alert WebhookTestingAlert
 
 		data, err := io.ReadAll(r.Body)
-		require.Nil(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 
 		err = json.Unmarshal(data, &alert)
-		require.Nil(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 
 		ch <- alert
 	}))

--- a/test/smoke/webhookoncall_test.go
+++ b/test/smoke/webhookoncall_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/target/goalert/expflag"
 	"github.com/target/goalert/test/smoke/harness"
 )
@@ -33,16 +32,20 @@ type POSTDataOnCallNotification struct {
 func TestWebhookOnCallNotification(t *testing.T) {
 	t.Parallel()
 
-	ch := make(chan POSTDataOnCallNotification)
+	ch := make(chan POSTDataOnCallNotification, 1)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var alert POSTDataOnCallNotification
 
 		data, err := io.ReadAll(r.Body)
-		require.Nil(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 
 		err = json.Unmarshal(data, &alert)
-		require.Nil(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 
 		ch <- alert
 	}))

--- a/test/smoke/webhookoncall_test.go
+++ b/test/smoke/webhookoncall_test.go
@@ -1,0 +1,84 @@
+package smoke
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/expflag"
+	"github.com/target/goalert/test/smoke/harness"
+)
+
+type POSTDataOnCallUser struct {
+	ID   string
+	Name string
+	URL  string
+}
+
+type POSTDataOnCallNotification struct {
+	AppName      string
+	Type         string
+	Users        []POSTDataOnCallUser
+	ScheduleID   string
+	ScheduleName string
+	ScheduleURL  string
+}
+
+// TestWebhookOnCallNotification tests that the configured rule sends the intended notification to the webhook.
+func TestWebhookOnCallNotification(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan POSTDataOnCallNotification)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var alert POSTDataOnCallNotification
+
+		data, err := io.ReadAll(r.Body)
+		require.Nil(t, err)
+
+		err = json.Unmarshal(data, &alert)
+		require.Nil(t, err)
+
+		ch <- alert
+	}))
+
+	defer ts.Close()
+
+	sql := `
+	insert into users (id, name, email) 
+	values 
+		({{uuid "user"}}, 'bob', 'joe');
+	
+	insert into schedules (id, name, time_zone) 
+	values
+		({{uuid "sid"}}, 'testschedule', 'UTC');
+
+	insert into schedule_rules (id, schedule_id, sunday, monday, tuesday, wednesday, thursday, friday, saturday, start_time, end_time, tgt_user_id)
+	values
+		({{uuid "ruleID"}}, {{uuid "sid"}}, true, true, true, true, true, true, true, '00:00:00', '00:00:00', {{uuid "user"}});
+	
+	insert into notification_channels (id, type, name, value)
+	values
+		({{uuid "webhook"}}, 'WEBHOOK', 'url', '` + ts.URL + `');
+
+	insert into schedule_data (schedule_id, data)
+	values
+		({{uuid "sid"}}, '{"V1":{"OnCallNotificationRules": [{"ChannelID": {{uuidJSON "webhook"}}, "Time": "00:00" }]}}');
+	`
+
+	h := harness.NewHarnessWithFlags(t, sql, "webhook-notification-channel-type", expflag.FlagSet{expflag.ChanWebhook})
+	defer h.Close()
+
+	h.Trigger()
+
+	h.FastForward(24 * time.Hour)
+
+	alert := <-ch
+	assert.Equal(t, alert.Users[0].Name, "bob")
+	assert.Equal(t, alert.ScheduleName, "testschedule")
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Added additional smoke test ensuring that webhooks can receive notifications from a schedule's on-call notification rule.