### PR TITLE
fix: aligning esc policy notices

### DIFF
--- a/web/src/app/details/DetailsPage.tsx
+++ b/web/src/app/details/DetailsPage.tsx
@@ -97,7 +97,7 @@ export default function DetailsPage(p: DetailsPageProps): JSX.Element {
     <Grid container spacing={2}>
       {/* Notices */}
       <Grid item xs={12}>
-      {Array.isArray(p.notices) ? <Notices notices={p.notices} /> : p.notices}
+        {Array.isArray(p.notices) ? <Notices notices={p.notices} /> : p.notices}
       </Grid>
 
       {/* Header card */}

--- a/web/src/app/details/DetailsPage.tsx
+++ b/web/src/app/details/DetailsPage.tsx
@@ -96,7 +96,7 @@ export default function DetailsPage(p: DetailsPageProps): JSX.Element {
   return (
     <Grid container spacing={2}>
       {/* Notices */}
-      <Grid item xs={12} >
+      <Grid item xs={12}>
       {Array.isArray(p.notices) ? <Notices notices={p.notices} /> : p.notices}
       </Grid>
 

--- a/web/src/app/details/DetailsPage.tsx
+++ b/web/src/app/details/DetailsPage.tsx
@@ -96,7 +96,9 @@ export default function DetailsPage(p: DetailsPageProps): JSX.Element {
   return (
     <Grid container spacing={2}>
       {/* Notices */}
+      <Grid item xs={12} >
       {Array.isArray(p.notices) ? <Notices notices={p.notices} /> : p.notices}
+      </Grid>
 
       {/* Header card */}
       <Grid item xs={12} lg={!isMobile && p.links?.length ? 8 : 12}>


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Escalation policy notices now align with the main grid of the details page.

**Which issue(s) this PR fixes:**
Fixes #3197

**Screenshots:**
Before:
<img width="600" alt="Screenshot 2023-07-25 at 11 55 57 AM" src="https://github.com/target/goalert/assets/42848290/8f21c07e-846f-4cd7-a8f3-b56a4c41d408">
After:
<img width="600" alt="Screenshot 2023-07-25 at 11 59 12 AM" src="https://github.com/target/goalert/assets/42848290/f9a98ed9-9a05-4f7a-b908-3bc49123baf1">