### PR TITLE
feat: add service name/id field to webhook alerts

### DIFF
--- a/engine/sendmessage.go
+++ b/engine/sendmessage.go
@@ -55,6 +55,10 @@ func (p *Engine) sendMessage(ctx context.Context, msg *message.Message) (*notifi
 			Count:       count,
 		}
 	case notification.MessageTypeAlert:
+		name, _, err := p.a.ServiceInfo(ctx, msg.ServiceID)
+		if err != nil {
+			return nil, errors.Wrap(err, "lookup service info")
+		}
 		a, err := p.a.FindOne(ctx, msg.AlertID)
 		if err != nil {
 			return nil, errors.Wrap(err, "lookup alert")
@@ -68,11 +72,13 @@ func (p *Engine) sendMessage(ctx context.Context, msg *message.Message) (*notifi
 			stat = nil
 		}
 		notifMsg = notification.Alert{
-			Dest:       msg.Dest,
-			AlertID:    msg.AlertID,
-			Summary:    a.Summary,
-			Details:    a.Details,
-			CallbackID: msg.ID,
+			Dest:        msg.Dest,
+			AlertID:     msg.AlertID,
+			Summary:     a.Summary,
+			Details:     a.Details,
+			CallbackID:  msg.ID,
+			ServiceID:   a.ServiceID,
+			ServiceName: name,
 
 			OriginalStatus: stat,
 		}

--- a/notification/alert.go
+++ b/notification/alert.go
@@ -2,11 +2,13 @@ package notification
 
 // Alert represents outgoing notifications for alerts.
 type Alert struct {
-	Dest       Dest
-	CallbackID string // CallbackID is the identifier used to communicate a response to the notification
-	AlertID    int    // The global alert number
-	Summary    string
-	Details    string
+	Dest        Dest
+	CallbackID  string // CallbackID is the identifier used to communicate a response to the notification
+	AlertID     int    // The global alert number
+	Summary     string
+	Details     string
+	ServiceID   string
+	ServiceName string
 
 	// OriginalStatus is the status of the first Alert notification to this Dest for this AlertID.
 	OriginalStatus *SendResult

--- a/notification/store.go
+++ b/notification/store.go
@@ -479,26 +479,3 @@ func scanStatus(row scannable) (*SendResult, time.Time, error) {
 
 	return &s, createdAt.Time, nil
 }
-
-// ServiceInfo will return the name of the given service ID as well as the current number
-// of unacknowledged alerts.
-func (s *Store) ServiceInfo(ctx context.Context, serviceID string) (string, int, error) {
-	err := permission.LimitCheckAny(ctx, permission.User)
-	if err != nil {
-		return "", 0, err
-	}
-
-	err = validate.UUID("ServiceID", serviceID)
-	if err != nil {
-		return "", 0, err
-	}
-
-	var name string
-	var count int
-	err = s.svcInfo.QueryRowContext(ctx, serviceID).Scan(&name, &count)
-	if err != nil {
-		return "", 0, err
-	}
-
-	return name, count, nil
-}

--- a/notification/store.go
+++ b/notification/store.go
@@ -35,7 +35,6 @@ type Store struct {
 	sendTestLock                 *sql.Stmt
 	findManyMessageStatuses      *sql.Stmt
 	lastMessageStatus            *sql.Stmt
-	svcInfo                      *sql.Stmt
 
 	origAlertMessage *sql.Stmt
 
@@ -169,13 +168,6 @@ func NewStore(ctx context.Context, db *sql.DB) (*Store, error) {
 				(select type from notification_channels ch where ch.id = om.channel_id)
 			from outgoing_messages om
 			where message_type = $1 and contact_method_id = $2 and created_at >= $3
-		`),
-		svcInfo: p.P(`
-			SELECT
-				name,
-				(SELECT count(*) FROM alerts WHERE service_id = $1 AND status = 'triggered')
-			FROM services
-			WHERE id = $1
 		`),
 	}, p.Err
 }

--- a/notification/webhook/sender.go
+++ b/notification/webhook/sender.go
@@ -17,11 +17,13 @@ type Sender struct{}
 
 // POSTDataAlert represents fields in outgoing alert notification.
 type POSTDataAlert struct {
-	AppName string
-	Type    string
-	AlertID int
-	Summary string
-	Details string
+	AppName     string
+	Type        string
+	AlertID     int
+	Summary     string
+	Details     string
+	ServiceID   string
+	ServiceName string
 }
 
 // POSTDataAlertBundle represents fields in outgoing alert bundle notification.
@@ -102,11 +104,13 @@ func (s *Sender) Send(ctx context.Context, msg notification.Message) (*notificat
 		}
 	case notification.Alert:
 		payload = POSTDataAlert{
-			AppName: cfg.ApplicationName(),
-			Type:    "Alert",
-			Details: m.Details,
-			AlertID: m.AlertID,
-			Summary: m.Summary,
+			AppName:     cfg.ApplicationName(),
+			Type:        "Alert",
+			Details:     m.Details,
+			AlertID:     m.AlertID,
+			Summary:     m.Summary,
+			ServiceID:   m.ServiceID,
+			ServiceName: m.ServiceName,
 		}
 	case notification.AlertBundle:
 		payload = POSTDataAlertBundle{

--- a/test/smoke/webhook_test.go
+++ b/test/smoke/webhook_test.go
@@ -12,10 +12,12 @@ import (
 )
 
 type WebhookTestingAlert struct {
-	AlertID int
-	Type    string
-	Summary string
-	Details string
+	AlertID     int
+	Type        string
+	Summary     string
+	Details     string
+	ServiceID   string
+	ServiceName string
 }
 
 func TestWebhookAlert(t *testing.T) {
@@ -79,4 +81,6 @@ func TestWebhookAlert(t *testing.T) {
 	assert.Equal(t, alert.Type, "Alert")
 	assert.Equal(t, alert.Summary, "testing summary")
 	assert.Equal(t, alert.Details, "testing details")
+	assert.Equal(t, alert.ServiceID, h.UUID("sid"))
+	assert.Equal(t, alert.ServiceName, "service")
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Webhook alert bundle notifications included the service id and name which were not present in the alert type. This feat adds the service name and id field to the webhook alert notification post data. 

**Which issue(s) this PR fixes:**
#3009 

```
Before:
127.0.0.1 - - [26/Jul/2023 09:21:03] "POST /webhook HTTP/1.1" 200 -
Data received from Webhook is:  {'AppName': 'GoAlert', 'Type': 'Alert', 'AlertID': 79679, 'Summary': 'test3', 'Details': ''}

After:
127.0.0.1 - - [26/Jul/2023 09:39:48] "POST /webhook HTTP/1.1" 200 -
Data received from Webhook is:  {'AppName': 'GoAlert', 'Type': 'Alert', 'AlertID': 79679, 'Summary': 'test3', 'Details': '', 'ServiceID': 'df9cfe94-7a76-4757-94b5-bf6013af831e', 'ServiceName': 'test_webhook'}
```
