### PR TITLE
dev: run clean before building in Dockerfile

### DIFF
--- a/devtools/ci/dockerfiles/goalert/Dockerfile
+++ b/devtools/ci/dockerfiles/goalert/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/goalert/build-env:go1.20.5-postgres13 AS build
 COPY / /build/
 WORKDIR /build
-RUN make bin/build/goalert-linux-amd64
+RUN make clean bin/build/goalert-linux-amd64
 
 FROM docker.io/library/alpine
 RUN apk --no-cache add ca-certificates


### PR DESCRIPTION
**Description:**
Fixes an issue where building with the from-scratch Dockerfile can fail due to existing artifacts.