### PR TITLE
fix: prefix search

### DIFF
--- a/escalation/search.go
+++ b/escalation/search.go
@@ -55,7 +55,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		AND NOT pol.id = any(:omit)
 	{{end}}
 	{{if .Search}}
-		AND {{orderedSearch "search" "pol.name"}}
+		AND {{orderedPrefixSearch "search" "pol.name"}}
 	{{end}}
 	{{if .After.Name}}
 		AND

--- a/escalation/search.go
+++ b/escalation/search.go
@@ -55,7 +55,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		AND NOT pol.id = any(:omit)
 	{{end}}
 	{{if .Search}}
-		AND {{prefixSearch "search" "pol.name"}}
+		AND {{orderedSearch "search" "pol.name"}}
 	{{end}}
 	{{if .After.Name}}
 		AND

--- a/notification/search.go
+++ b/notification/search.go
@@ -91,9 +91,9 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 	{{end}}
 	{{if .Search}}
 		AND (
-			{{prefixSearch "search" "u.name"}}
+			{{orderedSearch "search" "u.name"}}
 			OR
-			{{prefixSearch "search" "s.name"}}
+			{{orderedSearch "search" "s.name"}}
 			OR
 				cm.value ILIKE '%' || :search || '%'
 			OR

--- a/notification/search.go
+++ b/notification/search.go
@@ -91,9 +91,9 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 	{{end}}
 	{{if .Search}}
 		AND (
-			{{orderedSearch "search" "u.name"}}
+			{{orderedPrefixSearch "search" "u.name"}}
 			OR
-			{{orderedSearch "search" "s.name"}}
+			{{orderedPrefixSearch "search" "s.name"}}
 			OR
 				cm.value ILIKE '%' || :search || '%'
 			OR

--- a/schedule/rotation/search.go
+++ b/schedule/rotation/search.go
@@ -57,7 +57,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		AND NOT rot.id = any(:omit)
 	{{end}}
 	{{if .Search}}
-		AND {{prefixSearch "search" "rot.name"}}
+		AND {{orderedSearch "search" "rot.name"}}
 	{{end}}
 	{{if .After.Name}}
 		AND

--- a/schedule/rotation/search.go
+++ b/schedule/rotation/search.go
@@ -57,7 +57,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		AND NOT rot.id = any(:omit)
 	{{end}}
 	{{if .Search}}
-		AND {{orderedSearch "search" "rot.name"}}
+		AND {{orderedPrefixSearch "search" "rot.name"}}
 	{{end}}
 	{{if .After.Name}}
 		AND

--- a/schedule/search.go
+++ b/schedule/search.go
@@ -56,7 +56,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		AND NOT sched.id = any(:omit)
 	{{end}}
 	{{if .Search}}
-		AND {{prefixSearch "search" "sched.name"}}
+		AND {{orderedSearch "search" "sched.name"}}
 	{{end}}
 	{{if .After.Name}}
 		AND

--- a/schedule/search.go
+++ b/schedule/search.go
@@ -56,7 +56,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		AND NOT sched.id = any(:omit)
 	{{end}}
 	{{if .Search}}
-		AND {{orderedSearch "search" "sched.name"}}
+		AND {{orderedPrefixSearch "search" "sched.name"}}
 	{{end}}
 	{{if .After.Name}}
 		AND

--- a/search/render.go
+++ b/search/render.go
@@ -42,6 +42,7 @@ func Helpers() template.FuncMap {
 	}
 }
 
+// splitSearchTerms will separate the words present in search and return a slice with them
 func splitSearchTerms(search string) []string {
 	search = strings.ToLower(search)
 	var terms []string
@@ -66,8 +67,14 @@ func splitSearchTerms(search string) []string {
 	return terms
 }
 
-func orderedPrefixRxFromTerms(terms []string) pgtype.Text {
-	rx := "\\m" + strings.Join(terms, ".*\\m")
+// orderedPrefixRxFromTerms returns a PSQL regular expression that will match
+// a string if:
+//
+// - it includes words with the all the given prefixes
+//
+// - those words are in the same order as the prefixes
+func orderedPrefixRxFromTerms(prefixes []string) pgtype.Text {
+	rx := "\\m" + strings.Join(prefixes, ".*\\m")
 
 	var t pgtype.Text
 	_ = t.Set(rx)

--- a/search/render.go
+++ b/search/render.go
@@ -42,11 +42,11 @@ func Helpers() template.FuncMap {
 	}
 }
 
-func orderedRxFromTerms(rx string) pgtype.Text {
-	rx = strings.ToLower(rx)
-	var terms string
+func orderedRxFromTerms(terms string) pgtype.Text {
+	terms = strings.ToLower(terms)
+	var rx string
 	var cur string
-	for _, r := range rx {
+	for _, r := range terms {
 		if unicode.IsLetter(r) || unicode.IsDigit(r) {
 			cur += string(r)
 			continue
@@ -55,24 +55,26 @@ func orderedRxFromTerms(rx string) pgtype.Text {
 			continue
 		}
 
-		if terms == "" {
-			terms = "\\m" + cur
+		if rx == "" {
+			rx = "\\m" + cur
 		} else {
-			terms = terms + "\\M.*\\m" + cur
+			// match end of word to ensure previous term is matched exactly
+			// consume greedily until current term prefix matches next word
+			rx = rx + "\\M.*\\m" + cur
 		}
 		cur = ""
 	}
 
 	if cur != "" {
-		if terms == "" {
-			terms = "\\m" + cur
+		if rx == "" {
+			rx = "\\m" + cur
 		} else {
-			terms = terms + "\\M.*\\m" + cur
+			rx = rx + "\\M.*\\m" + cur
 		}
 	}
 
 	var t pgtype.Text
-	_ = t.Set(terms)
+	_ = t.Set(rx)
 
 	return t
 }

--- a/service/search.go
+++ b/service/search.go
@@ -77,7 +77,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		)
 	{{end}}
 	{{- if and .Search (not .LabelKey) (not .IntegrationKey)}}
-		AND {{orderedSearch "search" "svc.name"}}
+		AND {{orderedPrefixSearch "search" "svc.name"}}
 	{{- end}}
 	{{- if .After.Name}}
 		AND

--- a/service/search.go
+++ b/service/search.go
@@ -77,7 +77,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		)
 	{{end}}
 	{{- if and .Search (not .LabelKey) (not .IntegrationKey)}}
-		AND {{prefixSearch "search" "svc.name"}}
+		AND {{orderedSearch "search" "svc.name"}}
 	{{- end}}
 	{{- if .After.Name}}
 		AND

--- a/user/search.go
+++ b/user/search.go
@@ -61,7 +61,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		AND not usr.id = any(:omit)
 	{{end}}
 	{{if .Search}}
-		AND {{prefixSearch "search" "usr.name"}} 
+		AND {{orderedSearch "search" "usr.name"}} 
 	{{end}}
 	{{if .After.Name}}
 		AND {{if not .FavoritesFirst}}

--- a/user/search.go
+++ b/user/search.go
@@ -61,7 +61,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		AND not usr.id = any(:omit)
 	{{end}}
 	{{if .Search}}
-		AND {{orderedSearch "search" "usr.name"}} 
+		AND {{orderedPrefixSearch "search" "usr.name"}} 
 	{{end}}
 	{{if .After.Name}}
 		AND {{if not .FavoritesFirst}}


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**

- Searching list pages (users, escalation policies, rotations, schedules, notifications, and services) only shows results that match the order of the search terms.
- Words can be skipped (e.g. the search "Serv Two" will return both "Service Two" and "Service One Two")

Before:
<img width="300" alt="Screenshot 2023-08-17 at 12 57 45 PM" src="https://github.com/target/goalert/assets/42848290/9b4bf2d4-ab6b-498f-b182-4b9097f90777">
<img width="300" alt="Screenshot 2023-08-17 at 12 57 35 PM" src="https://github.com/target/goalert/assets/42848290/cad7b80a-d728-4650-955b-f95a550ba5ac">

After:
<img width="300" alt="Screenshot 2023-08-17 at 12 20 49 PM" src="https://github.com/target/goalert/assets/42848290/50f924dd-7a8f-4b0e-a4b5-89dc1544a2d8">
<img width="300" alt="Screenshot 2023-08-17 at 12 20 55 PM" src="https://github.com/target/goalert/assets/42848290/9da07e32-aaa8-4c92-9795-360cf6c817ab">

**Which issue(s) this PR fixes:**
Fixes #3217 

**Describe any introduced API changes:**
Anything using `prefixSearch` now uses `orderedPrefixSearch`, which queries with a single regex.

Examples (`\m` matches beginning of word):
`\m{term 1}`
`\m{term 1}.*\m{term 2}`
`\m{term 1}.*\m{term 2}.*\m{term 3}`
