### PR TITLE
ep: fix webhook expansion when slack is disabled

### DIFF
--- a/web/src/app/escalation-policies/PolicyStepForm.js
+++ b/web/src/app/escalation-policies/PolicyStepForm.js
@@ -227,13 +227,13 @@ function PolicyStepForm(props) {
                   <Step>
                     <StepButton
                       aria-expanded={(
-                        step === (cfg['Webhook.Enable'] ? 4 : 3)
+                        step === (cfg['Slack.Enable'] ? 4 : 3)
                       ).toString()}
                       data-cy='webhook-step'
                       icon={<WebhookIcon />}
                       optional={optionalText}
                       onClick={() =>
-                        handleStepChange(cfg['Webhook.Enable'] ? 4 : 3)
+                        handleStepChange(cfg['Slack.Enable'] ? 4 : 3)
                       }
                       tabIndex={-1}
                     >


### PR DESCRIPTION
**Description:**
Fixes an issue that prevents configuring webhooks when Slack is disabled.

The current step index for webhooks changes based on whether `Slack.Enable` is set or not, but the logic was incorrectly checking the `Webhook.Enable` flag.

**Which issue(s) this PR fixes:**
Fixes #3263 

**Additional Info:**
This logic should be greatly simplified with the completion of #3206 
