### PR TITLE
timeutil: preserve field/type information when parsing ISODuration

### DIFF
--- a/graphql2/graphqlapp/alert.go
+++ b/graphql2/graphqlapp/alert.go
@@ -42,11 +42,13 @@ func (a *AlertLogEntry) ID(ctx context.Context, obj *alertlog.Entry) (int, error
 }
 
 func (a *AlertMetric) TimeToAck(ctx context.Context, obj *alertmetrics.Metric) (*timeutil.ISODuration, error) {
-	return &timeutil.ISODuration{TimePart: obj.TimeToAck}, nil
+	dur := timeutil.ISODurationFromTime(obj.TimeToAck)
+	return &dur, nil
 }
 
 func (a *AlertMetric) TimeToClose(ctx context.Context, obj *alertmetrics.Metric) (*timeutil.ISODuration, error) {
-	return &timeutil.ISODuration{TimePart: obj.TimeToClose}, nil
+	dur := timeutil.ISODurationFromTime(obj.TimeToClose)
+	return &dur, nil
 }
 
 func (a *AlertLogEntry) Timestamp(ctx context.Context, obj *alertlog.Entry) (*time.Time, error) {

--- a/graphql2/graphqlapp/messagelog.go
+++ b/graphql2/graphqlapp/messagelog.go
@@ -103,10 +103,10 @@ func (q *MessageLogConnectionStats) TimeSeries(ctx context.Context, opts *notifi
 		opts = &notification.SearchOptions{}
 	}
 
-	dur := input.BucketDuration.TimePart
-	dur += time.Duration(input.BucketDuration.Days) * 24 * time.Hour
-	dur += time.Duration(input.BucketDuration.Months) * 30 * 24 * time.Hour
-	dur += time.Duration(input.BucketDuration.Years) * 365 * 24 * time.Hour
+	dur := input.BucketDuration.TimePart()
+	dur += time.Duration(input.BucketDuration.Days()) * 24 * time.Hour
+	dur += time.Duration(input.BucketDuration.MonthPart) * 30 * 24 * time.Hour
+	dur += time.Duration(input.BucketDuration.YearPart) * 365 * 24 * time.Hour
 
 	var origin time.Time
 	if input.BucketOrigin != nil {

--- a/util/timeutil/isorinterval.go
+++ b/util/timeutil/isorinterval.go
@@ -23,7 +23,7 @@ func (r *ISORInterval) calcStart(end time.Time) error {
 		return fmt.Errorf("invalid interval: duration must be non-zero")
 	}
 	n := r.Repeat + 1
-	r.Start = end.AddDate(-r.Period.Years*n, -r.Period.Months*n, -r.Period.Days*n).Add(-r.Period.TimePart * time.Duration(n))
+	r.Start = end.AddDate(-r.Period.YearPart*n, -r.Period.MonthPart*n, -r.Period.Days()*n).Add(-r.Period.TimePart() * time.Duration(n))
 	return nil
 }
 
@@ -32,7 +32,7 @@ func (r *ISORInterval) calcPeriod(end time.Time) error {
 		return fmt.Errorf("invalid interval: end time must be after start time: %s", end.Format(time.RFC3339Nano))
 	}
 
-	r.Period.TimePart = end.Sub(r.Start) / time.Duration(r.Repeat+1)
+	r.Period.SetTimePart(end.Sub(r.Start) / time.Duration(r.Repeat+1))
 
 	return nil
 }
@@ -44,12 +44,12 @@ func (r ISORInterval) End() time.Time {
 	}
 
 	n := r.Repeat + 1
-	return r.Start.UTC().AddDate(r.Period.Years*n, r.Period.Months*n, r.Period.Days*n).Add(r.Period.TimePart * time.Duration(n))
+	return r.Start.UTC().AddDate(r.Period.YearPart*n, r.Period.MonthPart*n, r.Period.Days()*n).Add(r.Period.TimePart() * time.Duration(n))
 }
 
 // String returns the string representation of the interval.
 func (r ISORInterval) String() string {
-	if r.Period.Years == 0 && r.Period.Months == 0 && r.Period.Days == 0 {
+	if r.Period.YearPart == 0 && r.Period.MonthPart == 0 && r.Period.Days() == 0 {
 		// just a duration, use start/end format
 		return fmt.Sprintf("R%d/%s/%s", r.Repeat, r.Start.Format(time.RFC3339Nano), r.End().Format(time.RFC3339Nano))
 	}

--- a/util/timeutil/isorinterval_test.go
+++ b/util/timeutil/isorinterval_test.go
@@ -22,37 +22,37 @@ func TestParseISORInterval(t *testing.T) {
 	check("R0/2022-01-31T00:00:00Z/2023-01-31T00:00:00Z", timeutil.ISORInterval{
 		Repeat: 0,
 		Start:  time.Date(2022, 1, 31, 0, 0, 0, 0, time.UTC),
-		Period: timeutil.ISODuration{TimePart: time.Hour * 24 * 365},
+		Period: timeutil.ISODuration{HourPart: 24 * 365},
 	}, time.Date(2023, 1, 31, 0, 0, 0, 0, time.UTC))
 
 	check("R1/2022-01-31T00:00:00Z/2024-01-31T00:00:00Z", timeutil.ISORInterval{
 		Repeat: 1,
 		Start:  time.Date(2022, 1, 31, 0, 0, 0, 0, time.UTC),
-		Period: timeutil.ISODuration{TimePart: time.Hour * 24 * 365},
+		Period: timeutil.ISODuration{HourPart: 24 * 365},
 	}, time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC))
 
 	check("R0/2022-01-31T00:00:00Z/P1Y", timeutil.ISORInterval{
 		Repeat: 0,
 		Start:  time.Date(2022, 1, 31, 0, 0, 0, 0, time.UTC),
-		Period: timeutil.ISODuration{Years: 1},
+		Period: timeutil.ISODuration{YearPart: 1},
 	}, time.Date(2023, 1, 31, 0, 0, 0, 0, time.UTC))
 
 	check("R1/2022-01-31T00:00:00Z/P1Y", timeutil.ISORInterval{
 		Repeat: 1,
 		Start:  time.Date(2022, 1, 31, 0, 0, 0, 0, time.UTC),
-		Period: timeutil.ISODuration{Years: 1},
+		Period: timeutil.ISODuration{YearPart: 1},
 	}, time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC))
 
 	check("R0/P1Y/2023-01-31T00:00:00Z", timeutil.ISORInterval{
 		Repeat: 0,
 		Start:  time.Date(2022, 1, 31, 0, 0, 0, 0, time.UTC),
-		Period: timeutil.ISODuration{Years: 1},
+		Period: timeutil.ISODuration{YearPart: 1},
 	}, time.Date(2023, 1, 31, 0, 0, 0, 0, time.UTC))
 
 	check("R1/P1Y/2024-01-31T00:00:00Z", timeutil.ISORInterval{
 		Repeat: 1,
 		Start:  time.Date(2022, 1, 31, 0, 0, 0, 0, time.UTC),
-		Period: timeutil.ISODuration{Years: 1},
+		Period: timeutil.ISODuration{YearPart: 1},
 	}, time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC))
 
 }
@@ -67,22 +67,22 @@ func TestISORInterval_String(t *testing.T) {
 	check("R0/2022-01-31T00:00:00Z/P1Y", timeutil.ISORInterval{
 		Repeat: 0,
 		Start:  time.Date(2022, 1, 31, 0, 0, 0, 0, time.UTC),
-		Period: timeutil.ISODuration{Years: 1},
+		Period: timeutil.ISODuration{YearPart: 1},
 	})
 	check("R1/2022-01-31T00:00:00Z/P1Y", timeutil.ISORInterval{
 		Repeat: 1,
 		Start:  time.Date(2022, 1, 31, 0, 0, 0, 0, time.UTC),
-		Period: timeutil.ISODuration{Years: 1},
+		Period: timeutil.ISODuration{YearPart: 1},
 	})
 
 	check("R0/2022-01-31T00:00:00Z/2022-01-31T01:00:00Z", timeutil.ISORInterval{
 		Repeat: 0,
 		Start:  time.Date(2022, 1, 31, 0, 0, 0, 0, time.UTC),
-		Period: timeutil.ISODuration{TimePart: time.Hour},
+		Period: timeutil.ISODuration{HourPart: 1},
 	})
 	check("R1/2022-01-31T00:00:00Z/2022-01-31T02:00:00Z", timeutil.ISORInterval{
 		Repeat: 1,
 		Start:  time.Date(2022, 1, 31, 0, 0, 0, 0, time.UTC),
-		Period: timeutil.ISODuration{TimePart: time.Hour},
+		Period: timeutil.ISODuration{HourPart: 1},
 	})
 }


### PR DESCRIPTION
**Description:**
This PR updates the `timeutil.ISODuration` to preserve information about weeks, hours, minutes, and seconds.

Convenience methods were added for code that previously relied on the combined field values:
- The struct now has explicit fields for each part (e.g., `.YearPart` and `.WeekPart`)
- A `.TimePart()` method was added to convert hours/minutes/seconds into a `time.Duration`
- A `.SetTimePart(time.Duration)` method was added to do the reverse
- A `.Days()` method was added to give `.WeekPart` and `.DayPart` together

This allows the backend to use this type information and is necessary work for #3243 
