### PR TITLE
graphql: add `listGQLFields` query

### DIFF
--- a/graphql2/gqlgen.yml
+++ b/graphql2/gqlgen.yml
@@ -84,8 +84,6 @@ models:
     model: github.com/target/goalert/limit.ID
   DebugCarrierInfo:
     model: github.com/target/goalert/notification/twilio.CarrierInfo
-  UserSession:
-    model: github.com/target/goalert/auth.UserSession
   Notice:
     model: github.com/target/goalert/notice.Notice
   NoticeType:

--- a/graphql2/graphqlapp/query.go
+++ b/graphql2/graphqlapp/query.go
@@ -19,6 +19,15 @@ type (
 
 func (a *App) Query() graphql2.QueryResolver { return (*Query)(a) }
 
+func (q *Query) ListGQLFields(ctx context.Context, query *string) ([]string, error) {
+	if query == nil || *query == "" {
+		// List all fields if no query is provided.
+		return graphql2.SchemaFields(), nil
+	}
+
+	return graphql2.QueryFields(*query)
+}
+
 func (a *Query) ExperimentalFlags(ctx context.Context) ([]string, error) {
 	var flags []string
 	for _, f := range expflag.AllFlags() {

--- a/graphql2/graphqlapp/user.go
+++ b/graphql2/graphqlapp/user.go
@@ -4,7 +4,6 @@ import (
 	context "context"
 	"database/sql"
 
-	"github.com/target/goalert/auth"
 	"github.com/target/goalert/auth/basic"
 	"github.com/target/goalert/calsub"
 	"github.com/target/goalert/validation"
@@ -22,28 +21,41 @@ import (
 )
 
 type (
-	User        App
-	UserSession App
+	User App
 )
 
 func (a *App) User() graphql2.UserResolver { return (*User)(a) }
 
-func (a *App) UserSession() graphql2.UserSessionResolver { return (*UserSession)(a) }
+func (a *User) Sessions(ctx context.Context, obj *user.User) ([]graphql2.UserSession, error) {
+	sess, err := a.AuthHandler.FindAllUserSessions(ctx, obj.ID)
+	if err != nil {
+		return nil, err
+	}
 
-func (a *User) Sessions(ctx context.Context, obj *user.User) ([]auth.UserSession, error) {
-	return a.AuthHandler.FindAllUserSessions(ctx, obj.ID)
+	out := make([]graphql2.UserSession, len(sess))
+	for i, s := range sess {
+
+		out[i] = graphql2.UserSession{
+			ID:           s.ID,
+			UserAgent:    s.UserAgent,
+			CreatedAt:    s.CreatedAt,
+			LastAccessAt: s.LastAccessAt,
+			Current:      isCurrentSession(ctx, s.ID),
+		}
+	}
+
+	return out, nil
 }
-
-func (a *UserSession) Current(ctx context.Context, obj *auth.UserSession) (bool, error) {
+func isCurrentSession(ctx context.Context, sessID string) bool {
 	src := permission.Source(ctx)
 	if src == nil {
-		return false, nil
+		return false
 	}
 	if src.Type != permission.SourceTypeAuthProvider {
-		return false, nil
+		return false
 	}
 
-	return obj.ID == src.ID, nil
+	return src.ID == sessID
 }
 
 func (a *User) AuthSubjects(ctx context.Context, obj *user.User) ([]user.AuthSubject, error) {

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -686,6 +686,14 @@ type UserSearchOptions struct {
 	FavoritesFirst *bool               `json:"favoritesFirst,omitempty"`
 }
 
+type UserSession struct {
+	ID           string    `json:"id"`
+	Current      bool      `json:"current"`
+	UserAgent    string    `json:"userAgent"`
+	CreatedAt    time.Time `json:"createdAt"`
+	LastAccessAt time.Time `json:"lastAccessAt"`
+}
+
 type VerifyContactMethodInput struct {
 	ContactMethodID string `json:"contactMethodID"`
 	Code            int    `json:"code"`

--- a/graphql2/schema.go
+++ b/graphql2/schema.go
@@ -1,0 +1,67 @@
+package graphql2
+
+import (
+	_ "embed"
+	"sort"
+
+	"github.com/target/goalert/validation"
+	"github.com/vektah/gqlparser/v2"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/parser"
+	"github.com/vektah/gqlparser/v2/validator"
+)
+
+//go:embed schema.graphql
+var schema string
+
+var schemaFields []string
+var astSchema *ast.Schema
+
+// Schema will return the GraphQL schema.
+func Schema() string {
+	return schema
+}
+
+func init() {
+	schDoc, err := parser.ParseSchema(&ast.Source{Input: schema})
+	if err != nil {
+		panic(err)
+	}
+
+	sch, err := gqlparser.LoadSchema(&ast.Source{Input: schema})
+	if err != nil {
+		panic(err)
+	}
+	astSchema = sch
+
+	for _, typ := range schDoc.Definitions {
+		if typ.Kind != ast.Object {
+			continue
+		}
+		for _, f := range typ.Fields {
+			schemaFields = append(schemaFields, typ.Name+"."+f.Name)
+		}
+	}
+	sort.Strings(schemaFields)
+}
+
+// SchemaFields will return a list of all fields in the schema.
+func SchemaFields() []string { return schemaFields }
+
+// QueryFields will return a list of all fields that the given query references.
+func QueryFields(query string) ([]string, error) {
+	qDoc, qErr := gqlparser.LoadQuery(astSchema, query)
+	if len(qErr) > 0 {
+		return nil, validation.NewFieldError("Query", qErr.Error())
+	}
+
+	var fields []string
+	var e validator.Events
+	e.OnField(func(w *validator.Walker, field *ast.Field) {
+		fields = append(fields, field.ObjectDefinition.Name+"."+field.Name)
+	})
+	validator.Walk(astSchema, qDoc, &e)
+
+	sort.Strings(fields)
+	return fields, nil
+}

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -128,6 +128,8 @@ type Query {
   linkAccountInfo(token: ID!): LinkAccountInfo
 
   swoStatus: SWOStatus!
+
+  listGQLFields(query: String): [String!]!
 }
 
 type IntegrationKeyTypeInfo {

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -42,6 +42,7 @@ export interface Query {
   generateSlackAppManifest: string
   linkAccountInfo?: null | LinkAccountInfo
   swoStatus: SWOStatus
+  listGQLFields: string[]
 }
 
 export interface IntegrationKeyTypeInfo {


### PR DESCRIPTION
**Description:**
This PR adds a new `listGQLFields` query that can return all fields used by a valid query OR all valid fields for the schema (if a query is omitted).
It also serves as a way to validate a query against the current schema.

Additionally, `UserSession` was changed to use a gqlgen-generated model to eliminate a circular dependency on the `auth` package.

**Which issue(s) this PR fixes:**
Part of #3007 

**Describe any introduced API changes:**
- Added a query `listGQLFields`
![image](https://github.com/target/goalert/assets/595010/1b7fc84a-18f9-4437-af25-f309b2fcc344)
![image](https://github.com/target/goalert/assets/595010/b5c9fb60-7740-4886-8170-3b6a03566caf)
![image](https://github.com/target/goalert/assets/595010/3f22de46-57b7-439e-9503-b58318181ee7)
