### PR TITLE
jest: normalize whitespace before comparing timestamps

### DIFF
--- a/web/src/app/util/timeFormat.test.ts
+++ b/web/src/app/util/timeFormat.test.ts
@@ -8,7 +8,9 @@ import {
 describe('formatTimestamp', () => {
   const check = (opts: FormatTimestampArg, exp: string): void => {
     it(`${opts.time} === ${exp}`, () => {
-      expect(formatTimestamp(opts)).toBe(exp)
+      // different versions of node have different whitespace, so normalize it
+      const result = formatTimestamp(opts).replace(/[\s\u00A0\u202F]+/g, ' ')
+      expect(result).toBe(exp)
     })
   }
 


### PR DESCRIPTION
**Description:**
Fixes an issue where different versions of node break time format tests.

**Additional Info:**
https://github.com/nodejs/node/issues/46123
