### PR TITLE
dev: increase linter timeout

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -31,7 +31,7 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          args: --timeout 120s
+          args: --timeout 300s
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true


### PR DESCRIPTION
**Description:**
Increasing the linter timeout from 2 -> 5 min as it's been timing out half the time on new PRs.

Locally it completes in a few seconds, so likely due to heavy contention/cpu-throttle on the GH actions workers.
