### PR TITLE
Feature: Full Schedule Support in Calendar Subscriptions

### DIFF
--- a/calsub/queries.sql
+++ b/calsub/queries.sql
@@ -1,13 +1,25 @@
 -- name: FindOneCalSub :one
-SELECT id,
+SELECT
+    id,
     NAME,
     user_id,
     disabled,
     schedule_id,
     config,
     last_access
-FROM user_calendar_subscriptions
-WHERE id = $1;
+FROM
+    user_calendar_subscriptions
+WHERE
+    id = $1;
+
+-- name: CalSubUserNames :many
+SELECT
+    id,
+    name
+FROM
+    users
+WHERE
+    id = ANY ($1::uuid[]);
 
 -- name: CalSubRenderInfo :one
 SELECT
@@ -23,59 +35,70 @@ WHERE
     sub.id = $1;
 
 -- name: FindOneCalSubForUpdate :one
-SELECT id,
+SELECT
+    id,
     NAME,
     user_id,
     disabled,
     schedule_id,
     config,
     last_access
-FROM user_calendar_subscriptions
-WHERE id = $1 FOR
-UPDATE;
+FROM
+    user_calendar_subscriptions
+WHERE
+    id = $1
+FOR UPDATE;
 
 -- name: FindManyCalSubByUser :many
-SELECT id,
+SELECT
+    id,
     NAME,
     user_id,
     disabled,
     schedule_id,
     config,
     last_access
-FROM user_calendar_subscriptions
-WHERE user_id = $1;
+FROM
+    user_calendar_subscriptions
+WHERE
+    user_id = $1;
 
 -- name: DeleteManyCalSub :exec
 DELETE FROM user_calendar_subscriptions
-WHERE id = ANY($1::uuid [ ])
+WHERE id = ANY ($1::uuid[])
     AND user_id = $2;
 
 -- name: CreateCalSub :one
-INSERT INTO user_calendar_subscriptions (
-        id,
-        NAME,
-        user_id,
-        disabled,
-        schedule_id,
-        config
-    )
-VALUES ($1, $2, $3, $4, $5, $6) RETURNING created_at;
+INSERT INTO user_calendar_subscriptions(id, NAME, user_id, disabled, schedule_id, config)
+    VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING
+    created_at;
 
 -- name: Now :one
-SELECT now()::timestamptz;
+SELECT
+    now()::timestamptz;
 
 -- name: CalSubAuthUser :one
-UPDATE user_calendar_subscriptions
-SET last_access = now()
-WHERE NOT disabled
+UPDATE
+    user_calendar_subscriptions
+SET
+    last_access = now()
+WHERE
+    NOT disabled
     AND id = $1
-    AND date_trunc('second', created_at) = $2 RETURNING user_id;
+    AND date_trunc('second', created_at) = $2
+RETURNING
+    user_id;
 
 -- name: UpdateCalSub :exec
-UPDATE user_calendar_subscriptions
-SET NAME = $1,
+UPDATE
+    user_calendar_subscriptions
+SET
+    NAME = $1,
     disabled = $2,
     config = $3,
     last_update = now()
-WHERE id = $4
+WHERE
+    id = $4
     AND user_id = $5;
+

--- a/calsub/renderdata.go
+++ b/calsub/renderdata.go
@@ -15,4 +15,6 @@ type renderData struct {
 	ReminderMinutes []int
 	Version         string
 	GeneratedAt     time.Time
+	FullSchedule    bool
+	UserNames       map[string]string
 }

--- a/calsub/renderical.go
+++ b/calsub/renderical.go
@@ -23,7 +23,7 @@ METHOD:PUBLISH
 {{- range $i, $s := .Shifts}}
 BEGIN:VEVENT
 UID:{{index $eventUIDs $i}}
-SUMMARY:On-Call ({{$.ApplicationName}}: {{$.ScheduleName}}){{if $s.Truncated}} Begins*
+SUMMARY:{{if $.FullSchedule}}{{index $.UserNames $s.UserID}} {{end}}On-Call ({{$.ApplicationName}}: {{$.ScheduleName}}){{if $s.Truncated}} Begins*
 DESCRIPTION:The end time of this shift is unknown and will continue beyond what is displayed.
 {{- end }}
 DTSTAMP:{{$genTime.UTC.Format "20060102T150405Z"}}

--- a/calsub/subscriptionconfig.go
+++ b/calsub/subscriptionconfig.go
@@ -10,6 +10,7 @@ import (
 // SubscriptionConfig is the configuration for a calendar subscription.
 type SubscriptionConfig struct {
 	ReminderMinutes []int
+	FullSchedule    bool
 }
 
 var (

--- a/gadb/queries.sql.go
+++ b/gadb/queries.sql.go
@@ -390,11 +390,16 @@ func (q *Queries) AuthLinkUseReq(ctx context.Context, id uuid.UUID) (AuthLinkUse
 }
 
 const calSubAuthUser = `-- name: CalSubAuthUser :one
-UPDATE user_calendar_subscriptions
-SET last_access = now()
-WHERE NOT disabled
+UPDATE
+    user_calendar_subscriptions
+SET
+    last_access = now()
+WHERE
+    NOT disabled
     AND id = $1
-    AND date_trunc('second', created_at) = $2 RETURNING user_id
+    AND date_trunc('second', created_at) = $2
+RETURNING
+    user_id
 `
 
 type CalSubAuthUserParams struct {
@@ -444,16 +449,49 @@ func (q *Queries) CalSubRenderInfo(ctx context.Context, id uuid.UUID) (CalSubRen
 	return i, err
 }
 
+const calSubUserNames = `-- name: CalSubUserNames :many
+SELECT
+    id,
+    name
+FROM
+    users
+WHERE
+    id = ANY ($1::uuid[])
+`
+
+type CalSubUserNamesRow struct {
+	ID   uuid.UUID
+	Name string
+}
+
+func (q *Queries) CalSubUserNames(ctx context.Context, dollar_1 []uuid.UUID) ([]CalSubUserNamesRow, error) {
+	rows, err := q.db.QueryContext(ctx, calSubUserNames, pq.Array(dollar_1))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []CalSubUserNamesRow
+	for rows.Next() {
+		var i CalSubUserNamesRow
+		if err := rows.Scan(&i.ID, &i.Name); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const createCalSub = `-- name: CreateCalSub :one
-INSERT INTO user_calendar_subscriptions (
-        id,
-        NAME,
-        user_id,
-        disabled,
-        schedule_id,
-        config
-    )
-VALUES ($1, $2, $3, $4, $5, $6) RETURNING created_at
+INSERT INTO user_calendar_subscriptions(id, NAME, user_id, disabled, schedule_id, config)
+    VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING
+    created_at
 `
 
 type CreateCalSubParams struct {
@@ -481,7 +519,7 @@ func (q *Queries) CreateCalSub(ctx context.Context, arg CreateCalSubParams) (tim
 
 const deleteManyCalSub = `-- name: DeleteManyCalSub :exec
 DELETE FROM user_calendar_subscriptions
-WHERE id = ANY($1::uuid [ ])
+WHERE id = ANY ($1::uuid[])
     AND user_id = $2
 `
 
@@ -496,15 +534,18 @@ func (q *Queries) DeleteManyCalSub(ctx context.Context, arg DeleteManyCalSubPara
 }
 
 const findManyCalSubByUser = `-- name: FindManyCalSubByUser :many
-SELECT id,
+SELECT
+    id,
     NAME,
     user_id,
     disabled,
     schedule_id,
     config,
     last_access
-FROM user_calendar_subscriptions
-WHERE user_id = $1
+FROM
+    user_calendar_subscriptions
+WHERE
+    user_id = $1
 `
 
 type FindManyCalSubByUserRow struct {
@@ -549,15 +590,18 @@ func (q *Queries) FindManyCalSubByUser(ctx context.Context, userID uuid.UUID) ([
 }
 
 const findOneCalSub = `-- name: FindOneCalSub :one
-SELECT id,
+SELECT
+    id,
     NAME,
     user_id,
     disabled,
     schedule_id,
     config,
     last_access
-FROM user_calendar_subscriptions
-WHERE id = $1
+FROM
+    user_calendar_subscriptions
+WHERE
+    id = $1
 `
 
 type FindOneCalSubRow struct {
@@ -586,16 +630,19 @@ func (q *Queries) FindOneCalSub(ctx context.Context, id uuid.UUID) (FindOneCalSu
 }
 
 const findOneCalSubForUpdate = `-- name: FindOneCalSubForUpdate :one
-SELECT id,
+SELECT
+    id,
     NAME,
     user_id,
     disabled,
     schedule_id,
     config,
     last_access
-FROM user_calendar_subscriptions
-WHERE id = $1 FOR
-UPDATE
+FROM
+    user_calendar_subscriptions
+WHERE
+    id = $1
+FOR UPDATE
 `
 
 type FindOneCalSubForUpdateRow struct {
@@ -678,7 +725,8 @@ func (q *Queries) NoticeUnackedAlertsByService(ctx context.Context, dollar_1 uui
 }
 
 const now = `-- name: Now :one
-SELECT now()::timestamptz
+SELECT
+    now()::timestamptz
 `
 
 func (q *Queries) Now(ctx context.Context) (time.Time, error) {
@@ -941,12 +989,15 @@ func (q *Queries) StatusMgrUpdateSub(ctx context.Context, arg StatusMgrUpdateSub
 }
 
 const updateCalSub = `-- name: UpdateCalSub :exec
-UPDATE user_calendar_subscriptions
-SET NAME = $1,
+UPDATE
+    user_calendar_subscriptions
+SET
+    NAME = $1,
     disabled = $2,
     config = $3,
     last_update = now()
-WHERE id = $4
+WHERE
+    id = $4
     AND user_id = $5
 `
 

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -605,6 +605,7 @@ type ComplexityRoot struct {
 
 	UserCalendarSubscription struct {
 		Disabled        func(childComplexity int) int
+		FullSchedule    func(childComplexity int) int
 		ID              func(childComplexity int) int
 		LastAccess      func(childComplexity int) int
 		Name            func(childComplexity int) int
@@ -861,6 +862,7 @@ type UserResolver interface {
 }
 type UserCalendarSubscriptionResolver interface {
 	ReminderMinutes(ctx context.Context, obj *calsub.Subscription) ([]int, error)
+	FullSchedule(ctx context.Context, obj *calsub.Subscription) (bool, error)
 
 	Schedule(ctx context.Context, obj *calsub.Subscription) (*schedule.Schedule, error)
 
@@ -3675,6 +3677,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.UserCalendarSubscription.Disabled(childComplexity), true
+
+	case "UserCalendarSubscription.fullSchedule":
+		if e.complexity.UserCalendarSubscription.FullSchedule == nil {
+			break
+		}
+
+		return e.complexity.UserCalendarSubscription.FullSchedule(childComplexity), true
 
 	case "UserCalendarSubscription.id":
 		if e.complexity.UserCalendarSubscription.ID == nil {
@@ -12678,6 +12687,8 @@ func (ec *executionContext) fieldContext_Mutation_createUserCalendarSubscription
 				return ec.fieldContext_UserCalendarSubscription_name(ctx, field)
 			case "reminderMinutes":
 				return ec.fieldContext_UserCalendarSubscription_reminderMinutes(ctx, field)
+			case "fullSchedule":
+				return ec.fieldContext_UserCalendarSubscription_fullSchedule(ctx, field)
 			case "scheduleID":
 				return ec.fieldContext_UserCalendarSubscription_scheduleID(ctx, field)
 			case "schedule":
@@ -15783,6 +15794,8 @@ func (ec *executionContext) fieldContext_Query_userCalendarSubscription(ctx cont
 				return ec.fieldContext_UserCalendarSubscription_name(ctx, field)
 			case "reminderMinutes":
 				return ec.fieldContext_UserCalendarSubscription_reminderMinutes(ctx, field)
+			case "fullSchedule":
+				return ec.fieldContext_UserCalendarSubscription_fullSchedule(ctx, field)
 			case "scheduleID":
 				return ec.fieldContext_UserCalendarSubscription_scheduleID(ctx, field)
 			case "schedule":
@@ -22434,6 +22447,8 @@ func (ec *executionContext) fieldContext_User_calendarSubscriptions(ctx context.
 				return ec.fieldContext_UserCalendarSubscription_name(ctx, field)
 			case "reminderMinutes":
 				return ec.fieldContext_UserCalendarSubscription_reminderMinutes(ctx, field)
+			case "fullSchedule":
+				return ec.fieldContext_UserCalendarSubscription_fullSchedule(ctx, field)
 			case "scheduleID":
 				return ec.fieldContext_UserCalendarSubscription_scheduleID(ctx, field)
 			case "schedule":
@@ -22830,6 +22845,50 @@ func (ec *executionContext) fieldContext_UserCalendarSubscription_reminderMinute
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserCalendarSubscription_fullSchedule(ctx context.Context, field graphql.CollectedField, obj *calsub.Subscription) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UserCalendarSubscription_fullSchedule(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.UserCalendarSubscription().FullSchedule(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UserCalendarSubscription_fullSchedule(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserCalendarSubscription",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -27438,7 +27497,7 @@ func (ec *executionContext) unmarshalInputCreateUserCalendarSubscriptionInput(ct
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "reminderMinutes", "scheduleID", "disabled"}
+	fieldsInOrder := [...]string{"name", "reminderMinutes", "scheduleID", "disabled", "fullSchedule"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -27481,6 +27540,15 @@ func (ec *executionContext) unmarshalInputCreateUserCalendarSubscriptionInput(ct
 				return it, err
 			}
 			it.Disabled = data
+		case "fullSchedule":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("fullSchedule"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FullSchedule = data
 		}
 	}
 
@@ -29925,7 +29993,7 @@ func (ec *executionContext) unmarshalInputUpdateUserCalendarSubscriptionInput(ct
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "name", "reminderMinutes", "disabled"}
+	fieldsInOrder := [...]string{"id", "name", "reminderMinutes", "disabled", "fullSchedule"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -29968,6 +30036,15 @@ func (ec *executionContext) unmarshalInputUpdateUserCalendarSubscriptionInput(ct
 				return it, err
 			}
 			it.Disabled = data
+		case "fullSchedule":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("fullSchedule"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FullSchedule = data
 		}
 	}
 
@@ -36625,6 +36702,42 @@ func (ec *executionContext) _UserCalendarSubscription(ctx context.Context, sel a
 					}
 				}()
 				res = ec._UserCalendarSubscription_reminderMinutes(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "fullSchedule":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UserCalendarSubscription_fullSchedule(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/graphql2/graphqlapp/calendarsubscription.go
+++ b/graphql2/graphqlapp/calendarsubscription.go
@@ -21,6 +21,9 @@ func (a *App) UserCalendarSubscription() graphql2.UserCalendarSubscriptionResolv
 func (a *UserCalendarSubscription) ReminderMinutes(ctx context.Context, obj *calsub.Subscription) ([]int, error) {
 	return obj.Config.ReminderMinutes, nil
 }
+func (a *UserCalendarSubscription) FullSchedule(ctx context.Context, obj *calsub.Subscription) (bool, error) {
+	return obj.Config.FullSchedule, nil
+}
 
 func (a *UserCalendarSubscription) Schedule(ctx context.Context, obj *calsub.Subscription) (*schedule.Schedule, error) {
 	return a.ScheduleStore.FindOne(ctx, obj.ScheduleID)
@@ -55,6 +58,9 @@ func (m *Mutation) CreateUserCalendarSubscription(ctx context.Context, input gra
 		cs.Disabled = *input.Disabled
 	}
 	cs.Config.ReminderMinutes = input.ReminderMinutes
+	if input.FullSchedule != nil {
+		cs.Config.FullSchedule = *input.FullSchedule
+	}
 	err = withContextTx(ctx, m.DB, func(ctx context.Context, tx *sql.Tx) error {
 		var err error
 		cs, err = m.CalSubStore.CreateTx(ctx, tx, cs)
@@ -79,6 +85,9 @@ func (m *Mutation) UpdateUserCalendarSubscription(ctx context.Context, input gra
 		}
 		if input.ReminderMinutes != nil {
 			cs.Config.ReminderMinutes = input.ReminderMinutes
+		}
+		if input.FullSchedule != nil {
+			cs.Config.FullSchedule = *input.FullSchedule
 		}
 
 		return m.CalSubStore.UpdateTx(ctx, tx, cs)

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -188,6 +188,7 @@ type CreateUserCalendarSubscriptionInput struct {
 	ReminderMinutes []int  `json:"reminderMinutes,omitempty"`
 	ScheduleID      string `json:"scheduleID"`
 	Disabled        *bool  `json:"disabled,omitempty"`
+	FullSchedule    *bool  `json:"fullSchedule,omitempty"`
 }
 
 type CreateUserContactMethodInput struct {
@@ -629,6 +630,7 @@ type UpdateUserCalendarSubscriptionInput struct {
 	Name            *string `json:"name,omitempty"`
 	ReminderMinutes []int   `json:"reminderMinutes,omitempty"`
 	Disabled        *bool   `json:"disabled,omitempty"`
+	FullSchedule    *bool   `json:"fullSchedule,omitempty"`
 }
 
 type UpdateUserContactMethodInput struct {

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -628,17 +628,20 @@ input CreateUserCalendarSubscriptionInput {
   reminderMinutes: [Int!]
   scheduleID: ID!
   disabled: Boolean
+  fullSchedule: Boolean
 }
 input UpdateUserCalendarSubscriptionInput {
   id: ID!
   name: String
   reminderMinutes: [Int!]
   disabled: Boolean
+  fullSchedule: Boolean
 }
 type UserCalendarSubscription {
   id: ID!
   name: String!
   reminderMinutes: [Int!]!
+  fullSchedule: Boolean!
   scheduleID: ID!
   schedule: Schedule
   lastAccess: ISOTimestamp!

--- a/web/src/app/schedules/calendar-subscribe/CalendarSubscribeCreateDialog.js
+++ b/web/src/app/schedules/calendar-subscribe/CalendarSubscribeCreateDialog.js
@@ -54,6 +54,7 @@ export default function CalendarSubscribeCreateDialog(props) {
     name: '',
     scheduleID: props.scheduleID || null,
     reminderMinutes: [],
+    fullSchedule: false,
   })
 
   const [createSubscription, status] = useMutation(mutation, {
@@ -63,6 +64,7 @@ export default function CalendarSubscribeCreateDialog(props) {
         name: value.name,
         reminderMinutes: [0], // default reminder at shift start time
         disabled: false,
+        fullSchedule: value.fullSchedule,
       },
     },
   })

--- a/web/src/app/schedules/calendar-subscribe/CalendarSubscribeEditDialog.js
+++ b/web/src/app/schedules/calendar-subscribe/CalendarSubscribeEditDialog.js
@@ -14,6 +14,7 @@ const query = gql`
       id
       name
       scheduleID
+      fullSchedule
     }
   }
 `
@@ -31,6 +32,7 @@ export function CalendarSubscribeEditDialogContent(props) {
   const [value, setValue] = useState({
     name: _.get(data, 'name', ''),
     scheduleID: _.get(data, 'scheduleID', null),
+    fullSchedule: _.get(data, 'fullSchedule', false),
   })
 
   // setup the mutation
@@ -39,6 +41,7 @@ export function CalendarSubscribeEditDialogContent(props) {
       input: {
         id: props.data.id,
         name: value.name,
+        fullSchedule: value.fullSchedule,
       },
     },
     onCompleted: () => props.onClose(),

--- a/web/src/app/schedules/calendar-subscribe/CalendarSubscribeForm.js
+++ b/web/src/app/schedules/calendar-subscribe/CalendarSubscribeForm.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { PropTypes as p } from 'prop-types'
 import { FormContainer, FormField } from '../../forms'
-import { Grid, TextField } from '@mui/material'
+import { Checkbox, FormControlLabel, Grid, TextField } from '@mui/material'
 import { ScheduleSelect } from '../../selection'
 
 export default function CalendarSubscribeForm(props) {
@@ -33,6 +33,15 @@ export default function CalendarSubscribeForm(props) {
             required
             label='Schedule'
             name='scheduleID'
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <FormControlLabel
+            control={
+              <FormField component={Checkbox} checkbox name='fullSchedule' />
+            }
+            label='Include all user shifts (full schedule)'
+            labelPlacement='end'
           />
         </Grid>
       </Grid>

--- a/web/src/app/schedules/calendar-subscribe/CalendarSubscribeForm.js
+++ b/web/src/app/schedules/calendar-subscribe/CalendarSubscribeForm.js
@@ -40,7 +40,7 @@ export default function CalendarSubscribeForm(props) {
             control={
               <FormField component={Checkbox} checkbox name='fullSchedule' />
             }
-            label='Include all user shifts (full schedule)'
+            label='Include on-call shifts of other users'
             labelPlacement='end'
           />
         </Grid>

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -470,6 +470,7 @@ export interface CreateUserCalendarSubscriptionInput {
   reminderMinutes?: null | number[]
   scheduleID: string
   disabled?: null | boolean
+  fullSchedule?: null | boolean
 }
 
 export interface UpdateUserCalendarSubscriptionInput {
@@ -477,12 +478,14 @@ export interface UpdateUserCalendarSubscriptionInput {
   name?: null | string
   reminderMinutes?: null | number[]
   disabled?: null | boolean
+  fullSchedule?: null | boolean
 }
 
 export interface UserCalendarSubscription {
   id: string
   name: string
   reminderMinutes: number[]
+  fullSchedule: boolean
   scheduleID: string
   schedule?: null | Schedule
   lastAccess: ISOTimestamp


### PR DESCRIPTION
**Description:**
This PR introduces full schedule configuration support to GoAlert. With this change, users can now generate a calendar subscription that includes all team members' shifts for a specified schedule. This enhances visibility and allows easier management of on-call schedules in external calendar applications like Google Calendar.

Existing subscriptions can be changed to enable or disable this feature.

**Which issue(s) this PR fixes:**
Fixes #3061

**Out of Scope:**
No items are considered out of scope for this PR.

**Screenshots:**
![image](https://github.com/target/goalert/assets/595010/3ba0193d-137a-4cd0-b07e-49db261e2d6c)



**Describe any introduced user-facing changes:**
A new `fullSchedule` field has been added to the calendar subscription options. When enabled, the calendar event label changes from "On-Call \<App Name\>: \<Schedule Name\>" to "\<User Name\> On-Call \<App Name\>: \<Schedule Name\>". This option includes shifts for all users on the schedule, not just the current user.

**Describe any introduced API changes:**
- Added `fullSchedule` field to the calendar subscription API.

**Additional Info:**
This feature was developed in response to community feedback and similar requests over time.
