### PR TITLE
apikey: cache policy info lookup & last usage updates

### DIFF
--- a/apikey/lastusedcache.go
+++ b/apikey/lastusedcache.go
@@ -1,0 +1,34 @@
+package apikey
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/golang/groupcache/lru"
+	"github.com/google/uuid"
+)
+
+type lastUsedCache struct {
+	lru *lru.Cache
+
+	mx         sync.Mutex
+	updateFunc func(ctx context.Context, id uuid.UUID, ua, ip string) error
+}
+
+func newLastUsedCache(max int, updateFunc func(ctx context.Context, id uuid.UUID, ua, ip string) error) *lastUsedCache {
+	return &lastUsedCache{
+		lru:        lru.New(max),
+		updateFunc: updateFunc,
+	}
+}
+func (c *lastUsedCache) RecordUsage(ctx context.Context, id uuid.UUID, ua, ip string) error {
+	c.mx.Lock()
+	defer c.mx.Unlock()
+	if t, ok := c.lru.Get(id); ok && time.Since(t.(time.Time)) < time.Minute {
+		return nil
+	}
+
+	c.lru.Add(id, time.Now())
+	return c.updateFunc(ctx, id, ua, ip)
+}

--- a/apikey/lastusedcache.go
+++ b/apikey/lastusedcache.go
@@ -25,6 +25,8 @@ func newLastUsedCache(max int, updateFunc func(ctx context.Context, id uuid.UUID
 func (c *lastUsedCache) RecordUsage(ctx context.Context, id uuid.UUID, ua, ip string) error {
 	c.mx.Lock()
 	defer c.mx.Unlock()
+
+	// check if we've seen this key recently, and if it's been less than a minute
 	if t, ok := c.lru.Get(id); ok && time.Since(t.(time.Time)) < time.Minute {
 		return nil
 	}

--- a/apikey/polcache.go
+++ b/apikey/polcache.go
@@ -72,7 +72,7 @@ func (c *polCache) Get(ctx context.Context, key uuid.UUID) (value *policyInfo, o
 
 		// Since each key has a unique ID and is signed, we can
 		// safely assume that an invalid key will always be invalid
-		// and can be cached.
+		// and can be negatively cached.
 		if !isValid {
 			c.neg.Add(key, nil)
 			c.lru.Remove(key)
@@ -84,7 +84,7 @@ func (c *polCache) Get(ctx context.Context, key uuid.UUID) (value *policyInfo, o
 
 	// If the key is not in the cache, we need to fetch it,
 	// and add it to the cache. We can safely assume that
-	// the key is valid, when returned from the FillFunc.
+	// the key is valid when returned from the FillFunc.
 	value, isValid, err := c.cfg.FillFunc(ctx, key)
 	if err != nil {
 		return value, false, err

--- a/apikey/polcache.go
+++ b/apikey/polcache.go
@@ -1,0 +1,111 @@
+package apikey
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sync"
+
+	"github.com/golang/groupcache/lru"
+	"github.com/google/uuid"
+	"github.com/target/goalert/gadb"
+)
+
+// polCache handles caching of policyInfo objects, as well as negative caching
+// of invalid keys.
+type polCache struct {
+	lru *lru.Cache
+	neg *lru.Cache
+	mx  sync.Mutex
+
+	cfg polCacheConfig
+}
+
+type polCacheConfig struct {
+	FillFunc func(context.Context, uuid.UUID) (*policyInfo, bool, error)
+	Verify   func(context.Context, uuid.UUID) (bool, error)
+	MaxSize  int
+}
+
+func newPolCache(cfg polCacheConfig) *polCache {
+	return &polCache{
+		lru: lru.New(cfg.MaxSize),
+		neg: lru.New(cfg.MaxSize),
+		cfg: cfg,
+	}
+}
+
+// Revoke will add the key to the negative cache.
+func (c *polCache) Revoke(ctx context.Context, key uuid.UUID) error {
+	c.mx.Lock()
+	defer c.mx.Unlock()
+
+	c.neg.Add(key, nil)
+	c.lru.Remove(key)
+
+	return nil
+}
+
+// Get will return the policyInfo for the given key.
+//
+// If the key is in the cache, it will be verified before returning.
+//
+// If it is not in the cache, it will be fetched and added to the cache.
+//
+// If either the key is invalid or the policy is invalid, the key will be
+// added to the negative cache.
+func (c *polCache) Get(ctx context.Context, key uuid.UUID) (value *policyInfo, ok bool, err error) {
+	c.mx.Lock()
+	defer c.mx.Unlock()
+
+	if _, ok := c.neg.Get(key); ok {
+		return value, false, nil
+	}
+
+	if v, ok := c.lru.Get(key); ok {
+		// Check if the key is still valid before returning it,
+		// if it is not valid, we can remove it from the cache.
+		isValid, err := c.cfg.Verify(ctx, key)
+		if err != nil {
+			return value, false, err
+		}
+
+		// Since each key has a unique ID and is signed, we can
+		// safely assume that an invalid key will always be invalid
+		// and can be cached.
+		if !isValid {
+			c.neg.Add(key, nil)
+			c.lru.Remove(key)
+			return value, false, nil
+		}
+
+		return v.(*policyInfo), true, nil
+	}
+
+	// If the key is not in the cache, we need to fetch it,
+	// and add it to the cache. We can safely assume that
+	// the key is valid, when returned from the FillFunc.
+	value, isValid, err := c.cfg.FillFunc(ctx, key)
+	if err != nil {
+		return value, false, err
+	}
+	if !isValid {
+		c.neg.Add(key, nil)
+		return value, false, nil
+	}
+
+	c.lru.Add(key, value)
+	return value, true, nil
+}
+
+func (s *Store) _verifyPolicyID(ctx context.Context, id uuid.UUID) (bool, error) {
+	valid, err := gadb.New(s.db).APIKeyAuthCheck(ctx, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return valid, nil
+}

--- a/apikey/polcache.go
+++ b/apikey/polcache.go
@@ -36,14 +36,12 @@ func newPolCache(cfg polCacheConfig) *polCache {
 }
 
 // Revoke will add the key to the negative cache.
-func (c *polCache) Revoke(ctx context.Context, key uuid.UUID) error {
+func (c *polCache) Revoke(ctx context.Context, key uuid.UUID) {
 	c.mx.Lock()
 	defer c.mx.Unlock()
 
 	c.neg.Add(key, nil)
 	c.lru.Remove(key)
-
-	return nil
 }
 
 // Get will return the policyInfo for the given key.

--- a/apikey/store.go
+++ b/apikey/store.go
@@ -21,6 +21,7 @@ import (
 	"github.com/target/goalert/validation/validate"
 )
 
+// Store is used to manage API keys.
 type Store struct {
 	db  *sql.DB
 	key keyring.Keyring
@@ -29,6 +30,7 @@ type Store struct {
 	lastUsedCache *lastUsedCache
 }
 
+// NewStore will create a new Store.
 func NewStore(ctx context.Context, db *sql.DB, key keyring.Keyring) (*Store, error) {
 	s := &Store{
 		db:  db,
@@ -72,7 +74,7 @@ func (s *Store) AuthorizeGraphQL(ctx context.Context, tok, ua, ip string) (conte
 		return nil, err
 	}
 	if !valid {
-		// Successful negative cache lookup, we return Unauthorized because althought the token was validated, the key was revoked/removed.
+		// Successful negative cache lookup, we return Unauthorized because although the token was validated, the key was revoked/removed.
 		return ctx, permission.Unauthorized()
 	}
 	if !bytes.Equal(info.Hash, claims.PolicyHash) {

--- a/apikey/store.go
+++ b/apikey/store.go
@@ -94,7 +94,7 @@ func (s *Store) AuthorizeGraphQL(ctx context.Context, tok, ua, ip string) (conte
 		ID:   id.String(),
 		Type: permission.SourceTypeGQLAPIKey,
 	})
-	ctx = permission.UserContext(ctx, "", permission.RoleUnknown)
+	ctx = permission.UserContext(ctx, "", info.Policy.Role)
 
 	ctx = ContextWithPolicy(ctx, &info.Policy)
 	return ctx, nil

--- a/apikey/store.go
+++ b/apikey/store.go
@@ -21,18 +21,27 @@ import (
 	"github.com/target/goalert/validation/validate"
 )
 
-// Store is used to manage API keys.
 type Store struct {
 	db  *sql.DB
 	key keyring.Keyring
+
+	polCache      *polCache
+	lastUsedCache *lastUsedCache
 }
 
-// NewStore will create a new Store.
 func NewStore(ctx context.Context, db *sql.DB, key keyring.Keyring) (*Store, error) {
 	s := &Store{
 		db:  db,
 		key: key,
 	}
+
+	s.polCache = newPolCache(polCacheConfig{
+		FillFunc: s._fetchPolicyInfo,
+		Verify:   s._verifyPolicyID,
+		MaxSize:  1000,
+	})
+
+	s.lastUsedCache = newLastUsedCache(1000, s._updateLastUsed)
 
 	return s, nil
 }
@@ -58,21 +67,24 @@ func (s *Store) AuthorizeGraphQL(ctx context.Context, tok, ua, ip string) (conte
 		return ctx, permission.Unauthorized()
 	}
 
-	info, valid, err := s._fetchPolicyInfo(ctx, id)
+	info, valid, err := s.polCache.Get(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 	if !valid {
-		// Successful negative cache lookup, we return Unauthorized because although the token was validated, the key was revoked/removed.
+		// Successful negative cache lookup, we return Unauthorized because althought the token was validated, the key was revoked/removed.
 		return ctx, permission.Unauthorized()
 	}
 	if !bytes.Equal(info.Hash, claims.PolicyHash) {
+		// Successful cache lookup, but the policy has changed since the token was issued and so the token is no longer valid.
+		s.polCache.Revoke(ctx, id)
+
 		// We want to log this as a warning, because it is a potential security issue.
 		log.Log(ctx, fmt.Errorf("apikey: policy hash mismatch for key %s", id))
 		return ctx, permission.Unauthorized()
 	}
 
-	err = s._updateLastUsed(ctx, id, ua, ip)
+	err = s.lastUsedCache.RecordUsage(ctx, id, ua, ip)
 	if err != nil {
 		// Recording usage is not critical, so we log the error and continue.
 		log.Log(ctx, err)
@@ -82,7 +94,7 @@ func (s *Store) AuthorizeGraphQL(ctx context.Context, tok, ua, ip string) (conte
 		ID:   id.String(),
 		Type: permission.SourceTypeGQLAPIKey,
 	})
-	ctx = permission.UserContext(ctx, "", info.Policy.Role)
+	ctx = permission.UserContext(ctx, "", permission.RoleUnknown)
 
 	ctx = ContextWithPolicy(ctx, &info.Policy)
 	return ctx, nil


### PR DESCRIPTION
**Description:**
This PR adds a cache for API key policy info and last-usage updates.

This ensures that last-used info isn't updated more than once per minute (per instance). The policy cache ensures that repeated use of the same key doesn't require fetching and parsing the policy JSON for each request.

Additionally, invalid keys (that otherwise have a valid signature) are put in a negative cache. This means when a key is deleted, only the first request will require a DB lookup and subsequent requests from the same key will be rejected immediately.

**Which issue(s) this PR fixes:**
Part of #3007 
