### PR TITLE
apikey: add list and update of graphql api keys

### DIFF
--- a/apikey/queries.sql
+++ b/apikey/queries.sql
@@ -8,6 +8,7 @@ UPDATE
 SET
     name = $2,
     description = $3,
+    updated_at = now(),
     updated_by = $4
 WHERE
     id = $1;

--- a/apikey/queries.sql
+++ b/apikey/queries.sql
@@ -25,8 +25,13 @@ WHERE
 FOR UPDATE;
 
 -- name: APIKeyDelete :exec
-DELETE FROM gql_api_keys
-WHERE id = $1;
+UPDATE
+    gql_api_keys
+SET
+    deleted_at = now(),
+    deleted_by = $2
+WHERE
+    id = $1;
 
 -- name: APIKeyRecordUsage :exec
 -- APIKeyRecordUsage records the usage of an API key.

--- a/apikey/queries.sql
+++ b/apikey/queries.sql
@@ -2,6 +2,27 @@
 INSERT INTO gql_api_keys(id, name, description, POLICY, created_by, updated_by, expires_at)
         VALUES ($1, $2, $3, $4, $5, $6, $7);
 
+-- name: APIKeyUpdate :exec
+UPDATE
+    gql_api_keys
+SET
+    name = $2,
+    description = $3,
+    updated_by = $4
+WHERE
+    id = $1;
+
+-- name: APIKeyForUpdate :one
+SELECT
+    name,
+    description
+FROM
+    gql_api_keys
+WHERE
+    id = $1
+    AND deleted_at IS NULL
+FOR UPDATE;
+
 -- name: APIKeyDelete :exec
 DELETE FROM gql_api_keys
 WHERE id = $1;
@@ -34,4 +55,17 @@ WHERE
     gql_api_keys.id = $1
     AND gql_api_keys.deleted_at IS NULL
     AND gql_api_keys.expires_at > now();
+
+-- name: APIKeyList :many
+-- APIKeyList returns all API keys, along with the last time they were used.
+SELECT
+    gql_api_keys.*,
+    gql_api_key_usage.used_at AS last_used_at,
+    gql_api_key_usage.user_agent AS last_user_agent,
+    gql_api_key_usage.ip_address AS last_ip_address
+FROM
+    gql_api_keys
+    LEFT JOIN gql_api_key_usage ON gql_api_keys.id = gql_api_key_usage.api_key_id
+WHERE
+    gql_api_keys.deleted_at IS NULL;
 

--- a/apikey/store.go
+++ b/apikey/store.go
@@ -17,6 +17,7 @@ import (
 	"github.com/target/goalert/keyring"
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/util/log"
+	"github.com/target/goalert/util/sqlutil"
 	"github.com/target/goalert/validation"
 	"github.com/target/goalert/validation/validate"
 )
@@ -35,6 +36,138 @@ func NewStore(ctx context.Context, db *sql.DB, key keyring.Keyring) (*Store, err
 	}
 
 	return s, nil
+}
+
+type APIKeyInfo struct {
+	ID            uuid.UUID
+	Name          string
+	Description   string
+	ExpiresAt     time.Time
+	LastUsed      *APIKeyUsage
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	CreatedBy     *uuid.UUID
+	UpdatedBy     *uuid.UUID
+	AllowedFields []string
+}
+
+func (s *Store) FindAllAdminGraphQLKeys(ctx context.Context) ([]APIKeyInfo, error) {
+	err := permission.LimitCheckAny(ctx, permission.Admin)
+	if err != nil {
+		return nil, err
+	}
+
+	keys, err := gadb.New(s.db).APIKeyList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]APIKeyInfo, 0, len(keys))
+	for _, k := range keys {
+		k := k
+
+		var p GQLPolicy
+		err = json.Unmarshal(k.Policy, &p)
+		if err != nil {
+			log.Log(ctx, fmt.Errorf("invalid policy for key %s: %w", k.ID, err))
+			continue
+		}
+		if p.Version != 1 {
+			log.Log(ctx, fmt.Errorf("unknown policy version for key %s: %d", k.ID, p.Version))
+			continue
+		}
+
+		var lastUsed *APIKeyUsage
+		if k.LastUsedAt.Valid {
+			var ip string
+			if k.LastIpAddress.Valid {
+				ip = k.LastIpAddress.IPNet.IP.String()
+			}
+			lastUsed = &APIKeyUsage{
+				UserAgent: k.LastUserAgent.String,
+				IP:        ip,
+				Time:      k.LastUsedAt.Time,
+			}
+		}
+
+		res = append(res, APIKeyInfo{
+			ID:            k.ID,
+			Name:          k.Name,
+			Description:   k.Description,
+			ExpiresAt:     k.ExpiresAt,
+			LastUsed:      lastUsed,
+			CreatedAt:     k.CreatedAt,
+			UpdatedAt:     k.UpdatedAt,
+			CreatedBy:     &k.CreatedBy.UUID,
+			UpdatedBy:     &k.UpdatedBy.UUID,
+			AllowedFields: p.AllowedFields,
+		})
+	}
+
+	return res, nil
+}
+
+type APIKeyUsage struct {
+	UserAgent string
+	IP        string
+	Time      time.Time
+}
+
+type UpdateKey struct {
+	ID          uuid.UUID
+	Name        string
+	Description string
+}
+
+func (s *Store) UpdateAdminGraphQLKey(ctx context.Context, id uuid.UUID, name, desc *string) error {
+	err := permission.LimitCheckAny(ctx, permission.Admin)
+	if err != nil {
+		return err
+	}
+
+	if name != nil {
+		err = validate.IDName("Name", *name)
+	}
+	if desc != nil {
+		err = validate.Many(err, validate.Text("Description", *desc, 0, 255))
+	}
+	if err != nil {
+		return err
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer sqlutil.Rollback(ctx, "UpdateAdminGraphQLKey", tx)
+
+	key, err := gadb.New(tx).APIKeyForUpdate(ctx, id)
+	if err != nil {
+		return err
+	}
+	if name != nil {
+		key.Name = *name
+	}
+	if desc != nil {
+		key.Description = *desc
+	}
+
+	var user uuid.NullUUID
+	if u, err := uuid.Parse(permission.UserID(ctx)); err == nil {
+		user = uuid.NullUUID{UUID: u, Valid: true}
+	}
+
+	err = gadb.New(tx).APIKeyUpdate(ctx, gadb.APIKeyUpdateParams{
+		ID:          id,
+		Name:        key.Name,
+		Description: key.Description,
+		UpdatedBy:   user,
+	})
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit()
 }
 
 func (s *Store) DeleteAdminGraphQLKey(ctx context.Context, id uuid.UUID) error {

--- a/apikey/store.go
+++ b/apikey/store.go
@@ -176,7 +176,15 @@ func (s *Store) DeleteAdminGraphQLKey(ctx context.Context, id uuid.UUID) error {
 		return err
 	}
 
-	return gadb.New(s.db).APIKeyDelete(ctx, id)
+	var byID uuid.NullUUID
+	if id, err := uuid.Parse(permission.UserID(ctx)); err == nil {
+		byID = uuid.NullUUID{UUID: id, Valid: true}
+	}
+
+	return gadb.New(s.db).APIKeyDelete(ctx, gadb.APIKeyDeleteParams{
+		DeletedBy: byID,
+		ID:        id,
+	})
 }
 
 func (s *Store) AuthorizeGraphQL(ctx context.Context, tok, ua, ip string) (context.Context, error) {

--- a/gadb/queries.sql.go
+++ b/gadb/queries.sql.go
@@ -63,6 +63,30 @@ func (q *Queries) APIKeyDelete(ctx context.Context, id uuid.UUID) error {
 	return err
 }
 
+const aPIKeyForUpdate = `-- name: APIKeyForUpdate :one
+SELECT
+    name,
+    description
+FROM
+    gql_api_keys
+WHERE
+    id = $1
+    AND deleted_at IS NULL
+FOR UPDATE
+`
+
+type APIKeyForUpdateRow struct {
+	Name        string
+	Description string
+}
+
+func (q *Queries) APIKeyForUpdate(ctx context.Context, id uuid.UUID) (APIKeyForUpdateRow, error) {
+	row := q.db.QueryRowContext(ctx, aPIKeyForUpdate, id)
+	var i APIKeyForUpdateRow
+	err := row.Scan(&i.Name, &i.Description)
+	return i, err
+}
+
 const aPIKeyInsert = `-- name: APIKeyInsert :exec
 INSERT INTO gql_api_keys(id, name, description, POLICY, created_by, updated_by, expires_at)
         VALUES ($1, $2, $3, $4, $5, $6, $7)
@@ -91,6 +115,75 @@ func (q *Queries) APIKeyInsert(ctx context.Context, arg APIKeyInsertParams) erro
 	return err
 }
 
+const aPIKeyList = `-- name: APIKeyList :many
+SELECT
+    gql_api_keys.created_at, gql_api_keys.created_by, gql_api_keys.deleted_at, gql_api_keys.deleted_by, gql_api_keys.description, gql_api_keys.expires_at, gql_api_keys.id, gql_api_keys.name, gql_api_keys.policy, gql_api_keys.updated_at, gql_api_keys.updated_by,
+    gql_api_key_usage.used_at AS last_used_at,
+    gql_api_key_usage.user_agent AS last_user_agent,
+    gql_api_key_usage.ip_address AS last_ip_address
+FROM
+    gql_api_keys
+    LEFT JOIN gql_api_key_usage ON gql_api_keys.id = gql_api_key_usage.api_key_id
+WHERE
+    gql_api_keys.deleted_at IS NULL
+`
+
+type APIKeyListRow struct {
+	CreatedAt     time.Time
+	CreatedBy     uuid.NullUUID
+	DeletedAt     sql.NullTime
+	DeletedBy     uuid.NullUUID
+	Description   string
+	ExpiresAt     time.Time
+	ID            uuid.UUID
+	Name          string
+	Policy        json.RawMessage
+	UpdatedAt     time.Time
+	UpdatedBy     uuid.NullUUID
+	LastUsedAt    sql.NullTime
+	LastUserAgent sql.NullString
+	LastIpAddress pqtype.Inet
+}
+
+// APIKeyList returns all API keys, along with the last time they were used.
+func (q *Queries) APIKeyList(ctx context.Context) ([]APIKeyListRow, error) {
+	rows, err := q.db.QueryContext(ctx, aPIKeyList)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []APIKeyListRow
+	for rows.Next() {
+		var i APIKeyListRow
+		if err := rows.Scan(
+			&i.CreatedAt,
+			&i.CreatedBy,
+			&i.DeletedAt,
+			&i.DeletedBy,
+			&i.Description,
+			&i.ExpiresAt,
+			&i.ID,
+			&i.Name,
+			&i.Policy,
+			&i.UpdatedAt,
+			&i.UpdatedBy,
+			&i.LastUsedAt,
+			&i.LastUserAgent,
+			&i.LastIpAddress,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const aPIKeyRecordUsage = `-- name: APIKeyRecordUsage :exec
 INSERT INTO gql_api_key_usage(api_key_id, user_agent, ip_address)
     VALUES ($1::uuid, $2::text, $3::inet)
@@ -108,6 +201,34 @@ type APIKeyRecordUsageParams struct {
 // APIKeyRecordUsage records the usage of an API key.
 func (q *Queries) APIKeyRecordUsage(ctx context.Context, arg APIKeyRecordUsageParams) error {
 	_, err := q.db.ExecContext(ctx, aPIKeyRecordUsage, arg.KeyID, arg.UserAgent, arg.IpAddress)
+	return err
+}
+
+const aPIKeyUpdate = `-- name: APIKeyUpdate :exec
+UPDATE
+    gql_api_keys
+SET
+    name = $2,
+    description = $3,
+    updated_by = $4
+WHERE
+    id = $1
+`
+
+type APIKeyUpdateParams struct {
+	ID          uuid.UUID
+	Name        string
+	Description string
+	UpdatedBy   uuid.NullUUID
+}
+
+func (q *Queries) APIKeyUpdate(ctx context.Context, arg APIKeyUpdateParams) error {
+	_, err := q.db.ExecContext(ctx, aPIKeyUpdate,
+		arg.ID,
+		arg.Name,
+		arg.Description,
+		arg.UpdatedBy,
+	)
 	return err
 }
 

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -28310,7 +28310,7 @@ func (ec *executionContext) unmarshalInputCreateGQLAPIKeyInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "description", "allowedFields", "expiresAt"}
+	fieldsInOrder := [...]string{"name", "description", "allowedFields", "expiresAt", "role"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -28353,6 +28353,15 @@ func (ec *executionContext) unmarshalInputCreateGQLAPIKeyInput(ctx context.Conte
 				return it, err
 			}
 			it.ExpiresAt = data
+		case "role":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("role"))
+			data, err := ec.unmarshalNUserRole2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐUserRole(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Role = data
 		}
 	}
 

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -66,6 +66,7 @@ type ResolverRoot interface {
 	AlertMetric() AlertMetricResolver
 	EscalationPolicy() EscalationPolicyResolver
 	EscalationPolicyStep() EscalationPolicyStepResolver
+	GQLAPIKey() GQLAPIKeyResolver
 	HeartbeatMonitor() HeartbeatMonitorResolver
 	IntegrationKey() IntegrationKeyResolver
 	MessageLogConnectionStats() MessageLogConnectionStatsResolver
@@ -234,6 +235,26 @@ type ComplexityRoot struct {
 		Targets          func(childComplexity int) int
 	}
 
+	GQLAPIKey struct {
+		AllowedFields func(childComplexity int) int
+		CreatedAt     func(childComplexity int) int
+		CreatedBy     func(childComplexity int) int
+		Description   func(childComplexity int) int
+		ExpiresAt     func(childComplexity int) int
+		ID            func(childComplexity int) int
+		LastUsed      func(childComplexity int) int
+		Name          func(childComplexity int) int
+		Token         func(childComplexity int) int
+		UpdatedAt     func(childComplexity int) int
+		UpdatedBy     func(childComplexity int) int
+	}
+
+	GQLAPIKeyUsage struct {
+		IP   func(childComplexity int) int
+		Time func(childComplexity int) int
+		Ua   func(childComplexity int) int
+	}
+
 	HeartbeatMonitor struct {
 		Href           func(childComplexity int) int
 		ID             func(childComplexity int) int
@@ -331,6 +352,7 @@ type ComplexityRoot struct {
 		UpdateBasicAuth                    func(childComplexity int, input UpdateBasicAuthInput) int
 		UpdateEscalationPolicy             func(childComplexity int, input UpdateEscalationPolicyInput) int
 		UpdateEscalationPolicyStep         func(childComplexity int, input UpdateEscalationPolicyStepInput) int
+		UpdateGQLAPIKey                    func(childComplexity int, input UpdateGQLAPIKeyInput) int
 		UpdateHeartbeatMonitor             func(childComplexity int, input UpdateHeartbeatMonitorInput) int
 		UpdateRotation                     func(childComplexity int, input UpdateRotationInput) int
 		UpdateSchedule                     func(childComplexity int, input UpdateScheduleInput) int
@@ -397,6 +419,7 @@ type ComplexityRoot struct {
 		EscalationPolicy         func(childComplexity int, id string) int
 		ExperimentalFlags        func(childComplexity int) int
 		GenerateSlackAppManifest func(childComplexity int) int
+		GqlAPIKeys               func(childComplexity int) int
 		HeartbeatMonitor         func(childComplexity int, id string) int
 		IntegrationKey           func(childComplexity int, id string) int
 		IntegrationKeyTypes      func(childComplexity int) int
@@ -702,6 +725,11 @@ type EscalationPolicyStepResolver interface {
 	Targets(ctx context.Context, obj *escalation.Step) ([]assignment.RawTarget, error)
 	EscalationPolicy(ctx context.Context, obj *escalation.Step) (*escalation.Policy, error)
 }
+type GQLAPIKeyResolver interface {
+	CreatedBy(ctx context.Context, obj *GQLAPIKey) (*user.User, error)
+
+	UpdatedBy(ctx context.Context, obj *GQLAPIKey) (*user.User, error)
+}
 type HeartbeatMonitorResolver interface {
 	TimeoutMinutes(ctx context.Context, obj *heartbeat.Monitor) (int, error)
 
@@ -763,6 +791,7 @@ type MutationResolver interface {
 	SetConfig(ctx context.Context, input []ConfigValueInput) (bool, error)
 	SetSystemLimits(ctx context.Context, input []SystemLimitInput) (bool, error)
 	CreateGQLAPIKey(ctx context.Context, input CreateGQLAPIKeyInput) (*CreatedGQLAPIKey, error)
+	UpdateGQLAPIKey(ctx context.Context, input UpdateGQLAPIKeyInput) (bool, error)
 	DeleteGQLAPIKey(ctx context.Context, id string) (bool, error)
 	CreateBasicAuth(ctx context.Context, input CreateBasicAuthInput) (bool, error)
 	UpdateBasicAuth(ctx context.Context, input UpdateBasicAuthInput) (bool, error)
@@ -815,6 +844,7 @@ type QueryResolver interface {
 	GenerateSlackAppManifest(ctx context.Context) (string, error)
 	LinkAccountInfo(ctx context.Context, token string) (*LinkAccountInfo, error)
 	SwoStatus(ctx context.Context) (*SWOStatus, error)
+	GqlAPIKeys(ctx context.Context) ([]GQLAPIKey, error)
 	ListGQLFields(ctx context.Context, query *string) ([]string, error)
 }
 type RotationResolver interface {
@@ -1500,6 +1530,104 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.EscalationPolicyStep.Targets(childComplexity), true
 
+	case "GQLAPIKey.allowedFields":
+		if e.complexity.GQLAPIKey.AllowedFields == nil {
+			break
+		}
+
+		return e.complexity.GQLAPIKey.AllowedFields(childComplexity), true
+
+	case "GQLAPIKey.createdAt":
+		if e.complexity.GQLAPIKey.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.GQLAPIKey.CreatedAt(childComplexity), true
+
+	case "GQLAPIKey.createdBy":
+		if e.complexity.GQLAPIKey.CreatedBy == nil {
+			break
+		}
+
+		return e.complexity.GQLAPIKey.CreatedBy(childComplexity), true
+
+	case "GQLAPIKey.description":
+		if e.complexity.GQLAPIKey.Description == nil {
+			break
+		}
+
+		return e.complexity.GQLAPIKey.Description(childComplexity), true
+
+	case "GQLAPIKey.expiresAt":
+		if e.complexity.GQLAPIKey.ExpiresAt == nil {
+			break
+		}
+
+		return e.complexity.GQLAPIKey.ExpiresAt(childComplexity), true
+
+	case "GQLAPIKey.id":
+		if e.complexity.GQLAPIKey.ID == nil {
+			break
+		}
+
+		return e.complexity.GQLAPIKey.ID(childComplexity), true
+
+	case "GQLAPIKey.lastUsed":
+		if e.complexity.GQLAPIKey.LastUsed == nil {
+			break
+		}
+
+		return e.complexity.GQLAPIKey.LastUsed(childComplexity), true
+
+	case "GQLAPIKey.name":
+		if e.complexity.GQLAPIKey.Name == nil {
+			break
+		}
+
+		return e.complexity.GQLAPIKey.Name(childComplexity), true
+
+	case "GQLAPIKey.token":
+		if e.complexity.GQLAPIKey.Token == nil {
+			break
+		}
+
+		return e.complexity.GQLAPIKey.Token(childComplexity), true
+
+	case "GQLAPIKey.updatedAt":
+		if e.complexity.GQLAPIKey.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.GQLAPIKey.UpdatedAt(childComplexity), true
+
+	case "GQLAPIKey.updatedBy":
+		if e.complexity.GQLAPIKey.UpdatedBy == nil {
+			break
+		}
+
+		return e.complexity.GQLAPIKey.UpdatedBy(childComplexity), true
+
+	case "GQLAPIKeyUsage.ip":
+		if e.complexity.GQLAPIKeyUsage.IP == nil {
+			break
+		}
+
+		return e.complexity.GQLAPIKeyUsage.IP(childComplexity), true
+
+	case "GQLAPIKeyUsage.time":
+		if e.complexity.GQLAPIKeyUsage.Time == nil {
+			break
+		}
+
+		return e.complexity.GQLAPIKeyUsage.Time(childComplexity), true
+
+	case "GQLAPIKeyUsage.ua":
+		if e.complexity.GQLAPIKeyUsage.Ua == nil {
+			break
+		}
+
+		return e.complexity.GQLAPIKeyUsage.Ua(childComplexity), true
+
 	case "HeartbeatMonitor.href":
 		if e.complexity.HeartbeatMonitor.Href == nil {
 			break
@@ -2183,6 +2311,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.UpdateEscalationPolicyStep(childComplexity, args["input"].(UpdateEscalationPolicyStepInput)), true
 
+	case "Mutation.updateGQLAPIKey":
+		if e.complexity.Mutation.UpdateGQLAPIKey == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateGQLAPIKey_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateGQLAPIKey(childComplexity, args["input"].(UpdateGQLAPIKeyInput)), true
+
 	case "Mutation.updateHeartbeatMonitor":
 		if e.complexity.Mutation.UpdateHeartbeatMonitor == nil {
 			break
@@ -2592,6 +2732,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.GenerateSlackAppManifest(childComplexity), true
+
+	case "Query.gqlAPIKeys":
+		if e.complexity.Query.GqlAPIKeys == nil {
+			break
+		}
+
+		return e.complexity.Query.GqlAPIKeys(childComplexity), true
 
 	case "Query.heartbeatMonitor":
 		if e.complexity.Query.HeartbeatMonitor == nil {
@@ -4060,6 +4207,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdateBasicAuthInput,
 		ec.unmarshalInputUpdateEscalationPolicyInput,
 		ec.unmarshalInputUpdateEscalationPolicyStepInput,
+		ec.unmarshalInputUpdateGQLAPIKeyInput,
 		ec.unmarshalInputUpdateHeartbeatMonitorInput,
 		ec.unmarshalInputUpdateRotationInput,
 		ec.unmarshalInputUpdateScheduleInput,
@@ -4794,6 +4942,21 @@ func (ec *executionContext) field_Mutation_updateEscalationPolicy_args(ctx conte
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalNUpdateEscalationPolicyInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐUpdateEscalationPolicyInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_updateGQLAPIKey_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 UpdateGQLAPIKeyInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNUpdateGQLAPIKeyInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐUpdateGQLAPIKeyInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -9521,6 +9684,670 @@ func (ec *executionContext) fieldContext_EscalationPolicyStep_escalationPolicy(c
 	return fc, nil
 }
 
+func (ec *executionContext) _GQLAPIKey_id(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GQLAPIKey_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GQLAPIKey_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GQLAPIKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GQLAPIKey_name(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GQLAPIKey_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GQLAPIKey_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GQLAPIKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GQLAPIKey_description(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GQLAPIKey_description(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Description, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GQLAPIKey_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GQLAPIKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GQLAPIKey_createdAt(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GQLAPIKey_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNISOTimestamp2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GQLAPIKey_createdAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GQLAPIKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ISOTimestamp does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GQLAPIKey_createdBy(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GQLAPIKey_createdBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.GQLAPIKey().CreatedBy(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*user.User)
+	fc.Result = res
+	return ec.marshalOUser2ᚖgithubᚗcomᚋtargetᚋgoalertᚋuserᚐUser(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GQLAPIKey_createdBy(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GQLAPIKey",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_User_id(ctx, field)
+			case "role":
+				return ec.fieldContext_User_role(ctx, field)
+			case "name":
+				return ec.fieldContext_User_name(ctx, field)
+			case "email":
+				return ec.fieldContext_User_email(ctx, field)
+			case "contactMethods":
+				return ec.fieldContext_User_contactMethods(ctx, field)
+			case "notificationRules":
+				return ec.fieldContext_User_notificationRules(ctx, field)
+			case "calendarSubscriptions":
+				return ec.fieldContext_User_calendarSubscriptions(ctx, field)
+			case "statusUpdateContactMethodID":
+				return ec.fieldContext_User_statusUpdateContactMethodID(ctx, field)
+			case "authSubjects":
+				return ec.fieldContext_User_authSubjects(ctx, field)
+			case "sessions":
+				return ec.fieldContext_User_sessions(ctx, field)
+			case "onCallSteps":
+				return ec.fieldContext_User_onCallSteps(ctx, field)
+			case "isFavorite":
+				return ec.fieldContext_User_isFavorite(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GQLAPIKey_updatedAt(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GQLAPIKey_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNISOTimestamp2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GQLAPIKey_updatedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GQLAPIKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ISOTimestamp does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GQLAPIKey_updatedBy(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GQLAPIKey_updatedBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.GQLAPIKey().UpdatedBy(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*user.User)
+	fc.Result = res
+	return ec.marshalOUser2ᚖgithubᚗcomᚋtargetᚋgoalertᚋuserᚐUser(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GQLAPIKey_updatedBy(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GQLAPIKey",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_User_id(ctx, field)
+			case "role":
+				return ec.fieldContext_User_role(ctx, field)
+			case "name":
+				return ec.fieldContext_User_name(ctx, field)
+			case "email":
+				return ec.fieldContext_User_email(ctx, field)
+			case "contactMethods":
+				return ec.fieldContext_User_contactMethods(ctx, field)
+			case "notificationRules":
+				return ec.fieldContext_User_notificationRules(ctx, field)
+			case "calendarSubscriptions":
+				return ec.fieldContext_User_calendarSubscriptions(ctx, field)
+			case "statusUpdateContactMethodID":
+				return ec.fieldContext_User_statusUpdateContactMethodID(ctx, field)
+			case "authSubjects":
+				return ec.fieldContext_User_authSubjects(ctx, field)
+			case "sessions":
+				return ec.fieldContext_User_sessions(ctx, field)
+			case "onCallSteps":
+				return ec.fieldContext_User_onCallSteps(ctx, field)
+			case "isFavorite":
+				return ec.fieldContext_User_isFavorite(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GQLAPIKey_lastUsed(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GQLAPIKey_lastUsed(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LastUsed, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*GQLAPIKeyUsage)
+	fc.Result = res
+	return ec.marshalOGQLAPIKeyUsage2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐGQLAPIKeyUsage(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GQLAPIKey_lastUsed(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GQLAPIKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "time":
+				return ec.fieldContext_GQLAPIKeyUsage_time(ctx, field)
+			case "ua":
+				return ec.fieldContext_GQLAPIKeyUsage_ua(ctx, field)
+			case "ip":
+				return ec.fieldContext_GQLAPIKeyUsage_ip(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type GQLAPIKeyUsage", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GQLAPIKey_expiresAt(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GQLAPIKey_expiresAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ExpiresAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNISOTimestamp2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GQLAPIKey_expiresAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GQLAPIKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ISOTimestamp does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GQLAPIKey_allowedFields(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GQLAPIKey_allowedFields(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AllowedFields, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GQLAPIKey_allowedFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GQLAPIKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GQLAPIKey_token(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GQLAPIKey_token(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Token, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GQLAPIKey_token(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GQLAPIKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GQLAPIKeyUsage_time(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKeyUsage) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GQLAPIKeyUsage_time(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Time, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNISOTimestamp2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GQLAPIKeyUsage_time(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GQLAPIKeyUsage",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ISOTimestamp does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GQLAPIKeyUsage_ua(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKeyUsage) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GQLAPIKeyUsage_ua(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Ua, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GQLAPIKeyUsage_ua(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GQLAPIKeyUsage",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GQLAPIKeyUsage_ip(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKeyUsage) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GQLAPIKeyUsage_ip(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IP, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GQLAPIKeyUsage_ip(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GQLAPIKeyUsage",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _HeartbeatMonitor_id(ctx context.Context, field graphql.CollectedField, obj *heartbeat.Monitor) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_HeartbeatMonitor_id(ctx, field)
 	if err != nil {
@@ -13746,6 +14573,61 @@ func (ec *executionContext) fieldContext_Mutation_createGQLAPIKey(ctx context.Co
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_updateGQLAPIKey(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_updateGQLAPIKey(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateGQLAPIKey(rctx, fc.Args["input"].(UpdateGQLAPIKeyInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_updateGQLAPIKey(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateGQLAPIKey_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_deleteGQLAPIKey(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_deleteGQLAPIKey(ctx, field)
 	if err != nil {
@@ -17541,6 +18423,74 @@ func (ec *executionContext) fieldContext_Query_swoStatus(ctx context.Context, fi
 				return ec.fieldContext_SWOStatus_nextDBVersion(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type SWOStatus", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_gqlAPIKeys(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_gqlAPIKeys(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().GqlAPIKeys(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]GQLAPIKey)
+	fc.Result = res
+	return ec.marshalNGQLAPIKey2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐGQLAPIKeyᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_gqlAPIKeys(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_GQLAPIKey_id(ctx, field)
+			case "name":
+				return ec.fieldContext_GQLAPIKey_name(ctx, field)
+			case "description":
+				return ec.fieldContext_GQLAPIKey_description(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_GQLAPIKey_createdAt(ctx, field)
+			case "createdBy":
+				return ec.fieldContext_GQLAPIKey_createdBy(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_GQLAPIKey_updatedAt(ctx, field)
+			case "updatedBy":
+				return ec.fieldContext_GQLAPIKey_updatedBy(ctx, field)
+			case "lastUsed":
+				return ec.fieldContext_GQLAPIKey_lastUsed(ctx, field)
+			case "expiresAt":
+				return ec.fieldContext_GQLAPIKey_expiresAt(ctx, field)
+			case "allowedFields":
+				return ec.fieldContext_GQLAPIKey_allowedFields(ctx, field)
+			case "token":
+				return ec.fieldContext_GQLAPIKey_token(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type GQLAPIKey", field.Name)
 		},
 	}
 	return fc, nil
@@ -27360,7 +28310,7 @@ func (ec *executionContext) unmarshalInputCreateGQLAPIKeyInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "description", "allowedFields", "expiresAt", "role"}
+	fieldsInOrder := [...]string{"name", "description", "allowedFields", "expiresAt"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -27403,15 +28353,6 @@ func (ec *executionContext) unmarshalInputCreateGQLAPIKeyInput(ctx context.Conte
 				return it, err
 			}
 			it.ExpiresAt = data
-		case "role":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("role"))
-			data, err := ec.unmarshalNUserRole2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐUserRole(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Role = data
 		}
 	}
 
@@ -29996,6 +30937,53 @@ func (ec *executionContext) unmarshalInputUpdateEscalationPolicyStepInput(ctx co
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUpdateGQLAPIKeyInput(ctx context.Context, obj interface{}) (UpdateGQLAPIKeyInput, error) {
+	var it UpdateGQLAPIKeyInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "name", "description"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "name":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "description":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Description = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUpdateHeartbeatMonitorInput(ctx context.Context, obj interface{}) (UpdateHeartbeatMonitorInput, error) {
 	var it UpdateHeartbeatMonitorInput
 	asMap := map[string]interface{}{}
@@ -32419,6 +33407,194 @@ func (ec *executionContext) _EscalationPolicyStep(ctx context.Context, sel ast.S
 	return out
 }
 
+var gQLAPIKeyImplementors = []string{"GQLAPIKey"}
+
+func (ec *executionContext) _GQLAPIKey(ctx context.Context, sel ast.SelectionSet, obj *GQLAPIKey) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, gQLAPIKeyImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("GQLAPIKey")
+		case "id":
+			out.Values[i] = ec._GQLAPIKey_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "name":
+			out.Values[i] = ec._GQLAPIKey_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "description":
+			out.Values[i] = ec._GQLAPIKey_description(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "createdAt":
+			out.Values[i] = ec._GQLAPIKey_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "createdBy":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._GQLAPIKey_createdBy(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "updatedAt":
+			out.Values[i] = ec._GQLAPIKey_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "updatedBy":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._GQLAPIKey_updatedBy(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "lastUsed":
+			out.Values[i] = ec._GQLAPIKey_lastUsed(ctx, field, obj)
+		case "expiresAt":
+			out.Values[i] = ec._GQLAPIKey_expiresAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "allowedFields":
+			out.Values[i] = ec._GQLAPIKey_allowedFields(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "token":
+			out.Values[i] = ec._GQLAPIKey_token(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var gQLAPIKeyUsageImplementors = []string{"GQLAPIKeyUsage"}
+
+func (ec *executionContext) _GQLAPIKeyUsage(ctx context.Context, sel ast.SelectionSet, obj *GQLAPIKeyUsage) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, gQLAPIKeyUsageImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("GQLAPIKeyUsage")
+		case "time":
+			out.Values[i] = ec._GQLAPIKeyUsage_time(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "ua":
+			out.Values[i] = ec._GQLAPIKeyUsage_ua(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "ip":
+			out.Values[i] = ec._GQLAPIKeyUsage_ip(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var heartbeatMonitorImplementors = []string{"HeartbeatMonitor"}
 
 func (ec *executionContext) _HeartbeatMonitor(ctx context.Context, sel ast.SelectionSet, obj *heartbeat.Monitor) graphql.Marshaler {
@@ -33315,6 +34491,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "createGQLAPIKey":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createGQLAPIKey(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updateGQLAPIKey":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateGQLAPIKey(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -34593,6 +35776,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_swoStatus(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "gqlAPIKeys":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_gqlAPIKeys(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -38803,6 +40008,54 @@ func (ec *executionContext) marshalNEscalationPolicyStep2ᚕgithubᚗcomᚋtarge
 	return ret
 }
 
+func (ec *executionContext) marshalNGQLAPIKey2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐGQLAPIKey(ctx context.Context, sel ast.SelectionSet, v GQLAPIKey) graphql.Marshaler {
+	return ec._GQLAPIKey(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNGQLAPIKey2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐGQLAPIKeyᚄ(ctx context.Context, sel ast.SelectionSet, v []GQLAPIKey) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNGQLAPIKey2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐGQLAPIKey(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalNHeartbeatMonitor2githubᚗcomᚋtargetᚋgoalertᚋheartbeatᚐMonitor(ctx context.Context, sel ast.SelectionSet, v heartbeat.Monitor) graphql.Marshaler {
 	return ec._HeartbeatMonitor(ctx, sel, &v)
 }
@@ -40508,6 +41761,11 @@ func (ec *executionContext) unmarshalNUpdateEscalationPolicyStepInput2githubᚗc
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNUpdateGQLAPIKeyInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐUpdateGQLAPIKeyInput(ctx context.Context, v interface{}) (UpdateGQLAPIKeyInput, error) {
+	res, err := ec.unmarshalInputUpdateGQLAPIKeyInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNUpdateHeartbeatMonitorInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐUpdateHeartbeatMonitorInput(ctx context.Context, v interface{}) (UpdateHeartbeatMonitorInput, error) {
 	res, err := ec.unmarshalInputUpdateHeartbeatMonitorInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -41578,6 +42836,13 @@ func (ec *executionContext) marshalOEscalationPolicyStep2ᚖgithubᚗcomᚋtarge
 		return graphql.Null
 	}
 	return ec._EscalationPolicyStep(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOGQLAPIKeyUsage2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐGQLAPIKeyUsage(ctx context.Context, sel ast.SelectionSet, v *GQLAPIKeyUsage) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._GQLAPIKeyUsage(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOHeartbeatMonitor2ᚖgithubᚗcomᚋtargetᚋgoalertᚋheartbeatᚐMonitor(ctx context.Context, sel ast.SelectionSet, v *heartbeat.Monitor) graphql.Marshaler {

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -244,7 +244,6 @@ type ComplexityRoot struct {
 		ID            func(childComplexity int) int
 		LastUsed      func(childComplexity int) int
 		Name          func(childComplexity int) int
-		Token         func(childComplexity int) int
 		UpdatedAt     func(childComplexity int) int
 		UpdatedBy     func(childComplexity int) int
 	}
@@ -1585,13 +1584,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.GQLAPIKey.Name(childComplexity), true
-
-	case "GQLAPIKey.token":
-		if e.complexity.GQLAPIKey.Token == nil {
-			break
-		}
-
-		return e.complexity.GQLAPIKey.Token(childComplexity), true
 
 	case "GQLAPIKey.updatedAt":
 		if e.complexity.GQLAPIKey.UpdatedAt == nil {
@@ -10175,47 +10167,6 @@ func (ec *executionContext) fieldContext_GQLAPIKey_allowedFields(ctx context.Con
 	return fc, nil
 }
 
-func (ec *executionContext) _GQLAPIKey_token(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKey) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_GQLAPIKey_token(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Token, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_GQLAPIKey_token(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "GQLAPIKey",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _GQLAPIKeyUsage_time(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKeyUsage) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_GQLAPIKeyUsage_time(ctx, field)
 	if err != nil {
@@ -18487,8 +18438,6 @@ func (ec *executionContext) fieldContext_Query_gqlAPIKeys(ctx context.Context, f
 				return ec.fieldContext_GQLAPIKey_expiresAt(ctx, field)
 			case "allowedFields":
 				return ec.fieldContext_GQLAPIKey_allowedFields(ctx, field)
-			case "token":
-				return ec.fieldContext_GQLAPIKey_token(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type GQLAPIKey", field.Name)
 		},
@@ -33530,8 +33479,6 @@ func (ec *executionContext) _GQLAPIKey(ctx context.Context, sel ast.SelectionSet
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "token":
-			out.Values[i] = ec._GQLAPIKey_token(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql2/graphqlapp/gqlapikeys.go
+++ b/graphql2/graphqlapp/gqlapikeys.go
@@ -2,18 +2,103 @@ package graphqlapp
 
 import (
 	"context"
+	"database/sql"
+	"time"
 
 	"github.com/target/goalert/apikey"
 	"github.com/target/goalert/expflag"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/permission"
+	"github.com/target/goalert/user"
 	"github.com/target/goalert/validation"
 )
 
-func (a *Mutation) DeleteGQLAPIKey(ctx context.Context, input string) (bool, error) {
+type GQLAPIKey App
+
+func (a *App) GQLAPIKey() graphql2.GQLAPIKeyResolver { return (*GQLAPIKey)(a) }
+
+func (a *GQLAPIKey) CreatedBy(ctx context.Context, obj *graphql2.GQLAPIKey) (*user.User, error) {
+	if obj.CreatedBy == nil {
+		return nil, nil
+	}
+
+	return (*App)(a).FindOneUser(ctx, obj.CreatedBy.ID)
+}
+
+func (a *GQLAPIKey) UpdatedBy(ctx context.Context, obj *graphql2.GQLAPIKey) (*user.User, error) {
+	if obj.UpdatedBy == nil {
+		return nil, nil
+	}
+
+	return (*App)(a).FindOneUser(ctx, obj.UpdatedBy.ID)
+}
+
+func (q *Query) GqlAPIKeys(ctx context.Context) ([]graphql2.GQLAPIKey, error) {
+	if !expflag.ContextHas(ctx, expflag.GQLAPIKey) {
+		return nil, validation.NewGenericError("experimental flag not enabled")
+	}
+	err := permission.LimitCheckAny(ctx, permission.Admin)
+	if err != nil {
+		return nil, err
+	}
+
+	keys, err := q.APIKeyStore.FindAllAdminGraphQLKeys(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]graphql2.GQLAPIKey, len(keys))
+	for i, k := range keys {
+		res[i] = graphql2.GQLAPIKey{
+			ID:            k.ID.String(),
+			Name:          k.Name,
+			Description:   k.Description,
+			CreatedAt:     k.CreatedAt,
+			UpdatedAt:     k.UpdatedAt,
+			ExpiresAt:     k.ExpiresAt,
+			AllowedFields: k.AllowedFields,
+		}
+
+		if k.CreatedBy != nil {
+			res[i].CreatedBy = &user.User{ID: k.CreatedBy.String()}
+		}
+		if k.UpdatedBy != nil {
+			res[i].UpdatedBy = &user.User{ID: k.UpdatedBy.String()}
+		}
+
+		if k.LastUsed != nil {
+			res[i].LastUsed = &graphql2.GQLAPIKeyUsage{
+				Time: k.LastUsed.Time,
+				Ua:   k.LastUsed.UserAgent,
+				IP:   k.LastUsed.IP,
+			}
+		}
+	}
+
+	return res, nil
+}
+
+func nullTimeToPointer(nt sql.NullTime) *time.Time {
+	if !nt.Valid {
+		return nil
+	}
+	return &nt.Time
+}
+
+func (a *Mutation) UpdateGQLAPIKey(ctx context.Context, input graphql2.UpdateGQLAPIKeyInput) (bool, error) {
 	if !expflag.ContextHas(ctx, expflag.GQLAPIKey) {
 		return false, validation.NewGenericError("experimental flag not enabled")
 	}
+	id, err := parseUUID("ID", input.ID)
+	if err != nil {
+		return false, err
+	}
+
+	err = a.APIKeyStore.UpdateAdminGraphQLKey(ctx, id, input.Name, input.Description)
+	return err == nil, err
+}
+
+func (a *Mutation) DeleteGQLAPIKey(ctx context.Context, input string) (bool, error) {
 	id, err := parseUUID("ID", input)
 	if err != nil {
 		return false, err

--- a/graphql2/graphqlapp/gqlapikeys.go
+++ b/graphql2/graphqlapp/gqlapikeys.go
@@ -2,8 +2,6 @@ package graphqlapp
 
 import (
 	"context"
-	"database/sql"
-	"time"
 
 	"github.com/target/goalert/apikey"
 	"github.com/target/goalert/expflag"
@@ -76,13 +74,6 @@ func (q *Query) GqlAPIKeys(ctx context.Context) ([]graphql2.GQLAPIKey, error) {
 	}
 
 	return res, nil
-}
-
-func nullTimeToPointer(nt sql.NullTime) *time.Time {
-	if !nt.Valid {
-		return nil
-	}
-	return &nt.Time
 }
 
 func (a *Mutation) UpdateGQLAPIKey(ctx context.Context, input graphql2.UpdateGQLAPIKeyInput) (bool, error) {

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -145,7 +145,6 @@ type CreateGQLAPIKeyInput struct {
 	Description   string    `json:"description"`
 	AllowedFields []string  `json:"allowedFields"`
 	ExpiresAt     time.Time `json:"expiresAt"`
-	Role          UserRole  `json:"role"`
 }
 
 type CreateHeartbeatMonitorInput struct {
@@ -294,6 +293,26 @@ type EscalationPolicySearchOptions struct {
 	Omit           []string `json:"omit,omitempty"`
 	FavoritesOnly  *bool    `json:"favoritesOnly,omitempty"`
 	FavoritesFirst *bool    `json:"favoritesFirst,omitempty"`
+}
+
+type GQLAPIKey struct {
+	ID            string          `json:"id"`
+	Name          string          `json:"name"`
+	Description   string          `json:"description"`
+	CreatedAt     time.Time       `json:"createdAt"`
+	CreatedBy     *user.User      `json:"createdBy,omitempty"`
+	UpdatedAt     time.Time       `json:"updatedAt"`
+	UpdatedBy     *user.User      `json:"updatedBy,omitempty"`
+	LastUsed      *GQLAPIKeyUsage `json:"lastUsed,omitempty"`
+	ExpiresAt     time.Time       `json:"expiresAt"`
+	AllowedFields []string        `json:"allowedFields"`
+	Token         *string         `json:"token,omitempty"`
+}
+
+type GQLAPIKeyUsage struct {
+	Time time.Time `json:"time"`
+	Ua   string    `json:"ua"`
+	IP   string    `json:"ip"`
 }
 
 type IntegrationKeyConnection struct {
@@ -602,6 +621,12 @@ type UpdateEscalationPolicyStepInput struct {
 	ID           string                 `json:"id"`
 	DelayMinutes *int                   `json:"delayMinutes,omitempty"`
 	Targets      []assignment.RawTarget `json:"targets,omitempty"`
+}
+
+type UpdateGQLAPIKeyInput struct {
+	ID          string  `json:"id"`
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
 }
 
 type UpdateHeartbeatMonitorInput struct {

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -307,7 +307,6 @@ type GQLAPIKey struct {
 	LastUsed      *GQLAPIKeyUsage `json:"lastUsed,omitempty"`
 	ExpiresAt     time.Time       `json:"expiresAt"`
 	AllowedFields []string        `json:"allowedFields"`
-	Token         *string         `json:"token,omitempty"`
 }
 
 type GQLAPIKeyUsage struct {

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -145,6 +145,7 @@ type CreateGQLAPIKeyInput struct {
 	Description   string    `json:"description"`
 	AllowedFields []string  `json:"allowedFields"`
 	ExpiresAt     time.Time `json:"expiresAt"`
+	Role          UserRole  `json:"role"`
 }
 
 type CreateHeartbeatMonitorInput struct {

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -1,3 +1,7 @@
+# Directive definitions are as per gqlgen documentation:
+# https://gqlgen.com/master/config#inline-config-with-directives
+
+# goField is used to tweak individual field configurations, rather than using gqlgen.yml
 directive @goField(
   forceResolver: Boolean
   name: String

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -3,9 +3,9 @@
 
 # goField is used to tweak individual field configurations, rather than using gqlgen.yml
 directive @goField(
-  forceResolver: Boolean
-  name: String
-  omittable: Boolean
+  forceResolver: Boolean # forces the field to be resolved by a resolver, even if it already has a value; useful for computed fields where the model already has a partial value
+  name: String # overrides the field name in the generated Go code
+  omittable: Boolean # creates the field with a wrapper type (graphql.Omittable[T]) with a boolean indicating if the field is null (similar to sql.NullString and friends)
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 type Query {

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -627,7 +627,6 @@ type GQLAPIKey {
   lastUsed: GQLAPIKeyUsage
   expiresAt: ISOTimestamp!
   allowedFields: [String!]!
-  token: String
 }
 
 type GQLAPIKeyUsage {

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -1,3 +1,9 @@
+directive @goField(
+  forceResolver: Boolean
+  name: String
+  omittable: Boolean
+) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+
 type Query {
   phoneNumberInfo(number: String!): PhoneNumberInfo
 
@@ -128,6 +134,8 @@ type Query {
   linkAccountInfo(token: ID!): LinkAccountInfo
 
   swoStatus: SWOStatus!
+
+  gqlAPIKeys: [GQLAPIKey!]!
 
   listGQLFields(query: String): [String!]!
 }
@@ -582,6 +590,7 @@ type Mutation {
   setSystemLimits(input: [SystemLimitInput!]!): Boolean!
 
   createGQLAPIKey(input: CreateGQLAPIKeyInput!): CreatedGQLAPIKey!
+  updateGQLAPIKey(input: UpdateGQLAPIKeyInput!): Boolean!
   deleteGQLAPIKey(id: ID!): Boolean!
 
   createBasicAuth(input: CreateBasicAuthInput!): Boolean!
@@ -598,7 +607,32 @@ input CreateGQLAPIKeyInput {
   description: String!
   allowedFields: [String!]!
   expiresAt: ISOTimestamp!
-  role: UserRole!
+}
+
+input UpdateGQLAPIKeyInput {
+  id: ID!
+  name: String
+  description: String
+}
+
+type GQLAPIKey {
+  id: ID!
+  name: String!
+  description: String!
+  createdAt: ISOTimestamp!
+  createdBy: User @goField(forceResolver: true)
+  updatedAt: ISOTimestamp!
+  updatedBy: User @goField(forceResolver: true)
+  lastUsed: GQLAPIKeyUsage
+  expiresAt: ISOTimestamp!
+  allowedFields: [String!]!
+  token: String
+}
+
+type GQLAPIKeyUsage {
+  time: ISOTimestamp!
+  ua: String!
+  ip: String!
 }
 
 input CreateBasicAuthInput {

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -607,6 +607,7 @@ input CreateGQLAPIKeyInput {
   description: String!
   allowedFields: [String!]!
   expiresAt: ISOTimestamp!
+  role: UserRole!
 }
 
 input UpdateGQLAPIKeyInput {

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -461,7 +461,6 @@ export interface GQLAPIKey {
   lastUsed?: null | GQLAPIKeyUsage
   expiresAt: ISOTimestamp
   allowedFields: string[]
-  token?: null | string
 }
 
 export interface GQLAPIKeyUsage {

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -42,6 +42,7 @@ export interface Query {
   generateSlackAppManifest: string
   linkAccountInfo?: null | LinkAccountInfo
   swoStatus: SWOStatus
+  gqlAPIKeys: GQLAPIKey[]
   listGQLFields: string[]
 }
 
@@ -424,6 +425,7 @@ export interface Mutation {
   setConfig: boolean
   setSystemLimits: boolean
   createGQLAPIKey: CreatedGQLAPIKey
+  updateGQLAPIKey: boolean
   deleteGQLAPIKey: boolean
   createBasicAuth: boolean
   updateBasicAuth: boolean
@@ -439,7 +441,32 @@ export interface CreateGQLAPIKeyInput {
   description: string
   allowedFields: string[]
   expiresAt: ISOTimestamp
-  role: UserRole
+}
+
+export interface UpdateGQLAPIKeyInput {
+  id: string
+  name?: null | string
+  description?: null | string
+}
+
+export interface GQLAPIKey {
+  id: string
+  name: string
+  description: string
+  createdAt: ISOTimestamp
+  createdBy?: null | User
+  updatedAt: ISOTimestamp
+  updatedBy?: null | User
+  lastUsed?: null | GQLAPIKeyUsage
+  expiresAt: ISOTimestamp
+  allowedFields: string[]
+  token?: null | string
+}
+
+export interface GQLAPIKeyUsage {
+  time: ISOTimestamp
+  ua: string
+  ip: string
 }
 
 export interface CreateBasicAuthInput {

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -441,6 +441,7 @@ export interface CreateGQLAPIKeyInput {
   description: string
   allowedFields: string[]
   expiresAt: ISOTimestamp
+  role: UserRole
 }
 
 export interface UpdateGQLAPIKeyInput {


### PR DESCRIPTION
**Description:**
This PR adds the ability to list and update GQL API keys.

**Which issue(s) this PR fixes:**
Part of #3007 

**Describe any introduced API changes:**
- query `gqlAPIKeys` to list all GQL API keys, including usage information
- mutation `updateGQLAPIKey` to update the name and/or description of a GQL API key

**Additional Information**
Start with `make start EXPERIMENTAL=gql-api-keys` to enable the API key flag