### PR TITLE
Smtp logger

### DIFF
--- a/app/initsmtpsrv.go
+++ b/app/initsmtpsrv.go
@@ -24,6 +24,7 @@ func (app *App) initSMTPServer(ctx context.Context) error {
 		TLSConfig:         app.cfg.TLSConfigSMTP,
 		MaxRecipients:     app.cfg.SMTPMaxRecipients,
 		BackgroundContext: app.LogBackgroundContext,
+		Logger:            app.cfg.Logger,
 		AuthorizeFunc: func(ctx context.Context, id string) (context.Context, error) {
 			tok, _, err := authtoken.Parse(id, nil)
 			if err != nil {

--- a/smtpsrv/config.go
+++ b/smtpsrv/config.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 
 	"github.com/target/goalert/alert"
+	"github.com/target/goalert/util/log"
 )
 
 // Config is used to configure the SMTP server.
@@ -15,6 +16,7 @@ type Config struct {
 	MaxRecipients  int
 
 	BackgroundContext func() context.Context
+	Logger            *log.Logger
 
 	AuthorizeFunc   func(ctx context.Context, id string) (context.Context, error)
 	CreateAlertFunc func(ctx context.Context, a *alert.Alert) error

--- a/smtpsrv/server.go
+++ b/smtpsrv/server.go
@@ -12,25 +12,31 @@ import (
 	"github.com/target/goalert/util/log"
 )
 
-// SMTPLogger implements the smtp.Logger interface using the main app Logger
+// SMTPLogger implements the smtp.Logger interface using the main app Logger.
 type SMTPLogger struct {
 	logger *log.Logger
 }
 
-// Printf adheres to smtp.Server's Logger interface while filtering out ECONNRESET errors caused by TCP health checks
+// Printf adheres to smtp.Server's Logger interface.
 func (l *SMTPLogger) Printf(format string, v ...interface{}) {
 	s := fmt.Sprintf(format, v...)
-	if !strings.Contains(s, "read: connection reset by peer") {
-		l.logger.Error(context.Background(), errors.New(s))
+	// TODO: Uses string compare to filter out errors caused by TCP health checks,
+	// remove once https://github.com/emersion/go-smtp/issues/236 has been fixed.
+	if strings.Contains(s, "read: connection reset by peer") {
+		return
 	}
+	l.logger.Error(context.Background(), errors.New(s))
 }
 
-// Print adheres to smtp.Server's Logger interface while filtering out ECONNRESET errors caused by TCP health checks
+// Print adheres to smtp.Server's Logger interface.
 func (l *SMTPLogger) Println(v ...interface{}) {
 	s := fmt.Sprint(v...)
-	if !strings.Contains(s, "read: connection reset by peer") {
-		l.logger.Error(context.Background(), errors.New(s))
+	// TODO: Uses string compare to filter out errors caused by TCP health checks,
+	// remove once https://github.com/emersion/go-smtp/issues/236 has been fixed.
+	if strings.Contains(s, "read: connection reset by peer") {
+		return
 	}
+	l.logger.Error(context.Background(), errors.New(s))
 }
 
 // Server implements an SMTP server that creates alerts.

--- a/smtpsrv/server.go
+++ b/smtpsrv/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/emersion/go-smtp"
@@ -16,12 +17,20 @@ type SMTPLogger struct {
 	logger *log.Logger
 }
 
+// Printf adheres to smtp.Server's Logger interface while filtering out ECONNRESET errors caused by TCP health checks
 func (l *SMTPLogger) Printf(format string, v ...interface{}) {
-	l.logger.Error(context.Background(), errors.New(fmt.Sprintf(format, v...)))
+	s := fmt.Sprintf(format, v...)
+	if !strings.Contains(s, "read: connection reset by peer") {
+		l.logger.Error(context.Background(), errors.New(s))
+	}
 }
 
+// Print adheres to smtp.Server's Logger interface while filtering out ECONNRESET errors caused by TCP health checks
 func (l *SMTPLogger) Println(v ...interface{}) {
-	l.logger.Error(context.Background(), errors.New(fmt.Sprint(v...)))
+	s := fmt.Sprint(v...)
+	if !strings.Contains(s, "read: connection reset by peer") {
+		l.logger.Error(context.Background(), errors.New(s))
+	}
 }
 
 // Server implements an SMTP server that creates alerts.


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Ensures built-in SMTP server for generating alerts uses GoAlert's structured logger instead of stdout from go-smtp's Server type.  Filters out excessive logging of ECONNRESET errors that result from common TCP probe healthchecks from load balancers--see https://github.com/emersion/go-smtp/issues/236

**Which issue(s) this PR fixes:**
Fixes #3335 

**Out of Scope:**
N/A

**Screenshots:**
N/A

**Describe any introduced user-facing changes:**
N/A

**Describe any introduced API changes:**
N/A

**Additional Info:**
Once `emersion/go-smtp` handles zero-byte connections without logging an error, the conditional filter added here can be removed.
