### PR TITLE
services: update query to return maintenance_expires_at

### DIFF
--- a/service/search.go
+++ b/service/search.go
@@ -48,7 +48,8 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		svc.name,
 		svc.description,
 		svc.escalation_policy_id,
-		fav IS DISTINCT FROM NULL
+		fav IS DISTINCT FROM NULL,
+		svc.maintenance_expires_at
 	FROM services svc
 	{{if not .FavoritesOnly }}LEFT {{end}}JOIN user_favorites fav ON svc.id = fav.tgt_service_id AND {{if .FavoritesUserID}}fav.user_id = :favUserID{{else}}false{{end}}
 	{{if and .IntegrationKey}}
@@ -234,10 +235,12 @@ func (s *Store) Search(ctx context.Context, opts *SearchOptions) ([]Service, err
 	var result []Service
 	for rows.Next() {
 		var s Service
-		err = rows.Scan(&s.ID, &s.Name, &s.Description, &s.EscalationPolicyID, &s.isUserFavorite)
+		var maintExpiresAt sql.NullTime
+		err = rows.Scan(&s.ID, &s.Name, &s.Description, &s.EscalationPolicyID, &s.isUserFavorite, &maintExpiresAt)
 		if err != nil {
 			return nil, err
 		}
+		s.MaintenanceExpiresAt = maintExpiresAt.Time
 
 		result = append(result, s)
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Currently the `services()` query returns `null` for `maintenance_expires_at` for all services, this pr updates the search query to include it in the return.