### PR TITLE
validate/phone: switch to up-to-date phone number library

### DIFF
--- a/devtools/mocktwilio/lookup.go
+++ b/devtools/mocktwilio/lookup.go
@@ -6,8 +6,8 @@ import (
 	"path"
 	"strconv"
 
+	"github.com/nyaruka/phonenumbers"
 	"github.com/target/goalert/notification/twilio"
-	"github.com/ttacon/libphonenumber"
 )
 
 func (s *Server) serveLookup(w http.ResponseWriter, req *http.Request) {
@@ -23,14 +23,14 @@ func (s *Server) serveLookup(w http.ResponseWriter, req *http.Request) {
 		AddOns     *struct{}           `json:"add_ons"`
 		URL        string              `json:"url"`
 	}
-	n, err := libphonenumber.Parse(number, "")
+	n, err := phonenumbers.Parse(number, "")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	info.CC = strconv.Itoa(int(n.GetCountryCode()))
-	info.Fmt = libphonenumber.Format(n, libphonenumber.NATIONAL)
-	info.Number = libphonenumber.Format(n, libphonenumber.E164)
+	info.Fmt = phonenumbers.Format(n, phonenumbers.NATIONAL)
+	info.Number = phonenumbers.Format(n, phonenumbers.E164)
 	req.URL.Host = req.Host
 	info.URL = req.URL.String()
 

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/mailhog/storage v1.0.1
 	github.com/matcornic/hermes/v2 v2.1.0
 	github.com/mnako/letters v0.2.1
+	github.com/nyaruka/phonenumbers v1.1.8
 	github.com/oauth2-proxy/mockoidc v0.0.0-20220308204021-b9169deeb282
 	github.com/pelletier/go-toml/v2 v2.1.0
 	github.com/pkg/errors v0.9.1
@@ -41,7 +42,6 @@ require (
 	github.com/spf13/viper v1.16.0
 	github.com/sqlc-dev/pqtype v0.3.0
 	github.com/stretchr/testify v1.8.4
-	github.com/ttacon/libphonenumber v1.2.1
 	github.com/vektah/gqlparser/v2 v2.5.10
 	golang.org/x/crypto v0.13.0
 	golang.org/x/oauth2 v0.12.0
@@ -140,7 +140,6 @@ require (
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/t-k/fluent-logger-golang v1.0.0 // indirect
 	github.com/tinylib/msgp v1.1.8 // indirect
-	github.com/ttacon/builder v0.0.0-20170518171403-c099f663e1c2 // indirect
 	github.com/urfave/cli/v2 v2.25.7 // indirect
 	github.com/vanng822/css v1.0.1 // indirect
 	github.com/vanng822/go-premailer v1.20.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1078,6 +1078,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mnako/letters v0.2.1 h1:ZGFDSLruG2cbFM0bb1sYnCbBdTj6qAX9UlPO0qkxdIk=
 github.com/mnako/letters v0.2.1/go.mod h1:r1Z7i+QHqscls2Go1y2Q05RmrsNh2uDQz84DiSx7Bc4=
+github.com/nyaruka/phonenumbers v1.1.8 h1:mjFu85FeoH2Wy18aOMUvxqi1GgAqiQSJsa/cCC5yu2s=
+github.com/nyaruka/phonenumbers v1.1.8/go.mod h1:DC7jZd321FqUe+qWSNcHi10tyIyGNXGcNbfkPvdp1Vs=
 github.com/oauth2-proxy/mockoidc v0.0.0-20220308204021-b9169deeb282 h1:TQMyrpijtkFyXpNI3rY5hsZQZw+paiH+BfAlsb81HBY=
 github.com/oauth2-proxy/mockoidc v0.0.0-20220308204021-b9169deeb282/go.mod h1:rW25Kyd08Wdn3UVn0YBsDTSvReu0jqpmJKzxITPSjks=
 github.com/ogier/pflag v0.0.1 h1:RW6JSWSu/RkSatfcLtogGfFgpim5p7ARQ10ECk5O750=
@@ -1194,10 +1196,6 @@ github.com/t-k/fluent-logger-golang v1.0.0 h1:4IQzY+/l66Zkkhk9eB3LwF9vPkgKHJ1rpY
 github.com/t-k/fluent-logger-golang v1.0.0/go.mod h1:6vC3Vzp9Kva0l5J9+YDY5/ROePwkAqwLK+KneCjSm4w=
 github.com/tinylib/msgp v1.1.8 h1:FCXC1xanKO4I8plpHGH2P7koL/RzZs12l/+r7vakfm0=
 github.com/tinylib/msgp v1.1.8/go.mod h1:qkpG+2ldGg4xRFmx+jfTvZPxfGFhi64BcnL9vkCm/Tw=
-github.com/ttacon/builder v0.0.0-20170518171403-c099f663e1c2 h1:5u+EJUQiosu3JFX0XS0qTf5FznsMOzTjGqavBGuCbo0=
-github.com/ttacon/builder v0.0.0-20170518171403-c099f663e1c2/go.mod h1:4kyMkleCiLkgY6z8gK5BkI01ChBtxR0ro3I1ZDcGM3w=
-github.com/ttacon/libphonenumber v1.2.1 h1:fzOfY5zUADkCkbIafAed11gL1sW+bJ26p6zWLBMElR4=
-github.com/ttacon/libphonenumber v1.2.1/go.mod h1:E0TpmdVMq5dyVlQ7oenAkhsLu86OkUl+yR4OAxyEg/M=
 github.com/unrolled/render v1.0.3/go.mod h1:gN9T0NhL4Bfbwu8ann7Ry/TGHYfosul+J0obPf6NBdM=
 github.com/urfave/cli/v2 v2.25.7 h1:VAzn5oq403l5pHjc4OhD54+XGO9cdKVL/7lDjF+iKUs=
 github.com/urfave/cli/v2 v2.25.7/go.mod h1:8qnjx1vcq5s2/wpsqoZFndg2CE5tNFyrTvS6SinrnYQ=

--- a/graphql2/graphqlapp/toolbox.go
+++ b/graphql2/graphqlapp/toolbox.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/nyaruka/phonenumbers"
 	"github.com/target/goalert/notification"
 	"github.com/target/goalert/validation"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/target/goalert/notification/twilio"
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/validation/validate"
-	"github.com/ttacon/libphonenumber"
 )
 
 type safeErr struct{ error }
@@ -77,7 +77,7 @@ func (a *Mutation) DebugCarrierInfo(ctx context.Context, input graphql2.DebugCar
 }
 
 func (a *Query) PhoneNumberInfo(ctx context.Context, number string) (*graphql2.PhoneNumberInfo, error) {
-	p, err := libphonenumber.Parse(number, "")
+	p, err := phonenumbers.Parse(number, "")
 	if err != nil {
 		return &graphql2.PhoneNumberInfo{
 			ID:    number,
@@ -88,8 +88,8 @@ func (a *Query) PhoneNumberInfo(ctx context.Context, number string) (*graphql2.P
 	return &graphql2.PhoneNumberInfo{
 		ID:          number,
 		CountryCode: fmt.Sprintf("+%d", p.GetCountryCode()),
-		RegionCode:  libphonenumber.GetRegionCodeForNumber(p),
-		Formatted:   libphonenumber.Format(p, libphonenumber.INTERNATIONAL),
-		Valid:       libphonenumber.IsValidNumber(p),
+		RegionCode:  phonenumbers.GetRegionCodeForNumber(p),
+		Formatted:   phonenumbers.Format(p, phonenumbers.INTERNATIONAL),
+		Valid:       phonenumbers.IsValidNumber(p),
 	}, nil
 }

--- a/notification/twilio/sms.go
+++ b/notification/twilio/sms.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nyaruka/phonenumbers"
 	"github.com/target/goalert/alert"
 	"github.com/target/goalert/config"
 	"github.com/target/goalert/notification"
@@ -19,7 +20,6 @@ import (
 	"github.com/target/goalert/retry"
 	"github.com/target/goalert/util/log"
 	"github.com/target/goalert/validation"
-	"github.com/ttacon/libphonenumber"
 
 	"github.com/pkg/errors"
 )
@@ -213,11 +213,11 @@ func isStartMessage(body string) bool {
 
 // FriendlyValue will return the international formatting of the phone number.
 func (s *SMS) FriendlyValue(ctx context.Context, value string) (string, error) {
-	num, err := libphonenumber.Parse(value, "")
+	num, err := phonenumbers.Parse(value, "")
 	if err != nil {
 		return "", fmt.Errorf("parse number for formatting: %w", err)
 	}
-	return libphonenumber.Format(num, libphonenumber.INTERNATIONAL), nil
+	return phonenumbers.Format(num, phonenumbers.INTERNATIONAL), nil
 }
 
 func (s *SMS) ServeMessage(w http.ResponseWriter, req *http.Request) {

--- a/notification/twilio/voice.go
+++ b/notification/twilio/voice.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nyaruka/phonenumbers"
 	"github.com/pkg/errors"
 	"github.com/target/goalert/alert"
 	"github.com/target/goalert/config"
@@ -22,7 +23,6 @@ import (
 	"github.com/target/goalert/retry"
 	"github.com/target/goalert/util/log"
 	"github.com/target/goalert/validation"
-	"github.com/ttacon/libphonenumber"
 )
 
 // CallType indicates a supported Twilio voice call type.
@@ -605,11 +605,11 @@ func (v *Voice) ServeAlert(w http.ResponseWriter, req *http.Request) {
 
 // FriendlyValue will return the international formatting of the phone number.
 func (v *Voice) FriendlyValue(ctx context.Context, value string) (string, error) {
-	num, err := libphonenumber.Parse(value, "")
+	num, err := phonenumbers.Parse(value, "")
 	if err != nil {
 		return "", fmt.Errorf("parse number for formatting: %w", err)
 	}
-	return libphonenumber.Format(num, libphonenumber.INTERNATIONAL), nil
+	return phonenumbers.Format(num, phonenumbers.INTERNATIONAL), nil
 }
 
 // buildMessage is a function that will build the VoiceOptions object with the proper message contents

--- a/test/smoke/harness/datagen.go
+++ b/test/smoke/harness/datagen.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/nyaruka/phonenumbers"
 	"github.com/pkg/errors"
-	"github.com/ttacon/libphonenumber"
 )
 
 // DataGen handles generating random data for tests. It ties arbitrary ids to
@@ -101,11 +101,11 @@ func GenPhoneCC(cc string) string {
 	if err != nil {
 		panic(errors.Wrapf(err, "parse country code '%s'", cc))
 	}
-	region := libphonenumber.GetRegionCodeForCountryCode(ccInt)
+	region := phonenumbers.GetRegionCodeForCountryCode(ccInt)
 	if region == "" || region == "ZZ" {
 		panic(fmt.Sprintf("invalid cc '%s'", cc))
 	}
-	num := libphonenumber.GetExampleNumber(region)
+	num := phonenumbers.GetExampleNumber(region)
 	*num.NationalNumber = *num.NationalNumber + uint64(rand.Intn(9999))
-	return libphonenumber.Format(num, libphonenumber.E164)
+	return phonenumbers.Format(num, phonenumbers.E164)
 }

--- a/validation/validate/phone.go
+++ b/validation/validate/phone.go
@@ -2,11 +2,11 @@ package validate
 
 import (
 	"fmt"
-	"github.com/target/goalert/validation"
 	"regexp"
 	"strings"
 
-	"github.com/ttacon/libphonenumber"
+	"github.com/nyaruka/phonenumbers"
+	"github.com/target/goalert/validation"
 )
 
 var phoneRx = regexp.MustCompile(`^\+\d{1,15}$`)
@@ -26,12 +26,13 @@ func Phone(fname, phone string) error {
 	if !phoneRx.MatchString(phone) {
 		return validation.NewFieldError(fname, "must only contain digits")
 	}
-	p, err := libphonenumber.Parse(phone, "")
+
+	p, err := phonenumbers.Parse(phone, "")
 	if err != nil {
 		return validation.NewFieldError(fname, fmt.Sprintf("must be a valid number: %s", err.Error()))
 	}
 
-	if !libphonenumber.IsValidNumber(p) {
+	if !phonenumbers.IsValidNumber(p) {
 		return validation.NewFieldError(fname, "must be a valid number")
 	}
 	return nil


### PR DESCRIPTION
**Description:**
This PR replaces our phone number library with one that has up-to-date metadata.

The old library's last update/release was in March 2021.
The new library's last update/release was in August 2023.

Both are Go ports of Google's libphonenumber library and have identical APIs.

**Which issue(s) this PR fixes:**
Fixes #3340 

**Additional Info:**
- Replaces [github.com/ttacon/libphonenumber](https://github.com/ttacon/libphonenumber) with [github.com/nyaruka/phonenumbers](https://github.com/nyaruka/phonenumbers)
