### PR TITLE
show alerts to now in graph, update tooltip label

### DIFF
--- a/web/src/app/services/AlertMetrics/AlertCountGraph.tsx
+++ b/web/src/app/services/AlertMetrics/AlertCountGraph.tsx
@@ -74,7 +74,7 @@ export default function AlertCountGraph(
               <Tooltip
                 data-cy='metrics-tooltip'
                 cursor={{ fill: theme.palette.background.default }}
-                content={({ active, payload, label }) => {
+                content={({ active, payload }) => {
                   if (!active || !payload?.length) return null
 
                   const alertCountStr = `${payload[0].name}: ${payload[0].value}`
@@ -82,7 +82,9 @@ export default function AlertCountGraph(
                   const noiseCountStr = `${payload[2].name}: ${payload[2].value}`
                   return (
                     <Paper variant='outlined' sx={{ p: 1 }}>
-                      <Typography variant='body2'>{label}</Typography>
+                      <Typography variant='body2'>
+                        {payload[0].payload.label}
+                      </Typography>
                       <Typography variant='body2'>{alertCountStr}</Typography>
                       <Typography variant='body2'>
                         {escalatedCountStr}

--- a/web/src/app/services/AlertMetrics/AlertMetrics.tsx
+++ b/web/src/app/services/AlertMetrics/AlertMetrics.tsx
@@ -71,38 +71,25 @@ export default function AlertMetrics({
     return <GenericError error={alertsData.error.message} />
   }
 
-  function getRange(range: string): string {
-    switch (range) {
-      case 'P1W':
-        return 'past week'
-      case 'P2W':
-        return 'past 2 weeks'
-      case 'P1M':
-        return 'past month'
-      case 'P3M':
-        return 'past 3 months'
-      case 'P6M':
-        return 'past 6 months'
-      case 'P1Y':
-        return 'past year'
-      default:
-        return `past ${Math.ceil(until.diff(since, unit).as(unit))} ${unit}s`
-    }
-  }
-
   return (
     <Grid container spacing={2}>
       <Grid item xs={12}>
         <Card>
-          <CardHeader
-            component='h2'
-            title={`Daily alert metrics over the ${getRange(range)}`}
-          />
           <CardContent>
             <AlertMetricsFilter />
+            <CardHeader
+              title='Alert Averages'
+              component='h2'
+              sx={{ ml: '2rem', mb: 0, pb: 0 }}
+            />
             <AlertCountGraph
               data={graphData}
               loading={graphDataStatus.loading || alertsData.loading}
+            />
+            <CardHeader
+              title='Alert Averages'
+              component='h2'
+              sx={{ ml: '2rem', mb: 0, pb: 0 }}
             />
             <AlertAveragesGraph
               data={graphData}

--- a/web/src/app/services/AlertMetrics/AlertMetrics.tsx
+++ b/web/src/app/services/AlertMetrics/AlertMetrics.tsx
@@ -71,7 +71,24 @@ export default function AlertMetrics({
     return <GenericError error={alertsData.error.message} />
   }
 
-  const dayCount = Math.ceil(until.diff(since, unit).as(unit))
+  function getRange(range: string): string {
+    switch (range) {
+      case 'P1W':
+        return 'past week'
+      case 'P2W':
+        return 'past 2 weeks'
+      case 'P1M':
+        return 'past month'
+      case 'P3M':
+        return 'past 3 months'
+      case 'P6M':
+        return 'past 6 months'
+      case 'P1Y':
+        return 'past year'
+      default:
+        return `past ${Math.ceil(until.diff(since, unit).as(unit))} ${unit}s`
+    }
+  }
 
   return (
     <Grid container spacing={2}>
@@ -79,7 +96,7 @@ export default function AlertMetrics({
         <Card>
           <CardHeader
             component='h2'
-            title={`Daily alert metrics over the past ${dayCount} ${unit}s`}
+            title={`Daily alert metrics over the ${getRange(range)}`}
           />
           <CardContent>
             <AlertMetricsFilter />

--- a/web/src/app/services/AlertMetrics/AlertMetrics.tsx
+++ b/web/src/app/services/AlertMetrics/AlertMetrics.tsx
@@ -39,7 +39,7 @@ export default function AlertMetrics({
 
   const unit = units[ivl]
   const since = now.minus(Duration.fromISO(range)).startOf(unit)
-  const until = now.startOf(unit)
+  const until = now
 
   const alertOptions: AlertSearchOptions = {
     filterByServiceID: [serviceID],

--- a/web/src/app/services/AlertMetrics/AlertMetrics.tsx
+++ b/web/src/app/services/AlertMetrics/AlertMetrics.tsx
@@ -78,7 +78,7 @@ export default function AlertMetrics({
           <CardContent>
             <AlertMetricsFilter />
             <CardHeader
-              title='Alert Averages'
+              title='Alert Counts'
               component='h2'
               sx={{ ml: '2rem', mb: 0, pb: 0 }}
             />

--- a/web/src/app/services/AlertMetrics/AlertMetricsFilter.tsx
+++ b/web/src/app/services/AlertMetrics/AlertMetricsFilter.tsx
@@ -14,7 +14,7 @@ export default function AlertMetricsFilter(): JSX.Element {
   const [ivl, setIvl] = useURLParam<string>('interval', 'P1D')
 
   return (
-    <Grid container sx={{ marginLeft: '3rem' }}>
+    <Grid container sx={{ marginLeft: '3rem', pt: 3 }}>
       <Grid item xs={5}>
         <FormControl sx={{ width: '100%' }}>
           <InputLabel id='demo-simple-select-helper-label'>

--- a/web/src/app/services/AlertMetrics/useAlertMetrics.ts
+++ b/web/src/app/services/AlertMetrics/useAlertMetrics.ts
@@ -27,11 +27,18 @@ export function useAlertMetrics(opts: AlertMetricsOpts): AlertMetricPoint[] {
         month: 'short',
         day: 'numeric',
       })
-      const label = i.start.toLocaleString({
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-      })
+      const label =
+        i.start.toLocaleString({
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+        }) +
+        ' - ' +
+        i.end.toLocaleString({
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+        })
 
       const nextIvl = alerts.findIndex(
         (a) => !i.contains(DateTime.fromISO(a.metrics?.closedAt as string)),


### PR DESCRIPTION
**Description:**
This PR updates the UX of the alert metrics graph data, allowing the current week or month to render when "week" or "month" is the selected interval. Also updates the tooltip to show the range of time, rather than only the start date. 

**Which issue(s) this PR fixes:**
Fixes #3252

**Screenshots:**
Old:

![current](https://github.com/target/goalert/assets/11381794/64792fc9-aacc-405e-85c4-6ee686671961)
![current tooltip](https://github.com/target/goalert/assets/11381794/2987373a-e791-40fe-bfb1-b64b1ff6155e)

New:

![new](https://github.com/target/goalert/assets/11381794/491f4597-c374-4bfb-8f67-6c47bb7b338e)
![new tooltip](https://github.com/target/goalert/assets/11381794/37ca7737-38c0-4334-956c-20a1f0fac7ba)
