### PR TITLE
overrides: fix wrong param in search

### DIFF
--- a/gadb/queries.sql.go
+++ b/gadb/queries.sql.go
@@ -1134,7 +1134,7 @@ AND (
 AND (
     /* only include overrides that start before/within the search end */
     $7::timestamptz ISNULL
-    OR o.start_time <= $6)
+    OR o.start_time <= $7)
 AND (
     /* resume search after specified "cursor" override */
     $8::uuid ISNULL

--- a/override/queries.sql
+++ b/override/queries.sql
@@ -37,7 +37,7 @@ AND (
 AND (
     /* only include overrides that start before/within the search end */
     sqlc.narg(search_end)::timestamptz ISNULL
-    OR o.start_time <= @search_start)
+    OR o.start_time <= @search_end)
 AND (
     /* resume search after specified "cursor" override */
     @after_id::uuid ISNULL


### PR DESCRIPTION
**Description:**
Fixes an issue where searching with an end_time parameter caused no results to return.

**Additional Info:**
The `search_start` parameter was being used instead of `search_end` due to a typo.
