### PR TITLE
devtools/resetdb: increase variance in DelayMinutes

### DIFF
--- a/devtools/resetdb/datagen.go
+++ b/devtools/resetdb/datagen.go
@@ -168,7 +168,7 @@ func (d *datagen) NewNR(userID, cmID string) {
 		ID:              d.UUID(),
 		UserID:          userID,
 		ContactMethodID: cmID,
-		DelayMinutes:    d.ints.Gen(60, cmID),
+		DelayMinutes:    d.ints.Gen(600, cmID),
 	}
 	d.NotificationRules = append(d.NotificationRules, nr)
 }


### PR DESCRIPTION
**Description:**
Increases the values for `DelayMinutes` from 60 to 600. When setting the `SIZE=` parameter, we run out of potential values which results in a panic.

To test: `make regendb SIZE=10` -- this will regenerate the local test DB at 10x the normal size.
