### PR TITLE
apikey: Allow entering a query directly to generate Allowed Fields

### DIFF
--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyForm.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyForm.tsx
@@ -134,6 +134,10 @@ export default function AdminAPIKeyForm(
                   >
                     Select fields manually
                   </ClickableText>
+                  <div>
+                    Allowed fields:{' '}
+                    {exampleFields.length ? exampleFields.join(', ') : 'none'}
+                  </div>
                 </React.Fragment>
               }
             />

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyForm.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyForm.tsx
@@ -127,17 +127,19 @@ export default function AdminAPIKeyForm(
               error={!!example?.error}
               helperText={
                 <React.Fragment>
-                  <div>{example?.error?.message}</div>
+                  <span style={{ display: 'block' }}>
+                    {example?.error?.message}
+                  </span>
                   <ClickableText
                     onClick={() => setShowQuery(false)}
                     endIcon={<CompareArrows />}
                   >
                     Select fields manually
                   </ClickableText>
-                  <div>
+                  <span style={{ display: 'block' }}>
                     Allowed fields:{' '}
                     {exampleFields.length ? exampleFields.join(', ') : 'none'}
-                  </div>
+                  </span>
                 </React.Fragment>
               }
             />
@@ -169,7 +171,7 @@ export default function AdminAPIKeyForm(
                     onClick={() => setShowQuery(true)}
                     endIcon={<CompareArrows />}
                   >
-                    Enter example query instead
+                    Click here to enter example query instead
                   </ClickableText>
                 )
               }

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyForm.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyForm.tsx
@@ -160,12 +160,14 @@ export default function AdminAPIKeyForm(
               multiple
               required
               hint={
-                <ClickableText
-                  onClick={() => setShowQuery(true)}
-                  endIcon={<CompareArrows />}
-                >
-                  Enter example query instead
-                </ClickableText>
+                props.create && (
+                  <ClickableText
+                    onClick={() => setShowQuery(true)}
+                    endIcon={<CompareArrows />}
+                  >
+                    Enter example query instead
+                  </ClickableText>
+                )
               }
             />
           )}


### PR DESCRIPTION
**Description:**
Adds the ability to configure Allowed Fields by entering an example query.

Behind the experimental flag `gql-api-keys`. Run GoAlert with the command: `make start EXPERIMENTAL=gql-api-keys`

**Which issue(s) this PR fixes:**
Part of #3007

**Screenshots:**
![image](https://github.com/target/goalert/assets/595010/245d6c87-0612-4522-b1c7-46dd28ab595e)
![image](https://github.com/target/goalert/assets/595010/0d5da27d-69a7-48d9-ae04-2e50ab19c460)
![image](https://github.com/target/goalert/assets/595010/b3260939-9230-42e3-ba0e-eb3e59ea7bee)

**Describe any introduced user-facing changes:**
When creating an API key, the multi-select field can be swapped to input an example query directly.
