### PR TITLE
fix for missing function

### DIFF
--- a/dataloader/loader.go
+++ b/dataloader/loader.go
@@ -37,6 +37,16 @@ func NewStoreLoaderWithDB[V any](
 	})
 }
 
+func NewStoreLoaderIntWithDB[V any](
+	ctx context.Context,
+	db gadb.DBTX,
+	fetchMany func(context.Context, gadb.DBTX, []int) ([]V, error),
+) *Loader[int, V] {
+	return NewStoreLoaderInt(ctx, func(ctx context.Context, ids []int) ([]V, error) {
+		return fetchMany(ctx, db, ids)
+	})
+}
+
 type loaderConfig[K comparable, V any] struct {
 	FetchFunc func(context.Context, []K) ([]V, error) // FetchFunc should return resources for the provided IDs (order doesn't matter).
 	IDFunc    func(V) K                               // Should return the unique ID for a given resource.


### PR DESCRIPTION
Fix for missing function `dataloader.NewStoreLoaderIntWithDB` in `/Users/Z00BRNC/Projects/goalert/graphql2/graphqlapp/dataloaders.go`