### PR TITLE
ui: fix default value not set for temp sched dialog

### DIFF
--- a/web/src/app/schedules/ScheduleOverrideList.js
+++ b/web/src/app/schedules/ScheduleOverrideList.js
@@ -16,6 +16,7 @@ import { useScheduleTZ } from './useScheduleTZ'
 import { useIsWidthDown } from '../util/useWidth'
 import { OverrideDialogContext } from './ScheduleDetails'
 import TempSchedDialog from './temp-sched/TempSchedDialog'
+import { defaultTempSchedValue } from './temp-sched/sharedUtils'
 import ScheduleOverrideDialog from './ScheduleOverrideDialog'
 import CreateFAB from '../lists/CreateFAB'
 
@@ -58,9 +59,12 @@ export default function ScheduleOverrideList({ scheduleID }) {
 
   const [overrideDialog, setOverrideDialog] = useState(null)
   const [configTempSchedule, setConfigTempSchedule] = useState(null)
-  const onNewTempSched = useCallback(() => setConfigTempSchedule({}), [])
 
   const { zone, isLocalZone } = useScheduleTZ(scheduleID)
+  const onNewTempSched = useCallback(
+    () => setConfigTempSchedule(defaultTempSchedValue(zone)),
+    [],
+  )
 
   const subText = (n) => {
     const tzTimeStr = formatOverrideTime(n.start, n.end, zone)

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -167,7 +167,6 @@ export default function TempSchedShiftsList({
                 <span>{subText}</span>
               </Tooltip>
             ),
-            userID: s.userID,
             icon: <UserAvatar userID={s.userID} />,
             disabled: isHistoricShift,
             secondaryAction: index === 0 && (


### PR DESCRIPTION
Closes #3377

Fixes an issue where the default value was not set on the temporary schedule dialog, so the incoming data was not what was expected.

Also resolves a console error where `userID` is not a valid prop for a native HTML element.

**Out of scope:**
There's another console error related to `findDOMNode` being disabled with `React.StrictMode` enabled. This seems to be an issue with the transition library we are using, as this prop is not seen within our codebase. It will be worth looking into updating this package.