### PR TITLE
ui/service-metrics: Add filtering for admin service metrics

### DIFF
--- a/web/src/app/admin/admin-service-metrics/AdminServiceFilter.tsx
+++ b/web/src/app/admin/admin-service-metrics/AdminServiceFilter.tsx
@@ -105,7 +105,7 @@ function AdminServiceFilter(): JSX.Element {
               Service Filters
             </Typography>
             <Divider />
-            <List disablePadding>
+            <List>
               <ListItem>
                 <ListItemText primary='EP Step Targets' />
               </ListItem>
@@ -124,7 +124,7 @@ function AdminServiceFilter(): JSX.Element {
                   )}
                 />
               </ListItem>
-              <Divider />
+              <Divider sx={{ padding: '10px' }} />
               <ListItem>
                 <ListItemText primary='Integration Key Targets' />
               </ListItem>
@@ -149,7 +149,7 @@ function AdminServiceFilter(): JSX.Element {
                   )}
                 />
               </ListItem>
-              <Divider />
+              <Divider sx={{ padding: '10px' }} />
               <ListItem>
                 <ListItemText primary='Labels' />
               </ListItem>

--- a/web/src/app/admin/admin-service-metrics/AdminServiceFilter.tsx
+++ b/web/src/app/admin/admin-service-metrics/AdminServiceFilter.tsx
@@ -1,0 +1,222 @@
+import React, { useState } from 'react'
+import FilterList from '@mui/icons-material/FilterList'
+import Grid from '@mui/material/Grid'
+import { useResetURLParams, useURLParams } from '../../actions'
+import {
+  Autocomplete,
+  Button,
+  Chip,
+  ClickAwayListener,
+  Divider,
+  Drawer,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+  TextField,
+  Toolbar,
+  Typography,
+} from '@mui/material'
+import { LabelKeySelect } from '../../selection'
+import { LabelValueSelect } from '../../selection/LabelValueSelect'
+
+function AdminServiceFilter(): JSX.Element {
+  const [open, setOpen] = useState<boolean>(false)
+
+  const [params, setParams] = useURLParams({
+    epStepTgts: [] as string[],
+    intKeyTgts: [] as string[],
+    labelKey: '',
+    labelValue: '',
+  })
+
+  const resetAll = useResetURLParams(
+    'epStepTgts',
+    'intKeyTgts',
+    'labelKey',
+    'labelValue',
+  )
+
+  const removeFilter = (filterName: string): void => {
+    if (filterName === 'labelKey') {
+      setParams({ ...params, labelKey: '', labelValue: '' })
+      return
+    }
+    if (filterName === 'labelValue') {
+      setParams({ ...params, labelValue: '' })
+      return
+    }
+    setParams({ ...params, [filterName]: [] })
+  }
+
+  function renderFilterChips(): JSX.Element {
+    return (
+      <Stack direction='row' spacing={1} sx={{ marginTop: '10px' }}>
+        {!!params.epStepTgts.length && (
+          <Chip
+            label={'ep step targets=' + params.epStepTgts.join(',')}
+            onClick={() => setOpen(true)}
+            onDelete={() => removeFilter('epStepTgts')}
+          />
+        )}
+        {!!params.intKeyTgts.length && (
+          <Chip
+            label={'integration key targets=' + params.intKeyTgts.join(',')}
+            onClick={() => setOpen(true)}
+            onDelete={() => removeFilter('intKeyTgts')}
+          />
+        )}
+        {!!params.labelKey.length && (
+          <Chip
+            label={'key=' + params.labelKey}
+            onClick={() => setOpen(true)}
+            onDelete={() => {
+              removeFilter('labelKey')
+            }}
+          />
+        )}
+        {!!params.labelValue.length && (
+          <Chip
+            label={'value=' + params.labelValue}
+            onClick={() => setOpen(true)}
+            onDelete={() => removeFilter('labelValue')}
+          />
+        )}
+      </Stack>
+    )
+  }
+
+  function renderFilterDrawer(): JSX.Element {
+    return (
+      <ClickAwayListener
+        onClickAway={() => setOpen(false)}
+        mouseEvent='onMouseUp'
+      >
+        <Drawer
+          anchor='right'
+          open={open}
+          variant='persistent'
+          data-cy='admin-service-filter'
+        >
+          <Toolbar />
+          <Grid style={{ width: '30vw' }}>
+            <Typography variant='h6' style={{ margin: '16px' }}>
+              Service Filters
+            </Typography>
+            <Divider />
+            <List disablePadding>
+              <ListItem>
+                <ListItemText primary='EP Step Targets' />
+              </ListItem>
+              <ListItem>
+                <Autocomplete
+                  multiple
+                  fullWidth
+                  id='ep-step-targets'
+                  options={['slack', 'webhook', 'schedule', 'user', 'rotation']}
+                  value={params.epStepTgts}
+                  onChange={(_, value) =>
+                    setParams({ ...params, epStepTgts: value })
+                  }
+                  renderInput={(params) => (
+                    <TextField {...params} label='Select Channels' />
+                  )}
+                />
+              </ListItem>
+              <Divider />
+              <ListItem>
+                <ListItemText primary='Integration Key Targets' />
+              </ListItem>
+              <ListItem>
+                <Autocomplete
+                  multiple
+                  fullWidth
+                  id='int-key-targets'
+                  options={[
+                    'generic',
+                    'grafana',
+                    'site24x7',
+                    'prometheusAlertmanager',
+                    'email',
+                  ]}
+                  value={params.intKeyTgts}
+                  onChange={(_, value) =>
+                    setParams({ ...params, intKeyTgts: value })
+                  }
+                  renderInput={(params) => (
+                    <TextField {...params} label='Select Targets' />
+                  )}
+                />
+              </ListItem>
+              <Divider />
+              <ListItem>
+                <ListItemText primary='Labels' />
+              </ListItem>
+              <ListItem>
+                <LabelKeySelect
+                  name='label-key-select'
+                  label='Select Label Key'
+                  fullWidth
+                  value={params.labelKey}
+                  onChange={(value) =>
+                    setParams({
+                      ...params,
+                      labelKey: value,
+                      labelValue: '',
+                    })
+                  }
+                />
+              </ListItem>
+              <ListItem>
+                <LabelValueSelect
+                  name='label-value'
+                  fullWidth
+                  label='Select Label Value'
+                  labelKey={params.labelKey}
+                  value={params.labelValue}
+                  onChange={(value) =>
+                    setParams({ ...params, labelValue: value })
+                  }
+                  disabled={!params.labelKey}
+                />
+              </ListItem>
+              <ListItem>
+                <Button
+                  variant='outlined'
+                  sx={{ marginRight: '10px' }}
+                  onClick={resetAll}
+                >
+                  Clear All
+                </Button>
+              </ListItem>
+            </List>
+          </Grid>
+        </Drawer>
+      </ClickAwayListener>
+    )
+  }
+
+  return (
+    <React.Fragment>
+      <Grid container>
+        <Grid item xs>
+          {renderFilterChips()}
+        </Grid>
+        <Grid item xs>
+          <IconButton
+            aria-label='Filter Alerts'
+            onClick={() => setOpen(true)}
+            size='large'
+            sx={{ float: 'right' }}
+          >
+            <FilterList />
+          </IconButton>
+        </Grid>
+      </Grid>
+      {renderFilterDrawer()}
+    </React.Fragment>
+  )
+}
+
+export default AdminServiceFilter

--- a/web/src/app/admin/admin-service-metrics/AdminServiceMetrics.tsx
+++ b/web/src/app/admin/admin-service-metrics/AdminServiceMetrics.tsx
@@ -13,11 +13,18 @@ import {
 } from '@mui/icons-material'
 import { AlertSearchOptions, Service } from '../../../schema'
 import { useAlerts } from '../../services/AlertMetrics/useAlerts'
+import { useURLParams } from '../../actions'
 
 const STALE_ALERT_LIMIT = 2
 
 export default function AdminServiceMetrics(): JSX.Element {
   const now = useMemo(() => DateTime.now(), [])
+  const [params] = useURLParams({
+    epStepTgts: [] as string[],
+    intKeyTgts: [] as string[],
+    labelKey: '',
+    labelValue: '',
+  })
 
   const depKey = `${now}`
   const serviceData = useServices(depKey)
@@ -34,6 +41,12 @@ export default function AdminServiceMetrics(): JSX.Element {
     {
       services: serviceData.services,
       alerts: alertsData.alerts,
+      filters: {
+        labelKey: params.labelKey,
+        labelValue: params.labelValue,
+        epStepTgts: params.epStepTgts,
+        intKeyTgts: params.intKeyTgts,
+      },
     },
     {} as ServiceMetrics,
   )

--- a/web/src/app/admin/admin-service-metrics/useServiceMetrics.ts
+++ b/web/src/app/admin/admin-service-metrics/useServiceMetrics.ts
@@ -19,17 +19,18 @@ export type ServiceMetricFilters = {
 export type ServiceMetricOpts = {
   services: Service[]
   alerts: Alert[]
-  filters?: ServiceMetricFilters
+  filters: ServiceMetricFilters
 }
+
 export function useServiceMetrics(opts: ServiceMetricOpts): ServiceMetrics {
-  const { services, alerts, filters } = opts
+  const { services, filters, alerts } = opts
 
   const filterServices = (
     services: Service[],
-    filters?: ServiceMetricFilters,
+    filters: ServiceMetricFilters,
   ): Service[] => {
     return services.filter((svc) => {
-      if (filters?.labelKey) {
+      if (filters.labelKey) {
         const labelMatch = svc.labels.some(
           (label) =>
             filters.labelKey === label.key &&
@@ -54,8 +55,8 @@ export function useServiceMetrics(opts: ServiceMetricOpts): ServiceMetrics {
   }
 
   const calculateMetrics = (
-    filteredServices: Service[],
     alerts: Alert[],
+    filteredServices: Service[],
   ): ServiceMetrics => {
     const metrics = {
       keyTgtTotals: {},
@@ -83,6 +84,6 @@ export function useServiceMetrics(opts: ServiceMetricOpts): ServiceMetrics {
   }
 
   const filteredServices = filterServices(services, filters)
-  const metrics = calculateMetrics(filteredServices, alerts)
+  const metrics = calculateMetrics(alerts, filteredServices)
   return { ...metrics, filteredServices }
 }

--- a/web/src/app/selection/MaterialSelect.tsx
+++ b/web/src/app/selection/MaterialSelect.tsx
@@ -62,6 +62,7 @@ interface SelectOption {
 }
 
 interface CommonSelectProps {
+  fullWidth?: boolean
   disabled?: boolean
   error?: boolean
   isLoading?: boolean
@@ -96,6 +97,7 @@ export default function MaterialSelect(
 ): JSX.Element {
   const classes = useStyles()
   const {
+    fullWidth,
     disabled,
     error,
     isLoading,
@@ -182,6 +184,7 @@ export default function MaterialSelect(
       data-cy='material-select'
       data-cy-ready={!isLoading}
       classes={customCSS}
+      fullWidth={fullWidth}
       multiple={multiple}
       filterSelectedOptions={multiple && !disableCloseOnSelect}
       value={value}

--- a/web/src/app/selection/QuerySelect.js
+++ b/web/src/app/selection/QuerySelect.js
@@ -128,6 +128,7 @@ export const querySelectPropTypes = {
   formatInputOnChange: p.func,
   onChange: p.func,
   value: valueCheck,
+  fullWidth: p.bool,
   label: p.string,
   multiple: p.bool,
   name: p.string,


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x]  Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR adds filtering for service metrics data table by:
- Escalation policy targets
- Integration key targets
- Label keys and values

**Which issue(s) this PR fixes:**
Part of #3057

**Out of Scope:**
Additional metrics around integration key and escalation policy targets.

**Screenshots**
Filter side drawer:
<img width="1680" alt="Screenshot 2023-10-27 at 2 04 54 PM" src="https://github.com/target/goalert/assets/38022260/7bbe2ce3-0341-4620-94b1-151a1a8ec456">

