### PR TITLE
apikey: Switch policy from `allowedFields` to `query`

### DIFF
--- a/apikey/middleware.go
+++ b/apikey/middleware.go
@@ -1,0 +1,35 @@
+package apikey
+
+import (
+	"context"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/target/goalert/permission"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+)
+
+type Middleware struct{}
+
+var _ graphql.OperationContextMutator = Middleware{}
+
+func (Middleware) ExtensionName() string                          { return "GQLAPIKeyMiddleware" }
+func (Middleware) Validate(schema graphql.ExecutableSchema) error { return nil }
+
+func (Middleware) MutateOperationContext(ctx context.Context, rc *graphql.OperationContext) *gqlerror.Error {
+	p := PolicyFromContext(ctx)
+	if p == nil {
+		return nil
+	}
+
+	if p.Query != rc.RawQuery {
+		return &gqlerror.Error{
+			Err:     permission.Unauthorized(),
+			Message: "wrong query for API key",
+			Extensions: map[string]interface{}{
+				"code": "invalid_query",
+			},
+		}
+	}
+
+	return nil
+}

--- a/apikey/policy.go
+++ b/apikey/policy.go
@@ -4,7 +4,7 @@ import "github.com/target/goalert/permission"
 
 // GQLPolicy is a GraphQL API key policy.
 type GQLPolicy struct {
-	Version       int
-	AllowedFields []string
-	Role          permission.Role
+	Version int
+	Query   string
+	Role    permission.Role
 }

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -238,17 +238,17 @@ type ComplexityRoot struct {
 	}
 
 	GQLAPIKey struct {
-		AllowedFields func(childComplexity int) int
-		CreatedAt     func(childComplexity int) int
-		CreatedBy     func(childComplexity int) int
-		Description   func(childComplexity int) int
-		ExpiresAt     func(childComplexity int) int
-		ID            func(childComplexity int) int
-		LastUsed      func(childComplexity int) int
-		Name          func(childComplexity int) int
-		Role          func(childComplexity int) int
-		UpdatedAt     func(childComplexity int) int
-		UpdatedBy     func(childComplexity int) int
+		CreatedAt   func(childComplexity int) int
+		CreatedBy   func(childComplexity int) int
+		Description func(childComplexity int) int
+		ExpiresAt   func(childComplexity int) int
+		ID          func(childComplexity int) int
+		LastUsed    func(childComplexity int) int
+		Name        func(childComplexity int) int
+		Query       func(childComplexity int) int
+		Role        func(childComplexity int) int
+		UpdatedAt   func(childComplexity int) int
+		UpdatedBy   func(childComplexity int) int
 	}
 
 	GQLAPIKeyUsage struct {
@@ -430,7 +430,6 @@ type ComplexityRoot struct {
 		LabelValues              func(childComplexity int, input *LabelValueSearchOptions) int
 		Labels                   func(childComplexity int, input *LabelSearchOptions) int
 		LinkAccountInfo          func(childComplexity int, token string) int
-		ListGQLFields            func(childComplexity int, query *string) int
 		MessageLogs              func(childComplexity int, input *MessageLogSearchOptions) int
 		PhoneNumberInfo          func(childComplexity int, number string) int
 		Rotation                 func(childComplexity int, id string) int
@@ -849,7 +848,6 @@ type QueryResolver interface {
 	LinkAccountInfo(ctx context.Context, token string) (*LinkAccountInfo, error)
 	SwoStatus(ctx context.Context) (*SWOStatus, error)
 	GqlAPIKeys(ctx context.Context) ([]GQLAPIKey, error)
-	ListGQLFields(ctx context.Context, query *string) ([]string, error)
 }
 type RotationResolver interface {
 	IsFavorite(ctx context.Context, obj *rotation.Rotation) (bool, error)
@@ -1540,13 +1538,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.EscalationPolicyStep.Targets(childComplexity), true
 
-	case "GQLAPIKey.allowedFields":
-		if e.complexity.GQLAPIKey.AllowedFields == nil {
-			break
-		}
-
-		return e.complexity.GQLAPIKey.AllowedFields(childComplexity), true
-
 	case "GQLAPIKey.createdAt":
 		if e.complexity.GQLAPIKey.CreatedAt == nil {
 			break
@@ -1595,6 +1586,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.GQLAPIKey.Name(childComplexity), true
+
+	case "GQLAPIKey.query":
+		if e.complexity.GQLAPIKey.Query == nil {
+			break
+		}
+
+		return e.complexity.GQLAPIKey.Query(childComplexity), true
 
 	case "GQLAPIKey.role":
 		if e.complexity.GQLAPIKey.Role == nil {
@@ -2840,18 +2838,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.LinkAccountInfo(childComplexity, args["token"].(string)), true
-
-	case "Query.listGQLFields":
-		if e.complexity.Query.ListGQLFields == nil {
-			break
-		}
-
-		args, err := ec.field_Query_listGQLFields_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.ListGQLFields(childComplexity, args["query"].(*string)), true
 
 	case "Query.messageLogs":
 		if e.complexity.Query.MessageLogs == nil {
@@ -5409,21 +5395,6 @@ func (ec *executionContext) field_Query_linkAccountInfo_args(ctx context.Context
 		}
 	}
 	args["token"] = arg0
-	return args, nil
-}
-
-func (ec *executionContext) field_Query_listGQLFields_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 *string
-	if tmp, ok := rawArgs["query"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
-		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["query"] = arg0
 	return args, nil
 }
 
@@ -10168,8 +10139,8 @@ func (ec *executionContext) fieldContext_GQLAPIKey_expiresAt(ctx context.Context
 	return fc, nil
 }
 
-func (ec *executionContext) _GQLAPIKey_allowedFields(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKey) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_GQLAPIKey_allowedFields(ctx, field)
+func (ec *executionContext) _GQLAPIKey_query(ctx context.Context, field graphql.CollectedField, obj *GQLAPIKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GQLAPIKey_query(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -10182,7 +10153,7 @@ func (ec *executionContext) _GQLAPIKey_allowedFields(ctx context.Context, field 
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.AllowedFields, nil
+		return obj.Query, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -10194,12 +10165,12 @@ func (ec *executionContext) _GQLAPIKey_allowedFields(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_GQLAPIKey_allowedFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_GQLAPIKey_query(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "GQLAPIKey",
 		Field:      field,
@@ -18535,68 +18506,13 @@ func (ec *executionContext) fieldContext_Query_gqlAPIKeys(ctx context.Context, f
 				return ec.fieldContext_GQLAPIKey_lastUsed(ctx, field)
 			case "expiresAt":
 				return ec.fieldContext_GQLAPIKey_expiresAt(ctx, field)
-			case "allowedFields":
-				return ec.fieldContext_GQLAPIKey_allowedFields(ctx, field)
+			case "query":
+				return ec.fieldContext_GQLAPIKey_query(ctx, field)
 			case "role":
 				return ec.fieldContext_GQLAPIKey_role(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type GQLAPIKey", field.Name)
 		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Query_listGQLFields(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_listGQLFields(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().ListGQLFields(rctx, fc.Args["query"].(*string))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]string)
-	fc.Result = res
-	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Query_listGQLFields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_listGQLFields_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
 	}
 	return fc, nil
 }
@@ -28482,7 +28398,7 @@ func (ec *executionContext) unmarshalInputCreateGQLAPIKeyInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "description", "allowedFields", "expiresAt", "role"}
+	fieldsInOrder := [...]string{"name", "description", "expiresAt", "role", "query"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -28507,15 +28423,6 @@ func (ec *executionContext) unmarshalInputCreateGQLAPIKeyInput(ctx context.Conte
 				return it, err
 			}
 			it.Description = data
-		case "allowedFields":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("allowedFields"))
-			data, err := ec.unmarshalNString2ᚕstringᚄ(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.AllowedFields = data
 		case "expiresAt":
 			var err error
 
@@ -28534,6 +28441,15 @@ func (ec *executionContext) unmarshalInputCreateGQLAPIKeyInput(ctx context.Conte
 				return it, err
 			}
 			it.Role = data
+		case "query":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Query = data
 		}
 	}
 
@@ -33724,8 +33640,8 @@ func (ec *executionContext) _GQLAPIKey(ctx context.Context, sel ast.SelectionSet
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "allowedFields":
-			out.Values[i] = ec._GQLAPIKey_allowedFields(ctx, field, obj)
+		case "query":
+			out.Values[i] = ec._GQLAPIKey_query(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -36009,28 +35925,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_gqlAPIKeys(ctx, field)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			rrm := func(ctx context.Context) graphql.Marshaler {
-				return ec.OperationContext.RootResolverMiddleware(ctx,
-					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "listGQLFields":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_listGQLFields(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/graphql2/graphqlapp/gqlapikeys.go
+++ b/graphql2/graphqlapp/gqlapikeys.go
@@ -48,14 +48,14 @@ func (q *Query) GqlAPIKeys(ctx context.Context) ([]graphql2.GQLAPIKey, error) {
 	res := make([]graphql2.GQLAPIKey, len(keys))
 	for i, k := range keys {
 		res[i] = graphql2.GQLAPIKey{
-			ID:            k.ID.String(),
-			Name:          k.Name,
-			Description:   k.Description,
-			CreatedAt:     k.CreatedAt,
-			UpdatedAt:     k.UpdatedAt,
-			ExpiresAt:     k.ExpiresAt,
-			AllowedFields: k.AllowedFields,
-			Role:          graphql2.UserRole(k.Role),
+			ID:          k.ID.String(),
+			Name:        k.Name,
+			Description: k.Description,
+			CreatedAt:   k.CreatedAt,
+			UpdatedAt:   k.UpdatedAt,
+			ExpiresAt:   k.ExpiresAt,
+			Query:       k.Query,
+			Role:        graphql2.UserRole(k.Role),
 		}
 
 		if k.CreatedBy != nil {
@@ -109,7 +109,7 @@ func (a *Mutation) CreateGQLAPIKey(ctx context.Context, input graphql2.CreateGQL
 		Name:    input.Name,
 		Desc:    input.Description,
 		Expires: input.ExpiresAt,
-		Fields:  input.AllowedFields,
+		Query:   input.Query,
 		Role:    permission.Role(input.Role),
 	})
 	if err != nil {

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -141,11 +141,11 @@ type CreateEscalationPolicyStepInput struct {
 }
 
 type CreateGQLAPIKeyInput struct {
-	Name          string    `json:"name"`
-	Description   string    `json:"description"`
-	AllowedFields []string  `json:"allowedFields"`
-	ExpiresAt     time.Time `json:"expiresAt"`
-	Role          UserRole  `json:"role"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	ExpiresAt   time.Time `json:"expiresAt"`
+	Role        UserRole  `json:"role"`
+	Query       string    `json:"query"`
 }
 
 type CreateHeartbeatMonitorInput struct {
@@ -298,17 +298,17 @@ type EscalationPolicySearchOptions struct {
 }
 
 type GQLAPIKey struct {
-	ID            string          `json:"id"`
-	Name          string          `json:"name"`
-	Description   string          `json:"description"`
-	CreatedAt     time.Time       `json:"createdAt"`
-	CreatedBy     *user.User      `json:"createdBy,omitempty"`
-	UpdatedAt     time.Time       `json:"updatedAt"`
-	UpdatedBy     *user.User      `json:"updatedBy,omitempty"`
-	LastUsed      *GQLAPIKeyUsage `json:"lastUsed,omitempty"`
-	ExpiresAt     time.Time       `json:"expiresAt"`
-	AllowedFields []string        `json:"allowedFields"`
-	Role          UserRole        `json:"role"`
+	ID          string          `json:"id"`
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	CreatedAt   time.Time       `json:"createdAt"`
+	CreatedBy   *user.User      `json:"createdBy,omitempty"`
+	UpdatedAt   time.Time       `json:"updatedAt"`
+	UpdatedBy   *user.User      `json:"updatedBy,omitempty"`
+	LastUsed    *GQLAPIKeyUsage `json:"lastUsed,omitempty"`
+	ExpiresAt   time.Time       `json:"expiresAt"`
+	Query       string          `json:"query"`
+	Role        UserRole        `json:"role"`
 }
 
 type GQLAPIKeyUsage struct {

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -140,8 +140,6 @@ type Query {
   swoStatus: SWOStatus!
 
   gqlAPIKeys: [GQLAPIKey!]!
-
-  listGQLFields(query: String): [String!]!
 }
 
 type IntegrationKeyTypeInfo {
@@ -610,9 +608,9 @@ type CreatedGQLAPIKey {
 input CreateGQLAPIKeyInput {
   name: String!
   description: String!
-  allowedFields: [String!]!
   expiresAt: ISOTimestamp!
   role: UserRole!
+  query: String!
 }
 
 input UpdateGQLAPIKeyInput {
@@ -631,7 +629,7 @@ type GQLAPIKey {
   updatedBy: User @goField(forceResolver: true)
   lastUsed: GQLAPIKeyUsage
   expiresAt: ISOTimestamp!
-  allowedFields: [String!]!
+  query: String!
   role: UserRole!
 }
 

--- a/test/integration/gqlapikeys.spec.ts
+++ b/test/integration/gqlapikeys.spec.ts
@@ -56,7 +56,6 @@ test('GQL API keys', async ({ page, request, isMobile }) => {
   // click the li with the text "Admin"
   await page.click('li:text("Admin")')
 
-  await page.click('text=example query')
   await page.fill('[name="query"]', query)
 
   await page.click('text=Submit')

--- a/web/src/app/admin/AdminAPIKeys.tsx
+++ b/web/src/app/admin/AdminAPIKeys.tsx
@@ -6,7 +6,7 @@ import { Theme } from '@mui/material/styles'
 import { gql, useQuery } from 'urql'
 import { DateTime } from 'luxon'
 import AdminAPIKeysDrawer from './admin-api-keys/AdminAPIKeyDrawer'
-import { GQLAPIKey } from '../../schema'
+import { GQLAPIKey, Query } from '../../schema'
 import { Time } from '../util/Time'
 import FlatList, { FlatListListItem } from '../lists/FlatList'
 import Spinner from '../loading/components/Spinner'
@@ -28,7 +28,7 @@ const query = gql`
         ip
       }
       expiresAt
-      allowedFields
+      query
     }
   }
 `
@@ -61,13 +61,16 @@ export default function AdminAPIKeys(): JSX.Element {
 
   // Get API Key triggers/actions
   const context = useMemo(() => ({ additionalTypenames: ['GQLAPIKey'] }), [])
-  const [{ data, fetching, error }] = useQuery({ query, context })
+  const [{ data, error }] = useQuery<Pick<Query, 'gqlAPIKeys'>>({
+    query,
+    context,
+  })
 
   if (error) {
     return <GenericError error={error.message} />
   }
 
-  if (fetching && !data) {
+  if (!data) {
     return <Spinner />
   }
 
@@ -125,12 +128,7 @@ export default function AdminAPIKeys(): JSX.Element {
             />
           </Typography>
           <Typography variant='subtitle2' component='div' color='textSecondary'>
-            {key.allowedFields.length +
-              ' allowed field' +
-              (key.allowedFields.length > 1 ? 's' : '') +
-              (key.allowedFields.some((f) => f.startsWith('Mutation.'))
-                ? ''
-                : ' (read-only)')}
+            {key.query.includes('mutation') ? '' : '(read-only)'}
           </Typography>
         </React.Fragment>
       ),

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyCreateDialog.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyCreateDialog.tsx
@@ -27,7 +27,7 @@ const fromExistingQuery = gql`
       name
       description
       role
-      allowedFields
+      query
       createdAt
       expiresAt
     }
@@ -65,7 +65,7 @@ export default function AdminAPIKeyCreateDialog(props: {
     name: '',
     description: '',
     expiresAt: DateTime.utc().plus({ days: 7 }).toISO(),
-    allowedFields: [],
+    query: '',
     role: 'user',
   })
   const [status, createKey] = useMutation(newGQLAPIKeyQuery)
@@ -88,7 +88,7 @@ export default function AdminAPIKeyCreateDialog(props: {
     setValue({
       name: nextName(from.name),
       description: from.description,
-      allowedFields: from.allowedFields,
+      query: from.query,
       expiresAt: DateTime.utc().plus({ days: keyLifespan }).toISO(),
       role: from.role,
     })
@@ -102,7 +102,7 @@ export default function AdminAPIKeyCreateDialog(props: {
         input: {
           name: value.name,
           description: value.description,
-          allowedFields: value.allowedFields,
+          query: value.query,
           expiresAt: value.expiresAt,
           role: value.role,
         },

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyDrawer.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyDrawer.tsx
@@ -44,7 +44,7 @@ const query = gql`
         ip
       }
       expiresAt
-      allowedFields
+      query
       role
     }
   }
@@ -78,8 +78,6 @@ export default function AdminAPIKeyDrawer(props: Props): JSX.Element {
     data?.gqlAPIKeys?.find((d: GQLAPIKey) => {
       return d.id === apiKeyID
     }) || ({} as GQLAPIKey)
-
-  const allowFieldsStr = (apiKey?.allowedFields || []).join(', ')
 
   if (error) {
     return <GenericError error={error.message} />
@@ -133,8 +131,8 @@ export default function AdminAPIKeyDrawer(props: Props): JSX.Element {
             </ListItem>
             <ListItem divider>
               <ListItemText
-                primary='Allowed Fields'
-                secondary={allowFieldsStr}
+                primary='Query'
+                secondary={<Button variant='text'>Show Query</Button>}
               />
             </ListItem>
             <ListItem divider>

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyDrawer.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyDrawer.tsx
@@ -20,6 +20,7 @@ import { Time } from '../../util/Time'
 import { gql, useQuery } from 'urql'
 import Spinner from '../../loading/components/Spinner'
 import { GenericError } from '../../error-pages'
+import AdminAPIKeyShowQueryDialog from './AdminAPIKeyShowQueryDialog'
 
 // query for getting existing API Keys
 const query = gql`
@@ -71,6 +72,7 @@ export default function AdminAPIKeyDrawer(props: Props): JSX.Element {
   const isOpen = Boolean(apiKeyID)
   const [deleteDialog, setDialogDialog] = useState(false)
   const [editDialog, setEditDialog] = useState(false)
+  const [showQuery, setShowQuery] = useState(false)
 
   // Get API Key triggers/actions
   const [{ data, fetching, error }] = useQuery({ query })
@@ -96,6 +98,12 @@ export default function AdminAPIKeyDrawer(props: Props): JSX.Element {
         data-cy='debug-message-details'
       >
         <Toolbar />
+        {showQuery && (
+          <AdminAPIKeyShowQueryDialog
+            apiKeyID={apiKey.id}
+            onClose={() => setShowQuery(false)}
+          />
+        )}
         {deleteDialog ? (
           <AdminAPIKeyDeleteDialog
             onClose={(yes: boolean): void => {
@@ -132,7 +140,11 @@ export default function AdminAPIKeyDrawer(props: Props): JSX.Element {
             <ListItem divider>
               <ListItemText
                 primary='Query'
-                secondary={<Button variant='text'>Show Query</Button>}
+                secondary={
+                  <Button variant='text' onClick={() => setShowQuery(true)}>
+                    Show Query
+                  </Button>
+                }
               />
             </ListItem>
             <ListItem divider>

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyEditDialog.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyEditDialog.tsx
@@ -21,7 +21,7 @@ const query = gql`
       name
       description
       expiresAt
-      allowedFields
+      query
       role
     }
   }

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyForm.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyForm.tsx
@@ -1,28 +1,10 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import Grid from '@mui/material/Grid'
 import { FormContainer, FormField } from '../../forms'
 import { FieldError } from '../../util/errutil'
 import { CreateGQLAPIKeyInput } from '../../../schema'
 import AdminAPIKeyExpirationField from './AdminAPIKeyExpirationField'
-import { gql, useQuery } from 'urql'
-import { GenericError } from '../../error-pages'
-import Spinner from '../../loading/components/Spinner'
 import { TextField, MenuItem } from '@mui/material'
-import MaterialSelect from '../../selection/MaterialSelect'
-import ClickableText from '../../util/ClickableText'
-import CompareArrows from '@mui/icons-material/CompareArrows'
-
-const query = gql`
-  query ListGQLFieldsQuery {
-    listGQLFields
-  }
-`
-
-const queryFields = gql`
-  query ListExampleFieldsQuery($query: String!) {
-    listGQLFields(query: $query)
-  }
-`
 
 type AdminAPIKeyFormProps = {
   errors: FieldError[]
@@ -37,39 +19,6 @@ type AdminAPIKeyFormProps = {
 export default function AdminAPIKeyForm(
   props: AdminAPIKeyFormProps,
 ): JSX.Element {
-  const [showQuery, setShowQuery] = useState(false)
-  const [exampleQuery, setExampleQuery] = useState('')
-
-  const [{ data, fetching, error }] = useQuery({
-    query,
-  })
-
-  const [example] = useQuery({
-    query: queryFields,
-    pause: !showQuery || !exampleQuery,
-    variables: {
-      query: exampleQuery,
-    },
-  })
-  const exampleFields = example?.data?.listGQLFields || []
-  const exampleLoaded = !example?.fetching && !example?.error
-
-  useEffect(() => {
-    if (!showQuery) return
-    if (!exampleQuery) return
-    if (!exampleLoaded) return
-
-    props.onChange({ ...props.value, allowedFields: exampleFields })
-  }, [exampleFields, showQuery, exampleQuery, exampleLoaded])
-
-  if (error) {
-    return <GenericError error={error.message} />
-  }
-
-  if (fetching && !data) {
-    return <Spinner />
-  }
-
   return (
     <FormContainer optionalLabels {...props}>
       <Grid container spacing={2}>
@@ -116,68 +65,16 @@ export default function AdminAPIKeyForm(
           />
         </Grid>
         <Grid item xs={12}>
-          {showQuery && (
-            <TextField
-              fullWidth
-              multiline
-              label='Example Query'
-              name='query'
-              placeholder='Enter GraphQL query here...'
-              value={exampleQuery}
-              onChange={(e) => setExampleQuery(e.target.value)}
-              error={!!example?.error}
-              helperText={
-                <React.Fragment>
-                  <span style={{ display: 'block' }}>
-                    {example?.error?.message}
-                  </span>
-                  <ClickableText
-                    onClick={() => setShowQuery(false)}
-                    endIcon={<CompareArrows />}
-                  >
-                    Select fields manually
-                  </ClickableText>
-                  <span style={{ display: 'block' }}>
-                    Allowed fields:{' '}
-                    {exampleFields.length ? exampleFields.join(', ') : 'none'}
-                  </span>
-                </React.Fragment>
-              }
-            />
-          )}
-          {!showQuery && (
-            <FormField
-              fullWidth
-              component={MaterialSelect}
-              name='allowedFields'
-              disabled={!props.create}
-              clientSideFilter
-              disableCloseOnSelect
-              optionsLimit={10}
-              options={data.listGQLFields.map((field: string) => ({
-                label: field,
-                value: field,
-              }))}
-              mapOnChangeValue={(selected: { value: string }[]) =>
-                selected.map((v) => v.value)
-              }
-              mapValue={(value: string[]) =>
-                value.map((v) => ({ label: v, value: v }))
-              }
-              multiple
-              required
-              hint={
-                props.create && (
-                  <ClickableText
-                    onClick={() => setShowQuery(true)}
-                    endIcon={<CompareArrows />}
-                  >
-                    Click here to enter example query instead
-                  </ClickableText>
-                )
-              }
-            />
-          )}
+          <FormField
+            component={TextField}
+            name='query'
+            fullWidth
+            multiline
+            rows={4}
+            required
+            disabled={!props.create}
+            placeholder='Enter GraphQL query here...'
+          />
         </Grid>
       </Grid>
     </FormContainer>

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyShowQueryDialog.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyShowQueryDialog.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import FormDialog from '../../dialogs/FormDialog'
+import { gql, useQuery } from 'urql'
+import { GenericError } from '../../error-pages'
+import Spinner from '../../loading/components/Spinner'
+import { GQLAPIKey } from '../../../schema'
+import { Grid, Typography } from '@mui/material'
+import CopyText from '../../util/CopyText'
+
+// query for getting existing API Keys
+const query = gql`
+  query gqlAPIKeysQuery {
+    gqlAPIKeys {
+      id
+      name
+      query
+    }
+  }
+`
+
+export default function AdminAPIKeyShowQueryDialog(props: {
+  apiKeyID: string
+  onClose: (yes: boolean) => void
+}): JSX.Element {
+  const [{ fetching, data, error }] = useQuery({
+    query,
+  })
+  const { apiKeyID, onClose } = props
+
+  if (fetching && !data) return <Spinner />
+  if (error) return <GenericError error={error.message} />
+
+  const key = data?.gqlAPIKeys?.find((d: GQLAPIKey) => {
+    return d.id === apiKeyID
+  })
+  if (!key) throw new Error('API Key not found')
+
+  return (
+    <FormDialog
+      title='API Key Query'
+      alert
+      subTitle={
+        'This is the fixed query allowed for the API key: ' + key.name + '.'
+      }
+      loading={fetching}
+      form={
+        <Grid item xs={12}>
+          <Typography sx={{ mb: 3 }}>
+            <code>
+              <CopyText
+                title={key.query}
+                value={key.query}
+                placement='bottom'
+              />
+            </code>
+          </Typography>
+        </Grid>
+      }
+      onClose={onClose}
+    />
+  )
+}

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -43,7 +43,6 @@ export interface Query {
   linkAccountInfo?: null | LinkAccountInfo
   swoStatus: SWOStatus
   gqlAPIKeys: GQLAPIKey[]
-  listGQLFields: string[]
 }
 
 export interface IntegrationKeyTypeInfo {
@@ -439,9 +438,9 @@ export interface CreatedGQLAPIKey {
 export interface CreateGQLAPIKeyInput {
   name: string
   description: string
-  allowedFields: string[]
   expiresAt: ISOTimestamp
   role: UserRole
+  query: string
 }
 
 export interface UpdateGQLAPIKeyInput {
@@ -460,7 +459,7 @@ export interface GQLAPIKey {
   updatedBy?: null | User
   lastUsed?: null | GQLAPIKeyUsage
   expiresAt: ISOTimestamp
-  allowedFields: string[]
+  query: string
   role: UserRole
 }
 


### PR DESCRIPTION
**Description:**
Updates the security model of the GQL API Key feature from a list of allowed fields, to a single static query document per key.

This allows additional flexibility to restrict an API key by resource and input parameters, while also working well with GraphQL features like `operationName` (a single query doc can be used for multiple operations).

Part of #3007 

**Out of Scope:**
- automatic persisted queries are compatible, but not implemented by this PR

**Screenshots:**
![image](https://github.com/target/goalert/assets/595010/82402ddd-fbea-4352-a5d2-3e7397765cee)
![image](https://github.com/target/goalert/assets/595010/0099cdf7-8f2d-4b7f-a30a-aa6c2b578502)
