### PR TITLE
label: convert non-search store methods to sqlc

### DIFF
--- a/graphql2/graphqlapp/service.go
+++ b/graphql2/graphqlapp/service.go
@@ -92,7 +92,7 @@ func (s *Service) Notices(ctx context.Context, raw *service.Service) ([]notice.N
 }
 
 func (s *Service) Labels(ctx context.Context, raw *service.Service) ([]label.Label, error) {
-	return s.LabelStore.FindAllByService(ctx, raw.ID)
+	return s.LabelStore.FindAllByService(ctx, s.DB, raw.ID)
 }
 
 func (s *Service) EscalationPolicy(ctx context.Context, raw *service.Service) (*escalation.Policy, error) {

--- a/label/queries.sql
+++ b/label/queries.sql
@@ -1,0 +1,27 @@
+-- name: LabelUniqueKeys :many
+SELECT DISTINCT
+    key
+FROM
+    labels;
+
+-- name: LabelFindAllByTarget :many
+SELECT
+    key,
+    value
+FROM
+    labels
+WHERE
+    tgt_service_id = $1;
+
+-- name: LabelDeleteKeyByTarget :exec
+DELETE FROM labels
+WHERE key = $1
+    AND tgt_service_id = $2;
+
+-- name: LabelSetByTarget :exec
+INSERT INTO labels(key, value, tgt_service_id)
+    VALUES ($1, $2, $3)
+ON CONFLICT (key, tgt_service_id)
+    DO UPDATE SET
+        value = $2;
+

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -30,6 +30,7 @@ sql:
       - apikey/queries.sql
       - override/queries.sql
       - schedule/queries.sql
+      - label/queries.sql
     engine: postgresql
     gen:
       go:


### PR DESCRIPTION
**Description:**
Converts store methods of `label.Store` to use `sqlc`

**Which issue(s) this PR fixes:**
- Prereq for work on #3403
- Part of #3235 

**Out of Scope:**
- Search endpoints using rendered SQL are unchanged

**Describe any introduced user-facing changes:**
N/A

**Describe any introduced API changes:**
N/A

