### PR TITLE
apikey: Fix timestamp displays

### DIFF
--- a/web/src/app/admin/AdminAPIKeys.tsx
+++ b/web/src/app/admin/AdminAPIKeys.tsx
@@ -125,6 +125,7 @@ export default function AdminAPIKeys(): JSX.Element {
             <Time
               prefix={hasExpired ? 'Expired ' : 'Expires '}
               time={key.expiresAt}
+              format='relative'
             />
           </Typography>
           <Typography variant='subtitle2' component='div' color='textSecondary'>
@@ -145,7 +146,12 @@ export default function AdminAPIKeys(): JSX.Element {
               component='div'
               color='textSecondary'
             >
-              <Time prefix='Last Used: ' time={key.expiresAt} />
+              Last Used:&nbsp;
+              {key.lastUsed ? (
+                <Time format='relative' time={key.lastUsed.time} />
+              ) : (
+                `Never`
+              )}
             </Typography>
           </Grid>
           <Grid

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyDrawer.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyDrawer.tsx
@@ -66,6 +66,29 @@ const useStyles = makeStyles(() => ({
   },
 }))
 
+function ActionBy(props: {
+  label: string
+  time?: string
+  name?: string
+}): React.ReactNode {
+  let record: React.ReactNode = 'Never'
+  if (props.time && props.name) {
+    record = (
+      <React.Fragment>
+        <Time format='relative' time={props.time} /> by {props.name}
+      </React.Fragment>
+    )
+  } else if (props.time) {
+    record = <Time format='relative' time={props.time} />
+  }
+
+  return (
+    <ListItem divider>
+      <ListItemText primary={props.label} secondary={record} />
+    </ListItem>
+  )
+}
+
 export default function AdminAPIKeyDrawer(props: Props): JSX.Element {
   const { onClose, apiKeyID } = props
   const classes = useStyles()
@@ -80,6 +103,8 @@ export default function AdminAPIKeyDrawer(props: Props): JSX.Element {
     data?.gqlAPIKeys?.find((d: GQLAPIKey) => {
       return d.id === apiKeyID
     }) || ({} as GQLAPIKey)
+
+  const lastUsed = apiKey?.lastUsed || null
 
   if (error) {
     return <GenericError error={error.message} />
@@ -138,6 +163,9 @@ export default function AdminAPIKeyDrawer(props: Props): JSX.Element {
               />
             </ListItem>
             <ListItem divider>
+              <ListItemText primary='Role' secondary={apiKey?.role} />
+            </ListItem>
+            <ListItem divider>
               <ListItemText
                 primary='Query'
                 secondary={
@@ -147,33 +175,23 @@ export default function AdminAPIKeyDrawer(props: Props): JSX.Element {
                 }
               />
             </ListItem>
-            <ListItem divider>
-              <ListItemText
-                primary='Creation Time'
-                secondary={<Time prefix='' time={apiKey?.createdAt} />}
-              />
-            </ListItem>
-            <ListItem divider>
-              <ListItemText
-                primary='Created By'
-                secondary={apiKey?.createdBy?.name}
-              />
-            </ListItem>
-            <ListItem divider>
-              <ListItemText
-                primary='Expires At'
-                secondary={<Time prefix='' time={apiKey?.expiresAt} />}
-              />
-            </ListItem>
-            <ListItem divider>
-              <ListItemText
-                primary='Updated By'
-                secondary={apiKey?.updatedBy?.name}
-              />
-            </ListItem>
-            <ListItem divider>
-              <ListItemText primary='Role' secondary={apiKey?.role} />
-            </ListItem>
+            <ActionBy
+              label='Created'
+              time={apiKey?.createdAt}
+              name={apiKey?.createdBy?.name}
+            />
+            <ActionBy
+              label='Updated'
+              time={apiKey?.updatedAt}
+              name={apiKey?.updatedBy?.name}
+            />
+            <ActionBy label='Expires' time={apiKey?.expiresAt} />
+
+            <ActionBy
+              label='Last Used'
+              time={lastUsed?.time}
+              name={lastUsed ? lastUsed.ua + ' from ' + lastUsed.ip : ''}
+            />
           </List>
           <Grid className={classes.buttons}>
             <ButtonGroup variant='contained'>

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyDrawer.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import {
   ClickAwayListener,
   Divider,
@@ -98,11 +98,20 @@ export default function AdminAPIKeyDrawer(props: Props): JSX.Element {
   const [showQuery, setShowQuery] = useState(false)
 
   // Get API Key triggers/actions
-  const [{ data, fetching, error }] = useQuery({ query })
+  const context = useMemo(() => ({ additionalTypenames: ['GQLAPIKey'] }), [])
+  const [{ data, error }] = useQuery({ query, context })
   const apiKey: GQLAPIKey =
     data?.gqlAPIKeys?.find((d: GQLAPIKey) => {
       return d.id === apiKeyID
     }) || ({} as GQLAPIKey)
+
+  useEffect(() => {
+    if (!isOpen) return
+    if (!data || apiKey.id) return
+
+    // If the API Key is not found, close the drawer.
+    onClose()
+  }, [isOpen, data, apiKey.id])
 
   const lastUsed = apiKey?.lastUsed || null
 
@@ -110,7 +119,7 @@ export default function AdminAPIKeyDrawer(props: Props): JSX.Element {
     return <GenericError error={error.message} />
   }
 
-  if (fetching && !data) {
+  if (isOpen && !apiKey.id) {
     return <Spinner />
   }
 
@@ -154,16 +163,16 @@ export default function AdminAPIKeyDrawer(props: Props): JSX.Element {
           <Divider />
           <List disablePadding>
             <ListItem divider>
-              <ListItemText primary='Name' secondary={apiKey?.name} />
+              <ListItemText primary='Name' secondary={apiKey.name} />
             </ListItem>
             <ListItem divider>
               <ListItemText
                 primary='Description'
-                secondary={apiKey?.description}
+                secondary={apiKey.description}
               />
             </ListItem>
             <ListItem divider>
-              <ListItemText primary='Role' secondary={apiKey?.role} />
+              <ListItemText primary='Role' secondary={apiKey.role} />
             </ListItem>
             <ListItem divider>
               <ListItemText
@@ -177,15 +186,15 @@ export default function AdminAPIKeyDrawer(props: Props): JSX.Element {
             </ListItem>
             <ActionBy
               label='Created'
-              time={apiKey?.createdAt}
-              name={apiKey?.createdBy?.name}
+              time={apiKey.createdAt}
+              name={apiKey.createdBy?.name}
             />
             <ActionBy
               label='Updated'
-              time={apiKey?.updatedAt}
-              name={apiKey?.updatedBy?.name}
+              time={apiKey.updatedAt}
+              name={apiKey.updatedBy?.name}
             />
-            <ActionBy label='Expires' time={apiKey?.expiresAt} />
+            <ActionBy label='Expires' time={apiKey.expiresAt} />
 
             <ActionBy
               label='Last Used'


### PR DESCRIPTION
**Description:**
- Fixes a bug in the API key display where 'Last Used' mistakenly displayed the expiration time.
- Show UA and IP of last used in details drawer
- Use relative time format for dates on keys

**Screenshots:**
If applicable, add some screenshots here.
![image](https://github.com/target/goalert/assets/595010/7f5ddcf7-ca48-4421-b6d6-ef0dc8f1b9af)
![image](https://github.com/target/goalert/assets/595010/5ac1f9c0-5856-41a8-97da-699a157b5f1a)
