### PR TITLE
ui/urql: transition to urql and use suspense to load user details

### DIFF
--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -19,6 +19,7 @@ import { styles as globalStyles } from '../styles/materialStyles'
 import { UserContactMethod } from '../../schema'
 import UserContactMethodCreateDialog from './UserContactMethodCreateDialog'
 import { useSessionInfo } from '../util/RequireConfig'
+import { useSuspenseContext } from './UserDetails'
 
 const query = gql`
   query cmList($id: ID!) {
@@ -70,6 +71,7 @@ export default function UserContactMethodList(
     variables: {
       id: props.userID,
     },
+    context: useSuspenseContext(),
   })
 
   const { userID: currentUserID } = useSessionInfo()

--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
-import { gql, useQuery } from '@apollo/client'
+import React, { useState, ReactNode } from 'react'
+import { gql, useQuery } from 'urql'
 import FlatList from '../lists/FlatList'
 import { Button, Card, CardHeader, Grid, IconButton } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
@@ -12,7 +12,6 @@ import UserContactMethodEditDialog from './UserContactMethodEditDialog'
 import { Warning } from '../icons'
 import UserContactMethodVerificationDialog from './UserContactMethodVerificationDialog'
 import { useIsWidthDown } from '../util/useWidth'
-import Spinner from '../loading/components/Spinner'
 import { GenericError, ObjectNotFound } from '../error-pages'
 import SendTestDialog from './SendTestDialog'
 import AppLink from '../util/AppLink'
@@ -56,7 +55,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export default function UserContactMethodList(
   props: UserContactMethodListProps,
-): JSX.Element {
+): ReactNode {
   const classes = useStyles()
   const mobile = useIsWidthDown('md')
 
@@ -66,7 +65,8 @@ export default function UserContactMethodList(
   const [showDeleteDialogByID, setShowDeleteDialogByID] = useState('')
   const [showSendTestByID, setShowSendTestByID] = useState('')
 
-  const { loading, error, data } = useQuery(query, {
+  const [{ fetching, error, data }] = useQuery({
+    query,
     variables: {
       id: props.userID,
     },
@@ -75,7 +75,7 @@ export default function UserContactMethodList(
   const { userID: currentUserID } = useSessionInfo()
   const isCurrentUser = props.userID === currentUserID
 
-  if (loading && !data) return <Spinner />
+  if (fetching && !data) return null
   if (data && !data.user) return <ObjectNotFound type='user' />
   if (error) return <GenericError error={error.message} />
 

--- a/web/src/app/users/UserDetails.tsx
+++ b/web/src/app/users/UserDetails.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
-import { useQuery, gql } from 'urql'
+import React, { Suspense, useState, useMemo } from 'react'
+import { useQuery, gql, OperationContext } from 'urql'
 import Delete from '@mui/icons-material/Delete'
 import LockOpenIcon from '@mui/icons-material/LockOpen'
 import DetailsPage from '../details/DetailsPage'
@@ -73,6 +73,15 @@ const profileQuery = gql`
   }
 `
 
+export function useSuspenseContext(): Partial<OperationContext> {
+  return useMemo(
+    () => ({
+      suspense: true,
+    }),
+    [],
+  )
+}
+
 function serviceCount(onCallSteps: EscalationPolicyStep[] = []): number {
   const svcs: { [Key: string]: boolean } = {}
   ;(onCallSteps || []).forEach((s) =>
@@ -107,6 +116,7 @@ export default function UserDetails(props: {
     query: isAdmin || userID === currentUserID ? profileQuery : userQuery,
     variables: { id: userID },
     pause: !userID,
+    context: useSuspenseContext(),
   })
 
   const loading = !isSessionReady || isQueryLoading
@@ -179,7 +189,7 @@ export default function UserDetails(props: {
   }
 
   return (
-    <React.Fragment>
+    <Suspense fallback={<Spinner />}>
       {showEdit && (
         <UserEditDialog
           onClose={() => setShowEdit(false)}
@@ -250,6 +260,6 @@ export default function UserDetails(props: {
         secondaryActions={options}
         links={links}
       />
-    </React.Fragment>
+    </Suspense>
   )
 }

--- a/web/src/app/users/UserDetails.tsx
+++ b/web/src/app/users/UserDetails.tsx
@@ -189,7 +189,7 @@ export default function UserDetails(props: {
   }
 
   return (
-    <Suspense fallback={<Spinner />}>
+    <React.Fragment>
       {showEdit && (
         <UserEditDialog
           onClose={() => setShowEdit(false)}
@@ -244,22 +244,27 @@ export default function UserDetails(props: {
           onClose={() => setCreateNR(false)}
         />
       )}
-      <DetailsPage
-        avatar={<UserAvatar userID={userID} />}
-        title={user.name + (svcCount ? ' (On-Call)' : '')}
-        subheader={user.email}
-        pageContent={
-          <Grid container spacing={2}>
-            <UserContactMethodList userID={userID} readOnly={props.readOnly} />
-            <UserNotificationRuleList
-              userID={userID}
-              readOnly={props.readOnly}
-            />
-          </Grid>
-        }
-        secondaryActions={options}
-        links={links}
-      />
-    </Suspense>
+      <Suspense fallback={<Spinner />}>
+        <DetailsPage
+          avatar={<UserAvatar userID={userID} />}
+          title={user.name + (svcCount ? ' (On-Call)' : '')}
+          subheader={user.email}
+          pageContent={
+            <Grid container spacing={2}>
+              <UserContactMethodList
+                userID={userID}
+                readOnly={props.readOnly}
+              />
+              <UserNotificationRuleList
+                userID={userID}
+                readOnly={props.readOnly}
+              />
+            </Grid>
+          }
+          secondaryActions={options}
+          links={links}
+        />
+      </Suspense>
+    </React.Fragment>
   )
 }

--- a/web/src/app/users/UserNotificationRuleList.tsx
+++ b/web/src/app/users/UserNotificationRuleList.tsx
@@ -1,5 +1,5 @@
 import React, { useState, ReactNode } from 'react'
-import { gql, QueryResult } from '@apollo/client'
+import { gql, useQuery } from 'urql'
 import {
   Button,
   Card,
@@ -10,7 +10,6 @@ import {
 } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
 import { Add, Delete } from '@mui/icons-material'
-import Query from '../util/Query'
 import FlatList from '../lists/FlatList'
 import { formatNotificationRule, sortNotificationRules } from './util'
 import UserNotificationRuleDeleteDialog from './UserNotificationRuleDeleteDialog'
@@ -18,6 +17,8 @@ import { styles as globalStyles } from '../styles/materialStyles'
 import UserNotificationRuleCreateDialog from './UserNotificationRuleCreateDialog'
 import { useIsWidthDown } from '../util/useWidth'
 import { User } from '../../schema'
+import { useSuspenseContext } from './UserDetails'
+import { ObjectNotFound, GenericError } from '../error-pages'
 
 const query = gql`
   query nrList($id: ID!) {
@@ -51,71 +52,75 @@ const useStyles = makeStyles((theme: Theme) => {
 export default function UserNotificationRuleList(props: {
   userID: string
   readOnly: boolean
-}): JSX.Element {
+}): ReactNode {
   const classes = useStyles()
   const mobile = useIsWidthDown('md')
   const [showAddDialog, setShowAddDialog] = useState(false)
   const [deleteID, setDeleteID] = useState(null)
 
-  function renderList(user: User): ReactNode {
-    return (
-      <Grid item xs={12}>
-        <Card>
-          <CardHeader
-            className={classes.cardHeader}
-            titleTypographyProps={{ component: 'h2', variant: 'h5' }}
-            title='Notification Rules'
-            action={
-              !mobile ? (
-                <Button
-                  title='Add Notification Rule'
-                  variant='contained'
-                  onClick={() => setShowAddDialog(true)}
-                  startIcon={<Add />}
-                  disabled={user.contactMethods.length === 0}
-                >
-                  Add Rule
-                </Button>
-              ) : null
-            }
-          />
-          <FlatList
-            data-cy='notification-rules'
-            items={sortNotificationRules(user.notificationRules).map((nr) => ({
-              title: formatNotificationRule(nr.delayMinutes, nr.contactMethod),
-              secondaryAction: props.readOnly ? null : (
-                <IconButton
-                  aria-label='Delete notification rule'
-                  onClick={() => setDeleteID(nr.id)}
-                  color='secondary'
-                >
-                  <Delete />
-                </IconButton>
-              ),
-            }))}
-            emptyMessage='No notification rules'
-          />
-        </Card>
-        {showAddDialog && (
-          <UserNotificationRuleCreateDialog
-            userID={props.userID}
-            onClose={() => setShowAddDialog(false)}
-          />
-        )}
-        {deleteID && (
-          <UserNotificationRuleDeleteDialog
-            ruleID={deleteID}
-            onClose={() => setDeleteID(null)}
-          />
-        )}
-      </Grid>
-    )
-  }
+  const [{ data, error, fetching }] = useQuery({
+    query,
+    variables: { id: props.userID },
+    context: useSuspenseContext(),
+  })
+
+  if (fetching && !data) return null
+  if (data && !data.user)
+    return <ObjectNotFound type='notifcation rules list' />
+  if (error) return <GenericError error={error.message} />
+
+  const { user }: { user: User } = data
+
   return (
-    <Query
-      query={query}
-      variables={{ id: props.userID }}
-      render={({ data }: QueryResult) => renderList(data.user)}
-    />
+    <Grid item xs={12}>
+      <Card>
+        <CardHeader
+          className={classes.cardHeader}
+          titleTypographyProps={{ component: 'h2', variant: 'h5' }}
+          title='Notification Rules'
+          action={
+            !mobile ? (
+              <Button
+                title='Add Notification Rule'
+                variant='contained'
+                onClick={() => setShowAddDialog(true)}
+                startIcon={<Add />}
+                disabled={user.contactMethods.length === 0}
+              >
+                Add Rule
+              </Button>
+            ) : null
+          }
+        />
+        <FlatList
+          data-cy='notification-rules'
+          items={sortNotificationRules(user.notificationRules).map((nr) => ({
+            title: formatNotificationRule(nr.delayMinutes, nr.contactMethod),
+            secondaryAction: props.readOnly ? null : (
+              <IconButton
+                aria-label='Delete notification rule'
+                onClick={() => setDeleteID(nr.id)}
+                color='secondary'
+              >
+                <Delete />
+              </IconButton>
+            ),
+          }))}
+          emptyMessage='No notification rules'
+        />
+      </Card>
+      {showAddDialog && (
+        <UserNotificationRuleCreateDialog
+          userID={props.userID}
+          onClose={() => setShowAddDialog(false)}
+        />
+      )}
+      {deleteID && (
+        <UserNotificationRuleDeleteDialog
+          ruleID={deleteID}
+          onClose={() => setDeleteID(null)}
+        />
+      )}
+    </Grid>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2990,7 +2990,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:15.7.9":
+"@types/prop-types@npm:15.7.9, @types/prop-types@npm:^15.7.9":
   version: 15.7.9
   resolution: "@types/prop-types@npm:15.7.9"
   checksum: c7591d3ff7593e243908a07e1d3e2bb6e8879008af5800d8378115a90d0fdf669a1cae72a6d7f69e59c4fa7bb4c8ed61f6ebc1c520fe110c6f2b03ac02414072
@@ -3001,13 +3001,6 @@ __metadata:
   version: 15.7.8
   resolution: "@types/prop-types@npm:15.7.8"
   checksum: 61dfad79da8b1081c450bab83b77935df487ae1cdd4660ec7df6be8e74725c15fa45cf486ce057addc956ca4ae78300b97091e2a25061133d1b9a1440bc896ae
-  languageName: node
-  linkType: hard
-
-"@types/prop-types@npm:^15.7.9":
-  version: 15.7.9
-  resolution: "@types/prop-types@npm:15.7.9"
-  checksum: c7591d3ff7593e243908a07e1d3e2bb6e8879008af5800d8378115a90d0fdf669a1cae72a6d7f69e59c4fa7bb4c8ed61f6ebc1c520fe110c6f2b03ac02414072
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Description:**
- Converts queries in `UserContactMethodList` and `UserNotificationRuleList` from `@apollo/client` to `urql`
- Uses a suspense context for the queries in `UserDetails`, `UserContactMethodList`, and `UserNotificationRuleList`

**Which issue(s) this PR fixes:**
- Part of #3240
- Separating out work from #3229

**Describe any introduced user-facing changes:**
- User details should load all at once after a centered spinner

**Additional Info:**
- `yarn.lock` got updated when I ran `make start`