### PR TITLE
ui/urql: update admin queries and mutations

### DIFF
--- a/web/src/app/admin/AdminConfig.tsx
+++ b/web/src/app/admin/AdminConfig.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useQuery, gql } from '@apollo/client'
+import { useQuery, gql } from 'urql'
 import Button from '@mui/material/Button'
 import ButtonGroup from '@mui/material/ButtonGroup'
 import Divider from '@mui/material/Divider'
@@ -87,13 +87,13 @@ export default function AdminConfig(): JSX.Element {
   const [values, setValues] = useState({})
   const [section, setSection] = useState(false as false | string)
 
-  const { data, loading, error } = useQuery(query)
+  const [{ data, fetching, error }] = useQuery({ query })
 
   if (error) {
     return <GenericError error={error.message} />
   }
 
-  if (loading && !data) {
+  if (fetching && !data) {
     return <Spinner />
   }
 

--- a/web/src/app/admin/AdminDialog.tsx
+++ b/web/src/app/admin/AdminDialog.tsx
@@ -68,12 +68,15 @@ function AdminDialog(props: AdminDialogProps): JSX.Element {
       title={`Apply Configuration Change${changes.length > 1 ? 's' : ''}?`}
       onClose={props.onClose}
       onSubmit={() =>
-        commit({
-          input: changes.map((c: { value: string; type: string }) => {
-            c.value = c.value === '' && c.type === 'number' ? '0' : c.value
-            return omit(c, ['oldValue', 'type'])
-          }),
-        }).then((res) => {
+        commit(
+          {
+            input: changes.map((c: { value: string; type: string }) => {
+              c.value = c.value === '' && c.type === 'number' ? '0' : c.value
+              return omit(c, ['oldValue', 'type'])
+            }),
+          },
+          { additionalTypenames: ['ConfigValue', 'SystemLimit'] },
+        ).then((res) => {
           if (res.error) return
 
           if (props.onComplete) props.onComplete()

--- a/web/src/app/admin/AdminLimits.tsx
+++ b/web/src/app/admin/AdminLimits.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useQuery, gql } from '@apollo/client'
+import { useQuery, gql } from 'urql'
 import Button from '@mui/material/Button'
 import ButtonGroup from '@mui/material/ButtonGroup'
 import Card from '@mui/material/Card'
@@ -22,6 +22,7 @@ const query = gql`
     }
   }
 `
+
 const mutation = gql`
   mutation ($input: [SystemLimitInput!]!) {
     setSystemLimits(input: $input)
@@ -56,13 +57,13 @@ export default function AdminLimits(): JSX.Element {
   const [confirm, setConfirm] = useState(false)
   const [values, setValues] = useState({})
 
-  const { data, loading, error } = useQuery(query)
+  const [{ data, fetching, error }] = useQuery({ query })
 
   if (error) {
     return <GenericError error={error.message} />
   }
 
-  if (loading && !data) {
+  if (fetching && !data) {
     return <Spinner />
   }
 

--- a/web/src/app/admin/AdminNumberLookup.tsx
+++ b/web/src/app/admin/AdminNumberLookup.tsx
@@ -63,12 +63,12 @@ export default function AdminNumberLookup(): JSX.Element {
   ] = useMutation(carrierInfoMut)
   const carrInfo = carrData?.debugCarrierInfo as DebugCarrierInfo
 
-  const [lastError, setLastError] = useState<CombinedError>()
+  const [lastError, setLastError] = useState<CombinedError | null>(null)
   useEffect(() => {
-    setLastError(queryError)
+    if (queryError) setLastError(queryError)
   }, [queryError])
   useEffect(() => {
-    setLastError(mutationError)
+    if (mutationError) setLastError(mutationError)
   }, [mutationError])
 
   function renderListItem(label: string, text = ''): JSX.Element {
@@ -148,11 +148,11 @@ export default function AdminNumberLookup(): JSX.Element {
         </Card>
       </Form>
 
-      <Dialog open={Boolean(lastError)} onClose={() => setLastError(undefined)}>
+      <Dialog open={Boolean(lastError)} onClose={() => setLastError(null)}>
         <DialogTitle>An error occurred</DialogTitle>
         <DialogContentError error={lastError?.message ?? ''} />
         <DialogActions>
-          <Button variant='contained' onClick={() => setLastError(undefined)}>
+          <Button variant='contained' onClick={() => setLastError(null)}>
             Okay
           </Button>
         </DialogActions>

--- a/web/src/app/admin/AdminSMSSend.tsx
+++ b/web/src/app/admin/AdminSMSSend.tsx
@@ -96,8 +96,8 @@ export default function AdminSMSSend(): JSX.Element {
           }).then((res) => {
             if (res.error) {
               setShowErrorDialog(true)
+              return
             }
-            console.log('res.data: ', res.data)
             setMessageID(res.data.debugSendSMS.id)
           })
         }}

--- a/web/src/app/admin/AdminSMSSend.tsx
+++ b/web/src/app/admin/AdminSMSSend.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
-import { useMutation } from '@apollo/client'
-import { gql, useQuery } from 'urql'
+import { gql, useQuery, useMutation } from 'urql'
 import { Form } from '../forms'
 import {
   Button,
@@ -64,18 +63,8 @@ export default function AdminSMSSend(): JSX.Element {
   const [body, setBody] = useState('')
   const [showErrorDialog, setShowErrorDialog] = useState(false)
 
-  const [send, { data: smsData, loading: smsLoading, error: smsError }] =
-    useMutation(sendSMSMutation, {
-      variables: {
-        input: {
-          from: fromNumber,
-          to: toNumber,
-          body,
-        },
-      },
-      onError: () => setShowErrorDialog(true),
-      onCompleted: (data) => setMessageID(data.debugSendSMS.id),
-    })
+  const [{ data: smsData, fetching: smsLoading, error: smsError }, commit] =
+    useMutation(sendSMSMutation)
 
   const [{ data }] = useQuery({
     query: debugMessageStatusQuery,
@@ -98,7 +87,19 @@ export default function AdminSMSSend(): JSX.Element {
       <Form
         onSubmit={(e: { preventDefault: () => void }) => {
           e.preventDefault()
-          send()
+          commit({
+            input: {
+              from: fromNumber,
+              to: toNumber,
+              body,
+            },
+          }).then((res) => {
+            if (res.error) {
+              setShowErrorDialog(true)
+            }
+            console.log('res.data: ', res.data)
+            setMessageID(res.data.debugSendSMS.id)
+          })
         }}
       >
         <Card>

--- a/web/src/app/admin/SlackActions.tsx
+++ b/web/src/app/admin/SlackActions.tsx
@@ -8,7 +8,7 @@ import DialogContentText from '@mui/material/DialogContentText'
 import DialogTitle from '@mui/material/DialogTitle'
 import Divider from '@mui/material/Divider'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
-import { gql, useLazyQuery } from '@apollo/client'
+import { gql, useQuery } from 'urql'
 import CardActions from '../details/CardActions'
 import Spinner from '../loading/components/Spinner'
 import { GenericError } from '../error-pages'
@@ -36,13 +36,13 @@ export default function SlackActions(): JSX.Element {
   const classes = useStyles()
   const [showManifest, setShowManifest] = useState(false)
 
-  const [getManifest, { called, loading, error, data }] = useLazyQuery(query, {
-    pollInterval: 0,
+  const [{ fetching, error, data }, commit] = useQuery({
+    query,
   })
   const manifest = data?.generateSlackAppManifest ?? ''
 
   function renderContent(): JSX.Element {
-    if (called && loading) return <Spinner />
+    if (fetching) return <Spinner />
     if (error) return <GenericError error={error.message} />
 
     return (
@@ -63,7 +63,7 @@ export default function SlackActions(): JSX.Element {
           {
             label: 'App Manifest',
             handleOnClick: () => {
-              getManifest()
+              commit()
               setShowManifest(true)
             },
           },

--- a/web/src/app/admin/SlackActions.tsx
+++ b/web/src/app/admin/SlackActions.tsx
@@ -36,9 +36,7 @@ export default function SlackActions(): JSX.Element {
   const classes = useStyles()
   const [showManifest, setShowManifest] = useState(false)
 
-  const [{ fetching, error, data }, commit] = useQuery({
-    query,
-  })
+  const [{ fetching, error, data }] = useQuery({ query })
   const manifest = data?.generateSlackAppManifest ?? ''
 
   function renderContent(): JSX.Element {
@@ -63,7 +61,6 @@ export default function SlackActions(): JSX.Element {
           {
             label: 'App Manifest',
             handleOnClick: () => {
-              commit()
               setShowManifest(true)
             },
           },


### PR DESCRIPTION
**Description:**
Updates `AdminConfig`, `AdminLimits`, `AdminNumberLookup`, `AdminSMSSend`, and `SlackActions` to use `urql` instead of `@apollo/client` for their queries and mutations

**Which issue(s) this PR fixes:**
Part of #3240