### PR TITLE
ui: convert FormContainer to hooks

### DIFF
--- a/web/src/app/forms/FormContainer.js
+++ b/web/src/app/forms/FormContainer.js
@@ -1,109 +1,75 @@
-import React from 'react'
+import React, { useEffect, useState, useRef, useContext } from 'react'
 import p from 'prop-types'
-import MountWatcher from '../util/MountWatcher'
-
 import { FormContext, FormContainerContext } from './context'
 import { get, set, cloneDeep } from 'lodash'
 
 // FormContainer handles grouping multiple FormFields.
 // It works with the Form component to handle validation.
-export class FormContainer extends React.PureComponent {
-  static propTypes = {
-    value: p.object,
+export function FormContainer(props) {
+  const {
+    value = {},
+    mapValue = (value) => value,
+    mapOnChangeValue = (value) => value,
+    onChange: handleOnChange = () => {},
+    optionalLabels,
+    disabled: containerDisabled,
+    removeFalseyIdxs,
+    errors = [],
+    children,
+  } = props
+  const [validationErrors, setValidationErrors] = useState([])
+  const _fields = useRef({}).current
 
-    errors: p.arrayOf(
-      p.shape({
-        message: p.string.isRequired,
-        field: p.string.isRequired,
-        helpLink: p.string,
-      }),
-    ),
+  const { disabled: formDisabled, addSubmitCheck } = useContext(FormContext)
 
-    onChange: p.func,
-    disabled: p.bool,
-
-    mapValue: p.func,
-    mapOnChangeValue: p.func,
-
-    // If true, will render optional fields with `(optional)` appended to the label.
-    // In addition, required fields will not be appended with `*`.
-    optionalLabels: p.bool,
-
-    // Enables functionality to remove an incoming value at it's index from
-    // an array field if the new value is falsey.
-    removeFalseyIdxs: p.bool,
-  }
-
-  static defaultProps = {
-    errors: [],
-    value: {},
-    onChange: () => {},
-
-    mapValue: (value) => value,
-    mapOnChangeValue: (value) => value,
-  }
-
-  state = {
-    validationErrors: [],
-  }
-
-  _fields = {}
-
-  addField = (fieldName, validate) => {
-    if (!this._fields[fieldName]) {
-      this._fields[fieldName] = []
+  const addField = (fieldName, validate) => {
+    if (!_fields[fieldName]) {
+      _fields[fieldName] = []
     }
-    this._fields[fieldName].push(validate)
+    _fields[fieldName].push(validate)
 
     return () => {
-      this._fields[fieldName] = this._fields[fieldName].filter(
-        (v) => v !== validate,
-      )
-      if (this._fields[fieldName].length === 0) {
-        delete this._fields[fieldName]
+      _fields[fieldName] = _fields[fieldName].filter((v) => v !== validate)
+      if (_fields[fieldName].length === 0) {
+        delete _fields[fieldName]
       }
     }
   }
 
-  onSubmit = () => {
+  const onSubmit = () => {
     const validate = (field) => {
       let err
       // find first error
-      this._fields[field].find((validate) => {
-        err = validate(get(this.props.value, field))
+      _fields[field].find((validate) => {
+        err = validate(get(value, field))
         return err
       })
       if (err) err.field = field
       return err
     }
-    const validationErrors = Object.keys(this._fields)
+    const errs = Object.keys(_fields)
       .map(validate)
       .filter((e) => e)
-    this.setState({ validationErrors })
-    if (validationErrors.length) return false
+    setValidationErrors(errs)
+    if (errs.length) return false
 
     return true
   }
 
-  onChange = (fieldName, e) => {
-    const {
-      mapValue,
-      mapOnChangeValue,
-      value: _value,
-      removeFalseyIdxs,
-    } = this.props
+  useEffect(() => addSubmitCheck(onSubmit), [value])
 
+  const onChange = (fieldName, e) => {
     // copy into a mutable object
-    const oldValue = cloneDeep(_value)
+    const oldValue = cloneDeep(value)
 
-    let value = e
-    if (e && e.target) value = e.target.value
+    let newValue = e
+    if (e && e.target) newValue = e.target.value
 
     // remove idx from array if new value is null when fieldName includes index
     // e.g. don't set array to something like [3, null, 6, 2, 9]
     // if "array[1]" is null, but rather set to [3, 6, 2, 9]
     if (
-      !value &&
+      !newValue &&
       fieldName.charAt(fieldName.length - 1) === ']' &&
       removeFalseyIdxs
     ) {
@@ -117,50 +83,58 @@ export class FormContainer extends React.PureComponent {
         return i !== parseInt(idx, 10)
       })
 
-      return this.props.onChange(
+      return handleOnChange(
         mapOnChangeValue(set(mapValue(oldValue), arrayPath, newArr)),
       )
     }
 
-    return this.props.onChange(
-      mapOnChangeValue(set(mapValue(oldValue), fieldName, value)),
+    return handleOnChange(
+      mapOnChangeValue(set(mapValue(oldValue), fieldName, newValue)),
     )
   }
 
-  render() {
-    return <FormContext.Consumer>{this.renderComponent}</FormContext.Consumer>
-  }
-
-  renderComponent = ({ disabled: formDisabled, addSubmitCheck }) => {
-    const {
-      value,
-      mapValue,
-      optionalLabels,
-      disabled: containerDisabled,
-    } = this.props
-
+  const renderComponent = () => {
     return (
-      <MountWatcher
-        onMount={() => {
-          this._unregister = addSubmitCheck(this.onSubmit)
-        }}
-        onUnmount={() => {
-          this._unregister()
+      <FormContainerContext.Provider
+        value={{
+          value: mapValue(value),
+          disabled: formDisabled || containerDisabled,
+          errors: validationErrors.concat(errors),
+          onChange,
+          addField,
+          optionalLabels,
         }}
       >
-        <FormContainerContext.Provider
-          value={{
-            value: mapValue(value),
-            disabled: formDisabled || containerDisabled,
-            errors: this.state.validationErrors.concat(this.props.errors),
-            onChange: this.onChange,
-            addField: this.addField,
-            optionalLabels,
-          }}
-        >
-          {this.props.children}
-        </FormContainerContext.Provider>
-      </MountWatcher>
+        {children}
+      </FormContainerContext.Provider>
     )
   }
+
+  return <FormContext.Consumer>{renderComponent}</FormContext.Consumer>
+}
+
+FormContainer.propTypes = {
+  value: p.object,
+  children: p.node,
+  errors: p.arrayOf(
+    p.shape({
+      message: p.string,
+      field: p.string,
+      helpLink: p.string,
+    }),
+  ),
+
+  onChange: p.func,
+  disabled: p.bool,
+
+  mapValue: p.func,
+  mapOnChangeValue: p.func,
+
+  // If true, will render optional fields with `(optional)` appended to the label.
+  // In addition, required fields will not be appended with `*`.
+  optionalLabels: p.bool,
+
+  // Enables functionality to remove an incoming value at it's index from
+  // an array field if the new value is falsey.
+  removeFalseyIdxs: p.bool,
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Converts `web/src/app/forms/FormContainer.js` component to use hooks.

**Which issue(s) this PR fixes:**
Fixes: #3044

**Out of Scope:**
Convert to typescript
