### PR TITLE
apikey: allow copy as JSON and fix query formatting

### DIFF
--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyDrawer.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyDrawer.tsx
@@ -178,7 +178,11 @@ export default function AdminAPIKeyDrawer(props: Props): JSX.Element {
               <ListItemText
                 primary='Query'
                 secondary={
-                  <Button variant='text' onClick={() => setShowQuery(true)}>
+                  <Button
+                    variant='outlined'
+                    onClick={() => setShowQuery(true)}
+                    sx={{ mt: 0.5 }}
+                  >
                     Show Query
                   </Button>
                 }

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyShowQueryDialog.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyShowQueryDialog.tsx
@@ -47,13 +47,15 @@ export default function AdminAPIKeyShowQueryDialog(props: {
         <Grid item xs={12}>
           <Typography sx={{ mb: 3 }}>
             <code>
-              <CopyText
-                title={key.query}
-                value={key.query}
-                placement='bottom'
-              />
+              <pre>{key.query}</pre>
             </code>
           </Typography>
+          <CopyText title='Copy Query' value={key.query} placement='bottom' />
+          <CopyText
+            title='Copy Query (as JSON)'
+            value={JSON.stringify(key.query)}
+            placement='bottom'
+          />
         </Grid>
       }
       onClose={onClose}

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyShowQueryDialog.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyShowQueryDialog.tsx
@@ -4,7 +4,7 @@ import { gql, useQuery } from 'urql'
 import { GenericError } from '../../error-pages'
 import Spinner from '../../loading/components/Spinner'
 import { GQLAPIKey } from '../../../schema'
-import { Grid, Typography } from '@mui/material'
+import { Grid, useTheme } from '@mui/material'
 import CopyText from '../../util/CopyText'
 
 // query for getting existing API Keys
@@ -22,6 +22,7 @@ export default function AdminAPIKeyShowQueryDialog(props: {
   apiKeyID: string
   onClose: (yes: boolean) => void
 }): JSX.Element {
+  const theme = useTheme()
   const [{ fetching, data, error }] = useQuery({
     query,
   })
@@ -44,18 +45,37 @@ export default function AdminAPIKeyShowQueryDialog(props: {
       }
       loading={fetching}
       form={
-        <Grid item xs={12}>
-          <Typography sx={{ mb: 3 }}>
-            <code>
-              <pre>{key.query}</pre>
+        <Grid container spacing={2}>
+          <Grid item xs={12}>
+            <code
+              style={{
+                fontSize: 'large',
+                color: theme.palette.getContrastText(
+                  theme.palette.secondary.main,
+                ),
+              }}
+            >
+              <pre
+                style={{
+                  backgroundColor: theme.palette.secondary.main,
+                  padding: 12,
+                  borderRadius: 6,
+                }}
+              >
+                {key.query}
+              </pre>
             </code>
-          </Typography>
-          <CopyText title='Copy Query' value={key.query} placement='bottom' />
-          <CopyText
-            title='Copy Query (as JSON)'
-            value={JSON.stringify(key.query)}
-            placement='bottom'
-          />
+          </Grid>
+          <Grid item xs={12}>
+            <CopyText title='Copy Query' value={key.query} placement='bottom' />
+          </Grid>
+          <Grid item xs={12}>
+            <CopyText
+              title='Copy Query (as JSON)'
+              value={JSON.stringify(key.query)}
+              placement='bottom'
+            />
+          </Grid>
         </Grid>
       }
       onClose={onClose}

--- a/web/src/app/util/CopyText.tsx
+++ b/web/src/app/util/CopyText.tsx
@@ -3,7 +3,7 @@ import makeStyles from '@mui/styles/makeStyles'
 import copyToClipboard from './copyToClipboard'
 import ContentCopy from 'mdi-material-ui/ContentCopy'
 import AppLink from './AppLink'
-import Tooltip, { TooltipProps } from '@mui/material/Tooltip'
+import { Typography, Tooltip, TooltipProps } from '@mui/material'
 
 const useStyles = makeStyles({
   copyContainer: {
@@ -52,7 +52,7 @@ export default function CopyText(props: CopyTextProps): JSX.Element {
     )
   } else {
     content = (
-      <span
+      <Typography
         className={classes.copyContainer}
         role='button'
         tabIndex={0}
@@ -75,7 +75,7 @@ export default function CopyText(props: CopyTextProps): JSX.Element {
           fontSize='small'
         />
         {props.title}
-      </span>
+      </Typography>
     )
   }
 


### PR DESCRIPTION
**Description:**
This PR improves the UX of the Show Query dialog when viewing API keys.

- Fixed formatting of the query text
- Adds the ability to copy as JSON so it can be pasted directly into code or a debugging tool

**Additional changes:**
- Updates `<CopyText />` to use `Typography` instead of a `span`. This resolves issues we have intermittently seen such as `Cannot have <p> be a child of <span>`

**Screenshots:**

![screenshot_2023-11-13_at_1 59 34_pm_360](https://github.com/target/goalert/assets/11381794/c2288c53-2b79-4122-a4d8-ebcc402f2262)

![screenshot_2023-11-13_at_1 54 21_pm](https://github.com/target/goalert/assets/11381794/432adbce-2742-46b4-b867-097591b4d2d3)

![screenshot_2023-11-13_at_1 54 32_pm](https://github.com/target/goalert/assets/11381794/8055dc9c-1b9e-472c-ab1b-65c200c488ae)