### PR TITLE
ui: Suspenseful loading

### DIFF
--- a/test/integration/admin.spec.ts
+++ b/test/integration/admin.spec.ts
@@ -16,31 +16,35 @@ test('Admin', async ({ page }) => {
   // wait for services to finish loading
   await expect(page.locator('.MuiDataGrid-overlay')).toHaveCount(0)
 
-  // get totalServices count
-  const totalServices = await page
+  const totalServicesLocator = page
+    .locator('.MuiCardHeader-content', { hasText: 'Total Services' })
     .locator('.MuiCardHeader-title')
-    .nth(0)
-    .innerText()
-  expect(parseInt(totalServices)).toBeGreaterThan(0)
+
+  // This will retry until the locator's text matches the regex (a number greater than 0)
+  // or the timeout is reached.
+  await expect(totalServicesLocator).toHaveText(/^[1-9]\d*$/)
 
   // get services missing integrations count
-  const missingInts = await page
+  const missingIntsLocator = page
+    .locator('.MuiCardHeader-content', {
+      hasText: 'Services With No Integrations',
+    })
     .locator('.MuiCardHeader-title')
-    .nth(1)
-    .innerText()
-  expect(parseInt(missingInts)).toBeGreaterThan(0)
+  await expect(missingIntsLocator).toHaveText(/^[1-9]\d*$/)
 
   // get services missing notifications count
-  const missingNotifs = await page
+  const missingNotifLocator = page
+    .locator('.MuiCardHeader-content', {
+      hasText: 'Services With Empty Escalation Policies',
+    })
     .locator('.MuiCardHeader-title')
-    .nth(2)
-    .innerText()
-  expect(missingNotifs).toBe('0')
+  await expect(missingNotifLocator).toHaveText('0')
 
   // get services reaching alert limit
-  const alertLimit = await page
+  const alertLimitLocator = page
+    .locator('.MuiCardHeader-content', {
+      hasText: 'Services Reaching Alert Limit',
+    })
     .locator('.MuiCardHeader-title')
-    .nth(3)
-    .innerText()
-  expect(alertLimit).toBe('0')
+  await expect(alertLimitLocator).toHaveText('0')
 })

--- a/test/integration/experimental-flags.spec.ts
+++ b/test/integration/experimental-flags.spec.ts
@@ -3,15 +3,13 @@ import { baseURLFromFlags, userSessionFile } from './lib'
 
 test.use({ storageState: userSessionFile })
 
-test.describe(() => {
-  // test a query for the current experimental flags (when example is set)
-  test('example experimental flag set', async ({ page }) => {
-    await page.goto(baseURLFromFlags(['example']))
-    await expect(page.locator('#content')).toHaveAttribute(
-      'data-exp-flag-example',
-      'true',
-    )
-  })
+// test a query for the current experimental flags (when example is set)
+test('example experimental flag set', async ({ page }) => {
+  await page.goto(baseURLFromFlags(['example']))
+  await expect(page.locator('#content')).toHaveAttribute(
+    'data-exp-flag-example',
+    'true',
+  )
 })
 
 // test a query for the current experimental flags (when none are set)

--- a/web/src/app/actions/auth.js
+++ b/web/src/app/actions/auth.js
@@ -11,9 +11,12 @@ export const AUTH_LOGOUT = 'AUTH_LOGOUT'
 export function authLogout(performFetch = false) {
   const payload = { type: AUTH_LOGOUT }
   if (!performFetch) return payload
-  return (dispatch) =>
+  return () =>
     fetch(pathPrefix + '/api/v2/identity/logout', {
       credentials: 'same-origin',
       method: 'POST',
-    }).then(dispatch(payload))
+    }).then(() => {
+      // just reload
+      window.location.reload()
+    })
 }

--- a/web/src/app/admin/AdminAPIKeys.tsx
+++ b/web/src/app/admin/AdminAPIKeys.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { Suspense, useMemo, useState } from 'react'
 import { Button, Card, Grid, Typography } from '@mui/material'
 import { Add } from '@mui/icons-material'
 import makeStyles from '@mui/styles/makeStyles'
@@ -187,39 +187,44 @@ export default function AdminAPIKeys(): JSX.Element {
 
   return (
     <React.Fragment>
-      <AdminAPIKeysDrawer
-        onClose={() => {
-          setSelectedAPIKey(null)
-        }}
-        apiKeyID={selectedAPIKey?.id}
-        onDuplicateClick={() => {
-          setCreateDialog(true)
-          setCreateFromID(selectedAPIKey?.id || '')
-        }}
-      />
-      {createDialog && (
-        <AdminAPIKeyCreateDialog
-          fromID={createFromID}
+      <Suspense>
+        <AdminAPIKeysDrawer
           onClose={() => {
-            setCreateDialog(false)
-            setCreateFromID('')
+            setSelectedAPIKey(null)
+          }}
+          apiKeyID={selectedAPIKey?.id}
+          onDuplicateClick={() => {
+            setCreateDialog(true)
+            setCreateFromID(selectedAPIKey?.id || '')
           }}
         />
-      )}
-      {deleteDialog && (
-        <AdminAPIKeyDeleteDialog
-          onClose={(): void => {
-            setDeleteDialog('')
-          }}
-          apiKeyID={deleteDialog}
-        />
-      )}
-      {editDialog && (
-        <AdminAPIKeyEditDialog
-          onClose={() => setEditDialog('')}
-          apiKeyID={editDialog}
-        />
-      )}
+      </Suspense>
+
+      <Suspense>
+        {createDialog && (
+          <AdminAPIKeyCreateDialog
+            fromID={createFromID}
+            onClose={() => {
+              setCreateDialog(false)
+              setCreateFromID('')
+            }}
+          />
+        )}
+        {deleteDialog && (
+          <AdminAPIKeyDeleteDialog
+            onClose={(): void => {
+              setDeleteDialog('')
+            }}
+            apiKeyID={deleteDialog}
+          />
+        )}
+        {editDialog && (
+          <AdminAPIKeyEditDialog
+            onClose={() => setEditDialog('')}
+            apiKeyID={editDialog}
+          />
+        )}
+      </Suspense>
       <div
         className={
           selectedAPIKey ? classes.containerSelected : classes.containerDefault

--- a/web/src/app/admin/AdminNumberLookup.tsx
+++ b/web/src/app/admin/AdminNumberLookup.tsx
@@ -47,6 +47,8 @@ const numInfoQuery = gql`
   }
 `
 
+const noSuspense = { suspense: false }
+
 export default function AdminNumberLookup(): JSX.Element {
   const [number, setNumber] = useState('')
   const [staleCarrier, setStaleCarrier] = useState(true)
@@ -54,6 +56,7 @@ export default function AdminNumberLookup(): JSX.Element {
   const [{ data: numData, error: queryError }] = useQuery({
     query: numInfoQuery,
     variables: { number },
+    context: noSuspense,
   })
   const numInfo = numData?.phoneNumberInfo as PhoneNumberInfo
 

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyDrawer.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { Suspense, useEffect, useMemo, useState } from 'react'
 import {
   ClickAwayListener,
   Divider,
@@ -132,30 +132,32 @@ export default function AdminAPIKeyDrawer(props: Props): JSX.Element {
         data-cy='debug-message-details'
       >
         <Toolbar />
-        {showQuery && (
-          <AdminAPIKeyShowQueryDialog
-            apiKeyID={apiKey.id}
-            onClose={() => setShowQuery(false)}
-          />
-        )}
-        {deleteDialog ? (
-          <AdminAPIKeyDeleteDialog
-            onClose={(yes: boolean): void => {
-              setDialogDialog(false)
+        <Suspense>
+          {showQuery && (
+            <AdminAPIKeyShowQueryDialog
+              apiKeyID={apiKey.id}
+              onClose={() => setShowQuery(false)}
+            />
+          )}
+          {deleteDialog ? (
+            <AdminAPIKeyDeleteDialog
+              onClose={(yes: boolean): void => {
+                setDialogDialog(false)
 
-              if (yes) {
-                onClose()
-              }
-            }}
-            apiKeyID={apiKey.id}
-          />
-        ) : null}
-        {editDialog ? (
-          <AdminAPIKeyEditDialog
-            onClose={() => setEditDialog(false)}
-            apiKeyID={apiKey.id}
-          />
-        ) : null}
+                if (yes) {
+                  onClose()
+                }
+              }}
+              apiKeyID={apiKey.id}
+            />
+          ) : null}
+          {editDialog ? (
+            <AdminAPIKeyEditDialog
+              onClose={() => setEditDialog(false)}
+              apiKeyID={apiKey.id}
+            />
+          ) : null}
+        </Suspense>
         <Grid style={{ width: '30vw' }}>
           <Typography variant='h6' style={{ margin: '16px' }}>
             API Key Details

--- a/web/src/app/escalation-policies/PolicyDetails.tsx
+++ b/web/src/app/escalation-policies/PolicyDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { Suspense, useState } from 'react'
 import { useQuery, gql } from 'urql'
 import _ from 'lodash'
 import { Edit, Delete } from '@mui/icons-material'
@@ -87,18 +87,20 @@ export default function PolicyDetails(props: {
           },
         ]}
       />
-      {showEditDialog && (
-        <PolicyEditDialog
-          escalationPolicyID={data.id}
-          onClose={() => setShowEditDialog(false)}
-        />
-      )}
-      {showDeleteDialog && (
-        <PolicyDeleteDialog
-          escalationPolicyID={data.id}
-          onClose={() => setShowDeleteDialog(false)}
-        />
-      )}
+      <Suspense>
+        {showEditDialog && (
+          <PolicyEditDialog
+            escalationPolicyID={data.id}
+            onClose={() => setShowEditDialog(false)}
+          />
+        )}
+        {showDeleteDialog && (
+          <PolicyDeleteDialog
+            escalationPolicyID={data.id}
+            onClose={() => setShowDeleteDialog(false)}
+          />
+        )}
+      </Suspense>
     </React.Fragment>
   )
 }

--- a/web/src/app/escalation-policies/PolicyStepsCard.js
+++ b/web/src/app/escalation-policies/PolicyStepsCard.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { Suspense, useRef, useState } from 'react'
 import { PropTypes as p } from 'prop-types'
 import Button from '@mui/material/Button'
 import Card from '@mui/material/Card'
@@ -201,20 +201,22 @@ export default function PolicyStepsCard(props) {
         />
         <DialogContentError error={errMsg} />
       </Dialog>
-      {editStepID && (
-        <PolicyStepEditDialog
-          escalationPolicyID={escalationPolicyID}
-          onClose={resetEditStep}
-          step={steps.filter((step) => step.id === editStepID)[0]}
-        />
-      )}
-      {deleteStep && (
-        <PolicyStepDeleteDialog
-          escalationPolicyID={escalationPolicyID}
-          onClose={() => setDeleteStep(false)}
-          stepID={deleteStep}
-        />
-      )}
+      <Suspense>
+        {editStepID && (
+          <PolicyStepEditDialog
+            escalationPolicyID={escalationPolicyID}
+            onClose={resetEditStep}
+            step={steps.filter((step) => step.id === editStepID)[0]}
+          />
+        )}
+        {deleteStep && (
+          <PolicyStepDeleteDialog
+            escalationPolicyID={escalationPolicyID}
+            onClose={() => setDeleteStep(false)}
+            stepID={deleteStep}
+          />
+        )}
+      </Suspense>
     </React.Fragment>
   )
 }

--- a/web/src/app/index.tsx
+++ b/web/src/app/index.tsx
@@ -1,4 +1,4 @@
-import React, { StrictMode } from 'react'
+import React, { StrictMode, Suspense } from 'react'
 import { createRoot } from 'react-dom/client'
 import { Provider as ReduxProvider } from 'react-redux'
 import { ApolloProvider } from '@apollo/client'
@@ -18,6 +18,9 @@ import { client as urqlClient } from './urql'
 import { Router } from 'wouter'
 
 import { Settings } from 'luxon'
+import Spinner from './loading/components/Spinner'
+import RequireAuth from './main/RequireAuth'
+import Login from './main/components/Login'
 Settings.throwOnInvalid = true
 
 declare module 'luxon' {
@@ -53,10 +56,14 @@ root.render(
           <ReduxProvider store={store}>
             <Router base={pathPrefix}>
               <URQLProvider value={urqlClient}>
-                <ConfigProvider>
-                  <NewVersionCheck />
-                  <App />
-                </ConfigProvider>
+                <NewVersionCheck />
+                <Suspense fallback={<Spinner />}>
+                  <RequireAuth fallback={<Login />}>
+                    <ConfigProvider>
+                      <App />
+                    </ConfigProvider>
+                  </RequireAuth>
+                </Suspense>
               </URQLProvider>
             </Router>
           </ReduxProvider>

--- a/web/src/app/main/App.tsx
+++ b/web/src/app/main/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useState } from 'react'
+import React, { Suspense, useEffect, useLayoutEffect, useState } from 'react'
 import AppBar from '@mui/material/AppBar'
 import Hidden from '@mui/material/Hidden'
 import Toolbar from '@mui/material/Toolbar'
@@ -6,13 +6,10 @@ import ToolbarPageTitle from './components/ToolbarPageTitle'
 import ToolbarAction from './components/ToolbarAction'
 import ErrorBoundary from './ErrorBoundary'
 import Grid from '@mui/material/Grid'
-import { useSelector } from 'react-redux'
-import { authSelector } from '../selectors'
 import { PageActionContainer, PageActionProvider } from '../util/PageActions'
 import SwipeableDrawer from '@mui/material/SwipeableDrawer'
 import LazyWideSideBar, { drawerWidth } from './WideSideBar'
 import LazyNewUserSetup from './components/NewUserSetup'
-import Login from './components/Login'
 import { SkipToContentLink } from '../util/SkipToContentLink'
 import { SearchContainer, SearchProvider } from '../util/AppBarSearchContainer'
 import makeStyles from '@mui/styles/makeStyles'
@@ -28,6 +25,7 @@ import { useExpFlag } from '../util/useExpFlag'
 import { NotificationProvider } from './SnackbarNotification'
 import ReactGA from 'react-ga4'
 import { useConfigValue } from '../util/RequireConfig'
+import Spinner from '../loading/components/Spinner'
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -66,21 +64,12 @@ export default function App(): JSX.Element {
   const [showMobile, setShowMobile] = useState(false)
   const fullScreen = useIsWidthDown('md')
   const marginLeft = fullScreen ? 0 : drawerWidth
-  const authValid = useSelector(authSelector)
   const urlKey = useURLKey()
   const hasExampleFlag = useExpFlag('example')
 
   useLayoutEffect(() => {
     setShowMobile(false)
   }, [urlKey])
-
-  if (!authValid) {
-    return (
-      <div className={classes.root}>
-        <Login />
-      </div>
-    )
-  }
 
   let cyFormat = 'wide'
   if (fullScreen) cyFormat = 'mobile'
@@ -101,11 +90,13 @@ export default function App(): JSX.Element {
                   showMobileSidebar={showMobile}
                   openMobileSidebar={() => setShowMobile(true)}
                 />
-                <ToolbarPageTitle />
-                <div style={{ flex: 1 }} />
-                <PageActionContainer />
-                <SearchContainer />
-                <UserSettingsPopover />
+                <Suspense>
+                  <ToolbarPageTitle />
+                  <div style={{ flex: 1 }} />
+                  <PageActionContainer />
+                  <SearchContainer />
+                  <UserSettingsPopover />
+                </Suspense>
               </Toolbar>
             </AppBar>
 
@@ -135,17 +126,19 @@ export default function App(): JSX.Element {
               data-exp-flag-example={String(hasExampleFlag)}
             >
               <ErrorBoundary>
-                <LazyNewUserSetup />
-                <AuthLink />
-                <Grid
-                  container
-                  justifyContent='center'
-                  className={classes.mainContainer}
-                >
-                  <Grid className={classes.containerClass} item>
-                    <AppRoutes />
+                <Suspense fallback={<Spinner />}>
+                  <LazyNewUserSetup />
+                  <AuthLink />
+                  <Grid
+                    container
+                    justifyContent='center'
+                    className={classes.mainContainer}
+                  >
+                    <Grid className={classes.containerClass} item>
+                      <AppRoutes />
+                    </Grid>
                   </Grid>
-                </Grid>
+                </Suspense>
               </ErrorBoundary>
             </main>
           </NotificationProvider>

--- a/web/src/app/main/App.tsx
+++ b/web/src/app/main/App.tsx
@@ -92,11 +92,11 @@ export default function App(): JSX.Element {
                 />
                 <Suspense>
                   <ToolbarPageTitle />
-                  <div style={{ flex: 1 }} />
-                  <PageActionContainer />
-                  <SearchContainer />
-                  <UserSettingsPopover />
                 </Suspense>
+                <div style={{ flex: 1 }} />
+                <PageActionContainer />
+                <SearchContainer />
+                <UserSettingsPopover />
               </Toolbar>
             </AppBar>
 

--- a/web/src/app/main/RequireAuth.tsx
+++ b/web/src/app/main/RequireAuth.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { gql, useQuery } from 'urql'
+import { GenericError } from '../error-pages'
+
+const checkAuthQuery = gql`
+  {
+    user {
+      id
+    }
+  }
+`
+
+type RequireAuthProps = {
+  children: React.ReactNode
+  fallback: React.ReactNode
+}
+export default function RequireAuth(props: RequireAuthProps): React.ReactNode {
+  const [{ error }] = useQuery({
+    query: checkAuthQuery,
+  })
+
+  // if network/unauthorized display fallback
+  if (error?.networkError) {
+    return props.fallback
+  }
+
+  // if other error display generic
+  if (error) {
+    return <GenericError error={error.message} />
+  }
+
+  // otherwise display children
+  return props.children
+}

--- a/web/src/app/main/components/Login.tsx
+++ b/web/src/app/main/components/Login.tsx
@@ -7,7 +7,7 @@ import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
 import Divider from '@mui/material/Divider'
 import makeStyles from '@mui/styles/makeStyles'
-import { useTheme } from '@mui/material'
+import { Theme, useTheme } from '@mui/material'
 import { getParameterByName } from '../../util/query_param'
 import { pathPrefix } from '../../env'
 
@@ -23,7 +23,15 @@ import darkModeLogoImgSrc from '../../public/logos/white/goalert-logo-white-scal
 
 const PROVIDERS_URL = pathPrefix + '/api/v2/identity/providers'
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    flexGrow: 1,
+    zIndex: 1,
+    position: 'relative',
+    display: 'flex',
+    backgroundColor: theme.palette.background.default,
+    height: '100%',
+  },
   card: {
     width: 'fit-content',
     maxWidth: '30em',
@@ -62,7 +70,7 @@ const useStyles = makeStyles({
     paddingLeft: '1em',
     paddingRight: '1em',
   },
-})
+}))
 type Field = {
   ID: string
   Label: string
@@ -240,20 +248,22 @@ export default function Login(): JSX.Element {
     )
 
   return (
-    <div className={classes.center}>
-      <Card className={classes.card}>
-        <CardContent>
-          <Grid container spacing={2} className={classes.gridContainer}>
-            <Grid item xs={12}>
-              {logo}
+    <div className={classes.root}>
+      <div className={classes.center}>
+        <Card className={classes.card}>
+          <CardContent>
+            <Grid container spacing={2} className={classes.gridContainer}>
+              <Grid item xs={12}>
+                {logo}
+              </Grid>
+              {providers.map((provider, idx) =>
+                renderProvider(provider, idx, providers.length),
+              )}
+              {errorJSX}
             </Grid>
-            {providers.map((provider, idx) =>
-              renderProvider(provider, idx, providers.length),
-            )}
-            {errorJSX}
-          </Grid>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      </div>
     </div>
   )
 }

--- a/web/src/app/rotations/RotationDetails.tsx
+++ b/web/src/app/rotations/RotationDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { Suspense, useState } from 'react'
 import { gql, useQuery } from 'urql'
 import _ from 'lodash'
 import { Redirect } from 'wouter'
@@ -59,18 +59,20 @@ export default function RotationDetails(props: {
 
   return (
     <React.Fragment>
-      {showEdit && (
-        <RotationEditDialog
-          rotationID={props.rotationID}
-          onClose={() => setShowEdit(false)}
-        />
-      )}
-      {showDelete && (
-        <RotationDeleteDialog
-          rotationID={props.rotationID}
-          onClose={() => setShowDelete(false)}
-        />
-      )}
+      <Suspense>
+        {showEdit && (
+          <RotationEditDialog
+            rotationID={props.rotationID}
+            onClose={() => setShowEdit(false)}
+          />
+        )}
+        {showDelete && (
+          <RotationDeleteDialog
+            rotationID={props.rotationID}
+            onClose={() => setShowDelete(false)}
+          />
+        )}
+      </Suspense>
       <DetailsPage
         avatar={<RotationAvatar />}
         title={data.name}

--- a/web/src/app/rotations/RotationUserList.tsx
+++ b/web/src/app/rotations/RotationUserList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { Suspense, useEffect, useState } from 'react'
 import { gql, useMutation, useQuery } from '@apollo/client'
 import Button from '@mui/material/Button'
 import Card from '@mui/material/Card'
@@ -141,27 +141,29 @@ function RotationUserList(props: RotationUserListProps): JSX.Element {
       {isMobile && (
         <CreateFAB title='Add User' onClick={() => setShowAddUser(true)} />
       )}
-      {deleteIndex !== null && (
-        <RotationUserDeleteDialog
-          rotationID={rotationID}
-          userIndex={deleteIndex}
-          onClose={() => setDeleteIndex(null)}
-        />
-      )}
-      {setActiveIndex !== null && (
-        <RotationSetActiveDialog
-          rotationID={rotationID}
-          userIndex={setActiveIndex}
-          onClose={() => setSetActiveIndex(null)}
-        />
-      )}
-      {showAddUser && (
-        <RotationAddUserDialog
-          rotationID={rotationID}
-          userIDs={userIDs ?? []}
-          onClose={() => setShowAddUser(false)}
-        />
-      )}
+      <Suspense>
+        {deleteIndex !== null && (
+          <RotationUserDeleteDialog
+            rotationID={rotationID}
+            userIndex={deleteIndex}
+            onClose={() => setDeleteIndex(null)}
+          />
+        )}
+        {setActiveIndex !== null && (
+          <RotationSetActiveDialog
+            rotationID={rotationID}
+            userIndex={setActiveIndex}
+            onClose={() => setSetActiveIndex(null)}
+          />
+        )}
+        {showAddUser && (
+          <RotationAddUserDialog
+            rotationID={rotationID}
+            userIDs={userIDs ?? []}
+            onClose={() => setShowAddUser(false)}
+          />
+        )}
+      </Suspense>
       <Card>
         <CardHeader
           className={classes.cardHeader}

--- a/web/src/app/schedules/ScheduleDetails.tsx
+++ b/web/src/app/schedules/ScheduleDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, Suspense } from 'react'
-import { gql, useQuery } from '@apollo/client'
+import { gql, useQuery } from 'urql'
 import _ from 'lodash'
 import { Edit, Delete } from '@mui/icons-material'
 
@@ -9,7 +9,6 @@ import ScheduleDeleteDialog from './ScheduleDeleteDialog'
 import ScheduleCalendarQuery from './calendar/ScheduleCalendarQuery'
 import { QuerySetFavoriteButton } from '../util/QuerySetFavoriteButton'
 import CalendarSubscribeButton from './calendar-subscribe/CalendarSubscribeButton'
-import Spinner from '../loading/components/Spinner'
 import { ObjectNotFound, GenericError } from '../error-pages'
 import TempSchedDialog from './temp-sched/TempSchedDialog'
 import TempSchedDeleteConfirmation from './temp-sched/TempSchedDeleteConfirmation'
@@ -96,18 +95,13 @@ export default function ScheduleDetails({
     null,
   )
 
-  const {
-    data: _data,
-    loading,
-    error,
-  } = useQuery(query, {
+  const [{ data: _data, error }] = useQuery({
+    query,
     variables: { id: scheduleID },
-    returnPartialData: true,
   })
 
   const data = _.get(_data, 'schedule', null)
 
-  if (loading && !data?.name) return <Spinner />
   if (error) return <GenericError error={error.message} />
 
   if (!data) {

--- a/web/src/app/schedules/ScheduleDetails.tsx
+++ b/web/src/app/schedules/ScheduleDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, Suspense } from 'react'
 import { gql, useQuery } from '@apollo/client'
 import _ from 'lodash'
 import { Edit, Delete } from '@mui/icons-material'
@@ -116,32 +116,34 @@ export default function ScheduleDetails({
 
   return (
     <React.Fragment>
-      {showEdit && (
-        <ScheduleEditDialog
-          scheduleID={scheduleID}
-          onClose={() => setShowEdit(false)}
-        />
-      )}
-      {showDelete && (
-        <ScheduleDeleteDialog
-          scheduleID={scheduleID}
-          onClose={() => setShowDelete(false)}
-        />
-      )}
-      {configTempSchedule && (
-        <TempSchedDialog
-          value={configTempSchedule}
-          onClose={() => setConfigTempSchedule(null)}
-          scheduleID={scheduleID}
-        />
-      )}
-      {deleteTempSchedule && (
-        <TempSchedDeleteConfirmation
-          value={deleteTempSchedule}
-          onClose={() => setDeleteTempSchedule(null)}
-          scheduleID={scheduleID}
-        />
-      )}
+      <Suspense>
+        {showEdit && (
+          <ScheduleEditDialog
+            scheduleID={scheduleID}
+            onClose={() => setShowEdit(false)}
+          />
+        )}
+        {showDelete && (
+          <ScheduleDeleteDialog
+            scheduleID={scheduleID}
+            onClose={() => setShowDelete(false)}
+          />
+        )}
+        {configTempSchedule && (
+          <TempSchedDialog
+            value={configTempSchedule}
+            onClose={() => setConfigTempSchedule(null)}
+            scheduleID={scheduleID}
+          />
+        )}
+        {deleteTempSchedule && (
+          <TempSchedDeleteConfirmation
+            value={deleteTempSchedule}
+            onClose={() => setDeleteTempSchedule(null)}
+            scheduleID={scheduleID}
+          />
+        )}
+      </Suspense>
       <DetailsPage
         avatar={<ScheduleAvatar />}
         title={data.name}
@@ -157,15 +159,17 @@ export default function ScheduleDetails({
             }}
           >
             {!isMobile && <ScheduleCalendarQuery scheduleID={scheduleID} />}
-            {overrideDialog && (
-              <ScheduleOverrideDialog
-                defaultValue={overrideDialog.defaultValue}
-                variantOptions={overrideDialog.variantOptions}
-                scheduleID={scheduleID}
-                onClose={() => setOverrideDialog(null)}
-                removeUserReadOnly={overrideDialog.removeUserReadOnly}
-              />
-            )}
+            <Suspense>
+              {overrideDialog && (
+                <ScheduleOverrideDialog
+                  defaultValue={overrideDialog.defaultValue}
+                  variantOptions={overrideDialog.variantOptions}
+                  scheduleID={scheduleID}
+                  onClose={() => setOverrideDialog(null)}
+                  removeUserReadOnly={overrideDialog.removeUserReadOnly}
+                />
+              )}
+            </Suspense>
           </OverrideDialogContext.Provider>
         }
         primaryActions={[

--- a/web/src/app/schedules/ScheduleOverrideList.js
+++ b/web/src/app/schedules/ScheduleOverrideList.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { Suspense, useCallback, useState } from 'react'
 import { Button, Grid, FormControlLabel, Switch, Tooltip } from '@mui/material'
 import { GroupAdd } from '@mui/icons-material'
 import { DateTime } from 'luxon'
@@ -207,36 +207,38 @@ export default function ScheduleOverrideList({ scheduleID }) {
       )}
 
       {/* create dialogs */}
-      {overrideDialog && (
-        <ScheduleOverrideDialog
-          defaultValue={overrideDialog.defaultValue}
-          variantOptions={overrideDialog.variantOptions}
-          scheduleID={scheduleID}
-          onClose={() => setOverrideDialog(null)}
-          removeUserReadOnly={overrideDialog.removeUserReadOnly}
-        />
-      )}
-      {configTempSchedule && (
-        <TempSchedDialog
-          value={configTempSchedule}
-          onClose={() => setConfigTempSchedule(null)}
-          scheduleID={scheduleID}
-        />
-      )}
+      <Suspense>
+        {overrideDialog && (
+          <ScheduleOverrideDialog
+            defaultValue={overrideDialog.defaultValue}
+            variantOptions={overrideDialog.variantOptions}
+            scheduleID={scheduleID}
+            onClose={() => setOverrideDialog(null)}
+            removeUserReadOnly={overrideDialog.removeUserReadOnly}
+          />
+        )}
+        {configTempSchedule && (
+          <TempSchedDialog
+            value={configTempSchedule}
+            onClose={() => setConfigTempSchedule(null)}
+            scheduleID={scheduleID}
+          />
+        )}
 
-      {/* edit dialogs by ID */}
-      {deleteID && (
-        <ScheduleOverrideDeleteDialog
-          overrideID={deleteID}
-          onClose={() => setDeleteID(null)}
-        />
-      )}
-      {editID && (
-        <ScheduleOverrideEditDialog
-          overrideID={editID}
-          onClose={() => setEditID(null)}
-        />
-      )}
+        {/* edit dialogs by ID */}
+        {deleteID && (
+          <ScheduleOverrideDeleteDialog
+            overrideID={deleteID}
+            onClose={() => setDeleteID(null)}
+          />
+        )}
+        {editID && (
+          <ScheduleOverrideEditDialog
+            overrideID={editID}
+            onClose={() => setEditID(null)}
+          />
+        )}
+      </Suspense>
     </OverrideDialogContext.Provider>
   )
 }

--- a/web/src/app/schedules/ScheduleRuleList.js
+++ b/web/src/app/schedules/ScheduleRuleList.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { Suspense, useState } from 'react'
 import { gql, useQuery } from '@apollo/client'
 import FlatList from '../lists/FlatList'
 import { Button, ButtonGroup, Card } from '@mui/material'
@@ -165,27 +165,29 @@ export default function ScheduleRuleList({ scheduleID }) {
           />
         )}
 
-        {createType && (
-          <ScheduleRuleCreateDialog
-            targetType={createType}
-            scheduleID={scheduleID}
-            onClose={() => setCreateType(null)}
-          />
-        )}
-        {editTarget && (
-          <ScheduleRuleEditDialog
-            target={editTarget}
-            scheduleID={scheduleID}
-            onClose={() => setEditTarget(null)}
-          />
-        )}
-        {deleteTarget && (
-          <ScheduleRuleDeleteDialog
-            target={deleteTarget}
-            scheduleID={scheduleID}
-            onClose={() => setDeleteTarget(null)}
-          />
-        )}
+        <Suspense>
+          {createType && (
+            <ScheduleRuleCreateDialog
+              targetType={createType}
+              scheduleID={scheduleID}
+              onClose={() => setCreateType(null)}
+            />
+          )}
+          {editTarget && (
+            <ScheduleRuleEditDialog
+              target={editTarget}
+              scheduleID={scheduleID}
+              onClose={() => setEditTarget(null)}
+            />
+          )}
+          {deleteTarget && (
+            <ScheduleRuleDeleteDialog
+              target={deleteTarget}
+              scheduleID={scheduleID}
+              onClose={() => setDeleteTarget(null)}
+            />
+          )}
+        </Suspense>
       </React.Fragment>
     )
   }

--- a/web/src/app/schedules/ScheduleShiftList.tsx
+++ b/web/src/app/schedules/ScheduleShiftList.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
 import { DateTime, DateTimeFormatOptions, Duration, Interval } from 'luxon'
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { Suspense, useCallback, useMemo, useState } from 'react'
 import CreateFAB from '../lists/CreateFAB'
 import FlatList, { FlatListListItem } from '../lists/FlatList'
 import { UserSelect } from '../selection'
@@ -410,22 +410,24 @@ function ScheduleShiftList({
       )}
 
       {/* create dialogs */}
-      {overrideDialog && (
-        <ScheduleOverrideDialog
-          defaultValue={overrideDialog.defaultValue}
-          variantOptions={overrideDialog.variantOptions}
-          scheduleID={scheduleID}
-          onClose={() => setOverrideDialog(null)}
-          removeUserReadOnly={overrideDialog.removeUserReadOnly}
-        />
-      )}
-      {configTempSchedule && (
-        <TempSchedDialog
-          value={configTempSchedule}
-          onClose={() => setConfigTempSchedule(null)}
-          scheduleID={scheduleID}
-        />
-      )}
+      <Suspense>
+        {overrideDialog && (
+          <ScheduleOverrideDialog
+            defaultValue={overrideDialog.defaultValue}
+            variantOptions={overrideDialog.variantOptions}
+            scheduleID={scheduleID}
+            onClose={() => setOverrideDialog(null)}
+            removeUserReadOnly={overrideDialog.removeUserReadOnly}
+          />
+        )}
+        {configTempSchedule && (
+          <TempSchedDialog
+            value={configTempSchedule}
+            onClose={() => setConfigTempSchedule(null)}
+            scheduleID={scheduleID}
+          />
+        )}
+      </Suspense>
     </OverrideDialogContext.Provider>
   )
 }

--- a/web/src/app/schedules/calendar/ScheduleCalendar.tsx
+++ b/web/src/app/schedules/calendar/ScheduleCalendar.tsx
@@ -384,11 +384,7 @@ function ScheduleCalendar(props: ScheduleCalendarProps): JSX.Element {
             onView={() => {}} // stub to hide false console err
             components={{
               // @ts-expect-error Property 'children' does not exist on type - yes it does
-              eventWrapper: ({ children, event }) => (
-                <ScheduleCalendarEventWrapper event={event}>
-                  {children}
-                </ScheduleCalendarEventWrapper>
-              ),
+              eventWrapper: ScheduleCalendarEventWrapper,
               toolbar: () => null,
             }}
           />

--- a/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.tsx
+++ b/web/src/app/schedules/calendar/ScheduleCalendarEventWrapper.tsx
@@ -1,4 +1,10 @@
-import React, { useContext, useState, MouseEvent, KeyboardEvent } from 'react'
+import React, {
+  useContext,
+  useState,
+  MouseEvent,
+  KeyboardEvent,
+  Suspense,
+} from 'react'
 import Button from '@mui/material/Button'
 import Grid from '@mui/material/Grid'
 import Popover from '@mui/material/Popover'
@@ -273,18 +279,20 @@ export default function ScheduleCalendarEventWrapper({
         'aria-pressed': open,
         'aria-describedby': id,
       })}
-      {showEditDialog && (
-        <ScheduleOverrideEditDialog
-          overrideID={showEditDialog}
-          onClose={() => setShowEditDialog('')}
-        />
-      )}
-      {showDeleteDialog && (
-        <ScheduleOverrideDeleteDialog
-          overrideID={showDeleteDialog}
-          onClose={() => setShowDeleteDialog('')}
-        />
-      )}
+      <Suspense>
+        {showEditDialog && (
+          <ScheduleOverrideEditDialog
+            overrideID={showEditDialog}
+            onClose={() => setShowEditDialog('')}
+          />
+        )}
+        {showDeleteDialog && (
+          <ScheduleOverrideDeleteDialog
+            overrideID={showDeleteDialog}
+            onClose={() => setShowDeleteDialog('')}
+          />
+        )}
+      </Suspense>
     </React.Fragment>
   )
 }

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -62,7 +62,7 @@ export default function TempSchedShiftsList({
   handleCoverageGapClick,
 }: TempSchedShiftsListProps): JSX.Element {
   const classes = useStyles()
-  const { q, zone, isLocalZone } = useScheduleTZ(scheduleID)
+  const { zone, isLocalZone } = useScheduleTZ(scheduleID)
   const [now, setNow] = useState(DateTime.now().setZone(zone))
   const shifts = useUserInfo(value)
   const [existingShifts] = useState(shifts)
@@ -80,7 +80,7 @@ export default function TempSchedShiftsList({
   }, [now])
 
   // wait for zone
-  if (q.loading || zone === '') {
+  if (zone === '') {
     return (
       <div className={classes.spinContainer}>
         <CircularProgress />

--- a/web/src/app/schedules/useScheduleTZ.ts
+++ b/web/src/app/schedules/useScheduleTZ.ts
@@ -1,4 +1,4 @@
-import { gql, QueryResult, useQuery } from '@apollo/client'
+import { gql, useQuery } from 'urql'
 import { DateTime } from 'luxon'
 
 const schedTZQuery = gql`
@@ -11,8 +11,7 @@ const schedTZQuery = gql`
 `
 
 interface ScheduleTZResult {
-  // q is the Apollo query status
-  q: QueryResult
+  q: { loading: false } // for compatability, until loading logic is removed (in favor of suspense)
   // zone is schedule time zone name if ready; else empty string
   zone: string
   // isLocalZone is true if schedule and system time zone are equal
@@ -22,7 +21,8 @@ interface ScheduleTZResult {
 }
 
 export function useScheduleTZ(scheduleID: string): ScheduleTZResult {
-  const q = useQuery(schedTZQuery, {
+  const [q] = useQuery({
+    query: schedTZQuery,
     variables: { id: scheduleID },
   })
   const zone = q.data?.schedule?.timeZone ?? 'local'
@@ -35,5 +35,5 @@ export function useScheduleTZ(scheduleID: string): ScheduleTZResult {
     )
   }
 
-  return { q, zone, isLocalZone, zoneAbbr }
+  return { q: { loading: false }, zone, isLocalZone, zoneAbbr }
 }

--- a/web/src/app/selection/QuerySelect.js
+++ b/web/src/app/selection/QuerySelect.js
@@ -30,6 +30,8 @@ const asArray = (value) => {
 const mapValueQuery = (query, index) =>
   mapInputVars(fieldAlias(query, 'data' + index), { id: 'id' + index })
 
+const noSuspenseContext = { suspense: false }
+
 // makeUseValues will return a hook that will fetch select values for the
 // given ids.
 function makeUseValues(query, mapNode) {
@@ -61,6 +63,7 @@ function makeUseValues(query, mapNode) {
       pause: !value.length,
       variables,
       requestPolicy: 'cache-first',
+      context: noSuspenseContext,
     })
 
     if (!value.length) {
@@ -100,6 +103,7 @@ function makeUseOptions(query, mapNode, vars, defaultVars) {
 
       pollInterval: 0,
       errorPolicy: 'all', // needs to be set explicitly for some reason
+      context: noSuspenseContext,
     })
 
     let result = []

--- a/web/src/app/services/HeartbeatMonitorList.tsx
+++ b/web/src/app/services/HeartbeatMonitorList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ReactElement } from 'react'
+import React, { useState, ReactElement, Suspense } from 'react'
 import { useQuery, gql } from 'urql'
 import Button from '@mui/material/Button'
 import Grid from '@mui/material/Grid'
@@ -157,24 +157,26 @@ export default function HeartbeatMonitorList(props: {
           title='Create Heartbeat Monitor'
         />
       )}
-      {showCreateDialog && (
-        <HeartbeatMonitorCreateDialog
-          serviceID={props.serviceID}
-          onClose={() => setShowCreateDialog(false)}
-        />
-      )}
-      {showEditDialogByID && (
-        <HeartbeatMonitorEditDialog
-          monitorID={showEditDialogByID}
-          onClose={() => setShowEditDialogByID(null)}
-        />
-      )}
-      {showDeleteDialogByID && (
-        <HeartbeatMonitorDeleteDialog
-          monitorID={showDeleteDialogByID}
-          onClose={() => setShowDeleteDialogByID(null)}
-        />
-      )}
+      <Suspense>
+        {showCreateDialog && (
+          <HeartbeatMonitorCreateDialog
+            serviceID={props.serviceID}
+            onClose={() => setShowCreateDialog(false)}
+          />
+        )}
+        {showEditDialogByID && (
+          <HeartbeatMonitorEditDialog
+            monitorID={showEditDialogByID}
+            onClose={() => setShowEditDialogByID(null)}
+          />
+        )}
+        {showDeleteDialogByID && (
+          <HeartbeatMonitorDeleteDialog
+            monitorID={showDeleteDialogByID}
+            onClose={() => setShowDeleteDialogByID(null)}
+          />
+        )}
+      </Suspense>
     </React.Fragment>
   )
 }

--- a/web/src/app/services/IntegrationKeyList.tsx
+++ b/web/src/app/services/IntegrationKeyList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { Suspense, useState } from 'react'
 import { gql, useQuery } from 'urql'
 import Button from '@mui/material/Button'
 import Grid from '@mui/material/Grid'
@@ -160,19 +160,20 @@ export default function IntegrationKeyList(props: {
           title='Create Integration Key'
         />
       )}
-
-      {create && (
-        <IntegrationKeyCreateDialog
-          serviceID={props.serviceID}
-          onClose={(): void => setCreate(false)}
-        />
-      )}
-      {deleteDialog && (
-        <IntegrationKeyDeleteDialog
-          integrationKeyID={deleteDialog}
-          onClose={(): void => setDeleteDialog(null)}
-        />
-      )}
+      <Suspense>
+        {create && (
+          <IntegrationKeyCreateDialog
+            serviceID={props.serviceID}
+            onClose={(): void => setCreate(false)}
+          />
+        )}
+        {deleteDialog && (
+          <IntegrationKeyDeleteDialog
+            integrationKeyID={deleteDialog}
+            onClose={(): void => setDeleteDialog(null)}
+          />
+        )}
+      </Suspense>
     </React.Fragment>
   )
 }

--- a/web/src/app/services/ServiceDetails.tsx
+++ b/web/src/app/services/ServiceDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { Suspense, useState } from 'react'
 import { gql, useQuery } from 'urql'
 import { Redirect } from 'wouter'
 import _ from 'lodash'
@@ -175,25 +175,27 @@ export default function ServiceDetails(props: {
           },
         ]}
       />
-      {showEdit && (
-        <ServiceEditDialog
-          onClose={() => setShowEdit(false)}
-          serviceID={serviceID}
-        />
-      )}
-      {showDelete && (
-        <ServiceDeleteDialog
-          onClose={() => setShowDelete(false)}
-          serviceID={serviceID}
-        />
-      )}
-      {showMaintMode && (
-        <ServiceMaintenanceModeDialog
-          onClose={() => setShowMaintMode(false)}
-          serviceID={serviceID}
-          expiresAt={data.service.maintenanceExpiresAt}
-        />
-      )}
+      <Suspense>
+        {showEdit && (
+          <ServiceEditDialog
+            onClose={() => setShowEdit(false)}
+            serviceID={serviceID}
+          />
+        )}
+        {showDelete && (
+          <ServiceDeleteDialog
+            onClose={() => setShowDelete(false)}
+            serviceID={serviceID}
+          />
+        )}
+        {showMaintMode && (
+          <ServiceMaintenanceModeDialog
+            onClose={() => setShowMaintMode(false)}
+            serviceID={serviceID}
+            expiresAt={data.service.maintenanceExpiresAt}
+          />
+        )}
+      </Suspense>
     </React.Fragment>
   )
 }

--- a/web/src/app/services/ServiceLabelList.tsx
+++ b/web/src/app/services/ServiceLabelList.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react'
+import React, { ReactElement, Suspense, useState } from 'react'
 import Button from '@mui/material/Button'
 import Grid from '@mui/material/Grid'
 import Card from '@mui/material/Card'
@@ -112,26 +112,29 @@ export default function ServiceLabelList(props: {
       {isMobile && (
         <CreateFAB onClick={() => setCreate(true)} title='Add Label' />
       )}
-      {create && (
-        <ServiceLabelSetDialog
-          serviceID={props.serviceID}
-          onClose={() => setCreate(false)}
-        />
-      )}
-      {editKey && (
-        <ServiceLabelEditDialog
-          serviceID={props.serviceID}
-          labelKey={editKey}
-          onClose={() => setEditKey(null)}
-        />
-      )}
-      {deleteKey && (
-        <ServiceLabelDeleteDialog
-          serviceID={props.serviceID}
-          labelKey={deleteKey}
-          onClose={() => setDeleteKey(null)}
-        />
-      )}
+
+      <Suspense>
+        {create && (
+          <ServiceLabelSetDialog
+            serviceID={props.serviceID}
+            onClose={() => setCreate(false)}
+          />
+        )}
+        {editKey && (
+          <ServiceLabelEditDialog
+            serviceID={props.serviceID}
+            labelKey={editKey}
+            onClose={() => setEditKey(null)}
+          />
+        )}
+        {deleteKey && (
+          <ServiceLabelDeleteDialog
+            serviceID={props.serviceID}
+            labelKey={deleteKey}
+            onClose={() => setDeleteKey(null)}
+          />
+        )}
+      </Suspense>
     </React.Fragment>
   )
 }

--- a/web/src/app/urql.ts
+++ b/web/src/app/urql.ts
@@ -2,7 +2,6 @@ import { retryExchange } from '@urql/exchange-retry'
 import {
   cacheExchange,
   createClient,
-  dedupExchange,
   fetchExchange,
   Exchange,
   Operation,
@@ -107,8 +106,8 @@ const apolloRefetchExchange: Exchange = ({ forward }) => {
 
 export const client = createClient({
   url: pathPrefix + '/api/graphql',
+  suspense: true,
   exchanges: [
-    dedupExchange,
     refetchExchange(),
     cacheExchange,
     apolloRefetchExchange,

--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -19,7 +19,6 @@ import { styles as globalStyles } from '../styles/materialStyles'
 import { UserContactMethod } from '../../schema'
 import UserContactMethodCreateDialog from './UserContactMethodCreateDialog'
 import { useSessionInfo } from '../util/RequireConfig'
-import { useSuspenseContext } from './UserDetails'
 
 const query = gql`
   query cmList($id: ID!) {
@@ -66,19 +65,17 @@ export default function UserContactMethodList(
   const [showDeleteDialogByID, setShowDeleteDialogByID] = useState('')
   const [showSendTestByID, setShowSendTestByID] = useState('')
 
-  const [{ fetching, error, data }] = useQuery({
+  const [{ error, data }] = useQuery({
     query,
     variables: {
       id: props.userID,
     },
-    context: useSuspenseContext(),
   })
 
   const { userID: currentUserID } = useSessionInfo()
   const isCurrentUser = props.userID === currentUserID
 
-  if (fetching && !data) return null
-  if (data && !data.user) return <ObjectNotFound type='user' />
+  if (!data?.user) return <ObjectNotFound type='user' />
   if (error) return <GenericError error={error.message} />
 
   const contactMethods = data.user.contactMethods

--- a/web/src/app/users/UserDetails.tsx
+++ b/web/src/app/users/UserDetails.tsx
@@ -1,5 +1,5 @@
-import React, { Suspense, useState, useMemo } from 'react'
-import { useQuery, gql, OperationContext } from 'urql'
+import React, { Suspense, useState } from 'react'
+import { useQuery, gql } from 'urql'
 import Delete from '@mui/icons-material/Delete'
 import LockOpenIcon from '@mui/icons-material/LockOpen'
 import DetailsPage from '../details/DetailsPage'
@@ -13,7 +13,6 @@ import UserContactMethodCreateDialog from './UserContactMethodCreateDialog'
 import UserNotificationRuleCreateDialog from './UserNotificationRuleCreateDialog'
 import UserContactMethodVerificationDialog from './UserContactMethodVerificationDialog'
 import _ from 'lodash'
-import Spinner from '../loading/components/Spinner'
 import { GenericError, ObjectNotFound } from '../error-pages'
 import { useSessionInfo } from '../util/RequireConfig'
 import UserEditDialog from './UserEditDialog'
@@ -73,15 +72,6 @@ const profileQuery = gql`
   }
 `
 
-export function useSuspenseContext(): Partial<OperationContext> {
-  return useMemo(
-    () => ({
-      suspense: true,
-    }),
-    [],
-  )
-}
-
 function serviceCount(onCallSteps: EscalationPolicyStep[] = []): number {
   const svcs: { [Key: string]: boolean } = {}
   ;(onCallSteps || []).forEach((s) =>
@@ -98,11 +88,8 @@ export default function UserDetails(props: {
   readOnly: boolean
 }): JSX.Element {
   const userID = props.userID
-  const {
-    userID: currentUserID,
-    isAdmin,
-    ready: isSessionReady,
-  } = useSessionInfo()
+  const { userID: currentUserID, isAdmin } = useSessionInfo()
+
   const [createCM, setCreateCM] = useState(false)
   const [createNR, setCreateNR] = useState(false)
   const [showEdit, setShowEdit] = useState(false)
@@ -112,17 +99,13 @@ export default function UserDetails(props: {
   const [showUserDeleteDialog, setShowUserDeleteDialog] = useState(false)
   const mobile = useIsWidthDown('md')
 
-  const [{ data, fetching: isQueryLoading, error }] = useQuery({
+  const [{ data, error }] = useQuery({
     query: isAdmin || userID === currentUserID ? profileQuery : userQuery,
     variables: { id: userID },
-    pause: !userID,
-    context: useSuspenseContext(),
   })
 
-  const loading = !isSessionReady || isQueryLoading
-
   if (error) return <GenericError error={error.message} />
-  if (!_.get(data, 'user.id')) return loading ? <Spinner /> : <ObjectNotFound />
+  if (!_.get(data, 'user.id')) return <ObjectNotFound />
 
   const user = _.get(data, 'user')
   const svcCount = serviceCount(user.onCallSteps)
@@ -190,20 +173,6 @@ export default function UserDetails(props: {
 
   return (
     <React.Fragment>
-      {showEdit && (
-        <UserEditDialog
-          onClose={() => setShowEdit(false)}
-          userID={userID}
-          role={user.role}
-        />
-      )}
-      {showUserDeleteDialog && (
-        <UserDeleteDialog
-          userID={userID}
-          onClose={() => setShowUserDeleteDialog(false)}
-        />
-      )}
-
       {/* dialogs only shown on mobile via FAB button */}
       {mobile && !props.readOnly ? (
         <SpeedDial
@@ -223,48 +192,59 @@ export default function UserDetails(props: {
           ]}
         />
       ) : null}
-      {createCM && (
-        <UserContactMethodCreateDialog
-          userID={userID}
-          onClose={(contactMethodID) => {
-            setCreateCM(false)
-            setShowVerifyDialogByID(contactMethodID)
-          }}
-        />
-      )}
-      {showVerifyDialogByID && (
-        <UserContactMethodVerificationDialog
-          contactMethodID={showVerifyDialogByID}
-          onClose={() => setShowVerifyDialogByID(null)}
-        />
-      )}
-      {createNR && (
-        <UserNotificationRuleCreateDialog
-          userID={userID}
-          onClose={() => setCreateNR(false)}
-        />
-      )}
-      <Suspense fallback={<Spinner />}>
-        <DetailsPage
-          avatar={<UserAvatar userID={userID} />}
-          title={user.name + (svcCount ? ' (On-Call)' : '')}
-          subheader={user.email}
-          pageContent={
-            <Grid container spacing={2}>
-              <UserContactMethodList
-                userID={userID}
-                readOnly={props.readOnly}
-              />
-              <UserNotificationRuleList
-                userID={userID}
-                readOnly={props.readOnly}
-              />
-            </Grid>
-          }
-          secondaryActions={options}
-          links={links}
-        />
+      <Suspense>
+        {showEdit && (
+          <UserEditDialog
+            onClose={() => setShowEdit(false)}
+            userID={userID}
+            role={user.role}
+          />
+        )}
+        {showUserDeleteDialog && (
+          <UserDeleteDialog
+            userID={userID}
+            onClose={() => setShowUserDeleteDialog(false)}
+          />
+        )}
+        {createCM && (
+          <UserContactMethodCreateDialog
+            userID={userID}
+            onClose={(contactMethodID) => {
+              setCreateCM(false)
+              setShowVerifyDialogByID(contactMethodID)
+            }}
+          />
+        )}
+        {showVerifyDialogByID && (
+          <UserContactMethodVerificationDialog
+            contactMethodID={showVerifyDialogByID}
+            onClose={() => setShowVerifyDialogByID(null)}
+          />
+        )}
+        {createNR && (
+          <UserNotificationRuleCreateDialog
+            userID={userID}
+            onClose={() => setCreateNR(false)}
+          />
+        )}
       </Suspense>
+
+      <DetailsPage
+        avatar={<UserAvatar userID={userID} />}
+        title={user.name + (svcCount ? ' (On-Call)' : '')}
+        subheader={user.email}
+        pageContent={
+          <Grid container spacing={2}>
+            <UserContactMethodList userID={userID} readOnly={props.readOnly} />
+            <UserNotificationRuleList
+              userID={userID}
+              readOnly={props.readOnly}
+            />
+          </Grid>
+        }
+        secondaryActions={options}
+        links={links}
+      />
     </React.Fragment>
   )
 }

--- a/web/src/app/users/UserNotificationRuleList.tsx
+++ b/web/src/app/users/UserNotificationRuleList.tsx
@@ -17,7 +17,6 @@ import { styles as globalStyles } from '../styles/materialStyles'
 import UserNotificationRuleCreateDialog from './UserNotificationRuleCreateDialog'
 import { useIsWidthDown } from '../util/useWidth'
 import { User } from '../../schema'
-import { useSuspenseContext } from './UserDetails'
 import { ObjectNotFound, GenericError } from '../error-pages'
 
 const query = gql`
@@ -61,10 +60,8 @@ export default function UserNotificationRuleList(props: {
   const [{ data, error, fetching }] = useQuery({
     query,
     variables: { id: props.userID },
-    context: useSuspenseContext(),
   })
 
-  if (fetching && !data) return null
   if (data && !data.user)
     return <ObjectNotFound type='notifcation rules list' />
   if (error) return <GenericError error={error.message} />

--- a/web/src/app/users/UserNotificationRuleList.tsx
+++ b/web/src/app/users/UserNotificationRuleList.tsx
@@ -57,7 +57,7 @@ export default function UserNotificationRuleList(props: {
   const [showAddDialog, setShowAddDialog] = useState(false)
   const [deleteID, setDeleteID] = useState(null)
 
-  const [{ data, error, fetching }] = useQuery({
+  const [{ data, error }] = useQuery({
     query,
     variables: { id: props.userID },
   })

--- a/web/src/app/util/RequireConfig.tsx
+++ b/web/src/app/util/RequireConfig.tsx
@@ -1,5 +1,5 @@
 import React, { ReactChild, useContext } from 'react'
-import { gql, useQuery } from '@apollo/client'
+import { gql, useQuery } from 'urql'
 import {
   ConfigType,
   ConfigValue,
@@ -44,8 +44,8 @@ type ConfigProviderProps = {
   children: ReactChild | ReactChild[]
 }
 
-export function ConfigProvider(props: ConfigProviderProps): JSX.Element {
-  const { data } = useQuery(query)
+export function ConfigProvider(props: ConfigProviderProps): React.ReactNode {
+  const [{ data }] = useQuery({ query })
 
   return (
     <ConfigContext.Provider

--- a/web/src/app/util/TelTextField.tsx
+++ b/web/src/app/util/TelTextField.tsx
@@ -26,6 +26,8 @@ const useStyles = makeStyles({
   },
 })
 
+const noSuspense = { suspense: false }
+
 export default function TelTextField(
   props: TextFieldProps & { value: string },
 ): JSX.Element {
@@ -46,6 +48,7 @@ export default function TelTextField(
     variables: { number: '+' + phoneNumber },
     requestPolicy: 'cache-first',
     pause: !phoneNumber || props.disabled,
+    context: noSuspense,
   })
 
   // fetch validation

--- a/web/src/app/util/useUserInfo.ts
+++ b/web/src/app/util/useUserInfo.ts
@@ -22,6 +22,8 @@ const infoQuery = gql`
   }
 `
 
+const noSuspense = { suspense: false }
+
 // useUserInfo will add `user` info to array items that contain a `userID`.
 export function useUserInfo<T extends HasUserID>(
   items: T[],
@@ -35,6 +37,7 @@ export function useUserInfo<T extends HasUserID>(
     variables,
     requestPolicy: 'cache-first',
     pause: items.length === 0,
+    context: noSuspense,
   })
 
   // handle error

--- a/web/src/cypress/e2e/temporarySchedule.cy.ts
+++ b/web/src/cypress/e2e/temporarySchedule.cy.ts
@@ -112,9 +112,7 @@ function testTemporarySchedule(screen: string): void {
       cy.get('[data-cy="shifts-list"]').should('contain', graphQLAddUser.name)
       cy.get(
         '[data-cy="shifts-list"] li [data-cy="delete shift index: 0"]',
-      ).click({
-        force: true,
-      }) // delete
+      ).click() // delete
       cy.get('[data-cy="shifts-list"]').should(
         'not.contain',
         graphQLAddUser.name,
@@ -158,9 +156,7 @@ function testTemporarySchedule(screen: string): void {
       cy.get('[data-cy="shifts-list"]').should('contain', graphQLAddUser.name)
       cy.get(
         '[data-cy="shifts-list"] li [data-cy="delete shift index: 0"]',
-      ).click({
-        force: true,
-      }) // delete
+      ).click() // delete
       cy.get('[data-cy="shifts-list"]').should(
         'not.contain',
         graphQLAddUser.name,


### PR DESCRIPTION
**Description:**
Updates the UI to enable `suspense` for all `urql` queries.

As components are migrated from apollo to urql, they will automatically get tracked by suspense.

Notably, <Suspense> boundaries were added:
- Around the entire app for the Login switch, with a new `RequireAuth` component (instead of the redux mess)
- Around the title bar text
- Around the page content
- Around groups of dialog boxes

The `QuerySelect` tool explicitly turns off suspenseful loading as it handles loading state internally and shouldn't trigger a page-level (or dialog-level) spin.

**Which issue(s) this PR fixes:**
Part of #2557

**Out of Scope:**
- apollo queries will not trigger Suspense, so some pages still aren't as nice as they will be
- `fetching`/`isLoading` logic will still need to be removed/cleaned up separately
- Cleaning up redux usage around auth detection

**Screenshots:**

<video src="https://github.com/target/goalert/assets/595010/7cdc0a07-0153-41a1-a94f-ce5c34d5ba18"></video>



**Describe any introduced user-facing changes:**
- Application-wide spinner will resolve once config has been loaded, or the Login page is ready
- Dialogs will not appear until their data has loaded (`urql` only)
- Title bar will be blank while the name is fetched, if missing (no "User" -> "Abigail" flicker)
- Pages using `urql` (and any nested components doing so) will spin until _all_ content is loaded

**Describe any introduced API changes:**
N/A

**Additional Info:**
With `suspense` enabled, a `useQuery` will never return `fetching: true` you will always get `data` or `error`.
