### PR TITLE
ui/service-metrics: fix service status in data table

### DIFF
--- a/web/src/app/admin/admin-service-metrics/AdminServiceMetrics.tsx
+++ b/web/src/app/admin/admin-service-metrics/AdminServiceMetrics.tsx
@@ -5,7 +5,6 @@ import { useServices } from './useServices'
 import { useWorker } from '../../worker'
 import { ServiceMetrics } from './useServiceMetrics'
 import AdminServiceTable from './AdminServiceTable'
-import { Theme } from '@mui/material/styles'
 import {
   ErrorOutline,
   WarningAmberOutlined,
@@ -181,7 +180,7 @@ export default function AdminServiceMetrics(): JSX.Element {
     return (
       <React.Fragment>
         <Grid item xs>
-          <Card sx={{ marginTop: (theme: Theme) => theme.spacing(1) }}>
+          <Card sx={{ marginTop: (theme) => theme.spacing(1) }}>
             <CardHeader
               title='Integration Key Usage'
               subheader={
@@ -200,7 +199,7 @@ export default function AdminServiceMetrics(): JSX.Element {
           </Card>
         </Grid>
         <Grid item xs>
-          <Card sx={{ marginTop: (theme: Theme) => theme.spacing(1) }}>
+          <Card sx={{ marginTop: (theme) => theme.spacing(1) }}>
             <CardHeader
               title='Escalation Policy Usage'
               subheader={
@@ -224,7 +223,7 @@ export default function AdminServiceMetrics(): JSX.Element {
 
   function renderServiceTable(): JSX.Element {
     return (
-      <Card sx={{ marginTop: (theme: Theme) => theme.spacing(1) }}>
+      <Card sx={{ marginTop: (theme) => theme.spacing(1) }}>
         <CardHeader title='Services' subheader={cardSubHeader} />
         <CardContent>
           <AdminServiceTable

--- a/web/src/app/admin/admin-service-metrics/AdminServiceMetrics.tsx
+++ b/web/src/app/admin/admin-service-metrics/AdminServiceMetrics.tsx
@@ -5,6 +5,7 @@ import { useServices } from './useServices'
 import { useWorker } from '../../worker'
 import { ServiceMetrics } from './useServiceMetrics'
 import AdminServiceTable from './AdminServiceTable'
+import { Theme } from '@mui/material/styles'
 import {
   ErrorOutline,
   WarningAmberOutlined,
@@ -180,7 +181,7 @@ export default function AdminServiceMetrics(): JSX.Element {
     return (
       <React.Fragment>
         <Grid item xs>
-          <Card sx={{ marginTop: (theme) => theme.spacing(1) }}>
+          <Card sx={{ marginTop: (theme: Theme) => theme.spacing(1) }}>
             <CardHeader
               title='Integration Key Usage'
               subheader={
@@ -199,7 +200,7 @@ export default function AdminServiceMetrics(): JSX.Element {
           </Card>
         </Grid>
         <Grid item xs>
-          <Card sx={{ marginTop: (theme) => theme.spacing(1) }}>
+          <Card sx={{ marginTop: (theme: Theme) => theme.spacing(1) }}>
             <CardHeader
               title='Escalation Policy Usage'
               subheader={
@@ -223,7 +224,7 @@ export default function AdminServiceMetrics(): JSX.Element {
 
   function renderServiceTable(): JSX.Element {
     return (
-      <Card sx={{ marginTop: (theme) => theme.spacing(1) }}>
+      <Card sx={{ marginTop: (theme: Theme) => theme.spacing(1) }}>
         <CardHeader title='Services' subheader={cardSubHeader} />
         <CardContent>
           <AdminServiceTable

--- a/web/src/app/admin/admin-service-metrics/AdminServiceTable.tsx
+++ b/web/src/app/admin/admin-service-metrics/AdminServiceTable.tsx
@@ -63,12 +63,12 @@ export default function AdminServiceTable(
       })
     }
 
-    const intKeys = service.integrationKeys
-    const hbMonitors = service.heartbeatMonitors
+    const hasIntKeys = !!service.integrationKeys.length
+    const hasMonitors = !!service.heartbeatMonitors.length
 
     return {
       hasEPSteps: !!targets.length,
-      hasIntegrations: !(!intKeys.length && !hbMonitors.length),
+      hasIntegrations: hasIntKeys || hasMonitors,
       hasNotices: !!service.notices.length,
       inMaintenance: !!service.maintenanceExpiresAt,
       hasStaleAlerts: staleAlertServices[service.name] > 0,

--- a/web/src/app/admin/admin-service-metrics/AdminServiceTable.tsx
+++ b/web/src/app/admin/admin-service-metrics/AdminServiceTable.tsx
@@ -66,7 +66,8 @@ export default function AdminServiceTable(
     return {
       hasEPSteps: !!targets.length,
       hasIntegrations:
-        !(!service.integrationKeys.length && !service.heartbeatMonitors.length),
+        !service.integrationKeys.length && !service.heartbeatMonitors.length
+      ),
       hasNotices: !!service.notices.length,
       inMaintenance: !!service.maintenanceExpiresAt,
       hasStaleAlerts: staleAlertServices[service.name] > 0,

--- a/web/src/app/admin/admin-service-metrics/AdminServiceTable.tsx
+++ b/web/src/app/admin/admin-service-metrics/AdminServiceTable.tsx
@@ -65,7 +65,7 @@ export default function AdminServiceTable(
 
     return {
       hasEPSteps: !!targets.length,
-      hasIntegrations:
+      hasIntegrations: !(
         !service.integrationKeys.length && !service.heartbeatMonitors.length
       ),
       hasNotices: !!service.notices.length,

--- a/web/src/app/admin/admin-service-metrics/AdminServiceTable.tsx
+++ b/web/src/app/admin/admin-service-metrics/AdminServiceTable.tsx
@@ -63,11 +63,12 @@ export default function AdminServiceTable(
       })
     }
 
+    const intKeys = service.integrationKeys
+    const hbMonitors = service.heartbeatMonitors
+
     return {
       hasEPSteps: !!targets.length,
-      hasIntegrations: !(
-        !service.integrationKeys.length && !service.heartbeatMonitors.length
-      ),
+      hasIntegrations: !(!intKeys.length && !hbMonitors.length),
       hasNotices: !!service.notices.length,
       inMaintenance: !!service.maintenanceExpiresAt,
       hasStaleAlerts: staleAlertServices[service.name] > 0,

--- a/web/src/app/admin/admin-service-metrics/AdminServiceTable.tsx
+++ b/web/src/app/admin/admin-service-metrics/AdminServiceTable.tsx
@@ -66,7 +66,7 @@ export default function AdminServiceTable(
     return {
       hasEPSteps: !!targets.length,
       hasIntegrations:
-        !!service.integrationKeys.length && !!service.heartbeatMonitors.length,
+        !(!service.integrationKeys.length && !service.heartbeatMonitors.length),
       hasNotices: !!service.notices.length,
       inMaintenance: !!service.maintenanceExpiresAt,
       hasStaleAlerts: staleAlertServices[service.name] > 0,


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
The warning icon for services without integrations was being applied incorrectly in the data table. It should only be applied to services that have no integration keys and no heartbeat monitors.
