### PR TITLE
dev: fix prettier formatting in vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,5 +117,13 @@
     "wonka": "6.3.4",
     "wouter": "2.12.1"
   },
-  "packageManager": "yarn@3.6.3"
+  "packageManager": "yarn@3.6.3",
+  "dependenciesMeta": {
+    "prettier@3.0.3": {
+      "unplugged": true
+    },
+    "prettier-plugin-go-template@0.0.15": {
+      "unplugged": true
+    }
+  }
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const pluginGoTemplate = require('prettier-plugin-go-template')
+const pluginGoTemplate = require.resolve('prettier-plugin-go-template')
 module.exports = {
   trailingComma: 'all',
   semi: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11387,6 +11387,11 @@ __metadata:
     urql: 4.0.5
     wonka: 6.3.4
     wouter: 2.12.1
+  dependenciesMeta:
+    prettier-plugin-go-template@0.0.15:
+      unplugged: true
+    prettier@3.0.3:
+      unplugged: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
**Description:**
Get auto formatting working again in vscode. Fixes an issue some people were seeing where prettier would only work via the command line.
