### PR TITLE
ui/escalation-policies: redirect to details page on create

### DIFF
--- a/web/src/app/escalation-policies/PolicyCreateDialog.tsx
+++ b/web/src/app/escalation-policies/PolicyCreateDialog.tsx
@@ -30,7 +30,6 @@ function PolicyCreateDialog(props: { onClose: () => void }): JSX.Element {
         favorite: true,
       },
     },
-    onCompleted: props.onClose,
   })
 
   const { loading, data, error } = createPolicyStatus


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Fixes a bug where creating a new escalation policy wasn't redirecting to the new policy's details page on creation.

**Which issue(s) this PR fixes:**
Fixes: #3460