### PR TITLE
ui/isopicker: Add soft limits for min and max, apply to override and temp sched.

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "react-redux": "8.1.3",
     "react-transition-group": "4.4.5",
     "react-virtualized-auto-sizer": "1.0.20",
-    "recharts": "2.9.3",
+    "recharts": "2.8.0",
     "redux": "4.2.1",
     "redux-devtools-extension": "2.13.9",
     "redux-thunk": "2.4.2",

--- a/web/src/app/forms/FormField.js
+++ b/web/src/app/forms/FormField.js
@@ -220,6 +220,16 @@ FormField.propTypes = {
   min: p.oneOfType([p.number, p.string]),
   max: p.oneOfType([p.number, p.string]),
 
+  // softMin and softMax values specify the range to filter changes
+  // expects an ISO timestamp, if string
+  softMin: p.oneOfType([p.number, p.string]),
+  softMax: p.oneOfType([p.number, p.string]),
+
+  // softMinLabel and softMaxLabel values specify the label to display
+  // if the softMin or softMax is exceeded.
+  softMinLabel: p.string,
+  softMaxLabel: p.string,
+
   // used if name is set,
   // but the error name is different from graphql responses
   errorName: p.string,

--- a/web/src/app/forms/context.js
+++ b/web/src/app/forms/context.js
@@ -6,6 +6,7 @@ export const FormContainerContext = React.createContext({
   errors: [],
   value: {},
   addField: () => () => {},
+  setValidationError: () => {},
   optionalLabels: false,
 })
 FormContainerContext.displayName = 'FormContainerContext'

--- a/web/src/app/schedules/ScheduleOverrideForm.tsx
+++ b/web/src/app/schedules/ScheduleOverrideForm.tsx
@@ -134,6 +134,8 @@ export default function ScheduleOverrideForm(
             timeZone={zone}
             required
             name='start'
+            softMax={props.value.end}
+            softMaxLabel='end time'
             disabled={!zone}
             hint={isLocalZone ? '' : fmtLocal(value.start)}
           />
@@ -145,6 +147,8 @@ export default function ScheduleOverrideForm(
             timeZone={zone}
             name='end'
             required
+            softMin={props.value.start}
+            softMinLabel='start time'
             disabled={!zone}
             hint={isLocalZone ? '' : fmtLocal(value.end)}
           />

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -301,6 +301,8 @@ export default function TempSchedDialog({
                   max={DateTime.fromISO(now, { zone })
                     .plus({ year: 1 })
                     .toISO()}
+                  softMax={value.end}
+                  softMaxLabel='end time'
                   validate={() => validate()}
                   timeZone={zone}
                   disabled={q.loading}
@@ -314,7 +316,8 @@ export default function TempSchedDialog({
                   required
                   name='end'
                   label='Schedule End'
-                  min={value.start}
+                  softMin={value.start}
+                  softMinLabel='start time'
                   max={DateTime.fromISO(value.start, { zone })
                     .plus({ month: 3 })
                     .toISO()}

--- a/web/src/app/util/ISOPickers.tsx
+++ b/web/src/app/util/ISOPickers.tsx
@@ -66,6 +66,7 @@ function ISOPicker(props: ISOPickerProps): JSX.Element {
   )
 
   function getSoftValidationError(value: string): string {
+    if (props.disabled) return ''
     let dt: DateTime
     try {
       dt = DateTime.fromISO(value, { zone })
@@ -95,7 +96,7 @@ function ISOPicker(props: ISOPickerProps): JSX.Element {
   useEffect(
     () =>
       setValidationError(props.name || '', getSoftValidationError(inputValue)),
-    [inputValue, valueAsDT, props.name, softMin, softMax],
+    [inputValue, props.disabled, valueAsDT, props.name, softMin, softMax],
   )
 
   useEffect(() => {

--- a/web/src/app/util/ISOPickers.tsx
+++ b/web/src/app/util/ISOPickers.tsx
@@ -102,8 +102,6 @@ function ISOPicker(props: ISOPickerProps): JSX.Element {
     setInputValue(valueAsDT?.toFormat(format) ?? '')
   }, [valueAsDT])
 
-  useEffect(() => {})
-
   const dtToISO = (dt: DateTime): string => {
     return dt.startOf(truncateTo).toUTC().toISO()
   }
@@ -141,13 +139,22 @@ function ISOPicker(props: ISOPickerProps): JSX.Element {
     return ''
   }
 
-  useEffect(() => {
-    const newVal = parseInputToISO(inputValue)
+  const handleChange = (newInputValue: string): void => {
+    const newVal = parseInputToISO(newInputValue)
     if (!newVal) return
     if (getSoftValidationError(newVal)) return
 
     onChange(newVal)
-  }, [inputValue, softMin, softMax])
+  }
+
+  useEffect(() => {
+    handleChange(inputValue)
+  }, [softMin, softMax]) // inputValue intentionally omitted to prevent loop
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    setInputValue(e.target.value)
+    handleChange(e.target.value)
+  }
 
   const defaultLabel = type === 'time' ? 'Select a time...' : 'Select a date...'
 
@@ -157,7 +164,7 @@ function ISOPicker(props: ISOPickerProps): JSX.Element {
       {...textFieldProps}
       type={type}
       value={inputValue}
-      onChange={(e) => setInputValue(e.target.value)}
+      onChange={handleInputChange}
       InputLabelProps={{ shrink: true, ...textFieldProps?.InputLabelProps }}
       inputProps={{
         min: min ? DateTime.fromISO(min, { zone }).toFormat(format) : undefined,

--- a/web/src/app/util/ISOPickers.tsx
+++ b/web/src/app/util/ISOPickers.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { DateTime, DateTimeUnit } from 'luxon'
 import { TextField, TextFieldProps, useTheme } from '@mui/material'
 import { useURLParam } from '../actions'
+import { FormContainerContext } from '../forms/context'
 
 interface ISOPickerProps extends ISOTextFieldProps {
   format: string
@@ -11,6 +12,16 @@ interface ISOPickerProps extends ISOTextFieldProps {
 
   min?: string
   max?: string
+
+  // softMin and softMax are used to set the min and max values of the input
+  // without restricting the value that can be entered.
+  //
+  // Values outside of the softMin and softMax will be stored in local state
+  // and will not be passed to the parent onChange.
+  softMin?: string
+  softMinLabel?: string
+  softMax?: string
+  softMaxLabel?: string
 }
 
 // Used for the native textfield component or the nested input component
@@ -32,31 +43,69 @@ function ISOPicker(props: ISOPickerProps): JSX.Element {
     min,
     max,
 
+    softMin,
+    softMax,
+
+    softMinLabel,
+    softMaxLabel,
+
     ...textFieldProps
   } = props
 
   const theme = useTheme()
   const [_zone] = useURLParam('tz', 'local')
   const zone = timeZone || _zone
-  let valueAsDT = props.value ? DateTime.fromISO(props.value, { zone }) : null
+  const valueAsDT = React.useMemo(
+    () => (props.value ? DateTime.fromISO(props.value, { zone }) : null),
+    [props.value, zone],
+  )
 
   // store input value as DT.format() string. pass to parent onChange as ISO string
   const [inputValue, setInputValue] = useState(
     valueAsDT?.toFormat(format) ?? '',
   )
 
+  function getSoftValidationError(value: string): string {
+    let dt: DateTime
+    try {
+      dt = DateTime.fromISO(value, { zone })
+    } catch (e) {
+      return `Invalid date/time`
+    }
+
+    if (softMin) {
+      const sMin = DateTime.fromISO(softMin)
+      if (dt < sMin) {
+        return `Value must be after ${softMinLabel || sMin.toFormat(format)}`
+      }
+    }
+    if (softMax) {
+      const sMax = DateTime.fromISO(softMax)
+      if (dt > sMax) {
+        return `Value must be before ${softMaxLabel || sMax.toFormat(format)}`
+      }
+    }
+
+    return ''
+  }
+
+  const { setValidationError } = React.useContext(FormContainerContext) as {
+    setValidationError: (name: string, errMsg: string) => void
+  }
+  useEffect(
+    () =>
+      setValidationError(props.name || '', getSoftValidationError(inputValue)),
+    [inputValue, valueAsDT, props.name, softMin, softMax],
+  )
+
   useEffect(() => {
     setInputValue(valueAsDT?.toFormat(format) ?? '')
   }, [valueAsDT])
 
-  // update isopickers render on reset
-  useEffect(() => {
-    valueAsDT = props.value ? DateTime.fromISO(props.value, { zone }) : null
-    setInputValue(valueAsDT ? valueAsDT.toFormat(format) : '')
-  }, [props.value])
+  useEffect(() => {})
 
   const dtToISO = (dt: DateTime): string => {
-    return dt.startOf(truncateTo).setZone(zone).toISO()
+    return dt.startOf(truncateTo).toUTC().toISO()
   }
 
   // parseInputToISO takes input from the form control and returns a string
@@ -65,8 +114,9 @@ function ISOPicker(props: ISOPickerProps): JSX.Element {
     if (!input) return ''
 
     // handle input in specific format e.g. MM/dd/yyyy
-    const inputAsDT = DateTime.fromFormat(input, format, { zone })
-    if (inputAsDT.isValid) {
+    try {
+      const inputAsDT = DateTime.fromFormat(input, format, { zone })
+
       if (valueAsDT && type === 'time') {
         return dtToISO(
           valueAsDT.set({
@@ -76,25 +126,28 @@ function ISOPicker(props: ISOPickerProps): JSX.Element {
         )
       }
       return dtToISO(inputAsDT)
+    } catch (e) {
+      // ignore if input doesn't match format
     }
 
     // if format string invalid, try validating input as iso string
-    const iso = DateTime.fromISO(input, { zone })
-    if (iso.isValid) return dtToISO(iso)
+    try {
+      const iso = DateTime.fromISO(input, { zone })
+      return dtToISO(iso)
+    } catch (e) {
+      // ignore if input doesn't match iso format
+    }
 
     return ''
   }
 
-  function handleChange(e: React.ChangeEvent<HTMLInputElement>): void {
-    setInputValue(e.target.value)
-    const newVal = parseInputToISO(e.target.value)
+  useEffect(() => {
+    const newVal = parseInputToISO(inputValue)
+    if (!newVal) return
+    if (getSoftValidationError(newVal)) return
 
-    // only fire the parent's `onChange` handler when we have a new valid value,
-    // taking care to ensure we ignore any zonal differences.
-    if (!valueAsDT || (newVal && newVal !== valueAsDT.toISO())) {
-      onChange(newVal)
-    }
-  }
+    onChange(newVal)
+  }, [inputValue, softMin, softMax])
 
   const defaultLabel = type === 'time' ? 'Select a time...' : 'Select a date...'
 
@@ -103,8 +156,8 @@ function ISOPicker(props: ISOPickerProps): JSX.Element {
       label={defaultLabel}
       {...textFieldProps}
       type={type}
-      value={valueAsDT ? valueAsDT.toFormat(format) : inputValue}
-      onChange={handleChange}
+      value={inputValue}
+      onChange={(e) => setInputValue(e.target.value)}
       InputLabelProps={{ shrink: true, ...textFieldProps?.InputLabelProps }}
       inputProps={{
         min: min ? DateTime.fromISO(min, { zone }).toFormat(format) : undefined,

--- a/web/src/app/util/ISOPickers.tsx
+++ b/web/src/app/util/ISOPickers.tsx
@@ -144,6 +144,7 @@ function ISOPicker(props: ISOPickerProps): JSX.Element {
     const newVal = parseInputToISO(newInputValue)
     if (!newVal) return
     if (getSoftValidationError(newVal)) return
+    if (newVal === valueAsDT?.toUTC().toISO()) return
 
     onChange(newVal)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4773,6 +4773,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-unit-converter@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "css-unit-converter@npm:1.1.2"
+  checksum: 07888033346a5128f34dbe2f72884c966d24e9f29db24416dcde92860242490617ef9a178ac193a92f730834bbeea026cdc7027701d92ba9bbbe59db7a37eb2a
+  languageName: node
+  linkType: hard
+
 "css-vendor@npm:^2.0.8":
   version: 2.0.8
   resolution: "css-vendor@npm:2.0.8"
@@ -10456,6 +10463,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-value-parser@npm:^3.3.0":
+  version: 3.3.1
+  resolution: "postcss-value-parser@npm:3.3.1"
+  checksum: 62cd26e1cdbcf2dcc6bcedf3d9b409c9027bc57a367ae20d31dd99da4e206f730689471fd70a2abe866332af83f54dc1fa444c589e2381bf7f8054c46209ce16
+  languageName: node
+  linkType: hard
+
 "postcss-value-parser@npm:^4.2.0":
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
@@ -10861,7 +10875,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-smooth@npm:^2.0.4":
+"react-smooth@npm:^2.0.2":
   version: 2.0.5
   resolution: "react-smooth@npm:2.0.5"
   dependencies:
@@ -10984,24 +10998,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"recharts@npm:2.9.3":
-  version: 2.9.3
-  resolution: "recharts@npm:2.9.3"
+"recharts@npm:2.8.0":
+  version: 2.8.0
+  resolution: "recharts@npm:2.8.0"
   dependencies:
     classnames: ^2.2.5
     eventemitter3: ^4.0.1
     lodash: ^4.17.19
     react-is: ^16.10.2
     react-resize-detector: ^8.0.4
-    react-smooth: ^2.0.4
+    react-smooth: ^2.0.2
     recharts-scale: ^0.4.4
-    tiny-invariant: ^1.3.1
+    reduce-css-calc: ^2.1.8
     victory-vendor: ^36.6.8
   peerDependencies:
     prop-types: ^15.6.0
     react: ^16.0.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: e08bcc76a1ec2ea0cbcfcf8f57013acd11fb5ac44f40f43bb208880a8c410a9bc8d0eb421e8d1a5943eb0899729ae136a579a8008c720cb2e18367771edd86d7
+  checksum: 4638bd5c6c2af8f5c79de5e13cce0e38f06e0bbb0a3c4df27a9b12632fd72c0a0604c8246f55e830f323dfa84a3da7cb2634c2243bb9c775d899fd71f9d4c87a
   languageName: node
   linkType: hard
 
@@ -11012,6 +11026,16 @@ __metadata:
     indent-string: ^5.0.0
     strip-indent: ^4.0.0
   checksum: 6944e7b1d8f3fd28c2515f5c605b9f7f0ea0f4edddf41890bbbdd4d9ee35abb7540c3b278f03ff827bd278bb6ff4a5bd8692ca406b748c5c1c3ce7355e9fbf8f
+  languageName: node
+  linkType: hard
+
+"reduce-css-calc@npm:^2.1.8":
+  version: 2.1.8
+  resolution: "reduce-css-calc@npm:2.1.8"
+  dependencies:
+    css-unit-converter: ^1.1.1
+    postcss-value-parser: ^3.3.0
+  checksum: 8fd27c06c4b443b84749a69a8b97d10e6ec7d142b625b41923a8807abb22b9e37e44df14e26cc606a802957be07bdce5e8ee2976a6952a7b438a7727007101e9
   languageName: node
   linkType: hard
 
@@ -11440,7 +11464,7 @@ __metadata:
     react-redux: 8.1.3
     react-transition-group: 4.4.5
     react-virtualized-auto-sizer: 1.0.20
-    recharts: 2.9.3
+    recharts: 2.8.0
     redux: 4.2.1
     redux-devtools-extension: 2.13.9
     redux-thunk: 2.4.2
@@ -12345,13 +12369,6 @@ __metadata:
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: a38c3e059853c494af95d50c072b83f8b676a9ba2818dcc5b108ef252230735c54e0185437618596c790bbba8fcdaef5b290405981ffa09dce67b1f1bf190cbd
-  languageName: node
-  linkType: hard
-
-"tiny-invariant@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "tiny-invariant@npm:1.3.1"
-  checksum: 872dbd1ff20a21303a2fd20ce3a15602cfa7fcf9b228bd694a52e2938224313b5385a1078cb667ed7375d1612194feaca81c4ecbe93121ca1baebe344de4f84c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Description:**
This PR adds soft min and max limits to the ISO Pickers to allow validation errors while keeping the "always valid" intervals.

**Which issue(s) this PR fixes:**
- Fixes #3456
- Fixes #3426

**Out of Scope:**
- Removing `ensureInterval` #3457

**Screenshots:**
![image](https://github.com/target/goalert/assets/595010/b4546808-5456-44a9-ad5f-c078ecb51952)

**Describe any introduced user-facing changes:**
- Fixes an issue where keyboard input on fields was buggy
- Start and End times no longer change each other

**Describe any introduced API changes:**
N/A

**Additional Info:**
- FormContainer now exposes `setValidationError` as a way to set validation errors up-front without waiting for submit
- FormField has `softMin` and `softMax` props added (and `softMinLabel` + `softMaxLabel`)
- ScheduleOverrideForm has `softMax` and `softMin` set on `start` and `end` times, respectively
- TempSchedDialog has `softMax` and `softMin` set on `start` and `end` times, respectively
- ISO Pickers will now store values outside of the soft limits in state (similar to other invalid input) before firing `onChange`. The `onChange` event will only fire for valid values. Furthermore, if the soft limits are updated, `onChange` will retro-actively fire to behave correctly in date-range scenarios.
- Recharts had to be reverted to 2.8.0, as 2.9.3 breaks tooltips and was causing tests to fail
