### PR TITLE
admin/alert-counts: use iso for storage, locale for display

### DIFF
--- a/web/src/app/admin/admin-alert-counts/AlertCountLineGraph.tsx
+++ b/web/src/app/admin/admin-alert-counts/AlertCountLineGraph.tsx
@@ -24,6 +24,7 @@ import {
   Tooltip,
 } from 'recharts'
 import Spinner from '../../loading/components/Spinner'
+import { Time } from '../../util/Time'
 
 interface AlertCountLineGraphProps {
   data: (typeof LineChart.defaultProps)['data']
@@ -148,7 +149,9 @@ export default function AlertCountLineGraph(
                   if (!active || !payload?.length) return null
                   return (
                     <Paper variant='outlined' sx={{ p: 1 }}>
-                      <Typography variant='body2'>{label}</Typography>
+                      <Typography variant='body2'>
+                        <Time time={label} />
+                      </Typography>
                       {payload.map((svc, idx) => {
                         return (
                           <React.Fragment key={idx}>

--- a/web/src/app/admin/admin-alert-counts/AlertCountLineGraph.tsx
+++ b/web/src/app/admin/admin-alert-counts/AlertCountLineGraph.tsx
@@ -94,17 +94,17 @@ export default function AlertCountLineGraph(
     }
   }
 
-  const formatTick = (label: string): string => {
+  const formatTick = (date: string): string => {
+    const dt = DateTime.fromISO(date)
     // check for default bounds
-    if (label.toString() !== '0' && label !== 'auto') {
-      const dateTime = DateTime.fromFormat(label, 'MMM d, t')
-      if (props.unit === 'month') return dateTime.toFormat('MMM')
-      if (props.unit === 'week' || props.unit === 'day')
-        return dateTime.toFormat('MMM d')
-      if (props.unit === 'hour' || props.unit === 'minute')
-        return dateTime.toFormat('t')
-    }
-    return ''
+
+    if (props.unit === 'month') return dt.toLocaleString({ month: 'long' })
+    if (props.unit === 'week' || props.unit === 'day')
+      return dt.toLocaleString({ month: 'short', day: 'numeric' })
+    if (props.unit === 'hour' || props.unit === 'minute')
+      return dt.toLocaleString({ hour: 'numeric', minute: 'numeric' })
+
+    return date
   }
 
   return (

--- a/web/src/app/admin/admin-alert-counts/AlertCountLineGraph.tsx
+++ b/web/src/app/admin/admin-alert-counts/AlertCountLineGraph.tsx
@@ -102,7 +102,8 @@ export default function AlertCountLineGraph(
     if (props.unit === 'month') return dt.toLocaleString({ month: 'long' })
     if (props.unit === 'week' || props.unit === 'day')
       return dt.toLocaleString({ month: 'short', day: 'numeric' })
-    if (props.unit === 'hour' || props.unit === 'minute')
+    if (props.unit === 'hour') return dt.toLocaleString({ hour: 'numeric' })
+    if (props.unit === 'minute')
       return dt.toLocaleString({ hour: 'numeric', minute: 'numeric' })
 
     return date

--- a/web/src/app/admin/admin-alert-counts/useAdminAlertCounts.ts
+++ b/web/src/app/admin/admin-alert-counts/useAdminAlertCounts.ts
@@ -20,7 +20,7 @@ export type AlertCountOpts = {
   alerts: Alert[]
 }
 
-function truncateDateTime(dateTime, duration) {
+function truncateDateTime(dateTime: DateTime, duration: Duration): DateTime {
   const durValues = duration.toObject()
   let truncDateTime = dateTime
 

--- a/web/src/app/admin/admin-alert-counts/useAdminAlertCounts.ts
+++ b/web/src/app/admin/admin-alert-counts/useAdminAlertCounts.ts
@@ -12,7 +12,6 @@ export type AlertCountSeries = {
 }
 export type AlertCountDataPoint = {
   date: string
-  label: string
   dayTotal: number
 }
 export type AlertCountOpts = {
@@ -31,26 +30,11 @@ export function useAdminAlertCounts(opts: AlertCountOpts): AlertCountSeries[] {
     Interval.fromISO(opts.int)
       .splitBy(Duration.fromISO(opts.dur))
       .map((i) => {
-        const date = i.start.toLocaleString({
-          month: 'short',
-          day: 'numeric',
-          hour: 'numeric',
-          minute: 'numeric',
-        })
-        const label = i.start.toLocaleString({
-          month: 'short',
-          day: 'numeric',
-          year: 'numeric',
-          hour: 'numeric',
-          minute: 'numeric',
-        })
-
         const bucket = alerts.filter((a) => {
           return i.contains(DateTime.fromISO(a.createdAt as string))
         })
         alertCounts.push({
-          date,
-          label,
+          date: i.start.toUTC().toISO(),
           dayTotal: bucket.length,
         })
         svcTotal += bucket.length

--- a/web/src/cypress/e2e/admin.cy.ts
+++ b/web/src/cypress/e2e/admin.cy.ts
@@ -224,12 +224,16 @@ function testAdmin(): void {
     })
 
     it('should display alert counts', () => {
-      const now = DateTime.local().minus({ hours: 22 }).toLocaleString({
-        month: 'short',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: 'numeric',
-      })
+      const now = DateTime.local()
+        .minus({ hours: 21 })
+        .set({ minute: 0 })
+        .toLocaleString({
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          hour: 'numeric',
+          minute: 'numeric',
+        })
 
       cy.get(`.recharts-line-dots circle[r=3]`).last().trigger('mouseover')
       cy.get('[data-cy=alert-count-graph]')


### PR DESCRIPTION
**Description:**
Uses ISO timestamps for storing/parsing timestamps and `toLocaleString` for display. Additionally, the time buckets are now truncated (e.g., to the hour when breaking down by hour)

Previously, the graph would break if the user's locale differed from the hard-coded format. Additionally, the displayed times wouldn't match the user's locale if it differed from the hard-coded format.

This change should ensure the logic works regardless of locale, and times on the X-axis will be rendered according to the user's locale.
