### PR TITLE
temp sched dialog: fix soft limits while typing

### DIFF
--- a/web/src/app/schedules/ScheduleOverrideForm.tsx
+++ b/web/src/app/schedules/ScheduleOverrideForm.tsx
@@ -135,7 +135,7 @@ export default function ScheduleOverrideForm(
             required
             name='start'
             softMax={props.value.end}
-            softMaxLabel='end time'
+            softMaxLabel='Must be before end time.'
             disabled={!zone}
             hint={isLocalZone ? '' : fmtLocal(value.start)}
           />
@@ -148,7 +148,7 @@ export default function ScheduleOverrideForm(
             name='end'
             required
             softMin={props.value.start}
-            softMinLabel='start time'
+            softMinLabel='Must be after start time.'
             disabled={!zone}
             hint={isLocalZone ? '' : fmtLocal(value.end)}
           />

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -302,7 +302,11 @@ export default function TempSchedDialog({
                     .plus({ year: 1 })
                     .toISO()}
                   softMax={value.end}
-                  softMaxLabel='end time'
+                  softMaxLabel='Must be before end time.'
+                  softMin={DateTime.fromISO(value.end)
+                    .plus({ month: -3 })
+                    .toISO()}
+                  softMinLabel='Must be within 3 months of end time.'
                   validate={() => validate()}
                   timeZone={zone}
                   disabled={q.loading}
@@ -316,11 +320,13 @@ export default function TempSchedDialog({
                   required
                   name='end'
                   label='Schedule End'
+                  min={now}
                   softMin={value.start}
-                  softMinLabel='start time'
-                  max={DateTime.fromISO(value.start, { zone })
+                  softMinLabel='Must be after start time.'
+                  softMax={DateTime.fromISO(value.start)
                     .plus({ month: 3 })
                     .toISO()}
+                  softMaxLabel='Must be within 3 months of start time.'
                   validate={() => validate()}
                   timeZone={zone}
                   disabled={q.loading}

--- a/web/src/app/util/ISOPickers.tsx
+++ b/web/src/app/util/ISOPickers.tsx
@@ -77,13 +77,13 @@ function ISOPicker(props: ISOPickerProps): JSX.Element {
     if (softMin) {
       const sMin = DateTime.fromISO(softMin)
       if (dt < sMin) {
-        return `Value must be after ${softMinLabel || sMin.toFormat(format)}`
+        return softMinLabel || `Value must be after ${sMin.toFormat(format)}`
       }
     }
     if (softMax) {
       const sMax = DateTime.fromISO(softMax)
       if (dt > sMax) {
-        return `Value must be before ${softMaxLabel || sMax.toFormat(format)}`
+        return softMaxLabel || `Value must be before ${sMax.toFormat(format)}`
       }
     }
 


### PR DESCRIPTION
**Description:**
Adds soft limits of 3 months for the TempSchedDialog start & end times to prevent it from crashing while rendering thousands of years worth of shifts (e.g., when typing the year)
