### PR TITLE
ui/message-logs: use a sane limit for the max num of graph points

### DIFF
--- a/web/src/app/admin/admin-message-logs/util.ts
+++ b/web/src/app/admin/admin-message-logs/util.ts
@@ -35,7 +35,7 @@ export function getValidIntervals(s: {
   return INTERVAL_OPTIONS.filter((o) => {
     const interval = Duration.fromISO(o.value).as('milliseconds')
     const points = duration / interval
-    return points >= 4 && points <= 1000
+    return points >= 4 && points <= 75
   })
 }
 


### PR DESCRIPTION
Reduces the limit from 1000 intervals on the graph to a max of 75. This still allows for weekly intervals for a full year (52) and all the minutes in an hour (60), but not by day for a full year (365), which is non-performant especially when segmentation is introduced in #3296, where more data is being loaded for each interval duration.