### PR TITLE
ui/urql: rotations

### DIFF
--- a/web/src/app/rotations/RotationAddUserDialog.tsx
+++ b/web/src/app/rotations/RotationAddUserDialog.tsx
@@ -46,7 +46,10 @@ const RotationAddUserDialog = (
             id: rotationID,
             userIDs: users,
           },
-        }).then(() => onClose())
+        }).then((result) => {
+          if (result.error) return
+          onClose()
+        })
       }
       form={
         <UserForm

--- a/web/src/app/rotations/RotationAddUserDialog.tsx
+++ b/web/src/app/rotations/RotationAddUserDialog.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
-import { useMutation } from '@apollo/client'
-import { gql } from 'urql'
+import { gql, useMutation } from 'urql'
 import { nonFieldErrors } from '../util/errutil'
 import UserForm from './UserForm'
 import FormDialog from '../dialogs/FormDialog'
@@ -34,27 +33,24 @@ const RotationAddUserDialog = (
   userIDs.forEach((u) => users.push(u))
   uIDs.forEach((u) => users.push(u))
 
-  const [updateRotationMutation, { loading, error }] = useMutation(mutation, {
-    variables: {
-      input: {
-        id: rotationID,
-        userIDs: users,
-      },
-    },
-    onCompleted: onClose,
-  })
+  const [{ error }, commit] = useMutation(mutation)
 
   return (
     <FormDialog
       title='Add User'
-      loading={loading}
       errors={nonFieldErrors(error)}
       onClose={onClose}
-      onSubmit={() => updateRotationMutation()}
+      onSubmit={() =>
+        commit({
+          input: {
+            id: rotationID,
+            userIDs: users,
+          },
+        }).then(() => onClose())
+      }
       form={
         <UserForm
           errors={nonFieldErrors(error)}
-          disabled={loading}
           value={value}
           onChange={(value: Value) => setValue(value)}
         />

--- a/web/src/app/rotations/RotationCreateDialog.tsx
+++ b/web/src/app/rotations/RotationCreateDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { gql, useMutation } from '@apollo/client'
+import { gql, useMutation } from 'urql'
 import { nonFieldErrors, fieldErrors } from '../util/errutil'
 import FormDialog from '../dialogs/FormDialog'
 import RotationForm from './RotationForm'
@@ -31,16 +31,7 @@ const RotationCreateDialog = (props: { onClose?: () => void }): JSX.Element => {
     shiftLength: 1,
     favorite: true,
   })
-  const [createRotationMutation, { loading, data, error }] = useMutation(
-    mutation,
-    {
-      variables: {
-        input: {
-          ...value,
-        },
-      },
-    },
-  )
+  const [{ data, error }, commit] = useMutation(mutation)
 
   if (data?.createRotation) {
     return <Redirect to={`/rotations/${data.createRotation.id}`} />
@@ -49,14 +40,18 @@ const RotationCreateDialog = (props: { onClose?: () => void }): JSX.Element => {
   return (
     <FormDialog
       title='Create Rotation'
-      loading={loading}
       errors={nonFieldErrors(error)}
       onClose={props.onClose}
-      onSubmit={() => createRotationMutation()}
+      onSubmit={() =>
+        commit({
+          input: {
+            ...value,
+          },
+        })
+      }
       form={
         <RotationForm
           errors={fieldErrors(error)}
-          disabled={loading}
           value={value}
           onChange={(value) => setValue(value)}
         />

--- a/web/src/app/rotations/RotationForm.tsx
+++ b/web/src/app/rotations/RotationForm.tsx
@@ -10,6 +10,7 @@ import { FieldError } from '../util/errutil'
 import { CreateRotationInput } from '../../schema'
 import { Time } from '../util/Time'
 import RotationFormHandoffTimes from './RotationFormHandoffTimes'
+import Spinner from '../loading/components/Spinner'
 
 interface RotationFormProps {
   value: CreateRotationInput
@@ -124,7 +125,13 @@ export default function RotationForm(props: RotationFormProps): JSX.Element {
             }
           />
         </Grid>
-        <Suspense>
+        <Suspense
+          fallback={
+            <Grid item xs={12} sx={{ height: '7rem' }}>
+              <Spinner text='Calculating...' />
+            </Grid>
+          }
+        >
           <RotationFormHandoffTimes value={value} />
         </Suspense>
       </Grid>

--- a/web/src/app/rotations/RotationForm.tsx
+++ b/web/src/app/rotations/RotationForm.tsx
@@ -1,24 +1,15 @@
-import React from 'react'
-import {
-  TextField,
-  Grid,
-  MenuItem,
-  Typography,
-  FormHelperText,
-} from '@mui/material'
-import makeStyles from '@mui/styles/makeStyles'
+import React, { Suspense } from 'react'
+import { TextField, Grid, MenuItem, FormHelperText } from '@mui/material'
 import { startCase } from 'lodash'
 import { DateTime } from 'luxon'
-import { useQuery, gql } from '@apollo/client'
-
 import { FormContainer, FormField } from '../forms'
 import { TimeZoneSelect } from '../selection'
 import { ISODateTimePicker } from '../util/ISOPickers'
 import NumberField from '../util/NumberField'
-import Spinner from '../loading/components/Spinner'
 import { FieldError } from '../util/errutil'
-import { CreateRotationInput, ISODuration, RotationType } from '../../schema'
+import { CreateRotationInput } from '../../schema'
 import { Time } from '../util/Time'
+import RotationFormHandoffTimes from './RotationFormHandoffTimes'
 
 interface RotationFormProps {
   value: CreateRotationInput
@@ -27,49 +18,7 @@ interface RotationFormProps {
   disabled?: boolean
 }
 
-const query = gql`
-  query calcRotationHandoffTimes($input: CalcRotationHandoffTimesInput) {
-    calcRotationHandoffTimes(input: $input)
-  }
-`
-
 const rotationTypes = ['hourly', 'daily', 'weekly', 'monthly']
-
-const useStyles = makeStyles({
-  handoffTimestamp: {
-    listStyle: 'none',
-  },
-  handoffsTitle: {
-    fontWeight: 'bolder',
-  },
-  tzContainer: {
-    display: 'flex',
-  },
-  handoffsContainer: {
-    height: '7rem',
-  },
-  handoffsList: {
-    margin: 0,
-    padding: 0,
-  },
-})
-
-// getShiftDuration converts a count and one of ['hourly', 'daily', 'weekly', 'monthly']
-// into the shift length to ISODuration.
-function getShiftDuration(count: number, type: RotationType): ISODuration {
-  switch (type) {
-    case 'monthly':
-      return `P${count}M`
-    case 'weekly':
-      return `P${count}W`
-    case 'daily':
-      return `P${count}D`
-    case 'hourly':
-      return `PT${count}H`
-    default:
-      throw new Error('unknown rotation type: ' + type)
-  }
-}
 
 const sameAsLocal = (t: string, z: string): boolean => {
   const inZone = DateTime.fromISO(t, { zone: z })
@@ -79,25 +28,9 @@ const sameAsLocal = (t: string, z: string): boolean => {
 
 export default function RotationForm(props: RotationFormProps): JSX.Element {
   const { value } = props
-  const classes = useStyles()
 
-  const { data, loading, error } = useQuery(query, {
-    variables: {
-      input: {
-        handoff: value.start,
-        timeZone: value.timeZone,
-        shiftLength: getShiftDuration(value.shiftLength as number, value.type),
-        count: 3,
-      },
-    },
-  })
-
-  const isCalculating = !data || loading
-
-  const isHandoffValid = DateTime.fromISO(value.start).isValid
   const handoffWarning =
     DateTime.fromISO(value.start).day > 28 && value.type === 'monthly'
-  const nextHandoffs = isCalculating ? [] : data.calcRotationHandoffTimes
 
   return (
     <FormContainer optionalLabels {...props}>
@@ -191,37 +124,9 @@ export default function RotationForm(props: RotationFormProps): JSX.Element {
             }
           />
         </Grid>
-
-        <Grid item xs={12} className={classes.handoffsContainer}>
-          <Typography variant='body2' className={classes.handoffsTitle}>
-            Upcoming Handoff times:
-          </Typography>
-          {isHandoffValid ? (
-            <ol className={classes.handoffsList}>
-              {nextHandoffs.map((time: string, i: number) => (
-                <Typography
-                  key={i}
-                  component='li'
-                  className={classes.handoffTimestamp}
-                  variant='body2'
-                >
-                  <Time time={time} zone={value.timeZone} />
-                </Typography>
-              ))}
-            </ol>
-          ) : (
-            <Typography variant='body2' color='textSecondary'>
-              Please enter a valid handoff time.
-            </Typography>
-          )}
-
-          {isCalculating && isHandoffValid && <Spinner text='Calculating...' />}
-          {error && isHandoffValid && (
-            <Typography variant='body2' color='error'>
-              {error.message}
-            </Typography>
-          )}
-        </Grid>
+        <Suspense>
+          <RotationFormHandoffTimes value={value} />
+        </Suspense>
       </Grid>
     </FormContainer>
   )

--- a/web/src/app/rotations/RotationFormHandoffTimes.tsx
+++ b/web/src/app/rotations/RotationFormHandoffTimes.tsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import { Grid, Typography } from '@mui/material'
+import { DateTime } from 'luxon'
+import { gql, useQuery } from 'urql'
+import { RotationType, ISODuration, CreateRotationInput } from '../../schema'
+import Spinner from '../loading/components/Spinner'
+import { Time } from '../util/Time'
+
+const query = gql`
+  query calcRotationHandoffTimes($input: CalcRotationHandoffTimesInput) {
+    calcRotationHandoffTimes(input: $input)
+  }
+`
+
+// getShiftDuration converts a count and one of ['hourly', 'daily', 'weekly', 'monthly']
+// into the shift length to ISODuration.
+function getShiftDuration(count: number, type: RotationType): ISODuration {
+  switch (type) {
+    case 'monthly':
+      return `P${count}M`
+    case 'weekly':
+      return `P${count}W`
+    case 'daily':
+      return `P${count}D`
+    case 'hourly':
+      return `PT${count}H`
+    default:
+      throw new Error('unknown rotation type: ' + type)
+  }
+}
+
+interface RotationFormHandoffTimesProps {
+  value: CreateRotationInput
+}
+
+export default function RotationFormHandoffTimes({
+  value,
+}: RotationFormHandoffTimesProps): JSX.Element {
+  const [{ data, fetching, error }] = useQuery({
+    query,
+    variables: {
+      input: {
+        handoff: value.start,
+        timeZone: value.timeZone,
+        shiftLength: getShiftDuration(value.shiftLength as number, value.type),
+        count: 3,
+      },
+    },
+  })
+  const isCalculating = !data || fetching
+
+  const isHandoffValid = DateTime.fromISO(value.start).isValid
+  const nextHandoffs = isCalculating ? [] : data.calcRotationHandoffTimes
+
+  return (
+    <Grid item xs={12} sx={{ height: '7rem' }}>
+      <Typography variant='body2' sx={{ fontWeight: 'bolder' }}>
+        Upcoming Handoff times:
+      </Typography>
+      {isHandoffValid ? (
+        <ol style={{ margin: 0, padding: 0 }}>
+          {nextHandoffs.map((time: string, i: number) => (
+            <Typography
+              key={i}
+              component='li'
+              variant='body2'
+              sx={{ listStyle: 'none' }}
+            >
+              <Time time={time} zone={value.timeZone} />
+            </Typography>
+          ))}
+        </ol>
+      ) : (
+        <Typography variant='body2' color='textSecondary'>
+          Please enter a valid handoff time.
+        </Typography>
+      )}
+
+      {isCalculating && isHandoffValid && <Spinner text='Calculating...' />}
+      {error && isHandoffValid && (
+        <Typography variant='body2' color='error'>
+          {error.message}
+        </Typography>
+      )}
+    </Grid>
+  )
+}

--- a/web/src/app/rotations/RotationFormHandoffTimes.tsx
+++ b/web/src/app/rotations/RotationFormHandoffTimes.tsx
@@ -3,7 +3,6 @@ import { Grid, Typography } from '@mui/material'
 import { DateTime } from 'luxon'
 import { gql, useQuery } from 'urql'
 import { RotationType, ISODuration, CreateRotationInput } from '../../schema'
-import Spinner from '../loading/components/Spinner'
 import { Time } from '../util/Time'
 
 const query = gql`
@@ -76,7 +75,6 @@ export default function RotationFormHandoffTimes({
         </Typography>
       )}
 
-      {isCalculating && isHandoffValid && <Spinner text='Calculating...' />}
       {error && isHandoffValid && (
         <Typography variant='body2' color='error'>
           {error.message}

--- a/web/src/app/util/errutil.ts
+++ b/web/src/app/util/errutil.ts
@@ -87,7 +87,9 @@ export function fieldErrors(err?: ApolloError | CombinedError): FieldError[] {
 }
 
 // allErrors will return a flat list of all errors in the graphQL error.
-export function allErrors(err?: ApolloError): (FieldError | Error)[] {
+export function allErrors(
+  err?: ApolloError | CombinedError,
+): (FieldError | Error)[] {
   if (!err) return []
   return nonFieldErrors(err).concat(fieldErrors(err))
 }


### PR DESCRIPTION
Migrates from `@apollo/client` to `urql` for the following files:
- `web/src/app/rotations/RotationAddUserDialog.tsx`
- `web/src/app/rotations/RotationCreateDialog.tsx`
- `web/src/app/rotations/RotationForm.tsx`

Also puts the handoff times grid item in its own component so it can suspensefully load (the entire page spins in the background without it)

`RotationsUserList` is out of scope as it has caching updates, so I would prefer this be worked on & opened as a PR by itself.