### PR TITLE
apikey: Fix issue where omitting the `query` field doesn't work

### DIFF
--- a/apikey/middleware.go
+++ b/apikey/middleware.go
@@ -10,18 +10,18 @@ import (
 
 type Middleware struct{}
 
-var _ graphql.OperationContextMutator = Middleware{}
+var _ graphql.OperationParameterMutator = Middleware{}
 
 func (Middleware) ExtensionName() string                          { return "GQLAPIKeyMiddleware" }
 func (Middleware) Validate(schema graphql.ExecutableSchema) error { return nil }
 
-func (Middleware) MutateOperationContext(ctx context.Context, rc *graphql.OperationContext) *gqlerror.Error {
+func (Middleware) MutateOperationParameters(ctx context.Context, rc *graphql.RawParams) *gqlerror.Error {
 	p := PolicyFromContext(ctx)
 	if p == nil {
 		return nil
 	}
 
-	if rc.RawQuery == "" {
+	if rc.Query == "" {
 		// Allow query to be omitted for API key requests,
 		// since they are always fixed to the key itself.
 		//
@@ -31,10 +31,10 @@ func (Middleware) MutateOperationContext(ctx context.Context, rc *graphql.Operat
 		// This helps with things like key rotations, where the
 		// query may not be known to the client, or would otherwise
 		// be difficult to update.
-		rc.RawQuery = p.Query
+		rc.Query = p.Query
 	}
 
-	if p.Query != rc.RawQuery {
+	if p.Query != rc.Query {
 		return &gqlerror.Error{
 			Err:     permission.Unauthorized(),
 			Message: "wrong query for API key",

--- a/test/integration/gqlapikeys.spec.ts
+++ b/test/integration/gqlapikeys.spec.ts
@@ -95,6 +95,18 @@ test('GQL API keys', async ({ page, request, isMobile }) => {
   expect(data).toHaveProperty('data')
   expect(data.data).toHaveProperty('gqlAPIKeys')
 
+  resp = await request.post(gqlURL, {
+    headers: {
+      Authorization: `Bearer ${duplicateToken}`,
+    },
+    data: { query: '{wrongQuery}' },
+  })
+
+  expect(resp.status()).toBe(200)
+  const badResp = await resp.json()
+
+  expect(badResp).toHaveProperty('errors')
+
   type Key = {
     id: string
     name: string
@@ -115,7 +127,7 @@ test('GQL API keys', async ({ page, request, isMobile }) => {
       Authorization: `Bearer ${duplicateToken}`,
     },
     data: {
-      query,
+      // Note: `query` is omitted to validate that it is not required for gql API keys.
       operationName: 'DeleteAPIKey',
       variables: {
         id: originalID,


### PR DESCRIPTION
**Description:**
Implemented the wrong interface and as a result, omitting the `query` field would result in a validation error.

The playwright test was updated to validate that omitting `query` in the request payload works correctly.
