### PR TITLE
ui/profile: convert UserContactMethodVerificationForm to typescript

### DIFF
--- a/web/src/app/users/UserContactMethodVerificationForm.js
+++ b/web/src/app/users/UserContactMethodVerificationForm.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { useMutation, gql } from '@apollo/client'
+import { useMutation, gql } from 'urql'
 import p from 'prop-types'
 import Grid from '@mui/material/Grid'
 import TextField from '@mui/material/TextField'
@@ -32,25 +32,27 @@ const useStyles = makeStyles({
 export default function UserContactMethodVerificationForm(props) {
   const classes = useStyles()
 
-  const [sendCode, sendCodeStatus] = useMutation(sendVerificationCodeMutation, {
-    variables: {
-      input: {
-        contactMethodID: props.contactMethodID,
-      },
-    },
-  })
+  const [sendCodeStatus, sendCode] = useMutation(sendVerificationCodeMutation)
 
   function sendAndCatch() {
     // Clear error on new actions.
     props.setSendError(null)
-    sendCode().catch((err) => props.setSendError(err.message))
+    sendCode({
+      input: {
+        contactMethodID: props.contactMethodID,
+      },
+    }).catch((err) => props.setSendError(err.message))
   }
 
   // Attempt to send a code on load, but it's ok if it fails.
   //
   // We only want to display an error in response to a user action.
   useEffect(() => {
-    sendCode().catch(() => {})
+    sendCode({
+      input: {
+        contactMethodID: props.contactMethodID,
+      },
+    }).catch(() => {})
   }, [])
 
   return (

--- a/web/src/app/users/UserContactMethodVerificationForm.tsx
+++ b/web/src/app/users/UserContactMethodVerificationForm.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles({
 interface UserContactMethodVerificationFormProps {
   contactMethodID: string
   disabled: boolean
-  errors: Error[]
+  errors?: Error[]
   onChange: (value: { code: string }) => void
   setSendError: (err: string) => void
   value: {

--- a/web/src/app/users/UserContactMethodVerificationForm.tsx
+++ b/web/src/app/users/UserContactMethodVerificationForm.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react'
 import { useMutation, gql } from 'urql'
-import p from 'prop-types'
 import Grid from '@mui/material/Grid'
 import TextField from '@mui/material/TextField'
 import LoadingButton from '../loading/components/LoadingButton'
@@ -29,14 +28,26 @@ const useStyles = makeStyles({
   },
 })
 
-export default function UserContactMethodVerificationForm(props) {
+interface UserContactMethodVerificationFormProps {
+  contactMethodID: string
+  disabled: boolean
+  errors: Error[]
+  onChange: (value: { code: string }) => void
+  setSendError: (err: string) => void
+  value: {
+    code: string
+  }
+}
+export default function UserContactMethodVerificationForm(
+  props: UserContactMethodVerificationFormProps,
+): React.ReactNode {
   const classes = useStyles()
 
   const [sendCodeStatus, sendCode] = useMutation(sendVerificationCodeMutation)
 
-  function sendAndCatch() {
+  function sendAndCatch(): void {
     // Clear error on new actions.
-    props.setSendError(null)
+    props.setSendError('')
     sendCode({
       input: {
         contactMethodID: props.contactMethodID,
@@ -60,7 +71,7 @@ export default function UserContactMethodVerificationForm(props) {
       <Grid container spacing={2}>
         <Grid item className={classes.sendGridItem}>
           <LoadingButton
-            loading={sendCodeStatus.loading}
+            loading={sendCodeStatus.fetching}
             disabled={props.disabled}
             buttonText='Resend Code'
             noSubmit
@@ -76,26 +87,10 @@ export default function UserContactMethodVerificationForm(props) {
             component={TextField}
             type='number'
             step='1'
-            mapOnChangeValue={(value) => value.toString()}
+            mapOnChangeValue={(value: number) => value.toString()}
           />
         </Grid>
       </Grid>
     </FormContainer>
   )
-}
-
-UserContactMethodVerificationForm.propTypes = {
-  contactMethodID: p.string.isRequired,
-  disabled: p.bool.isRequired,
-  errors: p.arrayOf(
-    p.shape({
-      field: p.oneOf(['code']).isRequired,
-      message: p.string.isRequired,
-    }),
-  ),
-  onChange: p.func.isRequired,
-  setSendError: p.func.isRequired,
-  value: p.shape({
-    code: p.string.isRequired,
-  }).isRequired,
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Converts `UserContactMethodVerificationForm` to use urql and typescript.

**Which issue(s) this PR fixes:**
Part of https://github.com/target/goalert/issues/2318 and https://github.com/target/goalert/issues/3240