### PR TITLE
graphql: Fix 500 errors on invalid JSON

### DIFF
--- a/graphql2/graphqlapp/app.go
+++ b/graphql2/graphqlapp/app.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -129,6 +130,17 @@ func isGQLValidation(gqlErr *gqlerror.Error) bool {
 
 	var numErr *strconv.NumError
 	if errors.As(gqlErr, &numErr) {
+		return true
+	}
+
+	if strings.HasPrefix(gqlErr.Message, "json request body") {
+		var body string
+		gqlErr.Message, body, _ = strings.Cut(gqlErr.Message, " body:") // remove body
+		if !strings.HasPrefix(strings.TrimSpace(body), "{") {
+			// Make the error more readable for common JSON errors.
+			gqlErr.Message = "json request body could not be decoded: body must be an object, missing '{'"
+		}
+
 		return true
 	}
 

--- a/test/smoke/graphqlerror_test.go
+++ b/test/smoke/graphqlerror_test.go
@@ -1,0 +1,37 @@
+package smoke
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/test/smoke/harness"
+)
+
+func TestGraphQLError(t *testing.T) {
+	h := harness.NewHarness(t, "", "ids-to-uuids")
+	defer h.Close()
+
+	req, err := http.NewRequest("POST", h.URL()+"/api/graphql", strings.NewReader(`"test"`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+h.GraphQLToken(harness.DefaultGraphQLAdminUserID))
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, 400, resp.StatusCode, "expected 400 error")
+
+	var r struct {
+		Errors []struct {
+			Message string
+		}
+	}
+	err = json.NewDecoder(resp.Body).Decode(&r)
+	require.NoError(t, err)
+	require.Len(t, r.Errors, 1)
+
+	require.Equal(t, "json request body could not be decoded: body must be an object, missing '{'", r.Errors[0].Message)
+}

--- a/test/smoke/harness/graphql.go
+++ b/test/smoke/harness/graphql.go
@@ -88,17 +88,9 @@ func (h *Harness) GraphQLQueryT(t *testing.T, query string) *QLResponse {
 	return h.GraphQLQueryUserT(t, DefaultGraphQLAdminUserID, query)
 }
 
-// GraphQLQueryUserT will perform a GraphQL query against the backend, internally
-// handling authentication. Queries are performed with the provided UserID.
-func (h *Harness) GraphQLQueryUserT(t *testing.T, userID, query string) *QLResponse {
-	t.Helper()
-	retry := 1
-	var err error
-	var resp *http.Response
-	var tok string
-
+func (h *Harness) GraphQLToken(userID string) string {
 	h.mx.Lock()
-	tok = h.gqlSessions[userID]
+	tok := h.gqlSessions[userID]
 	if tok == "" {
 		if userID == DefaultGraphQLAdminUserID {
 			h.createGraphQLUser(userID)
@@ -106,6 +98,18 @@ func (h *Harness) GraphQLQueryUserT(t *testing.T, userID, query string) *QLRespo
 		tok = h.createGraphQLSession(userID)
 	}
 	h.mx.Unlock()
+	return tok
+}
+
+// GraphQLQueryUserT will perform a GraphQL query against the backend, internally
+// handling authentication. Queries are performed with the provided UserID.
+func (h *Harness) GraphQLQueryUserT(t *testing.T, userID, query string) *QLResponse {
+	t.Helper()
+	retry := 1
+	var err error
+	var resp *http.Response
+
+	tok := h.GraphQLToken(userID)
 
 	for {
 		query = strings.Replace(query, "\t", "", -1)


### PR DESCRIPTION
**Description:**
Handles the case of invalid JSON in a request body to the `/api/graphql` endpoint.

- A 400 instead of 500 is returned
- The parse error is now returned (with body stripped)
- The common case of sending a non-object has a more clear error message (default would have been cant parse string into Go-type something something)

**Which issue(s) this PR fixes:**
Fixes #3498 

**Describe any introduced user-facing changes:**
N/A

**Describe any introduced API changes:**
Invalid JSON will now result in a 400 bad request rather than 500 unexpected error

**Additional Info:**
Added a smoke test to validate the new behavior.
