### PR TITLE
search: fix handling of underscores and add contains match for names

### DIFF
--- a/escalation/search.go
+++ b/escalation/search.go
@@ -55,7 +55,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		AND NOT pol.id = any(:omit)
 	{{end}}
 	{{if .Search}}
-		AND ({{orderedPrefixSearch "search" "pol.name"}} OR {{contains "search" "pol.description"}})
+		AND ({{orderedPrefixSearch "search" "pol.name"}} OR {{contains "search" "pol.description"}} OR {{contains "search" "pol.name"}})
 	{{end}}
 	{{if .After.Name}}
 		AND

--- a/notification/search.go
+++ b/notification/search.go
@@ -91,9 +91,9 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 	{{end}}
 	{{if .Search}}
 		AND (
-			{{orderedPrefixSearch "search" "u.name"}}
+			{{orderedPrefixSearch "search" "u.name"}} OR {{contains "search" "u.name"}}
 			OR
-			{{orderedPrefixSearch "search" "s.name"}}
+			{{orderedPrefixSearch "search" "s.name"}} OR {{contains "search" "s.name"}}
 			OR
 				cm.value ILIKE '%' || :search || '%'
 			OR

--- a/schedule/rotation/search.go
+++ b/schedule/rotation/search.go
@@ -57,7 +57,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		AND NOT rot.id = any(:omit)
 	{{end}}
 	{{if .Search}}
-		AND ({{orderedPrefixSearch "search" "rot.name"}} OR {{contains "search" "rot.description"}})
+		AND ({{orderedPrefixSearch "search" "rot.name"}} OR {{contains "search" "rot.description"}} OR {{contains "search" "rot.name"}})
 	{{end}}
 	{{if .After.Name}}
 		AND

--- a/schedule/search.go
+++ b/schedule/search.go
@@ -56,7 +56,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		AND NOT sched.id = any(:omit)
 	{{end}}
 	{{if .Search}}
-		AND ({{orderedPrefixSearch "search" "sched.name"}} OR {{contains "search" "sched.description"}})
+		AND ({{orderedPrefixSearch "search" "sched.name"}} OR {{contains "search" "sched.description"}} OR {{contains "search" "sched.name"}})
 	{{end}}
 	{{if .After.Name}}
 		AND

--- a/search/render.go
+++ b/search/render.go
@@ -24,7 +24,7 @@ type RenderData interface {
 func Helpers() template.FuncMap {
 	return template.FuncMap{
 		"orderedPrefixSearch": func(argName string, columnName string) string {
-			return fmt.Sprintf("lower(%s) ~ :~%s", columnName, argName)
+			return fmt.Sprintf("lower(REPLACE(REPLACE(%s, '_', ' '), '-', ' ')) ~ :~%s", columnName, argName)
 		},
 		"contains": func(argName string, columnName string) string {
 			// search for the term in the column

--- a/service/search.go
+++ b/service/search.go
@@ -78,7 +78,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		)
 	{{end}}
 	{{- if and .Search (not .LabelKey) (not .IntegrationKey)}}
-		AND ({{orderedPrefixSearch "search" "svc.name"}} OR {{contains "search" "svc.description"}})
+		AND ({{orderedPrefixSearch "search" "svc.name"}} OR {{contains "search" "svc.description"}} OR {{contains "search" "svc.name"}})
 	{{- end}}
 	{{- if .After.Name}}
 		AND

--- a/user/search.go
+++ b/user/search.go
@@ -62,7 +62,7 @@ var searchTemplate = template.Must(template.New("search").Funcs(search.Helpers()
 		AND not usr.id = any(:omit)
 	{{end}}
 	{{if .Search}}
-		AND {{orderedPrefixSearch "search" "usr.name"}} 
+		AND ({{orderedPrefixSearch "search" "usr.name"}}  OR {{contains "search" "usr.name"}})
 	{{end}}
 	{{if .After.Name}}
 		AND {{if not .FavoritesFirst}}


### PR DESCRIPTION
**Description:**
This PR fixes a bug where names containing underscores and hyphens could not be matched. Additionally, name matching will also include substring match in addition to prefix matches.
