### PR TITLE
ui: Markdown timestamp support

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "jest": "29.7.0",
     "lodash": "4.17.21",
     "luxon": "3.4.3",
+    "mdast-util-find-and-replace": "3.0.1",
     "mdi-material-ui": "7.7.0",
     "prettier": "3.1.0",
     "prettier-plugin-go-template": "0.0.15",

--- a/web/src/app/util/CopyText.tsx
+++ b/web/src/app/util/CopyText.tsx
@@ -16,13 +16,20 @@ const useStyles = makeStyles({
   icon: {
     paddingRight: 4,
   },
+  noTypography: {
+    display: 'inline',
+    textDecorationStyle: 'dotted',
+    textUnderlineOffset: '0.25rem',
+    textDecorationLine: 'underline',
+  },
 })
 
 interface CopyTextProps {
   placement?: TooltipProps['placement']
-  title?: string
+  title?: React.ReactNode
   value: string
   asURL?: boolean
+  noTypography?: boolean
 }
 
 export default function CopyText(props: CopyTextProps): JSX.Element {
@@ -49,6 +56,33 @@ export default function CopyText(props: CopyTextProps): JSX.Element {
         />
         {props.title}
       </AppLink>
+    )
+  } else if (props.noTypography) {
+    content = (
+      <span
+        className={classes.copyContainer + ' ' + classes.noTypography}
+        role='button'
+        tabIndex={0}
+        onClick={() => {
+          copyToClipboard(props.value)
+          setCopied(true)
+        }}
+        onKeyPress={(e) => {
+          if (e.key !== 'Enter') {
+            return
+          }
+
+          copyToClipboard(props.value)
+          setCopied(true)
+        }}
+      >
+        <ContentCopy
+          color='primary'
+          className={props.title ? classes.icon : undefined}
+          fontSize='small'
+        />
+        {props.title}
+      </span>
     )
   } else {
     content = (

--- a/web/src/app/util/Markdown.js
+++ b/web/src/app/util/Markdown.js
@@ -5,6 +5,7 @@ import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
 import makeStyles from '@mui/styles/makeStyles'
 import AppLink from './AppLink'
+import timestampSupport from './Markdown.timestampSupport'
 
 const useStyles = makeStyles({
   markdown: {
@@ -73,7 +74,7 @@ export default function Markdown(props) {
           </AppLink>
         ),
       }}
-      remarkPlugins={[remarkGfm, remarkBreaks]}
+      remarkPlugins={[timestampSupport, remarkGfm, remarkBreaks]}
       allowElement={(element) => {
         if (
           element.tagName === 'a' &&

--- a/web/src/app/util/Markdown.timestampSupport.tsx
+++ b/web/src/app/util/Markdown.timestampSupport.tsx
@@ -22,8 +22,8 @@ function fromISO(iso: string): Node {
 }
 
 // Mon Jan _2 15:04:05 MST 2006
-const unixStampRegex = /\w+\s+\w+\s+\d+\s+\d{2}:\d{2}:\d{2}\s\w+\s\d{4}/g
-function fromUnixStamp(unix: string): Node {
+const unixDateRegex = /\w+\s+\w+\s+\d+\s+\d{2}:\d{2}:\d{2}\s\w+\s\d{4}/g
+function fromUnixDate(unix: string): Node {
   return fromISO(new Date(unix).toISOString())
 }
 
@@ -31,8 +31,8 @@ function fromUnixStamp(unix: string): Node {
 // type.
 const isoTuple = [isoTimestampRegex, fromISO] as unknown as FindAndReplaceTuple
 const unixTuple = [
-  unixStampRegex,
-  fromUnixStamp,
+  unixDateRegex,
+  fromUnixDate,
 ] as unknown as FindAndReplaceTuple
 
 export default function timestampSupport() {

--- a/web/src/app/util/Markdown.timestampSupport.tsx
+++ b/web/src/app/util/Markdown.timestampSupport.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { findAndReplace } from 'mdast-util-find-and-replace'
+import { Time } from './Time'
+import CopyText from './CopyText'
+
+const isoTimestampRegex =
+  /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/g
+
+export default function timestampSupport() {
+  return function (tree: Parameters<typeof findAndReplace>[0]) {
+    findAndReplace(tree, [
+      isoTimestampRegex,
+
+      // @ts-expect-error mdast types are wrong
+      (value) => {
+        return {
+          type: 'element',
+          value: (
+            <CopyText
+              noTypography
+              title={<Time time={value} />}
+              value={value}
+            />
+          ),
+        }
+      },
+    ])
+  }
+}

--- a/web/src/app/util/Markdown.timestampSupport.tsx
+++ b/web/src/app/util/Markdown.timestampSupport.tsx
@@ -1,29 +1,42 @@
 import React from 'react'
-import { findAndReplace } from 'mdast-util-find-and-replace'
+import {
+  FindAndReplaceTuple,
+  findAndReplace,
+} from 'mdast-util-find-and-replace'
 import { Time } from './Time'
 import CopyText from './CopyText'
 
+type Node = {
+  type: 'element'
+  value: React.ReactNode
+}
+
+// 2006-01-02T15:04:05.999999999Z07:00
 const isoTimestampRegex =
-  /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/g
+  /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d(\.\d+)?([+-][0-2]\d:[0-5]\d|Z)/g
+function fromISO(iso: string): Node {
+  return {
+    type: 'element',
+    value: <CopyText noTypography title={<Time time={iso} />} value={iso} />,
+  }
+}
+
+// Mon Jan _2 15:04:05 MST 2006
+const unixStampRegex = /\w+\s+\w+\s+\d+\s+\d{2}:\d{2}:\d{2}\s\w+\s\d{4}/g
+function fromUnixStamp(unix: string): Node {
+  return fromISO(new Date(unix).toISOString())
+}
+
+// mdast types are wrong, so we have to cast to unknown and then to the correct
+// type.
+const isoTuple = [isoTimestampRegex, fromISO] as unknown as FindAndReplaceTuple
+const unixTuple = [
+  unixStampRegex,
+  fromUnixStamp,
+] as unknown as FindAndReplaceTuple
 
 export default function timestampSupport() {
   return function (tree: Parameters<typeof findAndReplace>[0]) {
-    findAndReplace(tree, [
-      isoTimestampRegex,
-
-      // @ts-expect-error mdast types are wrong
-      (value) => {
-        return {
-          type: 'element',
-          value: (
-            <CopyText
-              noTypography
-              title={<Time time={value} />}
-              value={value}
-            />
-          ),
-        }
-      },
-    ])
+    findAndReplace(tree, [isoTuple, unixTuple])
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9192,7 +9192,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mdast-util-find-and-replace@npm:^3.0.0":
+"mdast-util-find-and-replace@npm:3.0.1, mdast-util-find-and-replace@npm:^3.0.0":
   version: 3.0.1
   resolution: "mdast-util-find-and-replace@npm:3.0.1"
   dependencies:
@@ -11634,6 +11634,7 @@ __metadata:
     jest: 29.7.0
     lodash: 4.17.21
     luxon: 3.4.3
+    mdast-util-find-and-replace: 3.0.1
     mdi-material-ui: 7.7.0
     prettier: 3.1.0
     prettier-plugin-go-template: 0.0.15


### PR DESCRIPTION
**Description:**
This PR adds support for timestamps in the markdown renderer.

It adds support for ISO-formatted timestamps, with or without sub-second precision, as well as  UNIX date-formatted timestamps (like those used for heartbeat timeouts).

- `2006-01-02T15:04:05.999999999Z`
- `2006-01-02T15:04:05.99999999907:00`
- `2006-01-02T15:04:05Z`
- `Mon Jan  2 15:04:05 MST 2006`

Timestamps will be underlined and always converted to the users local timezone and can be clicked to copy the ISO-formatted string for use in filters, SQL queries, other systems, etc..

**Which issue(s) this PR fixes:**
Closes #2834 

**Screenshots:**
![image](https://github.com/target/goalert/assets/595010/8e738acc-56f9-49ff-9f04-b16a53a9e972)

**Describe any introduced user-facing changes:**
Timestamps in any markdown document, including alert details, will be automatically detected and converted to local time.

**Describe any introduced API changes:**
N/A
