### PR TITLE
ui/schedules: create confirmation component for editing a temporary schedule

### DIFF
--- a/web/src/app/lists/FlatList.tsx
+++ b/web/src/app/lists/FlatList.tsx
@@ -44,7 +44,8 @@ import { ExpandLess, ExpandMore } from '@mui/icons-material'
 const useStyles = makeStyles({
   alertAsButton: {
     width: '100%',
-    margin: '0.5rem 0 0.5rem 0',
+    marginTop: '6px',
+    marginBottom: '6px',
     '&:hover, &.Mui-focusVisible': {
       filter: 'brightness(90%)',
     },

--- a/web/src/app/lists/FlatList.tsx
+++ b/web/src/app/lists/FlatList.tsx
@@ -45,15 +45,16 @@ import { ExpandLess, ExpandMore } from '@mui/icons-material'
 const useStyles = makeStyles({
   alert: {
     margin: '0.5rem 0 0.5rem 0',
-    width: '100%',
   },
   alertAsButton: {
     width: '100%',
+    margin: '0.5rem 0 0.5rem 0',
     '&:hover, &.Mui-focusVisible': {
       filter: 'brightness(90%)',
     },
   },
   buttonBase: {
+    width: '100%',
     borderRadius: 4,
   },
   background: { backgroundColor: 'transparent' },

--- a/web/src/app/lists/FlatList.tsx
+++ b/web/src/app/lists/FlatList.tsx
@@ -36,16 +36,12 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import classnames from 'classnames'
 import { Notice, toSeverity } from '../details/Notices'
 import FlatListItem from './FlatListItem'
 import { DraggableListItem, getAnnouncements } from './DraggableListItem'
 import { ExpandLess, ExpandMore } from '@mui/icons-material'
 
 const useStyles = makeStyles({
-  alert: {
-    margin: '0.5rem 0 0.5rem 0',
-  },
   alertAsButton: {
     width: '100%',
     margin: '0.5rem 0 0.5rem 0',
@@ -57,7 +53,6 @@ const useStyles = makeStyles({
     width: '100%',
     borderRadius: 4,
   },
-  background: { backgroundColor: 'transparent' },
   slideEnter: {
     maxHeight: '0px',
     opacity: 0,
@@ -79,6 +74,11 @@ const useStyles = makeStyles({
     opacity: 0,
     transform: 'translateX(-100%)',
     transition: 'all 500ms',
+  },
+  subheader: {
+    backgroundColor: 'transparent',
+    paddingLeft: 0,
+    paddingBottom: '4px',
   },
 })
 
@@ -236,7 +236,7 @@ export default function FlatList({
     if (item.handleOnClick) {
       return (
         <ButtonBase
-          className={classnames(classes.buttonBase, classes.alert)}
+          className={classes.buttonBase}
           onClick={item.handleOnClick}
           data-cy={item['data-cy']}
         >
@@ -245,6 +245,7 @@ export default function FlatList({
             key={idx}
             severity={toSeverity(item.type)}
             icon={item.icon}
+            action={item.action}
           >
             {item.message && <AlertTitle>{item.message}</AlertTitle>}
             {item.details}
@@ -254,12 +255,7 @@ export default function FlatList({
     }
 
     return (
-      <Alert
-        key={idx}
-        className={classes.alert}
-        severity={toSeverity(item.type)}
-        icon={item.icon}
-      >
+      <Alert key={idx} severity={toSeverity(item.type)} icon={item.icon}>
         {item.message && <AlertTitle>{item.message}</AlertTitle>}
         {item.details}
       </Alert>
@@ -268,7 +264,7 @@ export default function FlatList({
 
   function renderSubheaderItem(item: FlatListSub, idx: number): JSX.Element {
     return (
-      <ListSubheader key={idx} className={classes.background}>
+      <ListSubheader key={idx} className={classes.subheader}>
         <Typography
           component='h2'
           variant='subtitle1'

--- a/web/src/app/lists/FlatListItem.tsx
+++ b/web/src/app/lists/FlatListItem.tsx
@@ -13,8 +13,9 @@ import { FlatListItem } from './FlatList'
 const useStyles = makeStyles(() => ({
   listItem: {
     width: '100%',
-    paddingTop: '6px',
-    paddingBottom: '6px',
+    marginTop: '6px',
+    marginBottom: '6px',
+    borderRadius: '4px',
   },
   listItemDisabled: {
     opacity: 0.6,

--- a/web/src/app/lists/FlatListItem.tsx
+++ b/web/src/app/lists/FlatListItem.tsx
@@ -13,6 +13,8 @@ import { FlatListItem } from './FlatList'
 const useStyles = makeStyles(() => ({
   listItem: {
     width: '100%',
+    paddingTop: '6px',
+    paddingBottom: '6px',
   },
   listItemDisabled: {
     opacity: 0.6,

--- a/web/src/app/lists/FlatListItem.tsx
+++ b/web/src/app/lists/FlatListItem.tsx
@@ -13,8 +13,8 @@ import { FlatListItem } from './FlatList'
 const useStyles = makeStyles(() => ({
   listItem: {
     width: '100%',
-    marginTop: '6px',
-    marginBottom: '6px',
+    marginTop: '8px',
+    marginBottom: '8px',
     borderRadius: '4px',
   },
   listItemDisabled: {

--- a/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
@@ -25,7 +25,6 @@ type AddShiftsStepProps = {
   onChange: (newValue: Shift[]) => void
 
   scheduleID: string
-  edit?: boolean
   showForm: boolean
   setShowForm: (showForm: boolean) => void
   shift: Shift | null

--- a/web/src/app/schedules/temp-sched/TempSchedConfirmation.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedConfirmation.tsx
@@ -45,7 +45,9 @@ export default function TempSchedConfirmation({
   return (
     <Grid container spacing={4}>
       <Grid item xs={6}>
-        <Typography variant='h6'>Current Temporary Schedule</Typography>
+        <Typography component='h3' sx={{ fontSize: '1.15rem' }}>
+          Current Temporary Schedule
+        </Typography>
         <TempSchedShiftsList
           confirmationStep
           scheduleID={scheduleID}
@@ -57,7 +59,9 @@ export default function TempSchedConfirmation({
         />
       </Grid>
       <Grid item xs={6}>
-        <Typography variant='h6'>Proposed Changes</Typography>
+        <Typography component='h3' sx={{ fontSize: '1.15rem' }}>
+          Proposed Changes
+        </Typography>
         <TempSchedShiftsList
           confirmationStep
           scheduleID={scheduleID}

--- a/web/src/app/schedules/temp-sched/TempSchedConfirmation.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedConfirmation.tsx
@@ -1,0 +1,68 @@
+import React, { ReactNode } from 'react'
+import { TempSchedValue } from './sharedUtils'
+import { Grid } from '@mui/material'
+import { gql, useQuery } from 'urql'
+import TempSchedShiftsList from './TempSchedShiftsList'
+
+const query = gql`
+  query schedShifts($id: ID!, $start: ISOTimestamp!, $end: ISOTimestamp!) {
+    schedule(id: $id) {
+      id
+      shifts(start: $start, end: $end) {
+        userID
+        user {
+          id
+          name
+        }
+        start
+        end
+        truncated
+      }
+    }
+  }
+`
+
+interface TempSchedConfirmationProps {
+  scheduleID: string
+  value: TempSchedValue
+}
+
+export default function TempSchedConfirmation({
+  scheduleID,
+  value,
+}: TempSchedConfirmationProps): ReactNode {
+  console.log(scheduleID)
+  const [{ data, fetching }] = useQuery({
+    query,
+    variables: {
+      id: scheduleID,
+      start: value.start,
+      end: value.end,
+    },
+  })
+
+  if (fetching) return 'Loading...'
+
+  return (
+    <Grid container spacing={4}>
+      <Grid item xs={6}>
+        <TempSchedShiftsList
+          scheduleID={scheduleID}
+          value={data.schedule.shifts}
+          start={value.start}
+          end={value.end}
+          edit={false}
+        />
+      </Grid>
+      <Grid item xs={6}>
+        <TempSchedShiftsList
+          scheduleID={scheduleID}
+          value={value.shifts}
+          start={value.start}
+          end={value.end}
+          edit={false}
+        />
+      </Grid>
+    </Grid>
+  )
+}

--- a/web/src/app/schedules/temp-sched/TempSchedConfirmation.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedConfirmation.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react'
 import { TempSchedValue } from './sharedUtils'
-import { Grid } from '@mui/material'
+import { Grid, Typography } from '@mui/material'
 import { gql, useQuery } from 'urql'
 import TempSchedShiftsList from './TempSchedShiftsList'
 
@@ -31,7 +31,6 @@ export default function TempSchedConfirmation({
   scheduleID,
   value,
 }: TempSchedConfirmationProps): ReactNode {
-  console.log(scheduleID)
   const [{ data, fetching }] = useQuery({
     query,
     variables: {
@@ -46,7 +45,9 @@ export default function TempSchedConfirmation({
   return (
     <Grid container spacing={4}>
       <Grid item xs={6}>
+        <Typography variant='h6'>Current Temporary Schedule</Typography>
         <TempSchedShiftsList
+          confirmationStep
           scheduleID={scheduleID}
           value={data.schedule.shifts}
           start={value.start}
@@ -55,7 +56,9 @@ export default function TempSchedConfirmation({
         />
       </Grid>
       <Grid item xs={6}>
+        <Typography variant='h6'>Proposed Changes</Typography>
         <TempSchedShiftsList
+          confirmationStep
           scheduleID={scheduleID}
           value={value.shifts}
           start={value.start}

--- a/web/src/app/schedules/temp-sched/TempSchedConfirmation.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedConfirmation.tsx
@@ -53,6 +53,7 @@ export default function TempSchedConfirmation({
           start={value.start}
           end={value.end}
           edit={false}
+          compareRemovals={value.shifts}
         />
       </Grid>
       <Grid item xs={6}>
@@ -64,6 +65,7 @@ export default function TempSchedConfirmation({
           start={value.start}
           end={value.end}
           edit={false}
+          compareAdditions={data.schedule.shifts}
         />
       </Grid>
     </Grid>

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -221,7 +221,15 @@ export default function TempSchedDialog({
     setSubmitSuccess(false)
   }
   const handleSubmit = (): void => {
-    commit()
+    if (hasCoverageGaps && !allowNoCoverage) {
+      setSubmitAttempt(true)
+      // Scroll to show gap in coverage error on top of shift list
+      if (shiftListRef?.current) {
+        shiftListRef.current.scrollIntoView({ behavior: 'smooth' })
+      }
+    } else {
+      commit()
+    }
   }
 
   const nonFieldErrs = nonFieldErrors(error).map((e) => ({

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -243,7 +243,7 @@ export default function TempSchedDialog({
     <FormDialog
       fullHeight
       maxWidth='lg'
-      title='Define a Temporary Schedule'
+      title={edit ? 'Edit a Temporary Schedule' : 'Define a Temporary Schedule'}
       onClose={onClose}
       onSubmit={handleSubmit}
       onNext={edit && !submitSuccess ? handleNext : null}
@@ -360,7 +360,11 @@ export default function TempSchedDialog({
                 className={classes.rightPane}
               >
                 <Grid item xs={12} ref={shiftListRef}>
-                  <Typography variant='subtitle1' component='h3'>
+                  <Typography
+                    variant='subtitle1'
+                    component='h3'
+                    sx={{ fontSize: '1.15rem' }}
+                  >
                     Shifts
                   </Typography>
 

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -44,12 +44,12 @@ const useStyles = makeStyles({
 
 type TempSchedShiftsListProps = {
   value: Shift[]
-  onRemove: (shift: Shift) => void
+  onRemove?: (shift: Shift) => void
   start: string
   end: string
   edit?: boolean
   scheduleID: string
-  handleCoverageGapClick: (coverageGap: Interval) => void
+  handleCoverageGapClick?: (coverageGap: Interval) => void
 }
 
 export default function TempSchedShiftsList({
@@ -179,7 +179,7 @@ export default function TempSchedShiftsList({
                     <Error color='error' />
                   </Tooltip>
                 )}
-                {!isHistoricShift && (
+                {!isHistoricShift && onRemove && (
                   <IconButton
                     data-cy={'delete shift index: ' + idx}
                     aria-label='delete shift'

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -125,7 +125,7 @@ export default function TempSchedShiftsList({
     const outOfBoundsItems = getOutOfBoundsItems(schedInterval, shifts, zone)
 
     const shiftItems = (() => {
-      return _.flatMap(shifts, (s, idx) => {
+      return _.flatMap(shifts, (s: Shift, idx) => {
         const shiftInv = parseInterval(s, zone)
         const isValid = schedInterval.engulfs(shiftInv)
         const dayInvs = splitAtMidnight(shiftInv)
@@ -185,8 +185,10 @@ export default function TempSchedShiftsList({
             })
             return !!res
           }
+          let dataCY = s.userID
           if (compareAdditions) {
             if (!compare(compareAdditions)) {
+              dataCY = s.userID + '-' + 'added'
               diffColor =
                 theme.palette.mode === 'dark'
                   ? green[900] + '50'
@@ -196,6 +198,7 @@ export default function TempSchedShiftsList({
 
           if (compareRemovals) {
             if (!compare(compareRemovals)) {
+              dataCY = s.userID + '-' + 'removed'
               diffColor =
                 theme.palette.mode === 'dark' ? red[900] + '50' : red[100]
             }
@@ -204,7 +207,7 @@ export default function TempSchedShiftsList({
           return {
             scrollIntoView: true,
             id: DateTime.fromISO(s.start).toISO() + s.userID + index.toString(),
-            title: s.user.name,
+            title: s.user?.name,
             subText: (
               <Tooltip title={!isLocalZone ? titleText : ''} placement='right'>
                 <span>{subText}</span>
@@ -235,6 +238,7 @@ export default function TempSchedShiftsList({
             ),
             at: inv.start,
             itemType: 'shift',
+            'data-cy': dataCY,
             sx: {
               backgroundColor: diffColor,
             },

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -50,6 +50,7 @@ type TempSchedShiftsListProps = {
   edit?: boolean
   scheduleID: string
   handleCoverageGapClick?: (coverageGap: Interval) => void
+  confirmationStep?: boolean
 }
 
 export default function TempSchedShiftsList({
@@ -60,6 +61,7 @@ export default function TempSchedShiftsList({
   onRemove,
   scheduleID,
   handleCoverageGapClick,
+  confirmationStep,
 }: TempSchedShiftsListProps): JSX.Element {
   const classes = useStyles()
   const { zone, isLocalZone } = useScheduleTZ(scheduleID)
@@ -256,7 +258,7 @@ export default function TempSchedShiftsList({
       } as Sortable<FlatListNotice>
     })()
 
-    return sortItems([
+    let items = sortItems([
       ...shiftItems,
       ...coverageGapItems,
       ...subheaderItems,
@@ -264,6 +266,17 @@ export default function TempSchedShiftsList({
       startItem,
       endItem,
     ])
+
+    // don't show out of bound items when confirming final submit
+    if (confirmationStep) {
+      items = items.filter((item) => {
+        return (
+          item.at >= DateTime.fromISO(start) && item.at <= DateTime.fromISO(end)
+        )
+      })
+    }
+
+    return items
   }
 
   return (

--- a/web/src/app/schedules/temp-sched/shiftsListUtil.tsx
+++ b/web/src/app/schedules/temp-sched/shiftsListUtil.tsx
@@ -12,6 +12,7 @@ import { parseInterval } from '../../util/shifts'
 import { Shift } from './sharedUtils'
 import { Tooltip } from '@mui/material'
 import { fmtLocal, fmtTime } from '../../util/timeFormat'
+import { InfoOutlined } from '@mui/icons-material'
 
 export type Sortable<T> = T & {
   // at is the earliest point in time for a list item
@@ -159,6 +160,11 @@ export function getCoverageGapItems(
       details: (
         <Tooltip title={!isLocalZone ? title : ''} placement='right'>
           <span>{details}</span>
+        </Tooltip>
+      ),
+      action: (
+        <Tooltip title='Click me to use this time range for a new shift'>
+          <InfoOutlined />
         </Tooltip>
       ),
       at: gap.start,

--- a/web/src/app/schedules/temp-sched/shiftsListUtil.tsx
+++ b/web/src/app/schedules/temp-sched/shiftsListUtil.tsx
@@ -119,7 +119,7 @@ export function getCoverageGapItems(
   schedInterval: Interval,
   shifts: Shift[],
   zone: ExplicitZone,
-  handleCoverageClick: (coverageGap: Interval) => void,
+  handleCoverageClick?: (coverageGap: Interval) => void,
 ): Sortable<FlatListNotice>[] {
   if (!schedInterval.isValid) {
     return []
@@ -164,7 +164,9 @@ export function getCoverageGapItems(
       at: gap.start,
       itemType: 'gap',
       handleOnClick: () => {
-        handleCoverageClick(gap)
+        if (handleCoverageClick) {
+          handleCoverageClick(gap)
+        }
       },
     }
   })

--- a/web/src/cypress/e2e/temporarySchedule.cy.ts
+++ b/web/src/cypress/e2e/temporarySchedule.cy.ts
@@ -129,9 +129,15 @@ function testTemporarySchedule(screen: string): void {
       )
       cy.get('button[data-cy="add-shift"]').click()
       cy.get('[data-cy="shifts-list"]').should('contain', manualAddUser.name)
-      cy.dialogClick('Submit')
+      cy.dialogClick('Next')
       cy.get('input[name="allowCoverageGaps"]').check()
-      cy.dialogFinish('Retry')
+      cy.dialogClick('Next')
+
+      // verify shifts on confirm screen
+      cy.get(`div[data-cy="${graphQLAddUser.id}-removed"]`).should('be.visible')
+      cy.get(`div[data-cy="${manualAddUser.id}-added"]`).should('be.visible')
+      cy.dialogFinish('Submit')
+
       cy.reload() // ensure calendar update
       cy.get('div').contains(manualAddUser.name).click()
       cy.get('div[data-cy="shift-tooltip"]').should('be.visible')
@@ -162,9 +168,15 @@ function testTemporarySchedule(screen: string): void {
         graphQLAddUser.name,
       )
 
-      cy.dialogClick('Submit')
+      cy.dialogClick('Next')
       cy.get('input[name="allowCoverageGaps"]').check()
-      cy.dialogFinish('Retry')
+      cy.dialogClick('Next')
+
+      // verify shifts on confirm screen
+      cy.get(`div[data-cy="${graphQLAddUser.id}-removed"]`).should('be.visible')
+      cy.get(`div[data-cy="${graphQLAddSecondUser.id}"]`).should('be.visible')
+      cy.dialogFinish('Submit')
+
       cy.reload() // ensure calendar update
       cy.get('div').contains(graphQLAddSecondUser.name).click()
       cy.get('div[data-cy="shift-tooltip"]').should('be.visible')
@@ -196,9 +208,15 @@ function testTemporarySchedule(screen: string): void {
       )
       cy.get('button[data-cy="add-shift"]').click()
       cy.get('[data-cy="shifts-list"]').should('contain', manualAddUser.name)
-      cy.dialogClick('Submit')
+      cy.dialogClick('Next')
       cy.get('input[name="allowCoverageGaps"]').check()
-      cy.dialogFinish('Retry')
+      cy.dialogClick('Next')
+
+      // verify shifts on confirm screen
+      cy.get(`div[data-cy="${graphQLAddUser.id}"]`).should('be.visible')
+      cy.get(`div[data-cy="${manualAddUser.id}-added"]`).should('be.visible')
+      cy.dialogFinish('Submit')
+
       cy.reload() // ensure calendar update
       cy.get('div').contains(manualAddUser.name).click()
       cy.get('div[data-cy="shift-tooltip"]').should('be.visible')


### PR DESCRIPTION
**Description:**
This PR adds a confirmation screen to the temporary schedule dialog (when editing). The experience should remain the same when creating a new temporary schedule.

When a temporary schedule is edited, after clicking on "Next", a new component will render displaying the current temporary schedule's shifts on the left, with the proposed changes on the right. If everything looks good, the user can submit- otherwise, they can click "Back" and continue to make changes.

Gap coverage errors will be handled before this screen.

**Which issue(s) this PR fixes:**
Closes #3497

**Out of Scope:**
N/A

**Screenshots:**
If applicable, add some screenshots here.

**Additional Info:**
An information icon has been added to the gap coverage list items to let the user know they can click on the coverage gap to automatically fill in the times for that range
