### PR TITLE
dev: pipe storybook warnings to null

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -11,11 +11,7 @@ function getAbsolutePath(value: string): any {
 }
 const config: StorybookConfig = {
   staticDirs: ['./static'],
-  stories: [
-    '../stories/**/*.mdx',
-    '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)',
-    '../web/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
-  ],
+  stories: ['../web/src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: [
     getAbsolutePath('@storybook/addon-links'),
     getAbsolutePath('@storybook/addon-essentials'),

--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ test-smoke: smoketest
 test-unit: test
 
 test-components:  $(NODE_DEPS) bin/waitfor
-	yarn build-storybook --test --quiet
+	yarn build-storybook --test --quiet 2>/dev/null
 	yarn concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
 		"yarn http-server storybook-static -a 127.0.0.1 --port 6008 --silent" \
 		"./bin/waitfor tcp://localhost:6008 && yarn test-storybook --ci --url http://127.0.0.1:6008"


### PR DESCRIPTION
**Description:**
Updating the Makefile to pipe storybook build stderr to `/dev/null`. Fixes the flood of logs when running `test-components`
