### PR TITLE
graphql: add destinationDisplayInfo query

### DIFF
--- a/engine/compatmanager/update.go
+++ b/engine/compatmanager/update.go
@@ -117,13 +117,13 @@ func (db *DB) updateContactMethods(ctx context.Context) error {
 		// but we need to store the contact method id in the format "team_id:subject_id"
 		teamID := strings.TrimPrefix(s.ProviderID, "slack:")
 		value := s.SubjectID
-		name, err := db.cs.TeamName(ctx, teamID)
+		team, err := db.cs.Team(ctx, teamID)
 		if err != nil {
 			log.Log(ctx, err)
 			continue
 		}
 
-		_, err = tx.StmtContext(ctx, db.insertCM).ExecContext(ctx, uuid.New(), name, "SLACK_DM", value, s.UserID)
+		_, err = tx.StmtContext(ctx, db.insertCM).ExecContext(ctx, uuid.New(), team.Name, "SLACK_DM", value, s.UserID)
 		if err != nil {
 			return fmt.Errorf("insert cm: %w", err)
 		}

--- a/graphql2/compatdestinput.go
+++ b/graphql2/compatdestinput.go
@@ -1,0 +1,19 @@
+package graphql2
+
+func (d DestinationInput) FieldValue(id string) string {
+	for _, f := range d.Values {
+		if f.FieldID == id {
+			return f.Value
+		}
+	}
+	return ""
+}
+
+func (d Destination) FieldValuePair(id string) FieldValuePair {
+	for _, f := range d.Values {
+		if f.FieldID == id {
+			return f
+		}
+	}
+	return FieldValuePair{}
+}

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -215,9 +215,17 @@ type ComplexityRoot struct {
 	}
 
 	Destination struct {
+		Display  func(childComplexity int) int
 		Type     func(childComplexity int) int
 		TypeInfo func(childComplexity int) int
 		Values   func(childComplexity int) int
+	}
+
+	DestinationDisplayInfo struct {
+		IconAltText func(childComplexity int) int
+		IconURL     func(childComplexity int) int
+		LinkURL     func(childComplexity int) int
+		Text        func(childComplexity int) int
 	}
 
 	DestinationFieldConfig struct {
@@ -457,6 +465,7 @@ type ComplexityRoot struct {
 		ConfigHints              func(childComplexity int) int
 		DebugMessageStatus       func(childComplexity int, input DebugMessageStatusInput) int
 		DebugMessages            func(childComplexity int, input *DebugMessagesInput) int
+		DestinationDisplayInfo   func(childComplexity int, input DestinationInput) int
 		DestinationFieldValidate func(childComplexity int, input DestinationFieldValidateInput) int
 		DestinationTypes         func(childComplexity int) int
 		EscalationPolicies       func(childComplexity int, input *EscalationPolicySearchOptions) int
@@ -892,6 +901,7 @@ type QueryResolver interface {
 	SwoStatus(ctx context.Context) (*SWOStatus, error)
 	DestinationTypes(ctx context.Context) ([]DestinationTypeInfo, error)
 	DestinationFieldValidate(ctx context.Context, input DestinationFieldValidateInput) (bool, error)
+	DestinationDisplayInfo(ctx context.Context, input DestinationInput) (*DestinationDisplayInfo, error)
 	GqlAPIKeys(ctx context.Context) ([]GQLAPIKey, error)
 }
 type RotationResolver interface {
@@ -1478,6 +1488,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.DebugSendSMSInfo.ProviderURL(childComplexity), true
 
+	case "Destination.display":
+		if e.complexity.Destination.Display == nil {
+			break
+		}
+
+		return e.complexity.Destination.Display(childComplexity), true
+
 	case "Destination.type":
 		if e.complexity.Destination.Type == nil {
 			break
@@ -1498,6 +1515,34 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Destination.Values(childComplexity), true
+
+	case "DestinationDisplayInfo.iconAltText":
+		if e.complexity.DestinationDisplayInfo.IconAltText == nil {
+			break
+		}
+
+		return e.complexity.DestinationDisplayInfo.IconAltText(childComplexity), true
+
+	case "DestinationDisplayInfo.iconURL":
+		if e.complexity.DestinationDisplayInfo.IconURL == nil {
+			break
+		}
+
+		return e.complexity.DestinationDisplayInfo.IconURL(childComplexity), true
+
+	case "DestinationDisplayInfo.linkURL":
+		if e.complexity.DestinationDisplayInfo.LinkURL == nil {
+			break
+		}
+
+		return e.complexity.DestinationDisplayInfo.LinkURL(childComplexity), true
+
+	case "DestinationDisplayInfo.text":
+		if e.complexity.DestinationDisplayInfo.Text == nil {
+			break
+		}
+
+		return e.complexity.DestinationDisplayInfo.Text(childComplexity), true
 
 	case "DestinationFieldConfig.fieldID":
 		if e.complexity.DestinationFieldConfig.FieldID == nil {
@@ -2941,6 +2986,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.DebugMessages(childComplexity, args["input"].(*DebugMessagesInput)), true
+
+	case "Query.destinationDisplayInfo":
+		if e.complexity.Query.DestinationDisplayInfo == nil {
+			break
+		}
+
+		args, err := ec.field_Query_destinationDisplayInfo_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.DestinationDisplayInfo(childComplexity, args["input"].(DestinationInput)), true
 
 	case "Query.destinationFieldValidate":
 		if e.complexity.Query.DestinationFieldValidate == nil {
@@ -5552,6 +5609,21 @@ func (ec *executionContext) field_Query_debugMessages_args(ctx context.Context, 
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalODebugMessagesInput2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDebugMessagesInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_destinationDisplayInfo_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 DestinationInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNDestinationInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -9422,6 +9494,236 @@ func (ec *executionContext) fieldContext_Destination_typeInfo(ctx context.Contex
 				return ec.fieldContext_DestinationTypeInfo_isSchedOnCallNotify(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type DestinationTypeInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Destination_display(ctx context.Context, field graphql.CollectedField, obj *Destination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Destination_display(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Display, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*DestinationDisplayInfo)
+	fc.Result = res
+	return ec.marshalNDestinationDisplayInfo2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationDisplayInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Destination_display(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Destination",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "text":
+				return ec.fieldContext_DestinationDisplayInfo_text(ctx, field)
+			case "iconURL":
+				return ec.fieldContext_DestinationDisplayInfo_iconURL(ctx, field)
+			case "iconAltText":
+				return ec.fieldContext_DestinationDisplayInfo_iconAltText(ctx, field)
+			case "linkURL":
+				return ec.fieldContext_DestinationDisplayInfo_linkURL(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DestinationDisplayInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DestinationDisplayInfo_text(ctx context.Context, field graphql.CollectedField, obj *DestinationDisplayInfo) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DestinationDisplayInfo_text(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Text, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DestinationDisplayInfo_text(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DestinationDisplayInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DestinationDisplayInfo_iconURL(ctx context.Context, field graphql.CollectedField, obj *DestinationDisplayInfo) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DestinationDisplayInfo_iconURL(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IconURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DestinationDisplayInfo_iconURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DestinationDisplayInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DestinationDisplayInfo_iconAltText(ctx context.Context, field graphql.CollectedField, obj *DestinationDisplayInfo) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DestinationDisplayInfo_iconAltText(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IconAltText, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DestinationDisplayInfo_iconAltText(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DestinationDisplayInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DestinationDisplayInfo_linkURL(ctx context.Context, field graphql.CollectedField, obj *DestinationDisplayInfo) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DestinationDisplayInfo_linkURL(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LinkURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DestinationDisplayInfo_linkURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DestinationDisplayInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -20177,6 +20479,95 @@ func (ec *executionContext) fieldContext_Query_destinationFieldValidate(ctx cont
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_destinationFieldValidate_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_destinationDisplayInfo(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_destinationDisplayInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Query().DestinationDisplayInfo(rctx, fc.Args["input"].(DestinationInput))
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			flagName, err := ec.unmarshalNString2string(ctx, "dest-types")
+			if err != nil {
+				return nil, err
+			}
+			if ec.directives.Experimental == nil {
+				return nil, errors.New("directive experimental is not implemented")
+			}
+			return ec.directives.Experimental(ctx, nil, directive0, flagName)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(*DestinationDisplayInfo); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/target/goalert/graphql2.DestinationDisplayInfo`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*DestinationDisplayInfo)
+	fc.Result = res
+	return ec.marshalNDestinationDisplayInfo2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationDisplayInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_destinationDisplayInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "text":
+				return ec.fieldContext_DestinationDisplayInfo_text(ctx, field)
+			case "iconURL":
+				return ec.fieldContext_DestinationDisplayInfo_iconURL(ctx, field)
+			case "iconAltText":
+				return ec.fieldContext_DestinationDisplayInfo_iconAltText(ctx, field)
+			case "linkURL":
+				return ec.fieldContext_DestinationDisplayInfo_linkURL(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DestinationDisplayInfo", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_destinationDisplayInfo_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -34519,6 +34910,65 @@ func (ec *executionContext) _Destination(ctx context.Context, sel ast.SelectionS
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "display":
+			out.Values[i] = ec._Destination_display(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var destinationDisplayInfoImplementors = []string{"DestinationDisplayInfo"}
+
+func (ec *executionContext) _DestinationDisplayInfo(ctx context.Context, sel ast.SelectionSet, obj *DestinationDisplayInfo) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, destinationDisplayInfoImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DestinationDisplayInfo")
+		case "text":
+			out.Values[i] = ec._DestinationDisplayInfo_text(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "iconURL":
+			out.Values[i] = ec._DestinationDisplayInfo_iconURL(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "iconAltText":
+			out.Values[i] = ec._DestinationDisplayInfo_iconAltText(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "linkURL":
+			out.Values[i] = ec._DestinationDisplayInfo_linkURL(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -37542,6 +37992,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_destinationFieldValidate(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "destinationDisplayInfo":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_destinationDisplayInfo(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -41719,6 +42191,20 @@ func (ec *executionContext) unmarshalNDebugSendSMSInput2githubᚗcomᚋtargetᚋ
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) marshalNDestinationDisplayInfo2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationDisplayInfo(ctx context.Context, sel ast.SelectionSet, v DestinationDisplayInfo) graphql.Marshaler {
+	return ec._DestinationDisplayInfo(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNDestinationDisplayInfo2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationDisplayInfo(ctx context.Context, sel ast.SelectionSet, v *DestinationDisplayInfo) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DestinationDisplayInfo(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNDestinationFieldConfig2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationFieldConfig(ctx context.Context, sel ast.SelectionSet, v DestinationFieldConfig) graphql.Marshaler {
 	return ec._DestinationFieldConfig(ctx, sel, &v)
 }
@@ -41769,6 +42255,11 @@ func (ec *executionContext) marshalNDestinationFieldConfig2ᚕgithubᚗcomᚋtar
 
 func (ec *executionContext) unmarshalNDestinationFieldValidateInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationFieldValidateInput(ctx context.Context, v interface{}) (DestinationFieldValidateInput, error) {
 	res, err := ec.unmarshalInputDestinationFieldValidateInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNDestinationInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationInput(ctx context.Context, v interface{}) (DestinationInput, error) {
+	res, err := ec.unmarshalInputDestinationInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/graphql2/graph/destinations.graphqls
+++ b/graphql2/graph/destinations.graphqls
@@ -9,6 +9,10 @@ extend type Query {
   # It does not guarantee that the value is valid for the destination type, only
   # that it is valid for the field (i.e., syntax/formatting).
   destinationFieldValidate(input: DestinationFieldValidateInput!): Boolean! @experimental(flagName: "dest-types")
+
+
+  # destinationDisplayInfo returns the display information for a destination.
+  destinationDisplayInfo(input: DestinationInput!): DestinationDisplayInfo! @experimental(flagName: "dest-types")
 }
 
 input DestinationFieldValidateInput {
@@ -26,6 +30,15 @@ type Destination {
   type: DestinationType!
   values: [FieldValuePair!]!
   typeInfo: DestinationTypeInfo!
+  display: DestinationDisplayInfo!
+}
+
+# DestinationDisplayInfo provides information for displaying a destination.
+type DestinationDisplayInfo {
+  text: String! # user-friendly text to display for this destination
+  iconURL: String! # URL to an icon to display for this destination
+  iconAltText: String! # alt text for the icon
+  linkURL: String! # URL to link to for more information about this destination
 }
 
 type FieldValuePair {

--- a/graphql2/graphqlapp/destinationtypes.go
+++ b/graphql2/graphqlapp/destinationtypes.go
@@ -2,6 +2,7 @@ package graphqlapp
 
 import (
 	"context"
+	"net/url"
 	"slices"
 
 	"github.com/nyaruka/phonenumbers"
@@ -34,6 +35,138 @@ const (
 	fieldRotationID   = "rotation-id"
 	fieldScheduleID   = "schedule-id"
 )
+
+func (a *Query) DestinationDisplayInfo(ctx context.Context, dest graphql2.DestinationInput) (*graphql2.DestinationDisplayInfo, error) {
+	app := (*App)(a)
+	cfg := config.FromContext(ctx)
+	switch dest.Type {
+	case destTwilioSMS:
+		return &graphql2.DestinationDisplayInfo{
+			IconURL:     "builtin://phone-text",
+			IconAltText: "Text Message",
+			Text:        dest.FieldValue(fieldPhoneNumber),
+		}, nil
+	case destTwilioVoice:
+		return &graphql2.DestinationDisplayInfo{
+			IconURL:     "builtin://phone-voice",
+			IconAltText: "Voice Call",
+			Text:        dest.FieldValue(fieldPhoneNumber),
+		}, nil
+	case destSMTP:
+		return &graphql2.DestinationDisplayInfo{
+			IconURL:     "builtin://email",
+			IconAltText: "Email",
+			Text:        dest.FieldValue(fieldEmailAddress),
+		}, nil
+	case destRotation:
+		r, err := app.FindOneRotation(ctx, dest.FieldValue(fieldRotationID))
+		if err != nil {
+			return nil, err
+		}
+		return &graphql2.DestinationDisplayInfo{
+			IconURL:     "builtin://rotation",
+			IconAltText: "Rotation",
+			LinkURL:     cfg.CallbackURL("/rotations/" + r.ID),
+			Text:        r.Name,
+		}, nil
+	case destSchedule:
+		s, err := app.FindOneSchedule(ctx, dest.FieldValue(fieldScheduleID))
+		if err != nil {
+			return nil, err
+		}
+		return &graphql2.DestinationDisplayInfo{
+			IconURL:     "builtin://schedule",
+			IconAltText: "Schedule",
+			LinkURL:     cfg.CallbackURL("/schedules/" + s.ID),
+			Text:        s.Name,
+		}, nil
+	case destUser:
+		u, err := app.FindOneUser(ctx, dest.FieldValue(fieldUserID))
+		if err != nil {
+			return nil, err
+		}
+		return &graphql2.DestinationDisplayInfo{
+			IconURL:     cfg.CallbackURL("/api/v2/user-avatar/" + u.ID),
+			IconAltText: "User",
+			LinkURL:     cfg.CallbackURL("/users/" + u.ID),
+			Text:        u.Name,
+		}, nil
+
+	case destWebhook:
+		u, err := url.Parse(dest.FieldValue(fieldWebhookURL))
+		if err != nil {
+			return nil, validation.WrapError(err)
+		}
+		return &graphql2.DestinationDisplayInfo{
+			IconURL:     "builtin://webhook",
+			IconAltText: "Webhook",
+			Text:        u.Hostname(),
+		}, nil
+	case destSlackDM:
+		u, err := app.SlackStore.User(ctx, dest.FieldValue(fieldSlackUserID))
+		if err != nil {
+			return nil, err
+		}
+
+		team, err := app.SlackStore.Team(ctx, u.TeamID)
+		if err != nil {
+			return nil, err
+		}
+
+		if team.IconURL == "" {
+			team.IconURL = "builtin://slack"
+		}
+		return &graphql2.DestinationDisplayInfo{
+			IconURL:     team.IconURL,
+			IconAltText: team.Name,
+			LinkURL:     "https://app.slack.com/client/" + url.PathEscape(team.ID) + "/" + url.PathEscape(u.ID),
+			Text:        u.Name,
+		}, nil
+	case destSlackChan:
+		ch, err := app.SlackStore.Channel(ctx, dest.FieldValue(fieldSlackChanID))
+		if err != nil {
+			return nil, err
+		}
+
+		team, err := app.SlackStore.Team(ctx, ch.TeamID)
+		if err != nil {
+			return nil, err
+		}
+
+		if team.IconURL == "" {
+			team.IconURL = "builtin://slack"
+		}
+		return &graphql2.DestinationDisplayInfo{
+			IconURL:     team.IconURL,
+			IconAltText: team.Name,
+			LinkURL:     "https://app.slack.com/client/" + url.PathEscape(team.ID) + "/" + url.PathEscape(ch.ID),
+			Text:        ch.Name,
+		}, nil
+
+	case destSlackUG:
+		ug, err := app.SlackStore.UserGroup(ctx, dest.FieldValue(fieldSlackUGID))
+		if err != nil {
+			return nil, err
+		}
+
+		team, err := app.SlackStore.Team(ctx, ug.TeamID)
+		if err != nil {
+			return nil, err
+		}
+
+		if team.IconURL == "" {
+			team.IconURL = "builtin://slack"
+		}
+		return &graphql2.DestinationDisplayInfo{
+			IconURL:     team.IconURL,
+			IconAltText: team.Name,
+			LinkURL:     "https://app.slack.com/client/" + url.PathEscape(team.ID) + "/manage/usergroups",
+			Text:        ug.Handle,
+		}, nil
+	}
+
+	return nil, validation.NewGenericError("unsupported data type")
+}
 
 func (q *Query) DestinationFieldValidate(ctx context.Context, input graphql2.DestinationFieldValidateInput) (bool, error) {
 	switch input.DestType {

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -292,9 +292,17 @@ type DebugSendSMSInput struct {
 }
 
 type Destination struct {
-	Type     string               `json:"type"`
-	Values   []FieldValuePair     `json:"values"`
-	TypeInfo *DestinationTypeInfo `json:"typeInfo"`
+	Type     string                  `json:"type"`
+	Values   []FieldValuePair        `json:"values"`
+	TypeInfo *DestinationTypeInfo    `json:"typeInfo"`
+	Display  *DestinationDisplayInfo `json:"display"`
+}
+
+type DestinationDisplayInfo struct {
+	Text        string `json:"text"`
+	IconURL     string `json:"iconURL"`
+	IconAltText string `json:"iconAltText"`
+	LinkURL     string `json:"linkURL"`
 }
 
 type DestinationFieldConfig struct {

--- a/notification/slack/usergroup.go
+++ b/notification/slack/usergroup.go
@@ -11,6 +11,7 @@ import (
 
 type UserGroup struct {
 	ID     string
+	TeamID string
 	Name   string
 	Handle string
 }
@@ -72,6 +73,7 @@ func (s *ChannelSender) ListUserGroups(ctx context.Context) ([]UserGroup, error)
 			ID:     g.ID,
 			Name:   g.Name,
 			Handle: "@" + g.Handle,
+			TeamID: g.TeamID,
 		}
 		res = append(res, grp)
 		s.ugInfoCache.Add(g.ID, grp)

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -340,9 +340,17 @@ export interface DebugSendSMSInput {
 }
 
 export interface Destination {
+  display: DestinationDisplayInfo
   type: DestinationType
   typeInfo: DestinationTypeInfo
   values: FieldValuePair[]
+}
+
+export interface DestinationDisplayInfo {
+  iconAltText: string
+  iconURL: string
+  linkURL: string
+  text: string
 }
 
 export interface DestinationFieldConfig {
@@ -682,6 +690,7 @@ export interface Query {
   configHints: ConfigHint[]
   debugMessageStatus: DebugMessageStatusInfo
   debugMessages: DebugMessage[]
+  destinationDisplayInfo: DestinationDisplayInfo
   destinationFieldValidate: boolean
   destinationTypes: DestinationTypeInfo[]
   escalationPolicies: EscalationPolicyConnection


### PR DESCRIPTION
**Description:**
Adds the `destinationDisplayInfo` query under the `dest-types` experiemental flag.

Run with `make start EXPERIMENTAL=dest-types`

**Describe any introduced API changes:**
Adds `Query.destinationDisplayInfo` for providing information for displaying a destination in the UI.

**Additional Info:**
- Updated `slack` package to provide `Team` including `IconURL`
- Added helper methods for getting field values from `DestintationInput`
- Added `destinationDisplayInfo` to schema behind experimental flag directive
- Added `TeamID` to usergroup metadata