### PR TITLE
ui: update Select gql imports to use urql

### DIFF
--- a/web/src/app/selection/EscalationPolicySelect.tsx
+++ b/web/src/app/selection/EscalationPolicySelect.tsx
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql } from 'urql'
 import { makeQuerySelect } from './QuerySelect'
 
 const query = gql`

--- a/web/src/app/selection/IntegrationKeySelect.tsx
+++ b/web/src/app/selection/IntegrationKeySelect.tsx
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql } from 'urql'
 import { IntegrationKey } from '../../schema'
 import { makeQuerySelect } from './QuerySelect'
 

--- a/web/src/app/selection/LabelKeySelect.tsx
+++ b/web/src/app/selection/LabelKeySelect.tsx
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql } from 'urql'
 import { makeQuerySelect } from './QuerySelect'
 
 const query = gql`

--- a/web/src/app/selection/LabelValueSelect.tsx
+++ b/web/src/app/selection/LabelValueSelect.tsx
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql } from 'urql'
 import { makeQuerySelect } from './QuerySelect'
 
 const query = gql`

--- a/web/src/app/selection/RotationSelect.js
+++ b/web/src/app/selection/RotationSelect.js
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql } from 'urql'
 import { makeQuerySelect } from './QuerySelect'
 
 const query = gql`

--- a/web/src/app/selection/ScheduleSelect.js
+++ b/web/src/app/selection/ScheduleSelect.js
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql } from 'urql'
 import { makeQuerySelect } from './QuerySelect'
 
 const query = gql`

--- a/web/src/app/selection/ServiceSelect.js
+++ b/web/src/app/selection/ServiceSelect.js
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql } from 'urql'
 import { makeQuerySelect } from './QuerySelect'
 
 const query = gql`

--- a/web/src/app/selection/SlackChannelSelect.js
+++ b/web/src/app/selection/SlackChannelSelect.js
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql } from 'urql'
 import { makeQuerySelect } from './QuerySelect'
 
 const query = gql`

--- a/web/src/app/selection/TimeZoneSelect.js
+++ b/web/src/app/selection/TimeZoneSelect.js
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql } from 'urql'
 import { makeQuerySelect } from './QuerySelect'
 
 const query = gql`

--- a/web/src/app/selection/UserSelect.js
+++ b/web/src/app/selection/UserSelect.js
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql } from 'urql'
 import { makeQuerySelect } from './QuerySelect'
 
 const query = gql`


### PR DESCRIPTION
Part of #3240

Updates the imports for all Select components to use `urql` instead of `@apollo/client`.