### PR TITLE
ui: update ServiceCreateDialog and ServiceLabelCreateDialog to use urql

### DIFF
--- a/web/src/app/services/ServiceLabelCreateDialog.tsx
+++ b/web/src/app/services/ServiceLabelCreateDialog.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
-import { gql, useMutation } from '@apollo/client'
-
+import { gql, useMutation } from 'urql'
 import { fieldErrors, nonFieldErrors } from '../util/errutil'
 import FormDialog from '../dialogs/FormDialog'
 import ServiceLabelForm from './ServiceLabelForm'
@@ -22,27 +21,31 @@ export default function ServiceLabelCreateDialog(
 ): JSX.Element {
   const [value, setValue] = useState<Label>({ key: '', value: '' })
 
-  const [createLabel, { loading, error }] = useMutation(mutation, {
-    variables: {
-      input: {
-        ...value,
-        target: { type: 'service', id: props.serviceID },
-      },
-    },
-    onCompleted: props.onClose,
-  })
+  const [{ error }, commit] = useMutation(mutation)
 
   return (
     <FormDialog
       title='Set Label Value'
-      loading={loading}
       errors={nonFieldErrors(error)}
       onClose={props.onClose}
-      onSubmit={() => createLabel()}
+      onSubmit={() =>
+        commit(
+          {
+            input: {
+              ...value,
+              target: { type: 'service', id: props.serviceID },
+            },
+          },
+          {
+            additionalTypenames: ['Service'],
+          },
+        ).then((result) => {
+          if (!result.error) props.onClose()
+        })
+      }
       form={
         <ServiceLabelForm
           errors={fieldErrors(error)}
-          disabled={loading}
           value={value}
           onChange={(val: Label) => setValue(val)}
         />


### PR DESCRIPTION
Part of #3240

Updates `ServiceCreateDialog` and `ServiceLabelCreateDialog` to use `urql` instead of `@apollo/client` 