### PR TITLE
util: add DestinationChip and DestinationInputChip components

### DIFF
--- a/web/src/app/util/DestinationChip.stories.tsx
+++ b/web/src/app/util/DestinationChip.stories.tsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import type { Meta, StoryObj } from '@storybook/react'
+import DestinationChip from './DestinationChip'
+import { expect } from '@storybook/jest'
+import { within } from '@storybook/testing-library'
+import { handleDefaultConfig } from '../storybook/graphql'
+
+const meta = {
+  title: 'util/DestinationChip',
+  component: DestinationChip,
+  render: function Component(args) {
+    return <DestinationChip {...args} />
+  },
+  tags: ['autodocs'],
+  parameters: {
+    msw: {
+      handlers: [handleDefaultConfig],
+    },
+  },
+} satisfies Meta<typeof DestinationChip>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const TextAndHref: Story = {
+  args: {
+    config: {
+      iconAltText: 'Schedule',
+      iconURL: 'builtin://schedule',
+      linkURL: 'test.com',
+      text: 'Forward Integrated Functionality Schedule',
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(
+      canvas.getByText('Forward Integrated Functionality Schedule'),
+    ).toBeVisible()
+
+    await expect(canvas.getByTestId('destination-chip')).toHaveAttribute(
+      'href',
+      'test.com',
+    )
+
+    await expect(await canvas.findByTestId('TodayIcon')).toBeVisible()
+    await expect(await canvas.findByTestId('CancelIcon')).toBeVisible()
+  },
+}
+
+export const RotationIcon: Story = {
+  args: {
+    config: {
+      iconAltText: 'Rotation',
+      iconURL: 'builtin://rotation',
+      linkURL: 'test.com',
+      text: 'Icon Test',
+    },
+    onDelete: undefined,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(await canvas.findByTestId('RotateRightIcon')).toBeVisible()
+  },
+}
+
+export const WebhookIcon: Story = {
+  args: {
+    config: {
+      iconAltText: 'Webhook',
+      iconURL: 'builtin://webhook',
+      linkURL: 'test.com',
+      text: 'Icon Test',
+    },
+    onDelete: undefined,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(await canvas.findByTestId('WebhookIcon')).toBeVisible()
+  },
+}
+
+export const Error: Story = {
+  args: {
+    error: 'something went wrong',
+    onDelete: undefined,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByText('ERROR: something went wrong')).toBeVisible()
+    await expect(await canvas.findByTestId('BrokenImageIcon')).toBeVisible()
+  },
+}

--- a/web/src/app/util/DestinationChip.stories.tsx
+++ b/web/src/app/util/DestinationChip.stories.tsx
@@ -41,7 +41,7 @@ export const TextAndHref: Story = {
   args: {
     iconAltText: 'Schedule',
     iconURL: 'builtin://schedule',
-    linkURL: 'test.com',
+    linkURL: 'https://example.com',
     text: 'Forward Integrated Functionality Schedule',
 
     onDelete: () => null,
@@ -55,7 +55,7 @@ export const TextAndHref: Story = {
 
     await expect(canvas.getByTestId('destination-chip')).toHaveAttribute(
       'href',
-      'test.com',
+      'https://example.com',
     )
 
     await expect(await canvas.findByTestId('TodayIcon')).toBeVisible()
@@ -67,7 +67,7 @@ export const RotationIcon: Story = {
   args: {
     iconAltText: 'Rotation',
     iconURL: 'builtin://rotation',
-    linkURL: 'test.com',
+    linkURL: 'https://example.com',
     text: 'Icon Test',
 
     onDelete: undefined,
@@ -82,8 +82,38 @@ export const WebhookIcon: Story = {
   args: {
     iconAltText: 'Webhook',
     iconURL: 'builtin://webhook',
-    linkURL: 'test.com',
+    linkURL: 'https://example.com',
     text: 'Icon Test',
+
+    onDelete: undefined,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(await canvas.findByTestId('WebhookIcon')).toBeVisible()
+  },
+}
+
+export const Loading: Story = {
+  args: {
+    iconAltText: 'Webhook',
+    iconURL: 'builtin://webhook',
+    linkURL: 'https://example.com',
+    text: '',
+
+    onDelete: undefined,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(await canvas.findByTestId('WebhookIcon')).toBeVisible()
+  },
+}
+
+export const NoIcon: Story = {
+  args: {
+    iconAltText: '',
+    iconURL: '',
+    linkURL: '',
+    text: 'No Icon Test',
 
     onDelete: undefined,
   },

--- a/web/src/app/util/DestinationChip.stories.tsx
+++ b/web/src/app/util/DestinationChip.stories.tsx
@@ -104,7 +104,7 @@ export const Loading: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
-    await expect(await canvas.findByTestId('WebhookIcon')).toBeVisible()
+    await expect(await canvas.findByTestId('spinner')).toBeVisible()
   },
 }
 
@@ -119,7 +119,7 @@ export const NoIcon: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
-    await expect(await canvas.findByTestId('WebhookIcon')).toBeVisible()
+    await expect(canvas.getByText('No Icon Test')).toBeVisible()
   },
 }
 

--- a/web/src/app/util/DestinationChip.stories.tsx
+++ b/web/src/app/util/DestinationChip.stories.tsx
@@ -12,6 +12,21 @@ const meta = {
     return <DestinationChip {...args} />
   },
   tags: ['autodocs'],
+  argTypes: {
+    iconURL: {
+      control: 'select',
+      options: [
+        'builtin://schedule',
+        'builtin://rotation',
+        'builtin://webhook',
+        'builtin://slack',
+      ],
+    },
+    onDelete: {
+      control: 'select',
+      options: [() => null, undefined],
+    },
+  },
   parameters: {
     msw: {
       handlers: [handleDefaultConfig],
@@ -24,12 +39,11 @@ type Story = StoryObj<typeof meta>
 
 export const TextAndHref: Story = {
   args: {
-    config: {
-      iconAltText: 'Schedule',
-      iconURL: 'builtin://schedule',
-      linkURL: 'test.com',
-      text: 'Forward Integrated Functionality Schedule',
-    },
+    iconAltText: 'Schedule',
+    iconURL: 'builtin://schedule',
+    linkURL: 'test.com',
+    text: 'Forward Integrated Functionality Schedule',
+
     onDelete: () => null,
   },
   play: async ({ canvasElement }) => {
@@ -51,12 +65,11 @@ export const TextAndHref: Story = {
 
 export const RotationIcon: Story = {
   args: {
-    config: {
-      iconAltText: 'Rotation',
-      iconURL: 'builtin://rotation',
-      linkURL: 'test.com',
-      text: 'Icon Test',
-    },
+    iconAltText: 'Rotation',
+    iconURL: 'builtin://rotation',
+    linkURL: 'test.com',
+    text: 'Icon Test',
+
     onDelete: undefined,
   },
   play: async ({ canvasElement }) => {
@@ -67,12 +80,11 @@ export const RotationIcon: Story = {
 
 export const WebhookIcon: Story = {
   args: {
-    config: {
-      iconAltText: 'Webhook',
-      iconURL: 'builtin://webhook',
-      linkURL: 'test.com',
-      text: 'Icon Test',
-    },
+    iconAltText: 'Webhook',
+    iconURL: 'builtin://webhook',
+    linkURL: 'test.com',
+    text: 'Icon Test',
+
     onDelete: undefined,
   },
   play: async ({ canvasElement }) => {
@@ -83,6 +95,10 @@ export const WebhookIcon: Story = {
 
 export const Error: Story = {
   args: {
+    iconAltText: '',
+    iconURL: '',
+    linkURL: '',
+    text: '',
     error: 'something went wrong',
     onDelete: undefined,
   },

--- a/web/src/app/util/DestinationChip.stories.tsx
+++ b/web/src/app/util/DestinationChip.stories.tsx
@@ -30,6 +30,7 @@ export const TextAndHref: Story = {
       linkURL: 'test.com',
       text: 'Forward Integrated Functionality Schedule',
     },
+    onDelete: () => null,
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)

--- a/web/src/app/util/DestinationChip.tsx
+++ b/web/src/app/util/DestinationChip.tsx
@@ -7,12 +7,9 @@ import {
   Today as ScheduleIcon,
   Webhook as WebhookIcon,
 } from '@mui/icons-material'
+import { DestinationDisplayInfo } from '../../schema'
 
-export type DestinationChipProps = {
-  iconAltText: string
-  iconURL: string
-  linkURL: string
-  text: string
+export type DestinationChipProps = DestinationDisplayInfo & {
   error?: string
 
   // If onDelete is provided, a delete icon will be shown.
@@ -25,6 +22,13 @@ const builtInIcons: { [key: string]: React.ReactNode } = {
   'builtin://webhook': <WebhookIcon />,
 }
 
+/**
+ * DestinationChip is used to display a selected destination value.
+ *
+ * You should almost never use this component directly. Instead, use
+ * DestinationInputChip, which will select the correct values based on the
+ * provided DestinationInput value.
+ */
 export default function DestinationChip(
   props: DestinationChipProps,
 ): React.ReactNode {

--- a/web/src/app/util/DestinationChip.tsx
+++ b/web/src/app/util/DestinationChip.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { DestinationDisplayInfo } from '../../schema'
 import { Avatar, Chip, CircularProgress } from '@mui/material'
 
 import {
@@ -10,8 +9,10 @@ import {
 } from '@mui/icons-material'
 
 export type DestinationChipProps = {
-  config?: DestinationDisplayInfo
-
+  iconAltText: string
+  iconURL: string
+  linkURL: string
+  text: string
   error?: string
 
   // If onDelete is provided, a delete icon will be shown.
@@ -48,7 +49,7 @@ export default function DestinationChip(
       />
     )
   }
-  if (!props.config) {
+  if (!props.text) {
     return (
       <Chip
         avatar={
@@ -70,11 +71,11 @@ export default function DestinationChip(
     )
   }
 
-  const builtInIcon = builtInIcons[props.config.iconURL] || null
+  const builtInIcon = builtInIcons[props.iconURL] || null
 
   const opts: { [key: string]: unknown } = {}
-  if (props.config.linkURL) {
-    opts.href = props.config.linkURL
+  if (props.linkURL) {
+    opts.href = props.linkURL
     opts.target = '_blank'
     opts.component = 'a'
     opts.rel = 'noopener noreferrer'
@@ -83,19 +84,19 @@ export default function DestinationChip(
   return (
     <Chip
       data-testid='destination-chip'
-      clickable={!!props.config.linkURL}
+      clickable={!!props.linkURL}
       {...opts}
       avatar={
-        props.config.iconURL ? (
+        props.iconURL ? (
           <Avatar
-            src={builtInIcon ? undefined : props.config.iconURL}
-            alt={props.config.iconAltText}
+            src={builtInIcon ? undefined : props.iconURL}
+            alt={props.iconAltText}
           >
             {builtInIcon}
           </Avatar>
         ) : undefined
       }
-      label={props.config.text}
+      label={props.text}
       onDelete={
         props.onDelete
           ? (e) => {

--- a/web/src/app/util/DestinationChip.tsx
+++ b/web/src/app/util/DestinationChip.tsx
@@ -1,0 +1,110 @@
+import React from 'react'
+import { DestinationDisplayInfo } from '../../schema'
+import { Avatar, Chip, CircularProgress } from '@mui/material'
+
+import {
+  BrokenImage,
+  RotateRight as RotationIcon,
+  Today as ScheduleIcon,
+  Webhook as WebhookIcon,
+} from '@mui/icons-material'
+
+export type DestinationChipProps = {
+  config?: DestinationDisplayInfo
+
+  error?: string
+
+  // If onDelete is provided, a delete icon will be shown.
+  onDelete?: () => void
+}
+
+const builtInIcons: { [key: string]: React.ReactNode } = {
+  'builtin://rotation': <RotationIcon />,
+  'builtin://schedule': <ScheduleIcon />,
+  'builtin://webhook': <WebhookIcon />,
+}
+
+export default function DestinationChip(
+  props: DestinationChipProps,
+): React.ReactNode {
+  if (props.error) {
+    return (
+      <Chip
+        avatar={
+          <Avatar>
+            <BrokenImage />
+          </Avatar>
+        }
+        label={'ERROR: ' + props.error}
+        onDelete={
+          props.onDelete
+            ? (e) => {
+                e.stopPropagation()
+                e.preventDefault()
+                props.onDelete?.()
+              }
+            : undefined
+        }
+      />
+    )
+  }
+  if (!props.config) {
+    return (
+      <Chip
+        avatar={
+          <Avatar>
+            <CircularProgress size='1em' />
+          </Avatar>
+        }
+        label='loading...'
+        onDelete={
+          props.onDelete
+            ? (e) => {
+                e.stopPropagation()
+                e.preventDefault()
+                props.onDelete?.()
+              }
+            : undefined
+        }
+      />
+    )
+  }
+
+  const builtInIcon = builtInIcons[props.config.iconURL] || null
+
+  const opts: { [key: string]: unknown } = {}
+  if (props.config.linkURL) {
+    opts.href = props.config.linkURL
+    opts.target = '_blank'
+    opts.component = 'a'
+    opts.rel = 'noopener noreferrer'
+  }
+
+  return (
+    <Chip
+      data-testid='destination-chip'
+      clickable={!!props.config.linkURL}
+      {...opts}
+      avatar={
+        props.config.iconURL ? (
+          <Avatar
+            src={builtInIcon ? undefined : props.config.iconURL}
+            alt={props.config.iconAltText}
+          >
+            {builtInIcon}
+          </Avatar>
+        ) : undefined
+      }
+      label={props.config.text}
+      onDelete={
+        props.onDelete
+          ? (e) => {
+              e.stopPropagation()
+              e.preventDefault()
+              props.onDelete?.()
+            }
+          : undefined
+      }
+    />
+  )
+}

--- a/web/src/app/util/DestinationChip.tsx
+++ b/web/src/app/util/DestinationChip.tsx
@@ -61,7 +61,7 @@ export default function DestinationChip(
             <CircularProgress size='1em' />
           </Avatar>
         }
-        label='loading...'
+        label='Loading...'
         onDelete={
           props.onDelete
             ? (e) => {

--- a/web/src/app/util/DestinationChip.tsx
+++ b/web/src/app/util/DestinationChip.tsx
@@ -58,7 +58,7 @@ export default function DestinationChip(
       <Chip
         avatar={
           <Avatar>
-            <CircularProgress size='1em' />
+            <CircularProgress data-testid='spinner' size='1em' />
           </Avatar>
         }
         label='Loading...'

--- a/web/src/app/util/DestinationInputChip.stories.tsx
+++ b/web/src/app/util/DestinationInputChip.stories.tsx
@@ -48,12 +48,13 @@ export const Render: Story = {
         },
       ],
     },
+    onDelete: () => null,
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
     await expect(
-      canvas.getByText('Corporate array Communications Rotation'),
+      await canvas.findByText('Corporate array Communications Rotation'),
     ).toBeVisible()
 
     await expect(canvas.getByTestId('destination-chip')).toHaveAttribute(

--- a/web/src/app/util/DestinationInputChip.stories.tsx
+++ b/web/src/app/util/DestinationInputChip.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
 import DestinationInputChip from './DestinationInputChip'
 import { expect } from '@storybook/jest'
-import { within } from '@storybook/testing-library'
+import { userEvent, within } from '@storybook/testing-library'
 import { handleDefaultConfig } from '../storybook/graphql'
 import { HttpResponse, graphql } from 'msw'
 
@@ -38,6 +38,9 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Render: Story = {
+  argTypes: {
+    onDelete: { action: 'delete' },
+  },
   args: {
     value: {
       type: 'builtin-rotation',
@@ -48,9 +51,8 @@ export const Render: Story = {
         },
       ],
     },
-    onDelete: () => null,
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement)
 
     await expect(
@@ -64,5 +66,10 @@ export const Render: Story = {
 
     await expect(await canvas.findByTestId('RotateRightIcon')).toBeVisible()
     await expect(await canvas.findByTestId('CancelIcon')).toBeVisible()
+
+    expect(args.onDelete).not.toHaveBeenCalled()
+    await userEvent.click(await canvas.findByTestId('CancelIcon'))
+    // should have called onDelete
+    expect(args.onDelete).toHaveBeenCalledTimes(1)
   },
 }

--- a/web/src/app/util/DestinationInputChip.stories.tsx
+++ b/web/src/app/util/DestinationInputChip.stories.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import type { Meta, StoryObj } from '@storybook/react'
+import DestinationInputChip from './DestinationInputChip'
+import { expect } from '@storybook/jest'
+import { within } from '@storybook/testing-library'
+import { handleDefaultConfig } from '../storybook/graphql'
+import { HttpResponse, graphql } from 'msw'
+
+const meta = {
+  title: 'util/DestinationInputChip',
+  component: DestinationInputChip,
+  render: function Component(args) {
+    return <DestinationInputChip {...args} />
+  },
+  tags: ['autodocs'],
+  parameters: {
+    msw: {
+      handlers: [
+        handleDefaultConfig,
+        graphql.query('DestDisplayInfo', () => {
+          return HttpResponse.json({
+            data: {
+              destinationDisplayInfo: {
+                text: 'Corporate array Communications Rotation',
+                iconAltText: 'Rotation',
+                iconURL: 'builtin://rotation',
+                linkURL: 'test.com',
+              },
+            },
+          })
+        }),
+      ],
+    },
+  },
+} satisfies Meta<typeof DestinationInputChip>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Render: Story = {
+  args: {
+    value: {
+      type: 'builtin-rotation',
+      values: [
+        {
+          fieldID: 'rotation-id',
+          value: 'bf227047-18b8-4de3-881c-24b9dd345670',
+        },
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(
+      canvas.getByText('Corporate array Communications Rotation'),
+    ).toBeVisible()
+
+    await expect(canvas.getByTestId('destination-chip')).toHaveAttribute(
+      'href',
+      'test.com',
+    )
+
+    await expect(await canvas.findByTestId('RotateRightIcon')).toBeVisible()
+    await expect(await canvas.findByTestId('CancelIcon')).toBeVisible()
+  },
+}

--- a/web/src/app/util/DestinationInputChip.tsx
+++ b/web/src/app/util/DestinationInputChip.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { DestinationDisplayInfo, DestinationInput } from '../../schema'
+import { gql, useQuery } from 'urql'
+import DestinationChip from './DestinationChip'
+
+export type DestinationInputChipProps = {
+  value: DestinationInput
+  onDelete?: () => void
+}
+
+const query = gql`
+  query DestDisplayInfo($input: DestinationInput!) {
+    destinationDisplayInfo(input: $input) {
+      text
+      iconURL
+      iconAltText
+      linkURL
+    }
+  }
+`
+
+const context = {
+  suspense: false,
+}
+
+// This is a simple wrapper around DestinationChip that takes a DestinationInput
+// instead of a DestinationDisplayInfo. It's useful for showing the destination
+// chips in the policy details page.
+export default function DestinationInputChip(
+  props: DestinationInputChipProps,
+): React.ReactNode {
+  const [{ data, error }] = useQuery<{
+    destinationDisplayInfo: DestinationDisplayInfo
+  }>({
+    query,
+    variables: {
+      input: props.value,
+    },
+    requestPolicy: 'cache-first',
+    context,
+  })
+
+  return (
+    <DestinationChip
+      error={error?.message}
+      config={data?.destinationDisplayInfo}
+      onDelete={props.onDelete}
+    />
+  )
+}

--- a/web/src/app/util/DestinationInputChip.tsx
+++ b/web/src/app/util/DestinationInputChip.tsx
@@ -42,8 +42,11 @@ export default function DestinationInputChip(
 
   return (
     <DestinationChip
+      iconAltText={data?.destinationDisplayInfo.iconAltText || ''}
+      iconURL={data?.destinationDisplayInfo.iconURL || ''}
+      linkURL={data?.destinationDisplayInfo.linkURL || ''}
+      text={data?.destinationDisplayInfo.text || ''}
       error={error?.message}
-      config={data?.destinationDisplayInfo}
       onDelete={props.onDelete}
     />
   )


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This pull request introduces the DestinationChip and DestinationInputChip components, an addition that is essential for facilitating the development of generic destinations with pluggable providers. These components play a role in processing props such as icons, text, and cancel functions, and rendering them on the screen.

**Which issue(s) this PR fixes:**
Part of https://github.com/target/goalert/issues/2639

**Screenshots:**
<img width="1062" alt="chips" src="https://github.com/target/goalert/assets/52386267/afd43ad0-039a-40d7-b44d-b71bf32e1687">

Icon Variations:
<img width="1108" alt="icon variations" src="https://github.com/target/goalert/assets/52386267/f93719dc-8cf2-41df-8be4-a6376dacdf81">

**Additional Info:**
Run `make storybook` to interact with new components.

These components will be unused in main application functions, until we have wired them in with future component updates, e.g. PolicyStepDialog components. 
