### PR TITLE
ui: update schedule oncall hooks and util to use urql

### DIFF
--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsCreateDialog.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsCreateDialog.tsx
@@ -32,7 +32,7 @@ export default function ScheduleOnCallNotificationsCreateDialog(
   )
 
   const [dialogErrors, fieldErrors] = mapOnCallErrors(m.error, q.error)
-  const busy = (q.loading && !zone) || m.loading
+  const busy = (q.fetching && !zone) || m.fetching
 
   return (
     <FormDialog

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsEditDialog.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsEditDialog.tsx
@@ -42,7 +42,7 @@ export default function ScheduleOnCallNotificationsEditDialog(
     <FormDialog
       title='Edit Notification Rule'
       errors={dialogErrors}
-      loading={(q.loading && !zone) || m.loading}
+      loading={(q.fetching && !zone) || m.fetching}
       onClose={() => p.onClose()}
       onSubmit={() => submit().then(p.onClose)}
       form={

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsList.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsList.tsx
@@ -46,7 +46,7 @@ export default function ScheduleOnCallNotificationsList({
             <FlatList
               headerNote={zone ? `Showing times for schedule in ${zone}.` : ''}
               emptyMessage={
-                q.loading
+                q.fetching
                   ? 'Loading notification rules...'
                   : 'No notification rules.'
               }

--- a/web/src/app/schedules/on-call-notifications/hooks.ts
+++ b/web/src/app/schedules/on-call-notifications/hooks.ts
@@ -118,7 +118,11 @@ export function useSetOnCallRulesSubmit(
   }
 
   const [m, commit] = useMutation(updateMutation)
-  return { m, submit: () => commit(variables).then(() => {}) }
+  return {
+    m,
+    submit: () =>
+      commit(variables, { additionalTypenames: ['Schedule'] }).then(() => {}),
+  }
 }
 
 export type UpdateOnCallRuleState = {

--- a/web/src/app/schedules/on-call-notifications/util.ts
+++ b/web/src/app/schedules/on-call-notifications/util.ts
@@ -1,4 +1,3 @@
-import { ApolloError } from '@apollo/client'
 import { DateTime } from 'luxon'
 
 import {
@@ -9,6 +8,8 @@ import {
 } from '../../../schema'
 import { allErrors, fieldErrors, nonFieldErrors } from '../../util/errutil'
 import { weekdaySummary } from '../util'
+import { ApolloError } from '@apollo/client'
+import { CombinedError } from 'urql'
 
 export type Value = {
   time: string | null
@@ -89,8 +90,8 @@ export const onCallRuleToInput = (
 }
 
 export function mapOnCallErrors(
-  mErr?: ApolloError | null,
-  ...qErr: Array<ApolloError | undefined>
+  mErr?: ApolloError | CombinedError | null,
+  ...qErr: Array<ApolloError | CombinedError | undefined>
 ): [Error[], RuleFieldError[]] {
   let dialogErrs: Error[] = []
   qErr.forEach((e) => (dialogErrs = dialogErrs.concat(allErrors(e))))

--- a/web/src/cypress/e2e/alerts.cy.ts
+++ b/web/src/cypress/e2e/alerts.cy.ts
@@ -413,8 +413,10 @@ function testAlerts(screen: ScreenFormat): void {
       cy.get('body').should('contain', 'CLOSED')
     })
 
-    it('should set alert noise reasons', () => {
+    it.only('should set alert noise reasons', () => {
       // set all noise reasons, checking carefully because of async setState
+      cy.get('path[id=crane-body]').should('not.exist')
+      cy.get('[data-cy=loading-spinner]').should('not.exist')
       cy.get('body').should('contain.text', 'Is this alert noise?')
       cy.get('[data-cy="False positive"] input[type="checkbox"]').check()
       cy.get('[data-cy="False positive"] input[type="checkbox"]').should(

--- a/web/src/cypress/e2e/alerts.cy.ts
+++ b/web/src/cypress/e2e/alerts.cy.ts
@@ -413,10 +413,8 @@ function testAlerts(screen: ScreenFormat): void {
       cy.get('body').should('contain', 'CLOSED')
     })
 
-    it.only('should set alert noise reasons', () => {
+    it('should set alert noise reasons', () => {
       // set all noise reasons, checking carefully because of async setState
-      cy.get('path[id=crane-body]').should('not.exist')
-      cy.get('[data-cy=loading-spinner]').should('not.exist')
       cy.get('body').should('contain.text', 'Is this alert noise?')
       cy.get('[data-cy="False positive"] input[type="checkbox"]').check()
       cy.get('[data-cy="False positive"] input[type="checkbox"]').should(


### PR DESCRIPTION
Part of https://github.com/target/goalert/issues/3240

- Updates `schedules/on-call-notifications/hooks.ts` to use `urql` instead of `@apollo/client`
- Adds support for `urql`'s `CombinedError` to `schedules/on-call-notifications/util.ts`
  - Apollo's `ApolloError` will be left in until `urql` has fully replaced`@apollo/client`