### PR TITLE
ui: DestinationSearchSelect component

### DIFF
--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -68,6 +68,7 @@ type ResolverRoot interface {
 	AlertMetric() AlertMetricResolver
 	EscalationPolicy() EscalationPolicyResolver
 	EscalationPolicyStep() EscalationPolicyStepResolver
+	FieldValuePair() FieldValuePairResolver
 	GQLAPIKey() GQLAPIKeyResolver
 	HeartbeatMonitor() HeartbeatMonitorResolver
 	IntegrationKey() IntegrationKeyResolver
@@ -279,9 +280,16 @@ type ComplexityRoot struct {
 		Targets          func(childComplexity int) int
 	}
 
+	FieldValueConnection struct {
+		Nodes    func(childComplexity int) int
+		PageInfo func(childComplexity int) int
+	}
+
 	FieldValuePair struct {
-		FieldID func(childComplexity int) int
-		Value   func(childComplexity int) int
+		FieldID    func(childComplexity int) int
+		IsFavorite func(childComplexity int) int
+		Label      func(childComplexity int) int
+		Value      func(childComplexity int) int
 	}
 
 	GQLAPIKey struct {
@@ -457,51 +465,53 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Alert                    func(childComplexity int, id int) int
-		Alerts                   func(childComplexity int, input *AlertSearchOptions) int
-		AuthSubjectsForProvider  func(childComplexity int, first *int, after *string, providerID string) int
-		CalcRotationHandoffTimes func(childComplexity int, input *CalcRotationHandoffTimesInput) int
-		Config                   func(childComplexity int, all *bool) int
-		ConfigHints              func(childComplexity int) int
-		DebugMessageStatus       func(childComplexity int, input DebugMessageStatusInput) int
-		DebugMessages            func(childComplexity int, input *DebugMessagesInput) int
-		DestinationDisplayInfo   func(childComplexity int, input DestinationInput) int
-		DestinationFieldValidate func(childComplexity int, input DestinationFieldValidateInput) int
-		DestinationTypes         func(childComplexity int) int
-		EscalationPolicies       func(childComplexity int, input *EscalationPolicySearchOptions) int
-		EscalationPolicy         func(childComplexity int, id string) int
-		ExperimentalFlags        func(childComplexity int) int
-		GenerateSlackAppManifest func(childComplexity int) int
-		GqlAPIKeys               func(childComplexity int) int
-		HeartbeatMonitor         func(childComplexity int, id string) int
-		IntegrationKey           func(childComplexity int, id string) int
-		IntegrationKeyTypes      func(childComplexity int) int
-		IntegrationKeys          func(childComplexity int, input *IntegrationKeySearchOptions) int
-		LabelKeys                func(childComplexity int, input *LabelKeySearchOptions) int
-		LabelValues              func(childComplexity int, input *LabelValueSearchOptions) int
-		Labels                   func(childComplexity int, input *LabelSearchOptions) int
-		LinkAccountInfo          func(childComplexity int, token string) int
-		MessageLogs              func(childComplexity int, input *MessageLogSearchOptions) int
-		PhoneNumberInfo          func(childComplexity int, number string) int
-		Rotation                 func(childComplexity int, id string) int
-		Rotations                func(childComplexity int, input *RotationSearchOptions) int
-		Schedule                 func(childComplexity int, id string) int
-		Schedules                func(childComplexity int, input *ScheduleSearchOptions) int
-		Service                  func(childComplexity int, id string) int
-		Services                 func(childComplexity int, input *ServiceSearchOptions) int
-		SlackChannel             func(childComplexity int, id string) int
-		SlackChannels            func(childComplexity int, input *SlackChannelSearchOptions) int
-		SlackUserGroup           func(childComplexity int, id string) int
-		SlackUserGroups          func(childComplexity int, input *SlackUserGroupSearchOptions) int
-		SwoStatus                func(childComplexity int) int
-		SystemLimits             func(childComplexity int) int
-		TimeZones                func(childComplexity int, input *TimeZoneSearchOptions) int
-		User                     func(childComplexity int, id *string) int
-		UserCalendarSubscription func(childComplexity int, id string) int
-		UserContactMethod        func(childComplexity int, id string) int
-		UserOverride             func(childComplexity int, id string) int
-		UserOverrides            func(childComplexity int, input *UserOverrideSearchOptions) int
-		Users                    func(childComplexity int, input *UserSearchOptions, first *int, after *string, search *string) int
+		Alert                     func(childComplexity int, id int) int
+		Alerts                    func(childComplexity int, input *AlertSearchOptions) int
+		AuthSubjectsForProvider   func(childComplexity int, first *int, after *string, providerID string) int
+		CalcRotationHandoffTimes  func(childComplexity int, input *CalcRotationHandoffTimesInput) int
+		Config                    func(childComplexity int, all *bool) int
+		ConfigHints               func(childComplexity int) int
+		DebugMessageStatus        func(childComplexity int, input DebugMessageStatusInput) int
+		DebugMessages             func(childComplexity int, input *DebugMessagesInput) int
+		DestinationDisplayInfo    func(childComplexity int, input DestinationInput) int
+		DestinationFieldSearch    func(childComplexity int, input DestinationFieldSearchInput) int
+		DestinationFieldValidate  func(childComplexity int, input DestinationFieldValidateInput) int
+		DestinationFieldValueName func(childComplexity int, input DestinationFieldValidateInput) int
+		DestinationTypes          func(childComplexity int) int
+		EscalationPolicies        func(childComplexity int, input *EscalationPolicySearchOptions) int
+		EscalationPolicy          func(childComplexity int, id string) int
+		ExperimentalFlags         func(childComplexity int) int
+		GenerateSlackAppManifest  func(childComplexity int) int
+		GqlAPIKeys                func(childComplexity int) int
+		HeartbeatMonitor          func(childComplexity int, id string) int
+		IntegrationKey            func(childComplexity int, id string) int
+		IntegrationKeyTypes       func(childComplexity int) int
+		IntegrationKeys           func(childComplexity int, input *IntegrationKeySearchOptions) int
+		LabelKeys                 func(childComplexity int, input *LabelKeySearchOptions) int
+		LabelValues               func(childComplexity int, input *LabelValueSearchOptions) int
+		Labels                    func(childComplexity int, input *LabelSearchOptions) int
+		LinkAccountInfo           func(childComplexity int, token string) int
+		MessageLogs               func(childComplexity int, input *MessageLogSearchOptions) int
+		PhoneNumberInfo           func(childComplexity int, number string) int
+		Rotation                  func(childComplexity int, id string) int
+		Rotations                 func(childComplexity int, input *RotationSearchOptions) int
+		Schedule                  func(childComplexity int, id string) int
+		Schedules                 func(childComplexity int, input *ScheduleSearchOptions) int
+		Service                   func(childComplexity int, id string) int
+		Services                  func(childComplexity int, input *ServiceSearchOptions) int
+		SlackChannel              func(childComplexity int, id string) int
+		SlackChannels             func(childComplexity int, input *SlackChannelSearchOptions) int
+		SlackUserGroup            func(childComplexity int, id string) int
+		SlackUserGroups           func(childComplexity int, input *SlackUserGroupSearchOptions) int
+		SwoStatus                 func(childComplexity int) int
+		SystemLimits              func(childComplexity int) int
+		TimeZones                 func(childComplexity int, input *TimeZoneSearchOptions) int
+		User                      func(childComplexity int, id *string) int
+		UserCalendarSubscription  func(childComplexity int, id string) int
+		UserContactMethod         func(childComplexity int, id string) int
+		UserOverride              func(childComplexity int, id string) int
+		UserOverrides             func(childComplexity int, input *UserOverrideSearchOptions) int
+		Users                     func(childComplexity int, input *UserSearchOptions, first *int, after *string, search *string) int
 	}
 
 	Rotation struct {
@@ -779,6 +789,9 @@ type EscalationPolicyStepResolver interface {
 	Targets(ctx context.Context, obj *escalation.Step) ([]assignment.RawTarget, error)
 	EscalationPolicy(ctx context.Context, obj *escalation.Step) (*escalation.Policy, error)
 }
+type FieldValuePairResolver interface {
+	Label(ctx context.Context, obj *FieldValuePair) (string, error)
+}
 type GQLAPIKeyResolver interface {
 	CreatedBy(ctx context.Context, obj *GQLAPIKey) (*user.User, error)
 
@@ -901,6 +914,8 @@ type QueryResolver interface {
 	SwoStatus(ctx context.Context) (*SWOStatus, error)
 	DestinationTypes(ctx context.Context) ([]DestinationTypeInfo, error)
 	DestinationFieldValidate(ctx context.Context, input DestinationFieldValidateInput) (bool, error)
+	DestinationFieldSearch(ctx context.Context, input DestinationFieldSearchInput) (*FieldValueConnection, error)
+	DestinationFieldValueName(ctx context.Context, input DestinationFieldValidateInput) (string, error)
 	DestinationDisplayInfo(ctx context.Context, input DestinationInput) (*DestinationDisplayInfo, error)
 	GqlAPIKeys(ctx context.Context) ([]GQLAPIKey, error)
 }
@@ -1796,12 +1811,40 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.EscalationPolicyStep.Targets(childComplexity), true
 
+	case "FieldValueConnection.nodes":
+		if e.complexity.FieldValueConnection.Nodes == nil {
+			break
+		}
+
+		return e.complexity.FieldValueConnection.Nodes(childComplexity), true
+
+	case "FieldValueConnection.pageInfo":
+		if e.complexity.FieldValueConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.FieldValueConnection.PageInfo(childComplexity), true
+
 	case "FieldValuePair.fieldID":
 		if e.complexity.FieldValuePair.FieldID == nil {
 			break
 		}
 
 		return e.complexity.FieldValuePair.FieldID(childComplexity), true
+
+	case "FieldValuePair.isFavorite":
+		if e.complexity.FieldValuePair.IsFavorite == nil {
+			break
+		}
+
+		return e.complexity.FieldValuePair.IsFavorite(childComplexity), true
+
+	case "FieldValuePair.label":
+		if e.complexity.FieldValuePair.Label == nil {
+			break
+		}
+
+		return e.complexity.FieldValuePair.Label(childComplexity), true
 
 	case "FieldValuePair.value":
 		if e.complexity.FieldValuePair.Value == nil {
@@ -2999,6 +3042,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.DestinationDisplayInfo(childComplexity, args["input"].(DestinationInput)), true
 
+	case "Query.destinationFieldSearch":
+		if e.complexity.Query.DestinationFieldSearch == nil {
+			break
+		}
+
+		args, err := ec.field_Query_destinationFieldSearch_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.DestinationFieldSearch(childComplexity, args["input"].(DestinationFieldSearchInput)), true
+
 	case "Query.destinationFieldValidate":
 		if e.complexity.Query.DestinationFieldValidate == nil {
 			break
@@ -3010,6 +3065,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.DestinationFieldValidate(childComplexity, args["input"].(DestinationFieldValidateInput)), true
+
+	case "Query.destinationFieldValueName":
+		if e.complexity.Query.DestinationFieldValueName == nil {
+			break
+		}
+
+		args, err := ec.field_Query_destinationFieldValueName_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.DestinationFieldValueName(childComplexity, args["input"].(DestinationFieldValidateInput)), true
 
 	case "Query.destinationTypes":
 		if e.complexity.Query.DestinationTypes == nil {
@@ -4503,6 +4570,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDebugMessageStatusInput,
 		ec.unmarshalInputDebugMessagesInput,
 		ec.unmarshalInputDebugSendSMSInput,
+		ec.unmarshalInputDestinationFieldSearchInput,
 		ec.unmarshalInputDestinationFieldValidateInput,
 		ec.unmarshalInputDestinationInput,
 		ec.unmarshalInputEscalationPolicySearchOptions,
@@ -5632,7 +5700,37 @@ func (ec *executionContext) field_Query_destinationDisplayInfo_args(ctx context.
 	return args, nil
 }
 
+func (ec *executionContext) field_Query_destinationFieldSearch_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 DestinationFieldSearchInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNDestinationFieldSearchInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationFieldSearchInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_Query_destinationFieldValidate_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 DestinationFieldValidateInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNDestinationFieldValidateInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationFieldValidateInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_destinationFieldValueName_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 DestinationFieldValidateInput
@@ -9424,6 +9522,10 @@ func (ec *executionContext) fieldContext_Destination_values(ctx context.Context,
 				return ec.fieldContext_FieldValuePair_fieldID(ctx, field)
 			case "value":
 				return ec.fieldContext_FieldValuePair_value(ctx, field)
+			case "label":
+				return ec.fieldContext_FieldValuePair_label(ctx, field)
+			case "isFavorite":
+				return ec.fieldContext_FieldValuePair_isFavorite(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FieldValuePair", field.Name)
 		},
@@ -11410,6 +11512,110 @@ func (ec *executionContext) fieldContext_EscalationPolicyStep_escalationPolicy(c
 	return fc, nil
 }
 
+func (ec *executionContext) _FieldValueConnection_nodes(ctx context.Context, field graphql.CollectedField, obj *FieldValueConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FieldValueConnection_nodes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Nodes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]FieldValuePair)
+	fc.Result = res
+	return ec.marshalNFieldValuePair2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldValuePairᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FieldValueConnection_nodes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FieldValueConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "fieldID":
+				return ec.fieldContext_FieldValuePair_fieldID(ctx, field)
+			case "value":
+				return ec.fieldContext_FieldValuePair_value(ctx, field)
+			case "label":
+				return ec.fieldContext_FieldValuePair_label(ctx, field)
+			case "isFavorite":
+				return ec.fieldContext_FieldValuePair_isFavorite(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type FieldValuePair", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FieldValueConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *FieldValueConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FieldValueConnection_pageInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FieldValueConnection_pageInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FieldValueConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _FieldValuePair_fieldID(ctx context.Context, field graphql.CollectedField, obj *FieldValuePair) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_FieldValuePair_fieldID(ctx, field)
 	if err != nil {
@@ -11493,6 +11699,94 @@ func (ec *executionContext) fieldContext_FieldValuePair_value(ctx context.Contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FieldValuePair_label(ctx context.Context, field graphql.CollectedField, obj *FieldValuePair) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FieldValuePair_label(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.FieldValuePair().Label(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FieldValuePair_label(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FieldValuePair",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FieldValuePair_isFavorite(ctx context.Context, field graphql.CollectedField, obj *FieldValuePair) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FieldValuePair_isFavorite(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IsFavorite, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FieldValuePair_isFavorite(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FieldValuePair",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -20479,6 +20773,122 @@ func (ec *executionContext) fieldContext_Query_destinationFieldValidate(ctx cont
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_destinationFieldValidate_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_destinationFieldSearch(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_destinationFieldSearch(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().DestinationFieldSearch(rctx, fc.Args["input"].(DestinationFieldSearchInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*FieldValueConnection)
+	fc.Result = res
+	return ec.marshalNFieldValueConnection2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldValueConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_destinationFieldSearch(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "nodes":
+				return ec.fieldContext_FieldValueConnection_nodes(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_FieldValueConnection_pageInfo(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type FieldValueConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_destinationFieldSearch_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_destinationFieldValueName(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_destinationFieldValueName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().DestinationFieldValueName(rctx, fc.Args["input"].(DestinationFieldValidateInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_destinationFieldValueName(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_destinationFieldValueName_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -31242,6 +31652,72 @@ func (ec *executionContext) unmarshalInputDebugSendSMSInput(ctx context.Context,
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputDestinationFieldSearchInput(ctx context.Context, obj interface{}) (DestinationFieldSearchInput, error) {
+	var it DestinationFieldSearchInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	if _, present := asMap["first"]; !present {
+		asMap["first"] = 15
+	}
+
+	fieldsInOrder := [...]string{"destType", "fieldID", "search", "omit", "after", "first"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "destType":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("destType"))
+			data, err := ec.unmarshalNDestinationType2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DestType = data
+		case "fieldID":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("fieldID"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FieldID = data
+		case "search":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("search"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Search = data
+		case "omit":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("omit"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Omit = data
+		case "after":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.After = data
+		case "first":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.First = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputDestinationFieldValidateInput(ctx context.Context, obj interface{}) (DestinationFieldValidateInput, error) {
 	var it DestinationFieldValidateInput
 	asMap := map[string]interface{}{}
@@ -35525,6 +36001,50 @@ func (ec *executionContext) _EscalationPolicyStep(ctx context.Context, sel ast.S
 	return out
 }
 
+var fieldValueConnectionImplementors = []string{"FieldValueConnection"}
+
+func (ec *executionContext) _FieldValueConnection(ctx context.Context, sel ast.SelectionSet, obj *FieldValueConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, fieldValueConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("FieldValueConnection")
+		case "nodes":
+			out.Values[i] = ec._FieldValueConnection_nodes(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "pageInfo":
+			out.Values[i] = ec._FieldValueConnection_pageInfo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var fieldValuePairImplementors = []string{"FieldValuePair"}
 
 func (ec *executionContext) _FieldValuePair(ctx context.Context, sel ast.SelectionSet, obj *FieldValuePair) graphql.Marshaler {
@@ -35539,12 +36059,53 @@ func (ec *executionContext) _FieldValuePair(ctx context.Context, sel ast.Selecti
 		case "fieldID":
 			out.Values[i] = ec._FieldValuePair_fieldID(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "value":
 			out.Values[i] = ec._FieldValuePair_value(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "label":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._FieldValuePair_label(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "isFavorite":
+			out.Values[i] = ec._FieldValuePair_isFavorite(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -37992,6 +38553,50 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_destinationFieldValidate(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "destinationFieldSearch":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_destinationFieldSearch(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "destinationFieldValueName":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_destinationFieldValueName(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -42253,6 +42858,11 @@ func (ec *executionContext) marshalNDestinationFieldConfig2ᚕgithubᚗcomᚋtar
 	return ret
 }
 
+func (ec *executionContext) unmarshalNDestinationFieldSearchInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationFieldSearchInput(ctx context.Context, v interface{}) (DestinationFieldSearchInput, error) {
+	res, err := ec.unmarshalInputDestinationFieldSearchInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNDestinationFieldValidateInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationFieldValidateInput(ctx context.Context, v interface{}) (DestinationFieldValidateInput, error) {
 	res, err := ec.unmarshalInputDestinationFieldValidateInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -42444,6 +43054,20 @@ func (ec *executionContext) marshalNEscalationPolicyStep2ᚕgithubᚗcomᚋtarge
 	}
 
 	return ret
+}
+
+func (ec *executionContext) marshalNFieldValueConnection2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldValueConnection(ctx context.Context, sel ast.SelectionSet, v FieldValueConnection) graphql.Marshaler {
+	return ec._FieldValueConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNFieldValueConnection2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldValueConnection(ctx context.Context, sel ast.SelectionSet, v *FieldValueConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._FieldValueConnection(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNFieldValueInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldValueInput(ctx context.Context, v interface{}) (FieldValueInput, error) {

--- a/graphql2/graph/destinations.graphqls
+++ b/graphql2/graph/destinations.graphqls
@@ -1,18 +1,23 @@
 extend type Query {
-
   # destinationTypes returns a list of destination types that can be used for
   # notifications.
   destinationTypes: [DestinationTypeInfo!]! @experimental(flagName: "dest-types")
-
   # destinationFieldValidate validates a destination field value as valid or invalid.
   #
   # It does not guarantee that the value is valid for the destination type, only
   # that it is valid for the field (i.e., syntax/formatting).
   destinationFieldValidate(input: DestinationFieldValidateInput!): Boolean! @experimental(flagName: "dest-types")
-
+  destinationFieldSearch(input: DestinationFieldSearchInput!): FieldValueConnection!
+  destinationFieldValueName(input: DestinationFieldValidateInput!): String!
 
   # destinationDisplayInfo returns the display information for a destination.
   destinationDisplayInfo(input: DestinationInput!): DestinationDisplayInfo! @experimental(flagName: "dest-types")
+}
+
+# FieldValueConnection is a connection to a list of FieldValuePairs.
+type FieldValueConnection {
+  nodes: [FieldValuePair!]!
+  pageInfo: PageInfo!
 }
 
 input DestinationFieldValidateInput {
@@ -24,6 +29,15 @@ input DestinationFieldValidateInput {
 # DestinationType represents a type of destination that can be used for
 # notifications.
 scalar DestinationType
+
+input DestinationFieldSearchInput {
+  destType: DestinationType! # the type of destination to search for
+  fieldID: ID! # the ID of the input field to search for
+  search: String # search string to match against
+  omit: [String!] # values/ids to omit from results
+  after: String # cursor to start search from
+  first: Int = 15 # number of results to return
+}
 
 # Destination represents a destination that can be used for notifications.
 type Destination {
@@ -45,6 +59,9 @@ type FieldValuePair {
   fieldID: ID! # The ID of the input field that this value is for.
 
   value: String! # The value of the input field.
+  label: String! @goField(forceResolver: true) # The user-friendly text for this value of the input field (e.g., if the value is a user ID, label would be the user's name).
+
+  isFavorite: Boolean! # if true, this value is a favorite for the user, only set for search results
 }
 
 input DestinationInput {

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -318,6 +318,15 @@ type DestinationFieldConfig struct {
 	SupportsValidation bool   `json:"supportsValidation"`
 }
 
+type DestinationFieldSearchInput struct {
+	DestType string   `json:"destType"`
+	FieldID  string   `json:"fieldID"`
+	Search   *string  `json:"search,omitempty"`
+	Omit     []string `json:"omit,omitempty"`
+	After    *string  `json:"after,omitempty"`
+	First    *int     `json:"first,omitempty"`
+}
+
 type DestinationFieldValidateInput struct {
 	DestType string `json:"destType"`
 	FieldID  string `json:"fieldID"`
@@ -357,14 +366,21 @@ type EscalationPolicySearchOptions struct {
 	FavoritesFirst *bool    `json:"favoritesFirst,omitempty"`
 }
 
+type FieldValueConnection struct {
+	Nodes    []FieldValuePair `json:"nodes"`
+	PageInfo *PageInfo        `json:"pageInfo"`
+}
+
 type FieldValueInput struct {
 	FieldID string `json:"fieldID"`
 	Value   string `json:"value"`
 }
 
 type FieldValuePair struct {
-	FieldID string `json:"fieldID"`
-	Value   string `json:"value"`
+	FieldID    string `json:"fieldID"`
+	Value      string `json:"value"`
+	Label      string `json:"label"`
+	IsFavorite bool   `json:"isFavorite"`
 }
 
 type GQLAPIKey struct {

--- a/web/src/app/selection/DestinationSearchSelect.stories.tsx
+++ b/web/src/app/selection/DestinationSearchSelect.stories.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import type { Meta, StoryObj } from '@storybook/react'
+import DestinationSearchSelect from './DestinationSearchSelect'
+import { expect } from '@storybook/jest'
+import { within } from '@storybook/testing-library'
+import { handleDefaultConfig } from '../storybook/graphql'
+import { HttpResponse, graphql } from 'msw'
+
+const meta = {
+  title: 'util/DestinationSearchSelect',
+  component: DestinationSearchSelect,
+  render: function Component(args) {
+    return <DestinationSearchSelect {...args} />
+  },
+  tags: ['autodocs'],
+  parameters: {
+    msw: {
+      handlers: [
+        handleDefaultConfig,
+        graphql.query('DestinationSearchSelect', () => {
+          return HttpResponse.json({
+            data: {
+              destinationFieldSearch: {
+                nodes: [
+                  {
+                    value: 'C03SJES5FA7',
+                    label: '#general',
+                    isFavorite: false,
+                    __typename: 'FieldValuePair',
+                  },
+                ],
+                __typename: 'FieldValueConnection',
+              },
+            },
+          })
+        }),
+        graphql.query('DestinationFieldValueName', ({ variables: vars }) => {
+          return HttpResponse.json({
+            data: {
+              destinationFieldValueName:
+                vars.input.value === 'C03SJES5FA7' ? '#general' : '',
+            },
+          })
+        }),
+      ],
+    },
+  },
+} satisfies Meta<typeof DestinationSearchSelect>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Render: Story = {
+  args: {
+    value: '',
+    config: {
+      fieldID: 'slack-channel-id',
+      hint: '',
+      hintURL: '',
+      inputType: 'text',
+      isSearchSelectable: true,
+      labelPlural: 'Slack Channels',
+      labelSingular: 'Slack Channel',
+      placeholderText: '',
+      prefix: '',
+      supportsValidation: false,
+    },
+    destType: 'builtin-slack-channel',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // should see #general channel as option
+    await userEvent.type(
+      canvas.getByPlaceholderText('Start typing...'),
+      '#general',
+    )
+  },
+}

--- a/web/src/app/selection/DestinationSearchSelect.stories.tsx
+++ b/web/src/app/selection/DestinationSearchSelect.stories.tsx
@@ -5,26 +5,38 @@ import { expect } from '@storybook/jest'
 import { within } from '@storybook/testing-library'
 import { handleDefaultConfig } from '../storybook/graphql'
 import { HttpResponse, graphql } from 'msw'
+import { useArgs } from '@storybook/preview-api'
 
 const meta = {
   title: 'util/DestinationSearchSelect',
   component: DestinationSearchSelect,
   render: function Component(args) {
-    return <DestinationSearchSelect {...args} />
+    const [, setArgs] = useArgs()
+    const onChange = (value: string): void => {
+      if (args.onChange) args.onChange(value)
+      setArgs({ value })
+    }
+    return <DestinationSearchSelect {...args} onChange={onChange} />
   },
   tags: ['autodocs'],
   parameters: {
     msw: {
       handlers: [
         handleDefaultConfig,
-        graphql.query('DestinationSearchSelect', () => {
+        graphql.query('DestinationFieldSearch', () => {
           return HttpResponse.json({
             data: {
               destinationFieldSearch: {
                 nodes: [
                   {
-                    value: 'C03SJES5FA7',
-                    label: '#general',
+                    value: 'value-id-1',
+                    label: '#value-one',
+                    isFavorite: false,
+                    __typename: 'FieldValuePair',
+                  },
+                  {
+                    value: 'value-id-2',
+                    label: '#value-two',
                     isFavorite: false,
                     __typename: 'FieldValuePair',
                   },
@@ -35,10 +47,13 @@ const meta = {
           })
         }),
         graphql.query('DestinationFieldValueName', ({ variables: vars }) => {
+          const names: Record<string, string> = {
+            'value-id-1': '#value-one',
+            'value-id-2': '#value-two',
+          }
           return HttpResponse.json({
             data: {
-              destinationFieldValueName:
-                vars.input.value === 'C03SJES5FA7' ? '#general' : '',
+              destinationFieldValueName: names[vars.input.value] || '',
             },
           })
         }),
@@ -50,30 +65,87 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Render: Story = {
+export const EmptyValue: Story = {
   args: {
     value: '',
-    config: {
-      fieldID: 'slack-channel-id',
-      hint: '',
-      hintURL: '',
-      inputType: 'text',
-      isSearchSelectable: true,
-      labelPlural: 'Slack Channels',
-      labelSingular: 'Slack Channel',
-      placeholderText: '',
-      prefix: '',
-      supportsValidation: false,
-    },
-    destType: 'builtin-slack-channel',
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement)
 
-    // should see #general channel as option
-    await userEvent.type(
-      canvas.getByPlaceholderText('Start typing...'),
-      '#general',
-    )
+    fieldID: 'field-id',
+    hint: '',
+    hintURL: '',
+    inputType: 'text',
+    isSearchSelectable: true,
+    labelPlural: 'Select Values',
+    labelSingular: 'Select Value',
+    placeholderText: 'asdf',
+    prefix: '',
+    supportsValidation: false,
+
+    destType: 'test-type',
   },
+  // play: async ({ canvasElement }) => {
+  //   const canvas = within(canvasElement)
+
+  //   // should see #general channel as option
+  //   await userEvent.type(
+  //     canvas.getByPlaceholderText('Start typing...'),
+  //     '#general',
+  //   )
+  // },
+}
+
+export const SelectedValue: Story = {
+  args: {
+    value: 'value-id-1',
+
+    fieldID: 'field-id',
+    hint: '',
+    hintURL: '',
+    inputType: 'text',
+    isSearchSelectable: true,
+    labelPlural: 'Select Values',
+    labelSingular: 'Select Value',
+    placeholderText: '',
+    prefix: '',
+    supportsValidation: false,
+
+    destType: 'test-type',
+  },
+  // play: async ({ canvasElement }) => {
+  //   const canvas = within(canvasElement)
+
+  //   // should see #general channel as option
+  //   await userEvent.type(
+  //     canvas.getByPlaceholderText('Start typing...'),
+  //     '#general',
+  //   )
+  // },
+}
+
+export const Disabled: Story = {
+  args: {
+    value: 'value-id-1',
+
+    fieldID: 'field-id',
+    hint: '',
+    hintURL: '',
+    inputType: 'text',
+    isSearchSelectable: true,
+    labelPlural: 'Select Values',
+    labelSingular: 'Select Value',
+    placeholderText: '',
+    prefix: '',
+    supportsValidation: false,
+
+    destType: 'test-type',
+    disabled: true,
+  },
+  // play: async ({ canvasElement }) => {
+  //   const canvas = within(canvasElement)
+
+  //   // should see #general channel as option
+  //   await userEvent.type(
+  //     canvas.getByPlaceholderText('Start typing...'),
+  //     '#general',
+  //   )
+  // },
 }

--- a/web/src/app/selection/DestinationSearchSelect.tsx
+++ b/web/src/app/selection/DestinationSearchSelect.tsx
@@ -1,0 +1,128 @@
+import React, { useState } from 'react'
+import { useQuery, gql } from 'urql'
+import {
+  DestinationFieldConfig,
+  DestinationType,
+  FieldValueConnection,
+} from '../../schema'
+import MaterialSelect from './MaterialSelect'
+import { FavoriteIcon } from '../util/SetFavoriteButton'
+
+const searchOptionsQuery = gql`
+  query DestinationSearchSelect($input: DestinationFieldSearchInput!) {
+    destinationFieldSearch(input: $input) {
+      nodes {
+        value
+        label
+        isFavorite
+      }
+    }
+  }
+`
+
+const selectedLabelQuery = gql`
+  query DestinationFieldValueName($input: DestinationFieldValidateInput!) {
+    destinationFieldValueName(input: $input)
+  }
+`
+
+const noSuspense = { suspense: false }
+
+export type DestinationSearchSelectProps = {
+  value: string
+  onChange?: (newValue: string) => void
+  config: DestinationFieldConfig
+  destType: DestinationType
+
+  disabled?: boolean
+}
+
+const cacheByJSON = {}
+
+function cachify<T>(val: T): T {
+  const json = JSON.stringify(val)
+  if (cacheByJSON[json]) return cacheByJSON[json]
+  cacheByJSON[json] = val
+
+  return val
+}
+
+export default function DestinationSearchSelect(
+  props: DestinationSearchSelectProps,
+): JSX.Element {
+  const [inputValue, setInputValue] = useState('')
+
+  // check validation of the input phoneNumber through graphql
+  const [{ data, fetching, error }] = useQuery<{
+    destinationFieldSearch: FieldValueConnection
+  }>({
+    query: searchOptionsQuery,
+    variables: {
+      input: {
+        destType: props.destType,
+        search: inputValue,
+        fieldID: props.config.fieldID,
+      },
+    },
+    requestPolicy: 'cache-first',
+    pause: props.disabled,
+    context: noSuspense,
+  })
+  const options = data?.destinationFieldSearch.nodes || []
+
+  const [{ data: selectedLabelData }] = useQuery<{
+    destinationFieldValueName: string
+  }>({
+    query: selectedLabelQuery,
+    variables: {
+      input: {
+        destType: props.destType,
+        value: props.value,
+        fieldID: props.config.fieldID,
+      },
+    },
+    requestPolicy: 'cache-first',
+    pause: props.disabled || !props.value,
+    context: noSuspense,
+  })
+  const selectedLabel = selectedLabelData?.destinationFieldValueName || ''
+
+  interface SelectOption {
+    value: string
+    label: string
+  }
+
+  function handleChange(val: SelectOption | SelectOption[]): void {
+    if (!props.onChange) return
+
+    // should not be possible since multiple is false
+    if (Array.isArray(val)) throw new Error('Multiple values not supported')
+
+    props.onChange(val.value)
+  }
+
+  const value = props.value
+    ? { label: selectedLabel, value: props.value }
+    : null
+
+  return (
+    <MaterialSelect
+      isLoading={fetching}
+      multiple={false}
+      noOptionsText='No options'
+      noOptionsError={error}
+      onInputChange={(val) => setInputValue(val)}
+      value={value as unknown as SelectOption}
+      label={props.config.labelSingular}
+      options={options
+        .map((opt) => ({
+          label: opt.label,
+          value: opt.value,
+          icon: opt.isFavorite ? <FavoriteIcon /> : undefined,
+        }))
+        .map(cachify)}
+      placeholder='Start typing...'
+      onChange={handleChange}
+    />
+  )
+}

--- a/web/src/app/selection/DestinationSearchSelect.tsx
+++ b/web/src/app/selection/DestinationSearchSelect.tsx
@@ -69,7 +69,7 @@ export default function DestinationSearchSelect(
   })
   const options = data?.destinationFieldSearch.nodes || []
 
-  const [{ data: selectedLabelData }] = useQuery<{
+  const [{ data: selectedLabelData, error: selectedErr }] = useQuery<{
     destinationFieldValueName: string
   }>({
     query: selectedLabelQuery,
@@ -84,7 +84,11 @@ export default function DestinationSearchSelect(
     pause: !props.value,
     context: noSuspense,
   })
-  const selectedLabel = selectedLabelData?.destinationFieldValueName || ''
+
+  let selectedLabel = selectedLabelData?.destinationFieldValueName || ''
+  if (selectedErr) {
+    selectedLabel = `ERROR: ${selectedErr.message}`
+  }
 
   interface SelectOption {
     value: string

--- a/web/src/app/selection/DestinationSearchSelect.tsx
+++ b/web/src/app/selection/DestinationSearchSelect.tsx
@@ -81,7 +81,7 @@ export default function DestinationSearchSelect(
       },
     },
     requestPolicy: 'cache-first',
-    pause: props.disabled || !props.value,
+    pause: !props.value,
     context: noSuspense,
   })
   const selectedLabel = selectedLabelData?.destinationFieldValueName || ''
@@ -109,6 +109,7 @@ export default function DestinationSearchSelect(
       isLoading={fetching}
       multiple={false}
       noOptionsText='No options'
+      disabled={props.disabled}
       noOptionsError={error}
       onInputChange={(val) => setInputValue(val)}
       value={value as unknown as SelectOption}

--- a/web/src/app/selection/DestinationSearchSelect.tsx
+++ b/web/src/app/selection/DestinationSearchSelect.tsx
@@ -9,7 +9,7 @@ import MaterialSelect from './MaterialSelect'
 import { FavoriteIcon } from '../util/SetFavoriteButton'
 
 const searchOptionsQuery = gql`
-  query DestinationSearchSelect($input: DestinationFieldSearchInput!) {
+  query DestinationFieldSearch($input: DestinationFieldSearchInput!) {
     destinationFieldSearch(input: $input) {
       nodes {
         value
@@ -28,20 +28,19 @@ const selectedLabelQuery = gql`
 
 const noSuspense = { suspense: false }
 
-export type DestinationSearchSelectProps = {
+export type DestinationSearchSelectProps = DestinationFieldConfig & {
   value: string
   onChange?: (newValue: string) => void
-  config: DestinationFieldConfig
   destType: DestinationType
 
   disabled?: boolean
 }
 
-const cacheByJSON = {}
+const cacheByJSON: Record<string, unknown> = {}
 
 function cachify<T>(val: T): T {
   const json = JSON.stringify(val)
-  if (cacheByJSON[json]) return cacheByJSON[json]
+  if (cacheByJSON[json]) return cacheByJSON[json] as T
   cacheByJSON[json] = val
 
   return val
@@ -61,7 +60,7 @@ export default function DestinationSearchSelect(
       input: {
         destType: props.destType,
         search: inputValue,
-        fieldID: props.config.fieldID,
+        fieldID: props.fieldID,
       },
     },
     requestPolicy: 'cache-first',
@@ -78,7 +77,7 @@ export default function DestinationSearchSelect(
       input: {
         destType: props.destType,
         value: props.value,
-        fieldID: props.config.fieldID,
+        fieldID: props.fieldID,
       },
     },
     requestPolicy: 'cache-first',
@@ -92,13 +91,13 @@ export default function DestinationSearchSelect(
     label: string
   }
 
-  function handleChange(val: SelectOption | SelectOption[]): void {
+  function handleChange(val: SelectOption | null): void {
     if (!props.onChange) return
 
     // should not be possible since multiple is false
     if (Array.isArray(val)) throw new Error('Multiple values not supported')
 
-    props.onChange(val.value)
+    props.onChange(val?.value || '')
   }
 
   const value = props.value
@@ -113,7 +112,7 @@ export default function DestinationSearchSelect(
       noOptionsError={error}
       onInputChange={(val) => setInputValue(val)}
       value={value as unknown as SelectOption}
-      label={props.config.labelSingular}
+      label={props.labelSingular}
       options={options
         .map((opt) => ({
           label: opt.label,

--- a/web/src/app/selection/DestinationSearchSelect.tsx
+++ b/web/src/app/selection/DestinationSearchSelect.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../schema'
 import MaterialSelect from './MaterialSelect'
 import { FavoriteIcon } from '../util/SetFavoriteButton'
+import AppLink from '../util/AppLink'
 
 const searchOptionsQuery = gql`
   query DestinationFieldSearch($input: DestinationFieldSearchInput!) {
@@ -34,6 +35,7 @@ export type DestinationSearchSelectProps = DestinationFieldConfig & {
   destType: DestinationType
 
   disabled?: boolean
+  error?: boolean
 }
 
 const cacheByJSON: Record<string, unknown> = {}
@@ -46,6 +48,14 @@ function cachify<T>(val: T): T {
   return val
 }
 
+/**
+ * DestinationSearchSelect is a select field that allows the user to select a
+ * destination from a list of options.
+ *
+ * You should almost never use this component directly. Instead, use
+ * DestinationField, which will select the correct component based on the
+ * destination type.
+ */
 export default function DestinationSearchSelect(
   props: DestinationSearchSelectProps,
 ): JSX.Element {
@@ -115,9 +125,19 @@ export default function DestinationSearchSelect(
       noOptionsText='No options'
       disabled={props.disabled}
       noOptionsError={error}
+      error={props.error}
       onInputChange={(val) => setInputValue(val)}
       value={value as unknown as SelectOption}
       label={props.labelSingular}
+      helperText={
+        props.hintURL ? (
+          <AppLink newTab to={props.hintURL}>
+            {props.hint}
+          </AppLink>
+        ) : (
+          props.hint
+        )
+      }
       options={options
         .map((opt) => ({
           label: opt.label,

--- a/web/src/app/selection/MaterialSelect.tsx
+++ b/web/src/app/selection/MaterialSelect.tsx
@@ -82,7 +82,7 @@ interface CommonSelectProps {
 
 interface SingleSelectProps {
   multiple: false
-  value: SelectOption
+  value: SelectOption | null
   onChange: (value: SelectOption | null) => void
 }
 

--- a/web/src/app/selection/MaterialSelect.tsx
+++ b/web/src/app/selection/MaterialSelect.tsx
@@ -78,6 +78,7 @@ interface CommonSelectProps {
   clientSideFilter?: boolean
   disableCloseOnSelect?: boolean
   optionsLimit?: number
+  helperText?: ReactNode
 }
 
 interface SingleSelectProps {
@@ -251,6 +252,7 @@ export default function MaterialSelect(
               const newInputVal: string = target.value
               setInputValue(newInputVal)
             }}
+            helperText={props.helperText}
             error={error}
           />
         )

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -366,6 +366,15 @@ export interface DestinationFieldConfig {
   supportsValidation: boolean
 }
 
+export interface DestinationFieldSearchInput {
+  after?: null | string
+  destType: DestinationType
+  fieldID: string
+  first?: null | number
+  omit?: null | string[]
+  search?: null | string
+}
+
 export interface DestinationFieldValidateInput {
   destType: DestinationType
   fieldID: string
@@ -426,6 +435,11 @@ export interface EscalationPolicyStep {
   targets: Target[]
 }
 
+export interface FieldValueConnection {
+  nodes: FieldValuePair[]
+  pageInfo: PageInfo
+}
+
 export interface FieldValueInput {
   fieldID: string
   value: string
@@ -433,6 +447,8 @@ export interface FieldValueInput {
 
 export interface FieldValuePair {
   fieldID: string
+  isFavorite: boolean
+  label: string
   value: string
 }
 
@@ -691,7 +707,9 @@ export interface Query {
   debugMessageStatus: DebugMessageStatusInfo
   debugMessages: DebugMessage[]
   destinationDisplayInfo: DestinationDisplayInfo
+  destinationFieldSearch: FieldValueConnection
   destinationFieldValidate: boolean
+  destinationFieldValueName: string
   destinationTypes: DestinationTypeInfo[]
   escalationPolicies: EscalationPolicyConnection
   escalationPolicy?: null | EscalationPolicy


### PR DESCRIPTION
**Description:**
This PR introduces the DestinationSearchSelect component which will be used as a generic component for search-selectable destinations (e.g., a slack channel)

**Which issue(s) this PR fixes:**
Part of https://github.com/target/goalert/issues/2639

**Out of Scope:**
- The `DestinationField` meta-component will be in a separate PR.

**Screenshots:**
![image](https://github.com/target/goalert/assets/595010/28b46af5-1ada-43c4-af0b-2e57a0f86efe)
![image](https://github.com/target/goalert/assets/595010/2c5fe4a8-26a0-4c2e-a3c6-ae7b7c203575)


**Describe any introduced user-facing changes:**
N/A

**Describe any introduced API changes:**
N/A

**Additional Info:**
Run `make storybook` to see the new component.
