### PR TITLE
ui/urql: update schedule queries and mutations

### DIFF
--- a/test/integration/schedules.spec.ts
+++ b/test/integration/schedules.spec.ts
@@ -64,5 +64,7 @@ test('local time hover', async ({ page, isMobile }) => {
 
   // should display schedule tz on hover
   await page.hover(`span:has-text("CST")`) // local TZ is configured to CST
-  await expect(page.locator('div[role=tooltip]')).toContainText('GMT')
+  await expect(page.locator('[data-testid="shift-tooltip"]')).toContainText(
+    'GMT',
+  )
 })

--- a/web/src/app/schedules/ScheduleCreateDialog.tsx
+++ b/web/src/app/schedules/ScheduleCreateDialog.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
-import { useMutation } from '@apollo/client'
-import { gql } from 'urql'
+import { gql, useMutation } from 'urql'
 import FormDialog from '../dialogs/FormDialog'
 import ScheduleForm, { Value } from './ScheduleForm'
 import { nonFieldErrors, fieldErrors } from '../util/errutil'
@@ -27,7 +26,7 @@ export default function ScheduleCreateDialog(props: {
     favorite: true,
   })
 
-  const [createSchedule, { loading, data, error }] = useMutation(mutation)
+  const [{ fetching, data, error }, commit] = useMutation(mutation)
 
   if (data && data.createSchedule) {
     return <Redirect to={`/schedules/${data.createSchedule.id}`} />
@@ -39,7 +38,7 @@ export default function ScheduleCreateDialog(props: {
       title='Create New Schedule'
       errors={nonFieldErrors(error)}
       onSubmit={() =>
-        createSchedule({
+        commit({
           variables: {
             input: {
               ...value,
@@ -55,7 +54,7 @@ export default function ScheduleCreateDialog(props: {
       }
       form={
         <ScheduleForm
-          disabled={loading}
+          disabled={fetching}
           errors={fieldErrors(error)}
           value={value}
           onChange={(value: Value) => setValue(value)}

--- a/web/src/app/schedules/ScheduleCreateDialog.tsx
+++ b/web/src/app/schedules/ScheduleCreateDialog.tsx
@@ -39,16 +39,14 @@ export default function ScheduleCreateDialog(props: {
       errors={nonFieldErrors(error)}
       onSubmit={() =>
         commit({
-          variables: {
-            input: {
-              ...value,
-              targets: [
-                {
-                  target: { type: 'user', id: '__current_user' },
-                  rules: [{}],
-                },
-              ],
-            },
+          input: {
+            ...value,
+            targets: [
+              {
+                target: { type: 'user', id: '__current_user' },
+                rules: [{}],
+              },
+            ],
           },
         })
       }

--- a/web/src/app/schedules/ScheduleDeleteDialog.tsx
+++ b/web/src/app/schedules/ScheduleDeleteDialog.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { useMutation } from '@apollo/client'
-import { useQuery, gql } from 'urql'
+import { gql, useQuery, useMutation } from 'urql'
 import { get } from 'lodash'
 import FormDialog from '../dialogs/FormDialog'
 import Spinner from '../loading/components/Spinner'
@@ -13,6 +12,7 @@ const query = gql`
     }
   }
 `
+
 const mutation = gql`
   mutation delete($input: [TargetInput!]!) {
     deleteAll(input: $input)
@@ -28,16 +28,7 @@ export default function ScheduleDeleteDialog(props: {
     variables: { id: props.scheduleID },
   })
 
-  const [deleteSchedule, deleteScheduleStatus] = useMutation(mutation, {
-    variables: {
-      input: [
-        {
-          type: 'schedule',
-          id: props.scheduleID,
-        },
-      ],
-    },
-  })
+  const [deleteScheduleStatus, commit] = useMutation(mutation)
 
   if (!data && fetching) return <Spinner />
 
@@ -47,10 +38,19 @@ export default function ScheduleDeleteDialog(props: {
       confirm
       subTitle={`This will delete the schedule: ${get(data, 'schedule.name')}`}
       caption='Deleting a schedule will also delete all associated rules and overrides.'
-      loading={deleteScheduleStatus.loading}
+      loading={deleteScheduleStatus.fetching}
       errors={deleteScheduleStatus.error ? [deleteScheduleStatus.error] : []}
       onClose={props.onClose}
-      onSubmit={() => deleteSchedule()}
+      onSubmit={() =>
+        commit({
+          input: [
+            {
+              type: 'schedule',
+              id: props.scheduleID,
+            },
+          ],
+        })
+      }
     />
   )
 }

--- a/web/src/app/schedules/ScheduleDeleteDialog.tsx
+++ b/web/src/app/schedules/ScheduleDeleteDialog.tsx
@@ -42,14 +42,17 @@ export default function ScheduleDeleteDialog(props: {
       errors={deleteScheduleStatus.error ? [deleteScheduleStatus.error] : []}
       onClose={props.onClose}
       onSubmit={() =>
-        commit({
-          input: [
-            {
-              type: 'schedule',
-              id: props.scheduleID,
-            },
-          ],
-        })
+        commit(
+          {
+            input: [
+              {
+                type: 'schedule',
+                id: props.scheduleID,
+              },
+            ],
+          },
+          { additionalTypenames: ['Schedule'] },
+        )
       }
     />
   )

--- a/web/src/app/schedules/ScheduleDetails.tsx
+++ b/web/src/app/schedules/ScheduleDetails.tsx
@@ -26,6 +26,7 @@ const query = gql`
     name
     description
   }
+
   query scheduleDetailsQuery($id: ID!) {
     schedule(id: $id) {
       ...ScheduleTitleQuery

--- a/web/src/app/schedules/ScheduleOverrideCreateDialog.tsx
+++ b/web/src/app/schedules/ScheduleOverrideCreateDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { gql, useMutation } from '@apollo/client'
+import { gql, useMutation } from 'urql'
 import FormDialog from '../dialogs/FormDialog'
 import { DateTime } from 'luxon'
 import ScheduleOverrideForm from './ScheduleOverrideForm'
@@ -55,6 +55,7 @@ const mutation = gql`
     }
   }
 `
+
 export default function ScheduleOverrideCreateDialog({
   scheduleID,
   variant,
@@ -70,15 +71,7 @@ export default function ScheduleOverrideCreateDialog({
 
   const notices = useOverrideNotices(scheduleID, value)
 
-  const [mutate, { loading, error }] = useMutation(mutation, {
-    variables: {
-      input: {
-        ...value,
-        scheduleID,
-      },
-    },
-    onCompleted: onClose,
-  })
+  const [{ fetching, error }, commit] = useMutation(mutation)
 
   return (
     <FormDialog
@@ -87,13 +80,25 @@ export default function ScheduleOverrideCreateDialog({
       subTitle={variantDetails[variant].desc}
       errors={nonFieldErrors(error)}
       notices={notices} // create and edit dialog
-      onSubmit={() => mutate()}
+      onSubmit={() =>
+        commit(
+          {
+            input: {
+              ...value,
+              scheduleID,
+            },
+          },
+          { additionalTypenames: ['UserOverrides'] },
+        ).then((result) => {
+          if (!result.error) onClose()
+        })
+      }
       form={
         <ScheduleOverrideForm
           add={variant !== 'remove'}
           remove={variant !== 'add'}
           scheduleID={scheduleID}
-          disabled={loading}
+          disabled={fetching}
           errors={fieldErrors(error)}
           value={value}
           onChange={(newValue) => setValue(newValue)}

--- a/web/src/app/schedules/ScheduleOverrideCreateDialog.tsx
+++ b/web/src/app/schedules/ScheduleOverrideCreateDialog.tsx
@@ -88,7 +88,7 @@ export default function ScheduleOverrideCreateDialog({
               scheduleID,
             },
           },
-          { additionalTypenames: ['UserOverrides'] },
+          { additionalTypenames: ['UserOverrideConnection', 'Schedule'] },
         ).then((result) => {
           if (!result.error) onClose()
         })

--- a/web/src/app/schedules/ScheduleOverrideDialog.js
+++ b/web/src/app/schedules/ScheduleOverrideDialog.js
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react'
-import { gql, useMutation } from '@apollo/client'
+import { gql, useMutation } from 'urql'
 import p from 'prop-types'
 import FormDialog from '../dialogs/FormDialog'
 import { DateTime } from 'luxon'
@@ -32,6 +32,7 @@ const useStyles = makeStyles({
     marginTop: '.3rem',
   },
 })
+
 export default function ScheduleOverrideDialog(props) {
   const { variantOptions = ['replace', 'remove', 'add', 'temp'] } = props
   const classes = useStyles()
@@ -53,15 +54,7 @@ export default function ScheduleOverrideDialog(props) {
 
   const notices = useOverrideNotices(props.scheduleID, value)
 
-  const [mutate, { loading, error }] = useMutation(mutation, {
-    variables: {
-      input: {
-        ...value,
-        scheduleID: props.scheduleID,
-      },
-    },
-    onCompleted: props.onClose,
-  })
+  const [{ fetching, error }, commit] = useMutation(mutation)
 
   useEffect(() => {
     setFieldErrors(getFieldErrors(error))
@@ -93,7 +86,7 @@ export default function ScheduleOverrideDialog(props) {
       }
       errors={nonFieldErrors(error)}
       notices={step === 0 ? [] : notices} // create and edit dialog
-      loading={loading}
+      loading={fetching}
       form={
         <React.Fragment>
           {/* Step 0: Choose override variant page */}
@@ -131,7 +124,7 @@ export default function ScheduleOverrideDialog(props) {
               add={activeVariant !== 'remove'}
               remove={activeVariant !== 'add'}
               scheduleID={props.scheduleID}
-              disabled={loading}
+              disabled={fetching}
               errors={fieldErrors}
               value={value}
               onChange={(newValue) => setValue(newValue)}
@@ -140,7 +133,19 @@ export default function ScheduleOverrideDialog(props) {
           )}
         </React.Fragment>
       }
-      onSubmit={() => mutate()}
+      onSubmit={() =>
+        commit(
+          {
+            input: {
+              ...value,
+              scheduleID: props.scheduleID,
+            },
+          },
+          { additionalTypenames: ['UserOverrides'] },
+        ).then((result) => {
+          if (!result.error) props.onClose()
+        })
+      }
       onNext={step < 1 ? onNext : null}
     />
   )

--- a/web/src/app/schedules/ScheduleOverrideDialog.js
+++ b/web/src/app/schedules/ScheduleOverrideDialog.js
@@ -141,7 +141,7 @@ export default function ScheduleOverrideDialog(props) {
               scheduleID: props.scheduleID,
             },
           },
-          { additionalTypenames: ['UserOverrides'] },
+          { additionalTypenames: ['UserOverrideConnection', 'Schedule'] },
         ).then((result) => {
           if (!result.error) props.onClose()
         })

--- a/web/src/app/schedules/ScheduleOverrideList.js
+++ b/web/src/app/schedules/ScheduleOverrideList.js
@@ -2,7 +2,7 @@ import React, { Suspense, useCallback, useState } from 'react'
 import { Button, Grid, FormControlLabel, Switch, Tooltip } from '@mui/material'
 import { GroupAdd } from '@mui/icons-material'
 import { DateTime } from 'luxon'
-import { gql } from '@apollo/client'
+import { gql } from 'urql'
 import QueryList from '../lists/QueryList'
 import { UserAvatar } from '../util/avatars'
 import OtherActions from '../util/OtherActions'
@@ -20,7 +20,6 @@ import { defaultTempSchedValue } from './temp-sched/sharedUtils'
 import ScheduleOverrideDialog from './ScheduleOverrideDialog'
 import CreateFAB from '../lists/CreateFAB'
 
-// the query name `scheduleOverrides` is used for refetch queries
 const query = gql`
   query scheduleOverrides($input: UserOverrideSearchOptions) {
     userOverrides(input: $input) {

--- a/web/src/app/schedules/ScheduleShiftList.tsx
+++ b/web/src/app/schedules/ScheduleShiftList.tsx
@@ -202,7 +202,14 @@ function ScheduleShiftList({
     const scheduleTZDetails = `Active after ${schedStartTime} ${tzAbbr}`
     const localTZDetails = `Active after ${localStartTime} ${localTzAbbr}`
     return (
-      <Tooltip title={scheduleTZDetails} placement='right'>
+      <Tooltip
+        title={scheduleTZDetails}
+        placement='right'
+        PopperProps={{
+          // @ts-expect-error test id
+          'data-testid': 'shift-tooltip',
+        }}
+      >
         <span>{localTZDetails}</span>
       </Tooltip>
     )


### PR DESCRIPTION
Description:
Updates `ScheduleCreateDialog`, `ScheduleDeleteDialog`, `ScheduleOverrideCreateDialog`, `ScheduleOverrideDialog`, and `ScheduleOverrideList` to use `urql` instead of `@apollo/client` for their queries and mutations

Which issue(s) this PR fixes:
Part of #3240