### PR TITLE
cli: check for scheme on public-url

### DIFF
--- a/app/cmd.go
+++ b/app/cmd.go
@@ -673,6 +673,9 @@ func getConfig(ctx context.Context) (Config, error) {
 		if err != nil {
 			return cfg, errors.Wrap(err, "parse public url")
 		}
+		if u.Scheme == "" {
+			return cfg, errors.New("public-url must be an absolute URL (missing scheme)")
+		}
 		if cfg.HTTPPrefix != "" {
 			return cfg, errors.New("public-url and http-prefix cannot be used together")
 		}


### PR DESCRIPTION
**Description:**
This PR adds a check for the scheme (http/https) in the public-url option on startup. If started with just a domain, for example, the app would previously start but return 404 errors.
