### PR TITLE
dev/admin: prod build validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ smoketest_db_dump
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+/.gitrev

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,13 @@ PG_VERSION=13
 # add all files except those under web/src/build and web/src/cypress
 NODE_DEPS=.pnp.cjs .yarnrc.yml $(shell find web/src -path web/src/build -prune -o -path web/src/cypress -prune -o -type f -print)
 
+# add .git/HEAD if it exists to NODE_DEPS
+# this is used to trigger a rebuild when committing changes to git
+# since the git commit hash is used in the build as the version
+ifneq ("$(wildcard .git/HEAD)","")
+NODE_DEPS += .git/HEAD
+endif
+
 # Use sha256sum on linux and shasum -a 256 on mac
 SHA_CMD := $(shell if [ -x "$(shell command -v sha256sum 2>/dev/null)" ]; then echo "sha256sum"; else echo "shasum -a 256"; fi)
 

--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,6 @@ PG_VERSION=13
 # add all files except those under web/src/build and web/src/cypress
 NODE_DEPS=.pnp.cjs .yarnrc.yml .gitrev $(shell find web/src -path web/src/build -prune -o -path web/src/cypress -prune -o -type f -print)
 
-# add .git/HEAD if it exists to NODE_DEPS
-# this is used to trigger a rebuild when committing changes to git
-# since the git commit hash is used in the build as the version
-ifneq ("$(wildcard .git/HEAD)","")
-NODE_DEPS += .git/HEAD
-endif
-
 # Use sha256sum on linux and shasum -a 256 on mac
 SHA_CMD := $(shell if [ -x "$(shell command -v sha256sum 2>/dev/null)" ]; then echo "sha256sum"; else echo "shasum -a 256"; fi)
 

--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ web/src/build/static/app.js: $(NODE_DEPS)
 	rm -rf web/src/build/static
 	mkdir -p web/src/build/static
 	cp -f web/src/app/public/icons/favicon-* web/src/app/public/logos/lightmode_* web/src/app/public/logos/darkmode_* web/src/build/static/
-	GOALERT_VERSION=$(GIT_VERSION) yarn run esbuild
+	GOALERT_VERSION=$(GIT_VERSION) yarn run esbuild --prod
 	touch "$@"
 
 notification/desttype_string.go: notification/desttype.go

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ YARN_VERSION=3.6.3
 PG_VERSION=13
 
 # add all files except those under web/src/build and web/src/cypress
-NODE_DEPS=.pnp.cjs .yarnrc.yml $(shell find web/src -path web/src/build -prune -o -path web/src/cypress -prune -o -type f -print)
+NODE_DEPS=.pnp.cjs .yarnrc.yml .gitrev $(shell find web/src -path web/src/build -prune -o -path web/src/cypress -prune -o -type f -print)
 
 # add .git/HEAD if it exists to NODE_DEPS
 # this is used to trigger a rebuild when committing changes to git

--- a/Makefile.binaries.mk
+++ b/Makefile.binaries.mk
@@ -15,7 +15,7 @@ endif
 
 GIT_COMMIT:=$(shell git rev-parse HEAD || echo '?')
 GIT_TREE:=$(shell git diff-index --quiet HEAD -- && echo clean || echo dirty)
-GIT_VERSION:=$(shell git describe --tags --dirty --match 'v*' || echo dev-$(shell date -u +"%Y%m%d%H%M%S"))
+GIT_VERSION:=$(shell git describe --tags --dirty --match 'v*' || echo dev)
 BUILD_DATE:=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BUILD_FLAGS=
 

--- a/Makefile.binaries.mk
+++ b/Makefile.binaries.mk
@@ -7,7 +7,7 @@ BIN_DIR=bin
 GO_DEPS := Makefile.binaries.mk $(shell find . -path ./web/src -prune -o -path ./vendor -prune -o -path ./.git -prune -o -type f -name "*.go" -print) go.sum
 GO_DEPS += migrate/migrations/ migrate/migrations/*.sql web/index.html graphql2/graphqlapp/slack.manifest.yaml swo/*/*.sql
 GO_DEPS += graphql2/mapconfig.go graphql2/maplimit.go graphql2/generated.go graphql2/models_gen.go
-GO_DEPS += web/explore.html web/live.js
+GO_DEPS += web/explore.html web/live.js .gitrev
 
 ifdef BUNDLE
 	GO_DEPS += web/src/build/static/app.js web/src/build/static/explore.js
@@ -18,6 +18,13 @@ GIT_TREE:=$(shell git diff-index --quiet HEAD -- && echo clean || echo dirty)
 GIT_VERSION:=$(shell git describe --tags --dirty --match 'v*' || echo dev-$(shell date -u +"%Y%m%d%H%M%S"))
 BUILD_DATE:=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BUILD_FLAGS=
+
+# update .gitrev with GIT_VERSION (unless it matches the current value)
+ifneq ($(shell cat .gitrev 2>/dev/null),$(GIT_VERSION))
+$(shell echo "$(GIT_VERSION)" > .gitrev)
+endif
+.gitrev:
+	@echo "$(GIT_VERSION)" > .gitrev
 
 export ZONEINFO:=$(shell go env GOROOT)/lib/time/zoneinfo.zip
 

--- a/Procfile.integration
+++ b/Procfile.integration
@@ -1,4 +1,1 @@
 build: while true; do make -qs bin/goalert BUNDLE=1 || make bin/goalert BUNDLE=1 || (echo '\033[0;31mBuild Failure'; sleep 3); sleep 0.1; done
-
-@watch-file=./web/src/esbuild.config.js
-ui: yarn run esbuild --watch --prod

--- a/Procfile.prod
+++ b/Procfile.prod
@@ -6,8 +6,4 @@ goalert: ./bin/goalert -l=localhost:3030 --db-url=postgres://goalert@localhost -
 smtp: go run github.com/mailhog/MailHog -ui-bind-addr=localhost:8025 -api-bind-addr=localhost:8025 -smtp-bind-addr=localhost:1025 | grep -v KEEPALIVE
 prom: bin/tools/prometheus --log.level=warn --config.file=devtools/prometheus/prometheus.yml --storage.tsdb.path=bin/prom-data/ --web.listen-address=localhost:9090
 
-
-@watch-file=./web/src/esbuild.config.js
-ui: yarn run esbuild --watch --prod
-
 oidc: ./bin/mockoidc

--- a/devtools/genmake/template.mk
+++ b/devtools/genmake/template.mk
@@ -13,7 +13,7 @@ endif
 
 GIT_COMMIT:=$(shell git rev-parse HEAD || echo '?')
 GIT_TREE:=$(shell git diff-index --quiet HEAD -- && echo clean || echo dirty)
-GIT_VERSION:=$(shell git describe --tags --dirty --match 'v*' || echo dev-$(shell date -u +"%Y%m%d%H%M%S"))
+GIT_VERSION:=$(shell git describe --tags --dirty --match 'v*' || echo dev)
 BUILD_DATE:=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BUILD_FLAGS=
 

--- a/devtools/genmake/template.mk
+++ b/devtools/genmake/template.mk
@@ -5,7 +5,7 @@ BIN_DIR=bin
 GO_DEPS := Makefile.binaries.mk $(shell find . -path ./web/src -prune -o -path ./vendor -prune -o -path ./.git -prune -o -type f -name "*.go" -print) go.sum
 GO_DEPS += migrate/migrations/ migrate/migrations/*.sql web/index.html graphql2/graphqlapp/slack.manifest.yaml swo/*/*.sql
 GO_DEPS += graphql2/mapconfig.go graphql2/maplimit.go graphql2/generated.go graphql2/models_gen.go
-GO_DEPS += web/explore.html web/live.js
+GO_DEPS += web/explore.html web/live.js .gitrev
 
 ifdef BUNDLE
 	GO_DEPS += web/src/build/static/app.js web/src/build/static/explore.js
@@ -16,6 +16,13 @@ GIT_TREE:=$(shell git diff-index --quiet HEAD -- && echo clean || echo dirty)
 GIT_VERSION:=$(shell git describe --tags --dirty --match 'v*' || echo dev-$(shell date -u +"%Y%m%d%H%M%S"))
 BUILD_DATE:=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BUILD_FLAGS=
+
+# update .gitrev with GIT_VERSION (unless it matches the current value)
+ifneq ($(shell cat .gitrev 2>/dev/null),$(GIT_VERSION))
+$(shell echo "$(GIT_VERSION)" > .gitrev)
+endif
+.gitrev:
+	@echo "$(GIT_VERSION)" > .gitrev
 
 export ZONEINFO:=$(shell go env GOROOT)/lib/time/zoneinfo.zip
 

--- a/web/handler.go
+++ b/web/handler.go
@@ -27,6 +27,11 @@ var liveJS []byte
 
 // validateAppJS will return an error if the app.js file is not valid or missing.
 func validateAppJS(fs fs.FS) error {
+	if version.GitVersion() == "dev" {
+		// skip validation in dev mode
+		return nil
+	}
+
 	fd, err := fs.Open("static/app.js")
 	if err != nil {
 		return fmt.Errorf("unable to open bundled app.js and ui-dir is unset, was make invoked with BUNDLE=1? (%w)", err)

--- a/web/handler.go
+++ b/web/handler.go
@@ -5,14 +5,18 @@ import (
 	"crypto/sha256"
 	"embed"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"html/template"
+	"io"
 	"io/fs"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/target/goalert/config"
 	"github.com/target/goalert/util/errutil"
+	"github.com/target/goalert/version"
 )
 
 //go:embed src/build
@@ -20,6 +24,45 @@ var bundleFS embed.FS
 
 //go:embed live.js
 var liveJS []byte
+
+// validateAppJS will return an error if the app.js file is not valid or missing.
+func validateAppJS(fs fs.FS) error {
+	fd, err := fs.Open("static/app.js")
+	if err != nil {
+		return fmt.Errorf("unable to open bundled app.js and ui-dir is unset, was make invoked with BUNDLE=1? (%w)", err)
+	}
+	defer fd.Close()
+
+	// read first 512 bytes
+	data, err := io.ReadAll(io.LimitReader(fd, 512))
+	if err != nil {
+		return fmt.Errorf("unable to read bundled app.js (%w)", err)
+	}
+
+	s := string(data)
+	if !strings.HasPrefix(s, "var GOALERT_VERSION=") {
+		return fmt.Errorf("bundled app.js is invalid, expected prefix \"var GOALERT_VERSION=\", got %q", s)
+	}
+
+	s, _, _ = strings.Cut(s, "\n") // only check first line
+	if !strings.HasSuffix(s, ";") {
+		return fmt.Errorf("bundled app.js is invalid, expected suffix \";\", got %q", s)
+	}
+
+	s = strings.TrimPrefix(s, "var GOALERT_VERSION=")
+	s = strings.TrimSuffix(s, ";")
+	var vers string
+	err = json.Unmarshal([]byte(s), &vers)
+	if err != nil {
+		return fmt.Errorf("bundled app.js is invalid, expected quoted string, got %q (%w)", s, err)
+	}
+
+	if vers != version.GitVersion() {
+		return fmt.Errorf("bundled app.js is invalid, version mismatch, expected %q, got %q", version.GitVersion(), vers)
+	}
+
+	return nil
+}
 
 // NewHandler creates a new http.Handler that will serve UI files
 // using bundled assets or locally if uiDir if set.
@@ -38,6 +81,12 @@ func NewHandler(uiDir, prefix string) (http.Handler, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		err = validateAppJS(sub)
+		if err != nil {
+			return nil, err
+		}
+
 		mux.Handle("/static/", NewEtagFileServer(http.FS(sub), true))
 	}
 

--- a/web/src/esbuild.config.js
+++ b/web/src/esbuild.config.js
@@ -34,6 +34,9 @@ const dynamicPublicPathPlugin = {
 async function run() {
   const method = process.argv.includes('--watch') ? 'context' : 'build'
 
+  if (!process.env.GOALERT_VERSION)
+    throw new Error('GOALERT_VERSION ENV var not set')
+
   const ctx = await require('esbuild')[method]({
     entryPoints: {
       explore: 'web/src/explore/explore.tsx',


### PR DESCRIPTION
**Description:**
This PR adds validation of the UI assets when running without the `--ui-dir` flag. A number of bugs/issues with development targets were also fixed.

- All files under `web/src` (other than `build/` and `cypress/`) will now trigger `app.js` to be rebuilt
- Fixed dependency issues where yarn commands would never result in a stable state (always rebuild)
- removed esbuild watcher from Procfiles that already use `BUNDLE=1` (they would clobber each other)
- `app.js` must now exist and the embedded `GOALERT_VERSION` **MUST** match the backend version (if `--ui-dir` is unset)
- esbuild will now abort immediately if `GOALERT_VERSION` is undefined
- Changing the `GIT_VERSION` (e.g., by making a commit) will now trigger a rebuild to keep version strings in sync

Additionally, `make start-prod` is much more efficient now and doesn't print endless noise in the console.
