### PR TITLE
ep: destinations: update step list/actions to use dest-types

### DIFF
--- a/graphql2/graph/escalationpolicy.graphqls
+++ b/graphql2/graph/escalationpolicy.graphqls
@@ -1,0 +1,3 @@
+extend type EscalationPolicyStep {
+    actions: [Destination!]! @experimental(flagName: "dest-types")
+}

--- a/graphql2/graphqlapp/compat.go
+++ b/graphql2/graphqlapp/compat.go
@@ -7,10 +7,54 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/target/goalert/assignment"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/notificationchannel"
 	"github.com/target/goalert/user/contactmethod"
 )
+
+// CompatTargetToDest converts an assignment.Target to a graphql2.Destination.
+func CompatTargetToDest(tgt assignment.Target) (graphql2.Destination, error) {
+	switch tgt.TargetType() {
+	case assignment.TargetTypeUser:
+		return graphql2.Destination{
+			Type: destUser,
+			Values: []graphql2.FieldValuePair{{
+				FieldID: fieldUserID,
+				Value:   tgt.TargetID(),
+			}}}, nil
+	case assignment.TargetTypeRotation:
+		return graphql2.Destination{
+			Type: destRotation,
+			Values: []graphql2.FieldValuePair{{
+				FieldID: fieldRotationID,
+				Value:   tgt.TargetID(),
+			}}}, nil
+	case assignment.TargetTypeSchedule:
+		return graphql2.Destination{
+			Type: destSchedule,
+			Values: []graphql2.FieldValuePair{{
+				FieldID: fieldScheduleID,
+				Value:   tgt.TargetID(),
+			}}}, nil
+	case assignment.TargetTypeChanWebhook:
+		return graphql2.Destination{
+			Type: destWebhook,
+			Values: []graphql2.FieldValuePair{{
+				FieldID: fieldWebhookURL,
+				Value:   tgt.TargetID(),
+			}}}, nil
+	case assignment.TargetTypeSlackChannel:
+		return graphql2.Destination{
+			Type: destSlackChan,
+			Values: []graphql2.FieldValuePair{{
+				FieldID: fieldSlackChanID,
+				Value:   tgt.TargetID(),
+			}}}, nil
+	}
+
+	return graphql2.Destination{}, fmt.Errorf("unknown target type: %s", tgt.TargetType())
+}
 
 // CompatNCToDest converts a notification channel to a destination.
 func (a *App) CompatNCToDest(ctx context.Context, ncID uuid.UUID) (*graphql2.Destination, error) {

--- a/graphql2/graphqlapp/escalationpolicy.go
+++ b/graphql2/graphqlapp/escalationpolicy.go
@@ -309,6 +309,23 @@ func (m *Mutation) UpdateEscalationPolicyStep(ctx context.Context, input graphql
 	return true, err
 }
 
+func (a *EscalationPolicyStep) Actions(ctx context.Context, raw *escalation.Step) ([]graphql2.Destination, error) {
+	tgts, err := a.Targets(ctx, raw)
+	if err != nil {
+		return nil, err
+	}
+
+	actions := make([]graphql2.Destination, len(tgts))
+	for i, tgt := range tgts {
+		actions[i], err = CompatTargetToDest(tgt)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return actions, nil
+}
+
 func (step *EscalationPolicyStep) Targets(ctx context.Context, raw *escalation.Step) ([]assignment.RawTarget, error) {
 	// TODO: use dataloader
 	var targets []assignment.Target

--- a/web/src/app/escalation-policies/PolicyStepsCard.jsx
+++ b/web/src/app/escalation-policies/PolicyStepsCard.jsx
@@ -19,7 +19,12 @@ import { reorderList } from '../rotations/util'
 import PolicyStepEditDialog from './PolicyStepEditDialog'
 import PolicyStepDeleteDialog from './PolicyStepDeleteDialog'
 import OtherActions from '../util/OtherActions'
-import { getStepNumber, renderChips, renderDelayMessage } from './stepUtil'
+import {
+  getStepNumber,
+  renderChips,
+  renderChipsDest,
+  renderDelayMessage,
+} from './stepUtil'
 
 const mutation = gql`
   mutation UpdateEscalationPolicyMutation(
@@ -171,7 +176,7 @@ export default function PolicyStepsCard(props) {
             ),
             subText: (
               <React.Fragment>
-                {renderChips(step)}
+                {step.actions ? renderChipsDest(step) : renderChips(step)}
                 {renderDelayMessage(steps, step, repeat)}
               </React.Fragment>
             ),

--- a/web/src/app/escalation-policies/PolicyStepsQuery.tsx
+++ b/web/src/app/escalation-policies/PolicyStepsQuery.tsx
@@ -42,6 +42,11 @@ export const policyStepsQueryDest = gql`
             linkURL
           }
         }
+        targets {
+          id
+          name
+          type
+        }
       }
     }
   }

--- a/web/src/app/escalation-policies/PolicyStepsQuery.tsx
+++ b/web/src/app/escalation-policies/PolicyStepsQuery.tsx
@@ -3,6 +3,7 @@ import { gql, useQuery } from '@apollo/client'
 import PolicyStepsCard from './PolicyStepsCard'
 import Spinner from '../loading/components/Spinner'
 import { GenericError, ObjectNotFound } from '../error-pages'
+import { useExpFlag } from '../util/useExpFlag'
 
 export const policyStepsQuery = gql`
   query stepsQuery($id: ID!) {
@@ -23,10 +24,38 @@ export const policyStepsQuery = gql`
   }
 `
 
+export const policyStepsQueryDest = gql`
+  query stepsQueryDest($id: ID!) {
+    escalationPolicy(id: $id) {
+      id
+      repeat
+      steps {
+        id
+        delayMinutes
+        stepNumber
+        actions {
+          type
+          displayInfo {
+            text
+            iconURL
+            iconAltText
+            linkURL
+          }
+        }
+      }
+    }
+  }
+`
+
 function PolicyStepsQuery(props: { escalationPolicyID: string }): JSX.Element {
-  const { data, loading, error } = useQuery(policyStepsQuery, {
-    variables: { id: props.escalationPolicyID },
-  })
+  const hasDestTypesFlag = useExpFlag('dest-types')
+
+  const { data, loading, error } = useQuery(
+    hasDestTypesFlag ? policyStepsQueryDest : policyStepsQuery,
+    {
+      variables: { id: props.escalationPolicyID },
+    },
+  )
 
   if (!data && loading) {
     return <Spinner />

--- a/web/src/app/escalation-policies/stepUtil.tsx
+++ b/web/src/app/escalation-policies/stepUtil.tsx
@@ -10,7 +10,8 @@ import {
   SlackChip,
   WebhookChip,
 } from '../util/Chips'
-import { Target } from '../../schema'
+import { EscalationPolicyStep, Target } from '../../schema'
+import DestinationChip from '../util/DestinationChip'
 
 interface Step {
   id: string
@@ -21,6 +22,29 @@ interface Step {
 export function getStepNumber(stepID: string, steps: Step[]): number {
   const sids = steps.map((s) => s.id)
   return sids.indexOf(stepID) + 1
+}
+
+export function renderChipsDest({
+  actions: _a,
+}: Pick<EscalationPolicyStep, 'actions'>): ReactElement {
+  const actions = sortBy(_a.slice(), ['type', 'displayInfo.text'])
+  if (!actions || actions.length === 0) {
+    return <Chip label='No actions' />
+  }
+
+  const items = actions.map((a, idx) => {
+    return (
+      <Grid item key={idx}>
+        <DestinationChip {...a.displayInfo} />
+      </Grid>
+    )
+  })
+
+  return (
+    <Grid container spacing={1}>
+      {items}
+    </Grid>
+  )
 }
 
 /*

--- a/web/src/app/util/DestinationAvatar.tsx
+++ b/web/src/app/util/DestinationAvatar.tsx
@@ -19,8 +19,6 @@ export type DestinationAvatarProps = {
   loading?: boolean
   iconURL?: string
   iconAltText?: string
-
-  size?: string
 }
 
 /**
@@ -31,32 +29,31 @@ export type DestinationAvatarProps = {
 export function DestinationAvatar(
   props: DestinationAvatarProps,
 ): React.ReactNode {
+  const { error, loading, iconURL, iconAltText, ...rest } = props
+
   if (props.error) {
     return (
-      <Avatar>
+      <Avatar {...rest}>
         <BrokenImage />
       </Avatar>
     )
   }
 
-  if (props.loading) {
+  if (loading) {
     return (
-      <Avatar>
-        <CircularProgress data-testid='spinner' size={props.size || '1em'} />
+      <Avatar {...rest}>
+        <CircularProgress data-testid='spinner' size='1em' />
       </Avatar>
     )
   }
 
-  if (!props.iconURL) {
+  if (!iconURL) {
     return null
   }
 
-  const builtInIcon = builtInIcons[props.iconURL] || null
+  const builtInIcon = builtInIcons[iconURL] || null
   return (
-    <Avatar
-      src={builtInIcon ? undefined : props.iconURL}
-      alt={props.iconAltText}
-    >
+    <Avatar {...rest} src={builtInIcon ? undefined : iconURL} alt={iconAltText}>
       {builtInIcon}
     </Avatar>
   )

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -432,6 +432,7 @@ export interface EscalationPolicySearchOptions {
 }
 
 export interface EscalationPolicyStep {
+  actions: Destination[]
   delayMinutes: number
   escalationPolicy?: null | EscalationPolicy
   id: string


### PR DESCRIPTION
**Description:**
This PR updates the policy step rendering to use `DestinationChip` when the `dest-types` experimental flag is set.

- PolicyStepQuery will now pick which query to use based on the flag
- PolicyStepCard will use the appropriate render function based on the provided data (`actions` or `targets`)
- Fixed a regression in avatar rendering that made the chip icons too big (needed to pass `...rest` props)

**Which issue(s) this PR fixes:**
Part of #2639 

**Out of Scope:**
- Dialogs will be handled separately

**Describe any introduced user-facing changes:**
N/A

**Describe any introduced API changes:**
- Adds a new `actions` field on `EscalationPolicyStep` listing Destinations for the step

**Additional Info:**
Use `make start` and `make start EXPERIMENTAL=dest-types` to compare the two modes (they should be pretty much identical)