### PR TITLE
dest: return proper data in graphql errors

### DIFF
--- a/graphql2/graphqlapp/app.go
+++ b/graphql2/graphqlapp/app.go
@@ -225,7 +225,15 @@ func (a *App) Handler() http.Handler {
 
 		var multiFieldErr validation.MultiFieldError
 		var singleFieldErr validation.FieldError
-		if errors.As(err, &multiFieldErr) {
+		var destErr *DestinationValidationError
+		if errors.As(err, &destErr) {
+			gqlErr.Message = err.Error()
+			gqlErr.Extensions = map[string]interface{}{
+				"isFieldError": true,
+				"fieldName":    "dest",
+				"details":      destErr,
+			}
+		} else if errors.As(err, &multiFieldErr) {
 			errs := make([]fieldErr, len(multiFieldErr.FieldErrors()))
 			for i, err := range multiFieldErr.FieldErrors() {
 				errs[i].FieldName = err.Field()

--- a/graphql2/graphqlapp/contactmethod.go
+++ b/graphql2/graphqlapp/contactmethod.go
@@ -139,8 +139,7 @@ func (m *Mutation) CreateUserContactMethod(ctx context.Context, input graphql2.C
 	cfg := config.FromContext(ctx)
 
 	if input.Dest != nil {
-		err := (*App)(m).ValidateDestination(ctx, input.Dest)
-		if err != nil {
+		if ok, err := (*App)(m).ValidateDestination(ctx, "dest", input.Dest); !ok {
 			return nil, err
 		}
 		t, v := CompatDestToCMTypeVal(*input.Dest)

--- a/graphql2/graphqlapp/contactmethod.go
+++ b/graphql2/graphqlapp/contactmethod.go
@@ -139,6 +139,10 @@ func (m *Mutation) CreateUserContactMethod(ctx context.Context, input graphql2.C
 	cfg := config.FromContext(ctx)
 
 	if input.Dest != nil {
+		err := (*App)(m).ValidateDestination(ctx, input.Dest)
+		if err != nil {
+			return nil, err
+		}
 		t, v := CompatDestToCMTypeVal(*input.Dest)
 		input.Type = &t
 		input.Value = &v

--- a/graphql2/graphqlapp/destinationvalidation.go
+++ b/graphql2/graphqlapp/destinationvalidation.go
@@ -1,0 +1,157 @@
+package graphqlapp
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/target/goalert/config"
+	"github.com/target/goalert/graphql2"
+	"github.com/target/goalert/validation"
+	"github.com/target/goalert/validation/validate"
+)
+
+type FieldValueError struct {
+	FieldID string `json:"fieldID"`
+	Message string `json:"message"`
+}
+
+type DestinationValidationError struct {
+	Type        string            `json:"type"` // always "DestinationValidationError"
+	FieldErrors []FieldValueError `json:"fieldErrors"`
+}
+
+func (e *DestinationValidationError) Error() string {
+	return "DestinationValidationError"
+}
+func (e *DestinationValidationError) ClientError() bool { return true }
+
+func newDestErr(errs ...error) error {
+	var destErr DestinationValidationError
+	destErr.Type = "DestinationValidationError"
+	for _, err := range errs {
+		if f, ok := err.(validation.FieldError); ok {
+			destErr.FieldErrors = append(destErr.FieldErrors, FieldValueError{
+				FieldID: f.Field(),
+				Message: f.Reason(),
+			})
+			continue
+		}
+
+		// non-field error, just return the bunch
+		return errors.Join(errs...)
+	}
+
+	return &destErr
+}
+
+// ValidateDestination will validate a destination input.
+//
+// In the future this will be a call to the plugin system.
+func (a *App) ValidateDestination(ctx context.Context, dest *graphql2.DestinationInput) error {
+	cfg := config.FromContext(ctx)
+	switch dest.Type {
+	case destTwilioSMS:
+		phone := dest.FieldValue(fieldPhoneNumber)
+		err := validate.Phone(fieldPhoneNumber, phone)
+		if err != nil {
+			return newDestErr(err)
+		}
+		return nil
+	case destTwilioVoice:
+		phone := dest.FieldValue(fieldPhoneNumber)
+		err := validate.Phone(fieldPhoneNumber, phone)
+		if err != nil {
+			return newDestErr(err)
+		}
+		return nil
+	case destSlackChan:
+		chanID := dest.FieldValue(fieldSlackChanID)
+		err := a.SlackStore.ValidateChannel(ctx, fieldSlackChanID, chanID)
+		if err != nil {
+			return newDestErr(err)
+		}
+
+		return nil
+	case destSlackDM:
+		userID := dest.FieldValue(fieldSlackUserID)
+		err := a.SlackStore.ValidateUser(ctx, fieldSlackUserID, userID)
+		if err != nil {
+			return newDestErr(err)
+		}
+		return nil
+	case destSlackUG:
+		ugID := dest.FieldValue(fieldSlackUGID)
+		chanID := dest.FieldValue(fieldSlackChanID)
+		err := a.SlackStore.ValidateUserGroup(ctx, fieldSlackUGID, ugID)
+		if err != nil {
+			return newDestErr(err)
+		}
+
+		err = a.SlackStore.ValidateChannel(ctx, fieldSlackChanID, chanID)
+		if err != nil {
+			return newDestErr(err)
+		}
+
+		return nil
+	case destSMTP:
+		email := dest.FieldValue(fieldEmailAddress)
+		err := validate.Email(fieldEmailAddress, email)
+		if err != nil {
+			return newDestErr(err)
+		}
+		return nil
+	case destWebhook:
+		url := dest.FieldValue(fieldWebhookURL)
+		err := validate.AbsoluteURL(fieldWebhookURL, url)
+		if err != nil {
+			return newDestErr(err)
+		}
+		if !cfg.ValidWebhookURL(url) {
+			return newDestErr(validation.NewFieldError(fieldWebhookURL, "url is not allowed by administator"))
+		}
+		return nil
+	case destSchedule: // must be valid UUID and exist
+		_, err := validate.ParseUUID(fieldScheduleID, dest.FieldValue(fieldScheduleID))
+		if err != nil {
+			return newDestErr(err)
+		}
+
+		_, err = a.ScheduleStore.FindOne(ctx, dest.FieldValue(fieldScheduleID))
+		if errors.Is(err, sql.ErrNoRows) {
+			return newDestErr(validation.NewFieldError(fieldScheduleID, "schedule does not exist"))
+		}
+
+		return err // return any other error
+	case destRotation: // must be valid UUID and exist
+		rotID := dest.FieldValue(fieldRotationID)
+		_, err := validate.ParseUUID(fieldRotationID, rotID)
+		if err != nil {
+			return newDestErr(err)
+		}
+		_, err = a.RotationStore.FindRotation(ctx, rotID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return newDestErr(validation.NewFieldError(fieldRotationID, "rotation does not exist"))
+		}
+
+		return err // return any other error
+
+	case destUser: // must be valid UUID and exist
+		userID := dest.FieldValue(fieldUserID)
+		uid, err := validate.ParseUUID(fieldUserID, userID)
+		if err != nil {
+			return newDestErr(err)
+		}
+		check, err := a.UserStore.UserExists(ctx)
+		if err != nil {
+			return fmt.Errorf("get user existance checker: %w", err)
+		}
+		if !check.UserExistsUUID(uid) {
+			return newDestErr(validation.NewFieldError(fieldUserID, "user does not exist"))
+		}
+		return nil
+	}
+
+	return fmt.Errorf("unsupported destination type: %s", dest.Type)
+}

--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -135,7 +135,7 @@ func mapError(ctx context.Context, err error) error {
 	return err
 }
 
-func (s *ChannelSender) ValidateChannel(ctx context.Context, fieldID, id string) error {
+func (s *ChannelSender) ValidateChannel(ctx context.Context, id string) error {
 	err := permission.LimitCheckAny(ctx, permission.User, permission.System)
 	if err != nil {
 		return err
@@ -148,7 +148,7 @@ func (s *ChannelSender) ValidateChannel(ctx context.Context, fieldID, id string)
 		res, err = s.loadChannel(ctx, id)
 		if err != nil {
 			if rootMsg(err) == "channel_not_found" {
-				return validation.NewFieldError(fieldID, "Channel does not exist, is private (need to invite goalert bot).")
+				return validation.NewGenericError("Channel does not exist, is private (need to invite goalert bot).")
 			}
 
 			return err
@@ -157,7 +157,7 @@ func (s *ChannelSender) ValidateChannel(ctx context.Context, fieldID, id string)
 	}
 
 	if res.IsArchived {
-		return validation.NewFieldError(fieldID, "Channel is archived.")
+		return validation.NewGenericError("Channel is archived.")
 	}
 
 	return nil

--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -75,6 +75,8 @@ type Channel struct {
 	ID     string
 	Name   string
 	TeamID string
+
+	IsArchived bool
 }
 
 // User contains information about a Slack user.
@@ -131,6 +133,34 @@ func mapError(ctx context.Context, err error) error {
 	}
 
 	return err
+}
+
+func (s *ChannelSender) ValidateChannel(ctx context.Context, fieldID, id string) error {
+	err := permission.LimitCheckAny(ctx, permission.User, permission.System)
+	if err != nil {
+		return err
+	}
+
+	s.chanMx.Lock()
+	defer s.chanMx.Unlock()
+	res, ok := s.chanCache.Get(id)
+	if !ok {
+		res, err = s.loadChannel(ctx, id)
+		if err != nil {
+			if rootMsg(err) == "channel_not_found" {
+				return validation.NewFieldError(fieldID, "Channel does not exist, is private (need to invite goalert bot).")
+			}
+
+			return err
+		}
+		s.chanCache.Add(id, res)
+	}
+
+	if res.IsArchived {
+		return validation.NewFieldError(fieldID, "Channel is archived.")
+	}
+
+	return nil
 }
 
 // Channel will lookup a single Slack channel for the bot.
@@ -232,6 +262,7 @@ func (s *ChannelSender) loadChannel(ctx context.Context, channelID string) (*Cha
 
 		ch.ID = resp.ID
 		ch.Name = "#" + resp.Name
+		ch.IsArchived = resp.IsArchived
 
 		return nil
 	})

--- a/notification/slack/user.go
+++ b/notification/slack/user.go
@@ -9,7 +9,7 @@ import (
 	"github.com/target/goalert/validation"
 )
 
-func (s *ChannelSender) ValidateUser(ctx context.Context, fieldID, id string) error {
+func (s *ChannelSender) ValidateUser(ctx context.Context, id string) error {
 	err := permission.LimitCheckAny(ctx, permission.User, permission.System)
 	if err != nil {
 		return err
@@ -17,7 +17,7 @@ func (s *ChannelSender) ValidateUser(ctx context.Context, fieldID, id string) er
 
 	_, err = s.User(ctx, id)
 	if rootMsg(err) == "user_not_found" {
-		return validation.NewFieldError(fieldID, "user not found")
+		return validation.NewGenericError("user not found")
 	}
 	if err != nil {
 		return fmt.Errorf("validate user: %w", err)

--- a/notification/slack/user.go
+++ b/notification/slack/user.go
@@ -6,7 +6,25 @@ import (
 
 	"github.com/slack-go/slack"
 	"github.com/target/goalert/permission"
+	"github.com/target/goalert/validation"
 )
+
+func (s *ChannelSender) ValidateUser(ctx context.Context, fieldID, id string) error {
+	err := permission.LimitCheckAny(ctx, permission.User, permission.System)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.User(ctx, id)
+	if rootMsg(err) == "user_not_found" {
+		return validation.NewFieldError(fieldID, "user not found")
+	}
+	if err != nil {
+		return fmt.Errorf("validate user: %w", err)
+	}
+
+	return nil
+}
 
 // User will lookup a single Slack user.
 func (s *ChannelSender) User(ctx context.Context, id string) (*User, error) {

--- a/notification/slack/usergroup.go
+++ b/notification/slack/usergroup.go
@@ -16,14 +16,14 @@ type UserGroup struct {
 	Handle string
 }
 
-func (s *ChannelSender) ValidateUserGroup(ctx context.Context, fieldID, id string) error {
+func (s *ChannelSender) ValidateUserGroup(ctx context.Context, id string) error {
 	ug, err := s._UserGroup(ctx, id)
 	if err != nil {
 		return err
 	}
 
 	if ug == nil {
-		return validation.NewFieldError(fieldID, "user group not found")
+		return validation.NewGenericError("user group not found")
 	}
 
 	return nil

--- a/notification/slack/usergroup.go
+++ b/notification/slack/usergroup.go
@@ -16,8 +16,34 @@ type UserGroup struct {
 	Handle string
 }
 
+func (s *ChannelSender) ValidateUserGroup(ctx context.Context, fieldID, id string) error {
+	ug, err := s._UserGroup(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if ug == nil {
+		return validation.NewFieldError(fieldID, "user group not found")
+	}
+
+	return nil
+}
+
 // User will lookup a single Slack user group.
 func (s *ChannelSender) UserGroup(ctx context.Context, id string) (*UserGroup, error) {
+	ug, err := s._UserGroup(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if ug == nil {
+		return nil, validation.NewGenericError("invalid user group id")
+	}
+
+	return ug, nil
+}
+
+// User will lookup a single Slack user group.
+func (s *ChannelSender) _UserGroup(ctx context.Context, id string) (*UserGroup, error) {
 	err := permission.LimitCheckAny(ctx, permission.User, permission.System)
 	if err != nil {
 		return nil, err

--- a/web/src/app/users/UserContactMethodFormDest.tsx
+++ b/web/src/app/users/UserContactMethodFormDest.tsx
@@ -18,7 +18,7 @@ export type Value = {
 export type UserContactMethodFormProps = {
   value: Value
 
-  errors?: Array<{ fieldID: string; message: string }>
+  errors?: Array<FieldError>
 
   disabled?: boolean
   edit?: boolean

--- a/web/src/app/users/UserContactMethodFormDest.tsx
+++ b/web/src/app/users/UserContactMethodFormDest.tsx
@@ -18,7 +18,7 @@ export type Value = {
 export type UserContactMethodFormProps = {
   value: Value
 
-  errors?: Array<FieldError>
+  errors?: Array<{ fieldID: string; message: string }>
 
   disabled?: boolean
   edit?: boolean


### PR DESCRIPTION
**Which issue(s) this PR fixes:**
This PR adds a normalized output to destination validation errors (currently only called from contact method input `dest` field).

- `extensions.code` will be one of: `INVALID_DESTINATION_TYPE` or `INVALID_DESTINATION_FIELD_VALUE`
- The `.path` property of errors will reflect the actual input field (and fieldID) that failed validation

**Out of Scope:**
Since no code currently uses this, tests will be added with the user contact method dialog PR(s).

**Describe any introduced user-facing changes:**
N/A

**Describe any introduced API changes:**
- Destination validation errors are now well-defined.

**Additional Info:**
Existing field errors are unaffected.
