### PR TITLE
github: labeler: enable fail_if_xl flag

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.draft == false
     name: Label the PR size
     steps:
-      - uses: codelytv/pr-size-labeler@54c3c1d94030222b5d7c46fe61ce7c83e6a51941
+      - uses: mastercactapus/pr-size-labeler@ae42264 # https://github.com/CodelyTV/pr-size-labeler/pull/61, updated with latest from main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: 'size/xs'
@@ -22,7 +22,7 @@ jobs:
           l_label: 'size/l'
           l_max_size: '500'
           xl_label: 'size/xl'
-          fail_if_xl: 'false'
+          fail_if_xl: 'true'
           message_if_xl: >
             This PR exceeds the recommended size of 500 lines.
             Please make sure you are NOT addressing multiple issues with one PR.

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.draft == false
     name: Label the PR size
     steps:
-      - uses: mastercactapus/pr-size-labeler@ae42264 # https://github.com/CodelyTV/pr-size-labeler/pull/61, updated with latest from main
+      - uses: mastercactapus/pr-size-labeler@ae422642f90ec42483651789f5501c149683f93d # https://github.com/CodelyTV/pr-size-labeler/pull/61, updated with latest from main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: 'size/xs'


### PR DESCRIPTION
**Description:**
Experiment to enable the `fail_if_xl` flag on the PR labeler (rejects PRs >500 lines)

- Updated to a version of the labeler that will ignore deleted files from line count calculation.
