### PR TITLE
fix: alert detail markdown link bug

### DIFF
--- a/web/src/app/util/safeURL.test.ts
+++ b/web/src/app/util/safeURL.test.ts
@@ -76,4 +76,13 @@ describe('safeURL', () => {
       '[0987654321](tel:1234567890)',
     ],
   })
+
+  checkIt('should work with query params', {
+    true: [
+      '[https://example.com/query?foo=1&bar=2](https://example.com/query?foo=1&amp;bar=2)',
+    ],
+    false: [
+      '[https://example.com/query?foo=1&bar=2](https://example.com/query?foo=1&bar=2]',
+    ],
+  })
 })

--- a/web/src/app/util/safeURL.ts
+++ b/web/src/app/util/safeURL.ts
@@ -1,7 +1,23 @@
+// decodeHtmlEntites will decode common HTML entities in a string.
+//
+// This is useful for ensuring that any encoded characters in the text are converted
+// back to their original form for comparision.
+function decodeHtmlEntites(text: string): string {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+}
+
 // safeURL will determine if a url is safe for linking.
 //
 // It tries to determine if the label is misleading.
 export function safeURL(url: string, label: string): boolean {
+  url = decodeHtmlEntites(url)
+  label = decodeHtmlEntites(label)
+
   if (url.startsWith('mailto:')) {
     const email = url.substr(7)
     return email === label && email.includes('@')
@@ -14,7 +30,7 @@ export function safeURL(url: string, label: string): boolean {
 
   // handle http protocols
   if (!/https?:\/\//.test(url)) return false // require absolute URLs
-  if (!/[./]/.test(label)) return true // don't consider it a path/url without slashes or periods
+  if (!/[./]/.test(url)) return true // don't consider it a path/url without slashes or periods
   if (url.startsWith(label)) return true // if it matches the beginning, then it's fine
   if (url.replace(/^https?:\/\//, '').startsWith(label)) return true // same prefix without protocol
   if (url.replace(/^https?:\/\//, '').startsWith('www.' + label)) return true // same prefix without protocol

--- a/web/src/app/util/safeURL.ts
+++ b/web/src/app/util/safeURL.ts
@@ -1,22 +1,21 @@
-// decodeHtmlEntites will decode common HTML entities in a string.
+// encodeHtmlEntities will encode common HTML entities in a string.
 //
-// This is useful for ensuring that any encoded characters in the text are converted
-// back to their original form for comparision.
-function decodeHtmlEntites(text: string): string {
+// This is useful for ensuring that comparisons between html encoded urls and
+// non-encoded labels are accurate
+function encodeHtmlEntities(text: string): string {
   return text
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
 }
 
 // safeURL will determine if a url is safe for linking.
 //
 // It tries to determine if the label is misleading.
 export function safeURL(url: string, label: string): boolean {
-  url = decodeHtmlEntites(url)
-  label = decodeHtmlEntites(label)
+  label = encodeHtmlEntities(label)
 
   if (url.startsWith('mailto:')) {
     const email = url.substr(7)

--- a/web/src/app/util/safeURL.ts
+++ b/web/src/app/util/safeURL.ts
@@ -30,7 +30,7 @@ export function safeURL(url: string, label: string): boolean {
 
   // handle http protocols
   if (!/https?:\/\//.test(url)) return false // require absolute URLs
-  if (!/[./]/.test(url)) return true // don't consider it a path/url without slashes or periods
+  if (!/[./]/.test(label)) return true // don't consider it a path/url without slashes or periods
   if (url.startsWith(label)) return true // if it matches the beginning, then it's fine
   if (url.replace(/^https?:\/\//, '').startsWith(label)) return true // same prefix without protocol
   if (url.replace(/^https?:\/\//, '').startsWith('www.' + label)) return true // same prefix without protocol


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
User indicated that hyperlinks which should be rendered correctly via markdown were displayed as text. The issues seems to be that the `<ReactMarkdown>` component checks for safeUrls with url and label where url is rendered with html entities causing special characters such as `&` to be converted to `&amp;`. This messes with the accuracy of safeUrls regex checks resulting in false negatives thus causing ReactMarkdown to display the hyperlinks as plain text. 

Adding preprocessing in the form of `encodeHtmlEntities()` ensures that the label/url comparisons are free of discrepancies caused by html entity conversions. 

**Which issue(s) this PR fixes:**
[For significant amounts of work, it is best to start an issue first, preferably before the work is started.
For large pull requests, be sure to reference the associated GitHub issue(s).]
https://github.com/target/goalert/issues/3628

**Describe any introduced user-facing changes:**
Markdowns should properly render hyperlinks where the url and label match
