### PR TITLE
dest: fix error handling for user contact method form

### DIFF
--- a/graphql2/graphqlapp/contactmethod.go
+++ b/graphql2/graphqlapp/contactmethod.go
@@ -139,7 +139,7 @@ func (m *Mutation) CreateUserContactMethod(ctx context.Context, input graphql2.C
 	cfg := config.FromContext(ctx)
 
 	if input.Dest != nil {
-		if ok, err := (*App)(m).ValidateDestination(ctx, "dest", input.Dest); !ok {
+		if ok, err := (*App)(m).ValidateDestination(ctx, "input.dest", input.Dest); !ok {
 			return nil, err
 		}
 		t, v := CompatDestToCMTypeVal(*input.Dest)

--- a/notification/slack/user.go
+++ b/notification/slack/user.go
@@ -17,7 +17,7 @@ func (s *ChannelSender) ValidateUser(ctx context.Context, id string) error {
 
 	_, err = s.User(ctx, id)
 	if rootMsg(err) == "user_not_found" {
-		return validation.NewGenericError("user not found")
+		return validation.NewGenericError("User not found.")
 	}
 	if err != nil {
 		return fmt.Errorf("validate user: %w", err)

--- a/web/src/app/forms/FormField.jsx
+++ b/web/src/app/forms/FormField.jsx
@@ -287,6 +287,8 @@ FormField.propTypes = {
 
   multiple: p.bool,
 
+  destFieldErrors: p.array,
+
   destType: p.string,
   options: p.arrayOf(
     p.shape({

--- a/web/src/app/selection/DestinationField.tsx
+++ b/web/src/app/selection/DestinationField.tsx
@@ -4,6 +4,7 @@ import DestinationInputDirect from './DestinationInputDirect'
 import { useDestinationType } from '../util/RequireConfig'
 import DestinationSearchSelect from './DestinationSearchSelect'
 import { Grid } from '@mui/material'
+import { InputFieldError } from '../util/errutil'
 
 export type DestinationFieldProps = {
   value: FieldValueInput[]
@@ -12,12 +13,12 @@ export type DestinationFieldProps = {
 
   disabled?: boolean
 
-  destFieldErrors?: DestFieldError[]
+  destFieldErrors?: InputFieldError[]
 }
 
-export interface DestFieldError {
-  fieldID: string
-  message: string
+function capFirstLetter(s: string): string {
+  if (s.length === 0) return s
+  return s.charAt(0).toUpperCase() + s.slice(1)
 }
 
 export default function DestinationField(
@@ -45,9 +46,15 @@ export default function DestinationField(
           props.onChange(newValues)
         }
 
-        const fieldErrMsg =
-          props.destFieldErrors?.find((err) => err.fieldID === field.fieldID)
-            ?.message || ''
+        // getFieldID returns the last segment of the path.
+        const getFieldID = (err: InputFieldError): string =>
+          err.path.split('.').pop() || ''
+
+        const fieldErrMsg = capFirstLetter(
+          props.destFieldErrors?.find(
+            (err) => getFieldID(err) === field.fieldID,
+          )?.message || '',
+        )
 
         if (field.isSearchSelectable)
           return (

--- a/web/src/app/users/UserContactMethodFormDest.stories.tsx
+++ b/web/src/app/users/UserContactMethodFormDest.stories.tsx
@@ -110,13 +110,10 @@ export const ErrorSingleField: Story = {
       statusUpdates: false,
     },
     disabled: false,
-    errors: [
+    fieldErrors: [
       {
-        field: 'name',
-        message: 'must begin with a letter',
-        name: 'FieldError',
-        path: [],
-        details: {},
+        message: 'number is too short', // note: the 'n' is lowercase
+        path: 'dest.values.phone-number',
       },
     ],
   },
@@ -125,9 +122,7 @@ export const ErrorSingleField: Story = {
     await userEvent.type(await canvas.findByLabelText('Phone Number'), '123')
 
     // ensure errors are shown
-    await expect(
-      await canvas.findByText('Must begin with a letter'),
-    ).toBeVisible()
+    await expect(await canvas.findByText('Number is too short')).toBeVisible() // note: the 'N' is capitalized
     await waitFor(async function CloseIcon() {
       await expect(await canvas.findByTestId('CloseIcon')).toBeVisible()
     })
@@ -158,13 +153,10 @@ export const ErrorMultiField: Story = {
       statusUpdates: false,
     },
     disabled: false,
-    errors: [
+    fieldErrors: [
       {
-        field: 'name',
+        path: 'name',
         message: 'must begin with a letter',
-        name: 'FieldError',
-        path: [],
-        details: {},
       },
     ],
   },

--- a/web/src/app/users/UserContactMethodFormDest.tsx
+++ b/web/src/app/users/UserContactMethodFormDest.tsx
@@ -47,20 +47,28 @@ export default function UserContactMethodFormDest(
     statusUpdateChecked = false
   }
 
+  const formErrors = []
+  if (props.typeError) {
+    formErrors.push({
+      // the old form code requires this shape to map errors to the correct field
+      message: props.typeError.message,
+      field: 'dest.type',
+    })
+  }
+  const nameErr = props.fieldErrors?.find(
+    (err) => err.path.split('.').pop() === 'name',
+  )
+  if (nameErr) {
+    formErrors.push({
+      message: nameErr.message,
+      field: 'name',
+    })
+  }
+
   return (
     <FormContainer
       {...other}
-      errors={
-        props.typeError
-          ? [
-              {
-                // the old form code requires this shape to map errors to the correct field
-                message: props.typeError.message,
-                field: 'dest.type',
-              },
-            ]
-          : []
-      }
+      errors={formErrors}
       value={value}
       mapOnChangeValue={(newValue: Value): Value => {
         if (newValue.dest.type === value.dest.type) {

--- a/web/src/app/users/UserContactMethodFormDest.tsx
+++ b/web/src/app/users/UserContactMethodFormDest.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { DestinationInput } from '../../schema'
 import { FormContainer, FormField } from '../forms'
 import { renderMenuItem } from '../selection/DisableableMenuItem'
-import { FieldError } from '../util/errutil'
+import { InputFieldError, SimpleError } from '../util/errutil'
 import DestinationField from '../selection/DestinationField'
 import { useContactMethodTypes } from '../util/RequireConfig'
 
@@ -18,7 +18,8 @@ export type Value = {
 export type UserContactMethodFormProps = {
   value: Value
 
-  errors?: Array<FieldError>
+  typeError?: SimpleError
+  fieldErrors?: Array<InputFieldError>
 
   disabled?: boolean
   edit?: boolean
@@ -49,6 +50,17 @@ export default function UserContactMethodFormDest(
   return (
     <FormContainer
       {...other}
+      errors={
+        props.typeError
+          ? [
+              {
+                // the old form code requires this shape to map errors to the correct field
+                message: props.typeError.message,
+                field: 'dest.type',
+              },
+            ]
+          : []
+      }
       value={value}
       mapOnChangeValue={(newValue: Value): Value => {
         if (newValue.dest.type === value.dest.type) {
@@ -74,6 +86,7 @@ export default function UserContactMethodFormDest(
           <FormField
             fullWidth
             name='dest.type'
+            label='Destination Type'
             required
             select
             disabled={edit}
@@ -98,6 +111,7 @@ export default function UserContactMethodFormDest(
             destType={value.dest.type}
             component={DestinationField}
             disabled={edit}
+            destFieldErrors={props.fieldErrors}
           />
         </Grid>
         <Grid item xs={12}>

--- a/web/src/app/util/errutil.test.ts
+++ b/web/src/app/util/errutil.test.ts
@@ -1,0 +1,37 @@
+import { GraphQLError } from 'graphql'
+import { getInputFieldErrors } from './errutil'
+
+describe('getInputFieldErrors', () => {
+  it('should split errors by path', () => {
+    const resp = [
+      {
+        message: 'test1',
+        path: ['foo', 'bar', 'dest', 'type'],
+        extensions: {
+          code: 'INVALID_DESTINATION_TYPE',
+        },
+      },
+      {
+        message: 'test2',
+        path: ['foo', 'bar', 'dest', 'values', 'example-field'],
+        extensions: {
+          code: 'INVALID_DESTINATION_FIELD_VALUE',
+        },
+      },
+    ] as unknown as GraphQLError[]
+
+    const [inputFieldErrors, otherErrors] = getInputFieldErrors(
+      ['foo.bar.dest.type', 'foo.bar.dest.values.example-field'],
+      resp,
+    )
+
+    expect(inputFieldErrors).toHaveLength(2)
+    expect(inputFieldErrors[0].message).toEqual('test1')
+    expect(inputFieldErrors[0].path).toEqual('foo.bar.dest.type')
+    expect(inputFieldErrors[1].message).toEqual('test2')
+    expect(inputFieldErrors[1].path).toEqual(
+      'foo.bar.dest.values.example-field',
+    )
+    expect(otherErrors).toHaveLength(0)
+  })
+})

--- a/web/src/errors.d.ts
+++ b/web/src/errors.d.ts
@@ -1,0 +1,27 @@
+/**
+ * INVALID_DESTINATION_TYPE is returned when the selected destination type is not valid, or is not allowed.
+ */
+export const INVALID_DESTINATION_TYPE = 'INVALID_DESTINATION_TYPE'
+
+/**
+ * INVALID_DESTINATION_FIELD_VALUE is returned when the value of a field on a destination is invalid.
+ */
+export const INVALID_DESTINATION_FIELD_VALUE = 'INVALID_DESTINATION_FIELD_VALUE'
+
+type KnownErrorCode = INVALID_DESTINATION_TYPE | INVALID_DESTINATION_FIELD_VALUE
+
+export type InvalidDestTypeError = {
+  message: string
+  path: readonly (string | number)[]
+  extensions: {
+    code: INVALID_DESTINATION_TYPE
+  }
+}
+
+export type InvalidFieldValueError = {
+  message: string
+  path: readonly (string | number)[]
+  extensions: {
+    code: INVALID_DESTINATION_FIELD_VALUE
+  }
+}


### PR DESCRIPTION
**Description:**
This PR makes changes to return coded errors for destination inputs that include a valid path and a known value for the `code` field in the return value. From the UI this allows mapping a validation error with a DestinationInput to the appropriate field.

**Which issue(s) this PR fixes:**
Part of #2639 
Prereq. for #3664 
