### PR TITLE
Pprof endpoint

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,7 +1,7 @@
 build: while true; do make -qs bin/goalert || make bin/goalert || (echo '\033[0;31mBuild Failure'; sleep 3); sleep 0.1; done
 
 @watch-file=./bin/goalert
-goalert: ./bin/goalert -l=localhost:3030 --ui-dir=web/src/build --db-url=postgres://goalert@localhost --listen-sysapi=localhost:1234 --listen-prometheus=localhost:2112 --smtp-listen=localhost:9025 --email-integration-domain=localhost
+goalert: ./bin/goalert -l=localhost:3030 --ui-dir=web/src/build --db-url=postgres://goalert@localhost --listen-sysapi=localhost:1234 --listen-prometheus=localhost:2112 --smtp-listen=localhost:9025 --email-integration-domain=localhost --listen-pprof=localhost:6060 --pprof-mutex-profile-fraction=1 --pprof-block-profile-rate=1000
 
 smtp: go run github.com/mailhog/MailHog -ui-bind-addr=localhost:8025 -api-bind-addr=localhost:8025 -smtp-bind-addr=localhost:1025 | grep -v KEEPALIVE
 prom: bin/tools/prometheus --log.level=warn --config.file=devtools/prometheus/prometheus.yml --storage.tsdb.path=bin/prom-data/ --web.listen-address=localhost:9090

--- a/Procfile.prod
+++ b/Procfile.prod
@@ -1,7 +1,7 @@
 build: while true; do make -qs bin/goalert BUNDLE=1 || make bin/goalert BUNDLE=1 || (echo '\033[0;31mBuild Failure'; sleep 3); sleep 0.1; done
 
 @watch-file=./bin/goalert
-goalert: ./bin/goalert -l=localhost:3030 --db-url=postgres://goalert@localhost --listen-sysapi=localhost:1234 --listen-prometheus=localhost:2112
+goalert: ./bin/goalert -l=localhost:3030 --db-url=postgres://goalert@localhost --listen-sysapi=localhost:1234 --listen-prometheus=localhost:2112 --listen-pprof=localhost:6060 --pprof-mutex-profile-fraction=1 --pprof-block-profile-rate=1000
 
 smtp: go run github.com/mailhog/MailHog -ui-bind-addr=localhost:8025 -api-bind-addr=localhost:8025 -smtp-bind-addr=localhost:1025 | grep -v KEEPALIVE
 prom: bin/tools/prometheus --log.level=warn --config.file=devtools/prometheus/prometheus.yml --storage.tsdb.path=bin/prom-data/ --web.listen-address=localhost:9090

--- a/app/cmd.go
+++ b/app/cmd.go
@@ -743,6 +743,8 @@ func init() {
 
 	RootCmd.PersistentFlags().StringP("listen-prometheus", "p", "", "Bind address for Prometheus metrics.")
 	RootCmd.PersistentFlags().String("listen-pprof", "", "Bind address for pprof.")
+	RootCmd.PersistentFlags().Int("pprof-block-profile-rate", 0, "Set the block profile rate in hz.")
+	RootCmd.PersistentFlags().Int("pprof-mutex-profile-fraction", 0, "Set the mutex profile fraction (rate is 1/this-value).")
 
 	RootCmd.Flags().String("tls-cert-file", "", "Specifies a path to a PEM-encoded certificate.  Has no effect if --listen-tls is unset.")
 	RootCmd.Flags().String("tls-key-file", "", "Specifies a path to a PEM-encoded private key file.  Has no effect if --listen-tls is unset.")

--- a/app/cmd.go
+++ b/app/cmd.go
@@ -97,8 +97,12 @@ Available Flags:
 		if err != nil {
 			return err
 		}
-		ctx := cmd.Context()
+		err = initPprofServer()
+		if err != nil {
+			return err
+		}
 
+		ctx := cmd.Context()
 		cfg, err := getConfig(ctx)
 		if err != nil {
 			return err
@@ -370,6 +374,11 @@ Migration: %s (#%d)
 			}
 
 			err = initPromServer()
+			if err != nil {
+				return err
+			}
+
+			err = initPprofServer()
 			if err != nil {
 				return err
 			}
@@ -733,6 +742,7 @@ func init() {
 	RootCmd.Flags().String("public-url", "", "Externally routable URL to the application. Used for validating callback requests, links, auth, and prefix calculation.")
 
 	RootCmd.PersistentFlags().StringP("listen-prometheus", "p", "", "Bind address for Prometheus metrics.")
+	RootCmd.PersistentFlags().String("listen-pprof", "", "Bind address for pprof.")
 
 	RootCmd.Flags().String("tls-cert-file", "", "Specifies a path to a PEM-encoded certificate.  Has no effect if --listen-tls is unset.")
 	RootCmd.Flags().String("tls-key-file", "", "Specifies a path to a PEM-encoded private key file.  Has no effect if --listen-tls is unset.")

--- a/app/pprof.go
+++ b/app/pprof.go
@@ -1,0 +1,36 @@
+package app
+
+import (
+	"net"
+	"net/http"
+	"net/http/pprof"
+
+	"github.com/spf13/viper"
+)
+
+func initPprofServer() error {
+	addr := viper.GetString("listen-pprof")
+	if addr == "" {
+		return nil
+	}
+
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+
+	mux := http.NewServeMux()
+
+	// Register pprof handlers (matches init() of net/http/pprof package)
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	srv := http.Server{
+		Handler: mux,
+	}
+	go func() { _ = srv.Serve(l) }()
+	return nil
+}

--- a/app/pprof.go
+++ b/app/pprof.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
+	"runtime"
 
 	"github.com/spf13/viper"
 )
@@ -27,6 +28,9 @@ func initPprofServer() error {
 	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	runtime.SetBlockProfileRate(viper.GetInt("pprof-block-profile-rate"))
+	runtime.SetMutexProfileFraction(viper.GetInt("pprof-mutex-profile-fraction"))
 
 	srv := http.Server{
 		Handler: mux,

--- a/web/src/app/localdev/LocalDev.tsx
+++ b/web/src/app/localdev/LocalDev.tsx
@@ -102,6 +102,11 @@ export default function LocalDev(): JSX.Element {
             'OIDC.UserInfoNamePath': 'preferred_username',
           }}
         />
+        <DevTool
+          name='pprof'
+          desc='Debug and profile the running server.'
+          url='http://localhost:6060/debug/pprof/'
+        />
       </Grid>
 
       {updateConfig && (


### PR DESCRIPTION
**Description:**
This PR adds a `listen-pprof` flag to enable profiling running instances of GoAlert (off by default)

**Which issue(s) this PR fixes:**
Closes #3642 

**Out of Scope:**
- A `default.pgo` can be added to `cmd/goalert/` to enable automatic optimizations, but is not in scope for this PR since the initial profile should come from real production workloads.

**Additional Info:**
- https://go.dev/blog/pprof
- https://go.dev/doc/pgo
