### PR TITLE
dest/graphql: convert comments to description strings

### DIFF
--- a/graphql2/graph/destinations.graphqls
+++ b/graphql2/graph/destinations.graphqls
@@ -1,66 +1,149 @@
 extend type Query {
-  # destinationTypes returns a list of destination types that can be used for
-  # notifications.
-  destinationTypes: [DestinationTypeInfo!]! @experimental(flagName: "dest-types")
-  # destinationFieldValidate validates a destination field value as valid or invalid.
-  #
-  # It does not guarantee that the value is valid for the destination type, only
-  # that it is valid for the field (i.e., syntax/formatting).
-  destinationFieldValidate(input: DestinationFieldValidateInput!): Boolean! @experimental(flagName: "dest-types")
-  destinationFieldSearch(input: DestinationFieldSearchInput!): FieldValueConnection! @experimental(flagName: "dest-types")
-  destinationFieldValueName(input: DestinationFieldValidateInput!): String! @experimental(flagName: "dest-types")
+  """
+  destinationTypes returns a list of destination types that can be used for
+  notifications.
+  """
+  destinationTypes: [DestinationTypeInfo!]!
+    @experimental(flagName: "dest-types")
 
-  # destinationDisplayInfo returns the display information for a destination.
-  destinationDisplayInfo(input: DestinationInput!): DestinationDisplayInfo! @experimental(flagName: "dest-types")
+  """
+  destinationFieldValidate validates a destination field value as valid or invalid.
+
+  It does not guarantee that the value is valid for the destination type, only
+  that it is valid for the field (i.e., syntax/formatting).
+  """
+  destinationFieldValidate(input: DestinationFieldValidateInput!): Boolean!
+    @experimental(flagName: "dest-types")
+  destinationFieldSearch(
+    input: DestinationFieldSearchInput!
+  ): FieldValueConnection! @experimental(flagName: "dest-types")
+  destinationFieldValueName(input: DestinationFieldValidateInput!): String!
+    @experimental(flagName: "dest-types")
+
+  """
+  destinationDisplayInfo returns the display information for a destination.
+  """
+  destinationDisplayInfo(input: DestinationInput!): DestinationDisplayInfo!
+    @experimental(flagName: "dest-types")
 }
 
-# FieldValueConnection is a connection to a list of FieldValuePairs.
+"""
+FieldValueConnection is a connection to a list of FieldValuePairs.
+"""
 type FieldValueConnection {
   nodes: [FieldValuePair!]!
   pageInfo: PageInfo!
 }
 
 input DestinationFieldValidateInput {
-  destType: DestinationType! # the type of destination to validate
-  fieldID: ID! # the ID of the input field to validate
-  value: String! # the value to validate
+  """
+  the type of destination to validate
+  """
+  destType: DestinationType!
+
+  """
+  the ID of the input field to validate
+  """
+  fieldID: ID!
+
+  """
+  the value to validate
+  """
+  value: String!
 }
 
-# DestinationType represents a type of destination that can be used for
-# notifications.
+"""
+DestinationType represents a type of destination that can be used for
+notifications.
+"""
 scalar DestinationType
 
 input DestinationFieldSearchInput {
-  destType: DestinationType! # the type of destination to search for
-  fieldID: ID! # the ID of the input field to search for
-  search: String # search string to match against
-  omit: [String!] # values/ids to omit from results
-  after: String # cursor to start search from
-  first: Int = 15 # number of results to return
+  """
+  the type of destination to search for
+  """
+  destType: DestinationType!
+
+  """
+  the ID of the input field to search for
+  """
+  fieldID: ID!
+
+  """
+  search string to match against
+  """
+  search: String
+
+  """
+  values/ids to omit from results
+  """
+  omit: [String!]
+
+  """
+  cursor to start search from
+  """
+  after: String
+
+  """
+  number of results to return
+  """
+  first: Int = 15
 }
 
-# Destination represents a destination that can be used for notifications.
+"""
+Destination represents a destination that can be used for notifications.
+"""
 type Destination {
   type: DestinationType!
   values: [FieldValuePair!]!
-  displayInfo: DestinationDisplayInfo!  @goField(forceResolver: true)
+  displayInfo: DestinationDisplayInfo! @goField(forceResolver: true)
 }
 
-# DestinationDisplayInfo provides information for displaying a destination.
+"""
+DestinationDisplayInfo provides information for displaying a destination.
+"""
 type DestinationDisplayInfo {
-  text: String! # user-friendly text to display for this destination
-  iconURL: String! # URL to an icon to display for this destination
-  iconAltText: String! # alt text for the icon
-  linkURL: String! # URL to link to for more information about this destination
+  """
+  user-friendly text to display for this destination
+  """
+  text: String!
+
+  """
+  URL to an icon to display for this destination
+  """
+  iconURL: String!
+
+  """
+  alt text for the icon
+  """
+  iconAltText: String!
+
+  """
+  URL to link to for more information about this destination
+  """
+  linkURL: String!
 }
 
 type FieldValuePair {
-  fieldID: ID! # The ID of the input field that this value is for.
+  """
+  The ID of the input field that this value is for.
+  """
+  fieldID: ID!
 
-  value: String! # The value of the input field.
-  label: String! @goField(forceResolver: true) # The user-friendly text for this value of the input field (e.g., if the value is a user ID, label would be the user's name).
+  """
+  The value of the input field.
+  """
+  value: String!
 
-  isFavorite: Boolean! # if true, this value is a favorite for the user, only set for search results
+  """
+  The user-friendly text for this value of the input field.
+  """
+  label: String! @goField(forceResolver: true)
+
+  """
+  if true, this value is a favorite for the user, only set for search results
+  """
+  isFavorite: Boolean!
 }
 
 input DestinationInput {
@@ -69,7 +152,10 @@ input DestinationInput {
 }
 
 input FieldValueInput {
-  fieldID: ID! # The ID of the input field that this value is for.
+  """
+  The ID of the input field that this value is for.
+  """
+  fieldID: ID!
   value: String!
 }
 
@@ -78,38 +164,102 @@ type DestinationTypeInfo {
 
   name: String!
 
-  iconURL: String! # URL to an icon to display for the destination type
-  iconAltText: String! # alt text for the icon
+  """
+  URL to an icon to display for the destination type
+  """
+  iconURL: String!
 
+  """
+  alt text for the icon, should be usable in place of the icon
+  """
+  iconAltText: String!
   disabledMessage: String!
 
-  enabled: Boolean! # if false, the destination type is disabled and cannot be used
-
+  """
+  if false, the destination type is disabled and cannot be used
+  """
+  enabled: Boolean!
   requiredFields: [DestinationFieldConfig!]!
 
-  userDisclaimer: String! # disclaimer text to display when a user is selecting this destination type for a contact method
+  """
+  disclaimer text to display when a user is selecting this destination type for a contact method
+  """
+  userDisclaimer: String!
 
-  isContactMethod: Boolean! # this destination type can be used as a user contact method
-  isEPTarget: Boolean! # this destination type can be used as an escalation policy step action
-  isSchedOnCallNotify: Boolean! # this destination type can be used for schedule on-call notifications
+  """
+  this destination type can be used as a user contact method
+  """
+  isContactMethod: Boolean!
 
-  supportsStatusUpdates: Boolean! # if true, the destination type supports status updates
-  statusUpdatesRequired: Boolean! # if true, the destination type requires status updates to be enabled
+  """
+  this destination type can be used as an escalation policy step action
+  """
+  isEPTarget: Boolean!
+
+  """
+  this destination type can be used for schedule on-call notifications
+  """
+  isSchedOnCallNotify: Boolean!
+
+  """
+  if true, the destination type supports status updates
+  """
+  supportsStatusUpdates: Boolean!
+
+  """
+  if true, the destination type requires status updates to be enabled
+  """
+  statusUpdatesRequired: Boolean!
 }
 
 type DestinationFieldConfig {
-  fieldID: ID! # unique ID for the input field
+  """
+  unique ID for the input field
+  """
+  fieldID: ID!
 
-  labelSingular: String! # user-friendly label
-  labelPlural: String! # user-friendly plural label
+  """
+  user-friendly label
+  """
+  labelSingular: String!
 
-  hint: String! # user-friendly helper text for input fields (i.e., "Enter a phone number")
-  hintURL: String! # URL to link to for more information about the destination type
-  placeholderText: String! # placeholder text to display in input fields (e.g., "Phone Number")
+  """
+  user-friendly plural label
+  """
+  labelPlural: String!
 
-  prefix: String! # the prefix to use when displaying the destination (e.g., "+" for phone numbers)
-  inputType: String! # the type of input field (type attribute) to use (e.g., "text" or "tel")
+  """
+  user-friendly helper text for input fields (i.e., "Enter a phone number")
+  """
+  hint: String!
 
-  isSearchSelectable: Boolean! # if true, the destination can be selected via search
-  supportsValidation: Boolean! # if true, the destination type supports validation
+  """
+  URL to link to for more information about the destination type
+  """
+  hintURL: String!
+
+  """
+  placeholder text to display in input fields (e.g., "Phone Number")
+  """
+  placeholderText: String!
+
+  """
+  the prefix to use when displaying the destination (e.g., "+" for phone numbers)
+  """
+  prefix: String!
+
+  """
+  the type of input field (type attribute) to use (e.g., "text" or "tel")
+  """
+  inputType: String!
+
+  """
+  if true, the destination can be selected via search
+  """
+  isSearchSelectable: Boolean!
+
+  """
+  if true, the destination type supports validation
+  """
+  supportsValidation: Boolean!
 }

--- a/graphql2/graph/destinations.graphqls
+++ b/graphql2/graph/destinations.graphqls
@@ -136,7 +136,7 @@ type FieldValuePair {
   value: String!
 
   """
-  The user-friendly text for this value of the input field.
+  The user-friendly text for this value of the input field (e.g., if the value is a user ID, label would be the user's name).
   """
   label: String! @goField(forceResolver: true)
 

--- a/graphql2/graph/errorcodes.graphqls
+++ b/graphql2/graph/errorcodes.graphqls
@@ -1,25 +1,22 @@
-
-
 """
 Known error codes that the server can return.
 
 These values will be returned in the `extensions.code` field of the error response.
 """
 enum ErrorCode {
+  """
+  The input value is invalid, the `path` field will contain the exact path to the invalid input.
 
-    """
-    The input value is invalid, the `path` field will contain the exact path to the invalid input.
+  A separate error will be returned for each invalid field.
+  """
+  INVALID_INPUT_VALUE
 
-    A separate error will be returned for each invalid field.
-    """
-    INVALID_INPUT_VALUE
+  """
+  The `path` field contains the exact path to the DestinationInput that is invalid.
 
-    """
-    The `path` field contains the exact path to the DestinationInput that is invalid.
+  The `extensions.fieldID` field contains the ID of the input field that is invalid.
 
-    The `extensions.fieldID` field contains the ID of the input field that is invalid.
-
-    A separate error will be returned for each invalid field.
-    """
-    INVALID_DEST_FIELD_VALUE
+  A separate error will be returned for each invalid field.
+  """
+  INVALID_DEST_FIELD_VALUE
 }

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -294,45 +294,70 @@ type DebugSendSMSInput struct {
 	Body string `json:"body"`
 }
 
+// Destination represents a destination that can be used for notifications.
 type Destination struct {
 	Type        string                  `json:"type"`
 	Values      []FieldValuePair        `json:"values"`
 	DisplayInfo *DestinationDisplayInfo `json:"displayInfo"`
 }
 
+// DestinationDisplayInfo provides information for displaying a destination.
 type DestinationDisplayInfo struct {
-	Text        string `json:"text"`
-	IconURL     string `json:"iconURL"`
+	// user-friendly text to display for this destination
+	Text string `json:"text"`
+	// URL to an icon to display for this destination
+	IconURL string `json:"iconURL"`
+	// alt text for the icon
 	IconAltText string `json:"iconAltText"`
-	LinkURL     string `json:"linkURL"`
+	// URL to link to for more information about this destination
+	LinkURL string `json:"linkURL"`
 }
 
 type DestinationFieldConfig struct {
-	FieldID            string `json:"fieldID"`
-	LabelSingular      string `json:"labelSingular"`
-	LabelPlural        string `json:"labelPlural"`
-	Hint               string `json:"hint"`
-	HintURL            string `json:"hintURL"`
-	PlaceholderText    string `json:"placeholderText"`
-	Prefix             string `json:"prefix"`
-	InputType          string `json:"inputType"`
-	IsSearchSelectable bool   `json:"isSearchSelectable"`
-	SupportsValidation bool   `json:"supportsValidation"`
+	// unique ID for the input field
+	FieldID string `json:"fieldID"`
+	// user-friendly label
+	LabelSingular string `json:"labelSingular"`
+	// user-friendly plural label
+	LabelPlural string `json:"labelPlural"`
+	// user-friendly helper text for input fields (i.e., "Enter a phone number")
+	Hint string `json:"hint"`
+	// URL to link to for more information about the destination type
+	HintURL string `json:"hintURL"`
+	// placeholder text to display in input fields (e.g., "Phone Number")
+	PlaceholderText string `json:"placeholderText"`
+	// the prefix to use when displaying the destination (e.g., "+" for phone numbers)
+	Prefix string `json:"prefix"`
+	// the type of input field (type attribute) to use (e.g., "text" or "tel")
+	InputType string `json:"inputType"`
+	// if true, the destination can be selected via search
+	IsSearchSelectable bool `json:"isSearchSelectable"`
+	// if true, the destination type supports validation
+	SupportsValidation bool `json:"supportsValidation"`
 }
 
 type DestinationFieldSearchInput struct {
-	DestType string   `json:"destType"`
-	FieldID  string   `json:"fieldID"`
-	Search   *string  `json:"search,omitempty"`
-	Omit     []string `json:"omit,omitempty"`
-	After    *string  `json:"after,omitempty"`
-	First    *int     `json:"first,omitempty"`
+	// the type of destination to search for
+	DestType string `json:"destType"`
+	// the ID of the input field to search for
+	FieldID string `json:"fieldID"`
+	// search string to match against
+	Search *string `json:"search,omitempty"`
+	// values/ids to omit from results
+	Omit []string `json:"omit,omitempty"`
+	// cursor to start search from
+	After *string `json:"after,omitempty"`
+	// number of results to return
+	First *int `json:"first,omitempty"`
 }
 
 type DestinationFieldValidateInput struct {
+	// the type of destination to validate
 	DestType string `json:"destType"`
-	FieldID  string `json:"fieldID"`
-	Value    string `json:"value"`
+	// the ID of the input field to validate
+	FieldID string `json:"fieldID"`
+	// the value to validate
+	Value string `json:"value"`
 }
 
 type DestinationInput struct {
@@ -341,19 +366,28 @@ type DestinationInput struct {
 }
 
 type DestinationTypeInfo struct {
-	Type                  string                   `json:"type"`
-	Name                  string                   `json:"name"`
-	IconURL               string                   `json:"iconURL"`
-	IconAltText           string                   `json:"iconAltText"`
-	DisabledMessage       string                   `json:"disabledMessage"`
-	Enabled               bool                     `json:"enabled"`
-	RequiredFields        []DestinationFieldConfig `json:"requiredFields"`
-	UserDisclaimer        string                   `json:"userDisclaimer"`
-	IsContactMethod       bool                     `json:"isContactMethod"`
-	IsEPTarget            bool                     `json:"isEPTarget"`
-	IsSchedOnCallNotify   bool                     `json:"isSchedOnCallNotify"`
-	SupportsStatusUpdates bool                     `json:"supportsStatusUpdates"`
-	StatusUpdatesRequired bool                     `json:"statusUpdatesRequired"`
+	Type string `json:"type"`
+	Name string `json:"name"`
+	// URL to an icon to display for the destination type
+	IconURL string `json:"iconURL"`
+	// alt text for the icon, should be usable in place of the icon
+	IconAltText     string `json:"iconAltText"`
+	DisabledMessage string `json:"disabledMessage"`
+	// if false, the destination type is disabled and cannot be used
+	Enabled        bool                     `json:"enabled"`
+	RequiredFields []DestinationFieldConfig `json:"requiredFields"`
+	// disclaimer text to display when a user is selecting this destination type for a contact method
+	UserDisclaimer string `json:"userDisclaimer"`
+	// this destination type can be used as a user contact method
+	IsContactMethod bool `json:"isContactMethod"`
+	// this destination type can be used as an escalation policy step action
+	IsEPTarget bool `json:"isEPTarget"`
+	// this destination type can be used for schedule on-call notifications
+	IsSchedOnCallNotify bool `json:"isSchedOnCallNotify"`
+	// if true, the destination type supports status updates
+	SupportsStatusUpdates bool `json:"supportsStatusUpdates"`
+	// if true, the destination type requires status updates to be enabled
+	StatusUpdatesRequired bool `json:"statusUpdatesRequired"`
 }
 
 type EscalationPolicyConnection struct {
@@ -370,21 +404,27 @@ type EscalationPolicySearchOptions struct {
 	FavoritesFirst *bool    `json:"favoritesFirst,omitempty"`
 }
 
+// FieldValueConnection is a connection to a list of FieldValuePairs.
 type FieldValueConnection struct {
 	Nodes    []FieldValuePair `json:"nodes"`
 	PageInfo *PageInfo        `json:"pageInfo"`
 }
 
 type FieldValueInput struct {
+	// The ID of the input field that this value is for.
 	FieldID string `json:"fieldID"`
 	Value   string `json:"value"`
 }
 
 type FieldValuePair struct {
-	FieldID    string `json:"fieldID"`
-	Value      string `json:"value"`
-	Label      string `json:"label"`
-	IsFavorite bool   `json:"isFavorite"`
+	// The ID of the input field that this value is for.
+	FieldID string `json:"fieldID"`
+	// The value of the input field.
+	Value string `json:"value"`
+	// The user-friendly text for this value of the input field.
+	Label string `json:"label"`
+	// if true, this value is a favorite for the user, only set for search results
+	IsFavorite bool `json:"isFavorite"`
 }
 
 type GQLAPIKey struct {

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -421,7 +421,7 @@ type FieldValuePair struct {
 	FieldID string `json:"fieldID"`
 	// The value of the input field.
 	Value string `json:"value"`
-	// The user-friendly text for this value of the input field.
+	// The user-friendly text for this value of the input field (e.g., if the value is a user ID, label would be the user's name).
 	Label string `json:"label"`
 	// if true, this value is a favorite for the user, only set for search results
 	IsFavorite bool `json:"isFavorite"`


### PR DESCRIPTION
**Description:**
This PR replaces comments (that were intended for documentation) to description strings which will appear in introspection (i.e., tools like GraphiQL and the built-in explorer)

- Also ran relevant files through prettier for formatting.
- No API changes were introduced.

**Out of Scope**
- Only updates and additions made as part of the destination/plugin work were changed.
