### PR TITLE
dev: fix PR merge conflict

### DIFF
--- a/graphql2/graphqlapp/destinationtypes.go
+++ b/graphql2/graphqlapp/destinationtypes.go
@@ -421,11 +421,10 @@ func (q *Query) DestinationTypes(ctx context.Context) ([]graphql2.DestinationTyp
 			Enabled:    true,
 			IsEPTarget: true,
 			RequiredFields: []graphql2.DestinationFieldConfig{{
-				FieldID:            fieldRotationID,
-				LabelSingular:      "Rotation",
-				LabelPlural:        "Rotations",
-				InputType:          "text",
-				IsSearchSelectable: true,
+				FieldID:        fieldRotationID,
+				Label:          "Rotation",
+				InputType:      "text",
+				SupportsSearch: true,
 			}},
 		},
 		{
@@ -435,11 +434,10 @@ func (q *Query) DestinationTypes(ctx context.Context) ([]graphql2.DestinationTyp
 			IsEPTarget:          true,
 			IsSchedOnCallNotify: true,
 			RequiredFields: []graphql2.DestinationFieldConfig{{
-				FieldID:            fieldScheduleID,
-				LabelSingular:      "Schedule",
-				LabelPlural:        "Schedules",
-				InputType:          "text",
-				IsSearchSelectable: true,
+				FieldID:        fieldScheduleID,
+				Label:          "Schedule",
+				InputType:      "text",
+				SupportsSearch: true,
 			}},
 		},
 		{
@@ -449,11 +447,10 @@ func (q *Query) DestinationTypes(ctx context.Context) ([]graphql2.DestinationTyp
 			IsEPTarget:          true,
 			IsSchedOnCallNotify: true,
 			RequiredFields: []graphql2.DestinationFieldConfig{{
-				FieldID:            fieldUserID,
-				LabelSingular:      "User",
-				LabelPlural:        "Users",
-				InputType:          "text",
-				IsSearchSelectable: true,
+				FieldID:        fieldUserID,
+				Label:          "User",
+				InputType:      "text",
+				SupportsSearch: true,
 			}},
 		},
 	}


### PR DESCRIPTION
**Description:**
2 incompatible PRs were merged at the same time resulting in a broken state.
- #3703 updated some schema fields (valid on its own)
- #3700 added new fields (valid on its own)

The schema normalization one didn't have the new fields, and the new fields PR didn't have the new normalized names. They both passed, but when both were merged, the new fields didn't match the new names.

This PR fixes the issue.
