### PR TITLE
dev: format graphql files with prettier

### DIFF
--- a/graphql2/graph/_Mutation.graphqls
+++ b/graphql2/graph/_Mutation.graphqls
@@ -1,4 +1,3 @@
-
 type Mutation {
   swoAction(action: SWOAction!): Boolean!
   linkAccount(token: ID!): Boolean!

--- a/graphql2/graph/_Query.graphqls
+++ b/graphql2/graph/_Query.graphqls
@@ -1,4 +1,3 @@
-
 type Query {
   phoneNumberInfo(number: String!): PhoneNumberInfo
 

--- a/graphql2/graph/escalationpolicy.graphqls
+++ b/graphql2/graph/escalationpolicy.graphqls
@@ -1,7 +1,7 @@
 extend type EscalationPolicyStep {
-    actions: [Destination!]! @experimental(flagName: "dest-types")
+  actions: [Destination!]! @experimental(flagName: "dest-types")
 }
 
 extend input CreateEscalationPolicyStepInput {
-    actions: [DestinationInput!] @goField(forceResolver: true) # force resolver for initial compat
+  actions: [DestinationInput!] @goField(forceResolver: true) # force resolver for initial compat
 }

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -1,4 +1,3 @@
-
 type IntegrationKeyTypeInfo {
   id: ID!
 
@@ -392,7 +391,6 @@ input CreateAlertInput {
 
 input CloseMatchingAlertInput {
   serviceID: ID! # service ID for the close operation.
-
   # summary (and details) will match an alert with the same values.
   #
   # They can be omitted if the dedup field is provided.
@@ -617,7 +615,11 @@ type Schedule {
   timeZone: String!
 
   assignedTo: [Target!]!
-  shifts(start: ISOTimestamp!, end: ISOTimestamp!, userIDs: [ID!]): [OnCallShift!]!
+  shifts(
+    start: ISOTimestamp!
+    end: ISOTimestamp!
+    userIDs: [ID!]
+  ): [OnCallShift!]!
 
   targets: [ScheduleTarget!]!
   target(input: TargetInput!): ScheduleTarget
@@ -1233,7 +1235,10 @@ input UpdateUserContactMethodInput {
   id: ID!
 
   name: String
-  value: String @deprecated(reason: "Updating value is not supported, delete and create a new contact method instead.")
+  value: String
+    @deprecated(
+      reason: "Updating value is not supported, delete and create a new contact method instead."
+    )
 
   # If true, this contact method will receive status updates.
   #

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "lint": "eslint --ext .js,.jsx,.ts,.tsx --fix . && stylelint --fix ./**/*.css",
-    "fmt": "prettier -l --write '**/*.{js,jsx,yml,yaml,json,css,ts,tsx,html}'",
+    "fmt": "prettier -l --write '**/*.{js,jsx,yml,yaml,json,css,ts,tsx,html,graphql,graphqls}'",
     "check": "tsc -p web/src/app/tsconfig.json && tsc -p web/src/cypress/tsconfig.json",
     "esbuild": "./web/src/esbuild.config.js",
     "esbuild-cy": "./web/src/esbuild.cypress.js",


### PR DESCRIPTION
**Description:**
Updates package.json to include `.graphql` and `.graphqls` files in prettier formatting.

Note: if vscode isn't already auto-formatting:
- ensure you have the `GraphQL` extension installed
- check for an error {} icon on the bottom bar (where you can select vscode-prettier as the formatted if it complains you have multiple)
