### PR TITLE
util/Markdown: fix handling of links with URL-escapable characters

### DIFF
--- a/web/src/app/util/Markdown.stories.tsx
+++ b/web/src/app/util/Markdown.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, within } from '@storybook/test'
+import Markdown from './Markdown'
+import { DateTime } from 'luxon'
+
+const meta = {
+  title: 'util/Markdown',
+  component: Markdown,
+  argTypes: {
+    value: {
+      control: 'textarea',
+    },
+  },
+  decorators: [],
+  tags: ['autodocs'],
+} satisfies Meta<typeof Markdown>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const BasicMarkdown: Story = {
+  args: {
+    value: '# Hello, world!',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // ensure the markdown is rendered as an h1
+    await expect(
+      await canvas.findByRole('heading', { level: 1 }),
+    ).toHaveTextContent('Hello, world!')
+  },
+}
+
+export const Timestamps: Story = {
+  args: {
+    value: 'Timestamps: 2022-01-01T00:00:00Z',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await canvas.findByText('Timestamps:') // wait for render
+
+    const el = canvasElement.querySelector('time')
+
+    await expect(
+      DateTime.fromISO(el?.getAttribute('datetime') || '')
+        .toUTC() // convert to UTC, in case the browser's timezone is different
+        .toISO(),
+    ).toBe('2022-01-01T00:00:00.000Z')
+  },
+}
+
+const validLinkDoc = `
+Valid:
+- [example.com/foo](https://example.com/foo)
+- [example.com](http://example.com)
+- [non-domain-name](https://non-domain.example.com)
+- [queryparam.example.com](http://queryparam.example.com?test=1)
+- [http://exact.example.com/foo?test=1&bar=2](http://exact.example.com/foo?test=1&bar=2)
+`
+
+export const ValidLinks: Story = {
+  args: {
+    value: validLinkDoc,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await canvas.findByText('Valid:') // wait for render
+
+    await expect(await canvas.findByText('example.com/foo')).toHaveAttribute(
+      'href',
+      'https://example.com/foo',
+    )
+    await expect(await canvas.findByText('example.com')).toHaveAttribute(
+      'href',
+      'http://example.com',
+    )
+    await expect(await canvas.findByText('non-domain-name')).toHaveAttribute(
+      'href',
+      'https://non-domain.example.com',
+    )
+    await expect(
+      await canvas.findByText('queryparam.example.com'),
+    ).toHaveAttribute('href', 'http://queryparam.example.com?test=1')
+    await expect(
+      await canvas.findByText('http://exact.example.com/foo?test=1&bar=2'),
+    ).toHaveAttribute('href', 'http://exact.example.com/foo?test=1&bar=2')
+  },
+}
+
+const invalidLinkDoc = `
+Invalid:
+- [example.com/wrongpath](https://example.com/foo)
+- [wrongdomain.example.com](http://example.com)
+- [http://wrongQuery.example.com/foo?test=1&bar=3](http://wrongQuery.example.com/foo?test=1&bar=2)
+`
+
+export const InvalidLinks: Story = {
+  args: {
+    value: invalidLinkDoc,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await canvas.findByText('Invalid:') // wait for render
+
+    expect(canvasElement.querySelectorAll('a')).toHaveLength(0) // no links should be rendered
+  },
+}

--- a/web/src/app/util/Markdown.stories.tsx
+++ b/web/src/app/util/Markdown.stories.tsx
@@ -59,6 +59,9 @@ Valid:
 - [http://exact.example.com/foo?test=1&bar=2](http://exact.example.com/foo?test=1&bar=2)
 - [http://exact2.example.com/foo?test=1&bar=2](http://exact2.example.com/foo?test=1&amp;bar=2)
 - [http://exact3.example.com/foo?test=1&amp;bar=2](http://exact3.example.com/foo?test=1&bar=2)
+- https://plain.example.com
+- <http://bad-slack.example.com | sometext>
+- https://escapable.example.com/foo?test=a|b&bar=2
 `
 
 export const ValidLinks: Story = {
@@ -93,6 +96,22 @@ export const ValidLinks: Story = {
     await expect(
       await canvas.findByText('http://exact3.example.com/foo?test=1&bar=2'),
     ).toHaveAttribute('href', 'http://exact3.example.com/foo?test=1&bar=2')
+    await expect(
+      await canvas.findByText('https://plain.example.com'),
+    ).toHaveAttribute('href', 'https://plain.example.com')
+    await expect(
+      await canvas.findByText('http://bad-slack.example.com'),
+    ).toHaveAttribute('href', 'http://bad-slack.example.com')
+
+    // ensure the pipe character is escaped
+    await expect(
+      await canvas.findByText(
+        'https://escapable.example.com/foo?test=a|b&bar=2',
+      ),
+    ).toHaveAttribute(
+      'href',
+      'https://escapable.example.com/foo?test=a%7Cb&bar=2',
+    )
   },
 }
 

--- a/web/src/app/util/Markdown.stories.tsx
+++ b/web/src/app/util/Markdown.stories.tsx
@@ -57,6 +57,8 @@ Valid:
 - [non-domain-name](https://non-domain.example.com)
 - [queryparam.example.com](http://queryparam.example.com?test=1)
 - [http://exact.example.com/foo?test=1&bar=2](http://exact.example.com/foo?test=1&bar=2)
+- [http://exact2.example.com/foo?test=1&bar=2](http://exact2.example.com/foo?test=1&amp;bar=2)
+- [http://exact3.example.com/foo?test=1&amp;bar=2](http://exact3.example.com/foo?test=1&bar=2)
 `
 
 export const ValidLinks: Story = {
@@ -85,6 +87,12 @@ export const ValidLinks: Story = {
     await expect(
       await canvas.findByText('http://exact.example.com/foo?test=1&bar=2'),
     ).toHaveAttribute('href', 'http://exact.example.com/foo?test=1&bar=2')
+    await expect(
+      await canvas.findByText('http://exact2.example.com/foo?test=1&bar=2'),
+    ).toHaveAttribute('href', 'http://exact2.example.com/foo?test=1&bar=2')
+    await expect(
+      await canvas.findByText('http://exact3.example.com/foo?test=1&bar=2'),
+    ).toHaveAttribute('href', 'http://exact3.example.com/foo?test=1&bar=2')
   },
 }
 

--- a/web/src/app/util/safeURL.test.ts
+++ b/web/src/app/util/safeURL.test.ts
@@ -79,10 +79,12 @@ describe('safeURL', () => {
 
   checkIt('should work with query params', {
     true: [
+      '[https://example.com/query?foo=1&bar=2](https://example.com/query?foo=1&bar=2)',
       '[https://example.com/query?foo=1&bar=2](https://example.com/query?foo=1&amp;bar=2)',
+      '[https://example.com/query?foo=1&amp;bar=2](https://example.com/query?foo=1&bar=2)',
     ],
     false: [
-      '[https://example.com/query?foo=1&bar=2](https://example.com/query?foo=1&bar=2]',
+      '[https://example.com/query?foo=1&bar=2](https://example.com/query?foo=1&bar=3)', // bar doesn't match
     ],
   })
 })

--- a/web/src/app/util/safeURL.ts
+++ b/web/src/app/util/safeURL.ts
@@ -4,7 +4,7 @@ import _ from 'lodash'
 //
 // It tries to determine if the label is misleading.
 export function safeURL(_url: string, _label: string): boolean {
-  const url = _.unescape(_url)
+  const url = decodeURI(_.unescape(_url))
   const label = _.unescape(_label)
 
   if (url.startsWith('mailto:')) {

--- a/web/src/app/util/safeURL.ts
+++ b/web/src/app/util/safeURL.ts
@@ -1,29 +1,19 @@
-// encodeHtmlEntities will encode common HTML entities in a string.
-//
-// This is useful for ensuring that comparisons between html encoded urls and
-// non-encoded labels are accurate
-function encodeHtmlEntities(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-}
+import _ from 'lodash'
 
 // safeURL will determine if a url is safe for linking.
 //
 // It tries to determine if the label is misleading.
-export function safeURL(url: string, label: string): boolean {
-  label = encodeHtmlEntities(label)
+export function safeURL(_url: string, _label: string): boolean {
+  const url = _.unescape(_url)
+  const label = _.unescape(_label)
 
   if (url.startsWith('mailto:')) {
-    const email = url.substr(7)
+    const email = url.slice(7)
     return email === label && email.includes('@')
   }
 
   if (url.startsWith('tel:')) {
-    const phone = url.substr(4)
+    const phone = url.slice(4)
     return phone === label && /^\+?[\d\- ]+$/.test(phone)
   }
 


### PR DESCRIPTION
**Description:**
Fixes an issue where URLs with characters like `|` aren't handled properly.

This PR ensures intended behavior where the printed/displayed link will show `|` and the `href` attribute will contain the properly escaped URL.
