### PR TITLE
dev: update demo container for integration test usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ docker run -it --rm -p 8081:8081 goalert/demo
 
 GoAlert will be running at [localhost:8081](http://localhost:8081). You can log in with `admin`/`admin123`.
 
+If you're using the demo container for integration testing:
+- A non-admin user is available as `user`/`user1234`.
+- You can specify the ENV variable `SKIP_SEED=1` to skip the initial seed data step.
+
 ## Contributing
 
 If you'd like to contribute to GoAlert, please see our [Contributing Guidelines](./CONTRIBUTING.md) and the [Development Setup Guide](./docs/development-setup.md).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ GoAlert will be running at [localhost:8081](http://localhost:8081). You can log 
 If you're using the demo container for integration testing:
 - A non-admin user is available as `user`/`user1234`.
 - You can specify the ENV variable `SKIP_SEED=1` to skip the initial seed data step.
-- You can get a session token via `curl -XPOST -H 'Referer: http://localhost:8081' -d 'username=admin&password=admin123' http://localhost:8081/api/v2/identity/providers/basic?noRedirect=1`.
+- You can get a session token via `curl -XPOST -H 'Referer: http://localhost:8081' -d 'username=admin&password=admin123' 'http://localhost:8081/api/v2/identity/providers/basic?noRedirect=1'`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ GoAlert will be running at [localhost:8081](http://localhost:8081). You can log 
 If you're using the demo container for integration testing:
 - A non-admin user is available as `user`/`user1234`.
 - You can specify the ENV variable `SKIP_SEED=1` to skip the initial seed data step.
+- You can get a session token via `curl -XPOST -H 'Referer: http://localhost:8081' -d 'username=admin&password=admin123' http://localhost:8081/api/v2/identity/providers/basic?noRedirect=1`.
 
 ## Contributing
 

--- a/devtools/ci/dockerfiles/demo/start.sh
+++ b/devtools/ci/dockerfiles/demo/start.sh
@@ -19,8 +19,15 @@ su postgres -s /bin/sh -c "pg_ctl start -w -l /var/log/postgresql/server.log"
 if ! test -f /init-data
 then
   echo Seeding DB with demo data...
-  /bin/resetdb -with-rand-data -admin-id=00000000-0000-0000-0000-000000000001 -db-url "$DB_URL" -skip-drop
-  /bin/goalert add-user --user-id=00000000-0000-0000-0000-000000000001 --user admin --pass admin123 --db-url "$DB_URL"
+  if [ "$SKIP_SEED" = "1" ]; then
+    /bin/goalert migrate --db-url "$DB_URL" # run migrations, but don't seed
+    /bin/goalert add-user --admin --user admin --pass admin123 --db-url "$DB_URL"
+  else
+    /bin/resetdb -with-rand-data -admin-id=00000000-0000-0000-0000-000000000001 -db-url "$DB_URL" -skip-drop
+    /bin/goalert add-user --user-id=00000000-0000-0000-0000-000000000001 --user admin --pass admin123 --db-url "$DB_URL"
+  fi
+
+  /bin/goalert add-user --user user --pass user1234 --db-url "$DB_URL"
   touch /init-data
 fi
 


### PR DESCRIPTION
**Description:**
Makes a couple small updates to the demo container for integration test use-cases:
- Added a non-admin login
- Added the ability to skip the DB seed step when not necessary

**Additional Info:**
To validate with docker:
```bash
# build dependencies
make bin/goalert-linux-amd64.tgz bin/linux-amd64/resetdb

# build container
docker build -t gademo -f devtools/ci/dockerfiles/demo/Dockerfile.prebuilt --build-arg ARCH=amd64 .

# Run _with_ seed data
docker run -it --rm -p 8081:8081 gademo

# Run _without_ seed data
docker run -it --rm -p 8081:8081 -e SKIP_SEED=1 gademo
```

Both should allow login of admin/admin123 and user/user1234, with the latter skipping the random data generation (no services, rotations, etc...)
