### PR TITLE
sched/notif: retain time and weekday filter if swapping radio options

### DIFF
--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsFormDest.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsFormDest.tsx
@@ -9,7 +9,7 @@ import {
 } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
 import { DateTime } from 'luxon'
-import React from 'react'
+import React, { useEffect } from 'react'
 
 import { FormContainer, FormField } from '../../forms'
 import { renderMenuItem } from '../../selection/DisableableMenuItem'
@@ -66,17 +66,35 @@ export default function ScheduleOnCallNotificationsFormDest(
     (d) => d.type === props.value.dest.type,
   )
 
+  const [ruleType, setRuleType] = React.useState<'on-change' | 'time-of-day'>(
+    props.value.time ? 'time-of-day' : 'on-change',
+  )
+  const [lastTime, setLastTime] = React.useState<string | null>(
+    props.value.time,
+  )
+  const [lastFilter, setLastFilter] = React.useState<WeekdayFilter>(
+    props.value.weekdayFilter,
+  )
+  useEffect(() => {
+    if (!props.value.time) return
+    setLastTime(props.value.time)
+    setLastFilter(props.value.weekdayFilter)
+  }, [props.value.time, props.value.weekdayFilter])
+
   if (!currentType) throw new Error('invalid destination type')
 
   const handleRuleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     if (e.target.value === 'on-change') {
+      setRuleType('on-change')
       props.onChange({ ...formProps.value, time: null, weekdayFilter: NO_DAY })
       return
     }
+
+    setRuleType('time-of-day')
     props.onChange({
       ...props.value,
-      weekdayFilter: EVERY_DAY,
-      time: DateTime.fromObject({ hour: 9 }, { zone }).toISO(),
+      weekdayFilter: lastTime ? lastFilter : EVERY_DAY,
+      time: lastTime || DateTime.fromObject({ hour: 9 }, { zone }).toISO(),
     })
   }
 
@@ -98,7 +116,7 @@ export default function ScheduleOnCallNotificationsFormDest(
         <Grid item>
           <RadioGroup
             name='ruleType'
-            value={formProps.value.time ? 'time-of-day' : 'on-change'}
+            value={ruleType}
             onChange={handleRuleChange}
           >
             <FormControlLabel


### PR DESCRIPTION
**Description:**
Updates the `*Dest` variant of the schedule notification form to preserve state of the time and weekday filter options.

**Out of Scope:**
The old non-dest form was not updated; this is ONLY when the `dest-types` flag is set to use the new form and dialog code.

**Screenshots:**

https://github.com/target/goalert/assets/595010/0be58b4c-22ea-483b-b1a9-00d05b5a81f8

**Describe any introduced user-facing changes:**
N/A just a quality-of-life fix

**Describe any introduced API changes:**
N/A

**Additional Info:**
Note: The parent `props.value` and `onChange` handlers still receive a `null` time when the value changes (no effect on API). This fix is handled purely in the form's state.

