### PR TITLE
intkeys: fix site24x7 label bug

### DIFF
--- a/graphql2/graphqlapp/config.go
+++ b/graphql2/graphqlapp/config.go
@@ -14,7 +14,7 @@ func (a *Query) IntegrationKeyTypes(ctx context.Context) ([]graphql2.Integration
 		{ID: "email", Name: "Email", Label: "Email Address", Enabled: cfg.EmailIngressEnabled()},
 		{ID: "generic", Name: "Generic API", Label: "Generic Webhook URL", Enabled: true},
 		{ID: "grafana", Name: "Grafana", Label: "Grafana Webhook URL", Enabled: true},
-		{ID: "site24x7", Name: "Generic", Label: "Site24x7 Webhook URL", Enabled: true},
+		{ID: "site24x7", Name: "Site 24x7", Label: "Site24x7 Webhook URL", Enabled: true},
 		{ID: "prometheusAlertmanager", Label: "Alertmanager Webhook URL", Name: "Prometheus Alertmanager", Enabled: true},
 	}, nil
 }

--- a/web/src/app/escalation-policies/PolicyStepCreateDialogDest.stories.tsx
+++ b/web/src/app/escalation-policies/PolicyStepCreateDialogDest.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
 import PolicyStepCreateDialogDest from './PolicyStepCreateDialogDest'
-import { expect, userEvent, waitFor, within } from '@storybook/test'
+import { expect, userEvent, waitFor, within, fn } from '@storybook/test'
 import { handleDefaultConfig, handleExpFlags } from '../storybook/graphql'
 import { HttpResponse, graphql } from 'msw'
 import { DestFieldValueError } from '../util/errtypes'
@@ -89,6 +89,7 @@ export const CreatePolicyStep: Story = {
   },
   args: {
     escalationPolicyID: '1',
+    onClose: fn(),
   },
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement)

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsEditDialogDest.stories.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsEditDialogDest.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
-import { expect, userEvent, waitFor, within } from '@storybook/test'
+import { expect, userEvent, waitFor, within, fn } from '@storybook/test'
 import ScheduleOnCallNotificationsEditDialogDest from './ScheduleOnCallNotificationsEditDialogDest'
 import { HttpResponse, graphql } from 'msw'
 import { handleDefaultConfig, handleExpFlags } from '../../storybook/graphql'
@@ -13,6 +13,7 @@ const meta = {
   args: {
     scheduleID: 'create-test',
     ruleID: 'existing-id',
+    onClose: fn(),
   },
   parameters: {
     docs: {


### PR DESCRIPTION
**Description:**
Fixes the Site 24x7 integration key type displaying as "Generic" in the dropdown.

- also fixes a couple typescript issues that made their way into master