### PR TITLE
util/sqlutil: fix handling of block delimiters in SplitQuery

### DIFF
--- a/util/sqlutil/splitquery.go
+++ b/util/sqlutil/splitquery.go
@@ -32,6 +32,7 @@ func sqlSplitBlock(delim []byte, blockIdx int, data []byte, atEOF bool) (advance
 	return next + advance, data[:next+len(token)], nil
 }
 
+// https://www.postgresql.org/docs/16/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING
 var splitRx = regexp.MustCompile(`\$[^$]*\$`)
 
 func sqlSplitQuery(data []byte, atEOF bool) (advance int, token []byte, err error) {

--- a/util/sqlutil/splitquery.go
+++ b/util/sqlutil/splitquery.go
@@ -35,29 +35,39 @@ func sqlSplitBlock(delim []byte, blockIdx int, data []byte, atEOF bool) (advance
 // https://www.postgresql.org/docs/16/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING
 var splitRx = regexp.MustCompile(`\$[^$]*\$`)
 
+// sqlSplitQuery is a bufio.SplitFunc that splits the input SQL query data into smaller queries or blocks based on semicolons and custom block patterns.
+//
+// More information on bufio.SplitFunc can be found here:
+// https://pkg.go.dev/bufio#SplitFunc
 func sqlSplitQuery(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	// If there's no more data and we're at the end of the file, return no data.
 	if atEOF && len(data) == 0 {
 		return 0, nil, nil
 	}
+
+	// Find the index of the first semicolon, which typically delimits SQL statements.
 	semiIdx := bytes.IndexRune(data, ';')
 
-	idx := splitRx.FindIndex(data)
-	if idx != nil && (semiIdx == -1 || semiIdx > idx[0]) {
-		// have block start and it comes before semi (or no semi)
-		return sqlSplitBlock(data[idx[0]:idx[1]], idx[0], data, atEOF)
+	// Attempt to find the start and end indices of a predefined block pattern in the data.
+	blockIdx := splitRx.FindIndex(data)
+
+	// Handling for cases with a predefined block pattern and where a semicolon does NOT precede the block pattern.
+	if blockIdx != nil && (semiIdx == -1 || semiIdx > blockIdx[0]) {
+		blockDelim := data[blockIdx[0]:blockIdx[1]]
+		// Process the delimited block separately, considering its specific start position within 'data'.
+		return sqlSplitBlock(blockDelim, blockIdx[0], data, atEOF)
 	}
 
-	// no block, or it comes later
 	if semiIdx == -1 {
 		if atEOF {
-			// return rest as the final query
+			// Returning the rest of the data as the final query when no more delimiters are found and we're at EOF.
 			return len(data), data, nil
 		}
 
-		return 0, nil, nil
+		return 0, nil, nil // Waiting for more data or a delimiter.
 	}
 
-	// return up to semi
+	// Return data up to the first semicolon as a discrete SQL statement.
 	return semiIdx + 1, data[:semiIdx], nil
 }
 

--- a/util/sqlutil/splitquery.go
+++ b/util/sqlutil/splitquery.go
@@ -3,11 +3,12 @@ package sqlutil
 import (
 	"bufio"
 	"bytes"
+	"regexp"
 	"strings"
 )
 
-func sqlSplitBlock(blockIdx int, data []byte, atEOF bool) (advance int, token []byte, err error) {
-	nextBlockIdx := bytes.Index(data[blockIdx+2:], []byte("$$"))
+func sqlSplitBlock(delim []byte, blockIdx int, data []byte, atEOF bool) (advance int, token []byte, err error) {
+	nextBlockIdx := bytes.Index(data[blockIdx+2:], delim)
 	if nextBlockIdx == -1 {
 		if atEOF {
 			// return rest as the final query
@@ -31,15 +32,18 @@ func sqlSplitBlock(blockIdx int, data []byte, atEOF bool) (advance int, token []
 	return next + advance, data[:next+len(token)], nil
 }
 
+var splitRx = regexp.MustCompile(`\$[^$]*\$`)
+
 func sqlSplitQuery(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	if atEOF && len(data) == 0 {
 		return 0, nil, nil
 	}
 	semiIdx := bytes.IndexRune(data, ';')
-	blockIdx := bytes.Index(data, []byte("$$"))
-	if blockIdx != -1 && (semiIdx == -1 || semiIdx > blockIdx) {
+
+	idx := splitRx.FindIndex(data)
+	if idx != nil && (semiIdx == -1 || semiIdx > idx[0]) {
 		// have block start and it comes before semi (or no semi)
-		return sqlSplitBlock(blockIdx, data, atEOF)
+		return sqlSplitBlock(data[idx[0]:idx[1]], idx[0], data, atEOF)
 	}
 
 	// no block, or it comes later

--- a/util/sqlutil/splitquery_test.go
+++ b/util/sqlutil/splitquery_test.go
@@ -6,9 +6,42 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const adv = `
+CREATE OR REPLACE FUNCTION public.fn_enforce_alert_limit()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    max_count INT := -1;
+    val_count INT := 0;
+BEGIN
+    SELECT INTO max_count max
+    FROM config_limits
+    WHERE id = 'unacked_alerts_per_service';
+
+    IF max_count = -1 THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT INTO val_count COUNT(*)
+    FROM alerts
+    WHERE service_id = NEW.service_id AND "status" = 'triggered';
+
+    IF val_count > max_count THEN
+        RAISE 'limit exceeded' USING ERRCODE='check_violation', CONSTRAINT='unacked_alerts_per_service_limit', HINT='max='||max_count;
+    END IF;
+
+    RETURN NEW;
+END;
+$function$
+;
+`
+
 func TestSplitQuery(t *testing.T) {
 	assert.Equal(t, []string{"foobar"}, SplitQuery("foobar"))
 	assert.Equal(t, []string{"foo", "bar"}, SplitQuery("foo;bar"))
 	assert.Equal(t, []string{"foo", "bar"}, SplitQuery("foo;bar;"))
 	assert.Equal(t, []string{"foo$$; $$bar", "baz"}, SplitQuery("foo$$; $$bar;baz"))
+
+	assert.Len(t, SplitQuery(adv), 1)
 }

--- a/util/sqlutil/splitquery_test.go
+++ b/util/sqlutil/splitquery_test.go
@@ -35,6 +35,8 @@ BEGIN
 END;
 $function$
 ;
+
+SELECT 1;
 `
 
 func TestSplitQuery(t *testing.T) {
@@ -43,5 +45,6 @@ func TestSplitQuery(t *testing.T) {
 	assert.Equal(t, []string{"foo", "bar"}, SplitQuery("foo;bar;"))
 	assert.Equal(t, []string{"foo$$; $$bar", "baz"}, SplitQuery("foo$$; $$bar;baz"))
 
-	assert.Len(t, SplitQuery(adv), 1)
+	// Test that a query with a more complex delimiter is split correctly.
+	assert.Len(t, SplitQuery(adv), 2)
 }


### PR DESCRIPTION
**Description:**
The `SplitQuery` function wrongly assumed `$$` was the only possible block delimiter, when it can be a user-defined tag like `$foobar$`

This PR fixes the bug and adds a test case for the more complex case.

More info:
https://www.postgresql.org/docs/16/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING