### PR TITLE
dest: Destination display error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ test-components:  $(NODE_DEPS) bin/waitfor
 	yarn playwright install chromium
 	yarn concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
 		"yarn http-server storybook-static -a 127.0.0.1 --port 6008 --silent" \
-		"./bin/waitfor tcp://localhost:6008 && yarn test-storybook --ci --url http://127.0.0.1:6008"
+		"./bin/waitfor tcp://localhost:6008 && yarn test-storybook --ci --url http://127.0.0.1:6008 --maxWorkers 2"
 
 storybook: ensure-yarn $(NODE_DEPS) # Start the Storybook UI
 	yarn storybook

--- a/devtools/gqltsgen/run.go
+++ b/devtools/gqltsgen/run.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sort"
+	"strings"
 
 	"github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -143,8 +145,11 @@ func main() {
 				typeName = "[boolean, boolean, boolean, boolean, boolean, boolean, boolean]"
 			}
 			fmt.Fprintf(w, "export type %s = %s\n\n", def.Name, typeName)
+		case ast.Union:
+			sort.Strings(def.Types)
+			fmt.Fprintf(w, "export type %s = %s\n\n", def.Name, strings.Join(def.Types, " | "))
 		default:
-			log.Fatal("Unsupported kind:", def.Name, def.Kind)
+			log.Fatalln("Unsupported kind:", def.Name, def.Kind)
 		}
 	}
 }

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -69,7 +69,6 @@ type ResolverRoot interface {
 	Destination() DestinationResolver
 	EscalationPolicy() EscalationPolicyResolver
 	EscalationPolicyStep() EscalationPolicyStepResolver
-	FieldValuePair() FieldValuePairResolver
 	GQLAPIKey() GQLAPIKeyResolver
 	HeartbeatMonitor() HeartbeatMonitorResolver
 	IntegrationKey() IntegrationKeyResolver
@@ -288,16 +287,21 @@ type ComplexityRoot struct {
 		Targets          func(childComplexity int) int
 	}
 
+	FieldSearchResult struct {
+		FieldID    func(childComplexity int) int
+		IsFavorite func(childComplexity int) int
+		Label      func(childComplexity int) int
+		Value      func(childComplexity int) int
+	}
+
 	FieldValueConnection struct {
 		Nodes    func(childComplexity int) int
 		PageInfo func(childComplexity int) int
 	}
 
 	FieldValuePair struct {
-		FieldID    func(childComplexity int) int
-		IsFavorite func(childComplexity int) int
-		Label      func(childComplexity int) int
-		Value      func(childComplexity int) int
+		FieldID func(childComplexity int) int
+		Value   func(childComplexity int) int
 	}
 
 	GQLAPIKey struct {
@@ -803,9 +807,6 @@ type EscalationPolicyStepResolver interface {
 	Targets(ctx context.Context, obj *escalation.Step) ([]assignment.RawTarget, error)
 	EscalationPolicy(ctx context.Context, obj *escalation.Step) (*escalation.Policy, error)
 	Actions(ctx context.Context, obj *escalation.Step) ([]Destination, error)
-}
-type FieldValuePairResolver interface {
-	Label(ctx context.Context, obj *FieldValuePair) (string, error)
 }
 type GQLAPIKeyResolver interface {
 	CreatedBy(ctx context.Context, obj *GQLAPIKey) (*user.User, error)
@@ -1846,6 +1847,34 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.EscalationPolicyStep.Targets(childComplexity), true
 
+	case "FieldSearchResult.fieldID":
+		if e.complexity.FieldSearchResult.FieldID == nil {
+			break
+		}
+
+		return e.complexity.FieldSearchResult.FieldID(childComplexity), true
+
+	case "FieldSearchResult.isFavorite":
+		if e.complexity.FieldSearchResult.IsFavorite == nil {
+			break
+		}
+
+		return e.complexity.FieldSearchResult.IsFavorite(childComplexity), true
+
+	case "FieldSearchResult.label":
+		if e.complexity.FieldSearchResult.Label == nil {
+			break
+		}
+
+		return e.complexity.FieldSearchResult.Label(childComplexity), true
+
+	case "FieldSearchResult.value":
+		if e.complexity.FieldSearchResult.Value == nil {
+			break
+		}
+
+		return e.complexity.FieldSearchResult.Value(childComplexity), true
+
 	case "FieldValueConnection.nodes":
 		if e.complexity.FieldValueConnection.Nodes == nil {
 			break
@@ -1866,20 +1895,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.FieldValuePair.FieldID(childComplexity), true
-
-	case "FieldValuePair.isFavorite":
-		if e.complexity.FieldValuePair.IsFavorite == nil {
-			break
-		}
-
-		return e.complexity.FieldValuePair.IsFavorite(childComplexity), true
-
-	case "FieldValuePair.label":
-		if e.complexity.FieldValuePair.Label == nil {
-			break
-		}
-
-		return e.complexity.FieldValuePair.Label(childComplexity), true
 
 	case "FieldValuePair.value":
 		if e.complexity.FieldValuePair.Value == nil {
@@ -9580,10 +9595,6 @@ func (ec *executionContext) fieldContext_Destination_values(ctx context.Context,
 				return ec.fieldContext_FieldValuePair_fieldID(ctx, field)
 			case "value":
 				return ec.fieldContext_FieldValuePair_value(ctx, field)
-			case "label":
-				return ec.fieldContext_FieldValuePair_label(ctx, field)
-			case "isFavorite":
-				return ec.fieldContext_FieldValuePair_isFavorite(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FieldValuePair", field.Name)
 		},
@@ -11588,6 +11599,182 @@ func (ec *executionContext) fieldContext_EscalationPolicyStep_actions(ctx contex
 	return fc, nil
 }
 
+func (ec *executionContext) _FieldSearchResult_fieldID(ctx context.Context, field graphql.CollectedField, obj *FieldSearchResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FieldSearchResult_fieldID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FieldSearchResult_fieldID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FieldSearchResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FieldSearchResult_value(ctx context.Context, field graphql.CollectedField, obj *FieldSearchResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FieldSearchResult_value(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Value, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FieldSearchResult_value(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FieldSearchResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FieldSearchResult_label(ctx context.Context, field graphql.CollectedField, obj *FieldSearchResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FieldSearchResult_label(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Label, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FieldSearchResult_label(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FieldSearchResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FieldSearchResult_isFavorite(ctx context.Context, field graphql.CollectedField, obj *FieldSearchResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FieldSearchResult_isFavorite(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IsFavorite, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FieldSearchResult_isFavorite(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FieldSearchResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _FieldValueConnection_nodes(ctx context.Context, field graphql.CollectedField, obj *FieldValueConnection) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_FieldValueConnection_nodes(ctx, field)
 	if err != nil {
@@ -11614,9 +11801,9 @@ func (ec *executionContext) _FieldValueConnection_nodes(ctx context.Context, fie
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]FieldValuePair)
+	res := resTmp.([]FieldSearchResult)
 	fc.Result = res
-	return ec.marshalNFieldValuePair2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldValuePairᚄ(ctx, field.Selections, res)
+	return ec.marshalNFieldSearchResult2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldSearchResultᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_FieldValueConnection_nodes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -11628,15 +11815,15 @@ func (ec *executionContext) fieldContext_FieldValueConnection_nodes(ctx context.
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "fieldID":
-				return ec.fieldContext_FieldValuePair_fieldID(ctx, field)
+				return ec.fieldContext_FieldSearchResult_fieldID(ctx, field)
 			case "value":
-				return ec.fieldContext_FieldValuePair_value(ctx, field)
+				return ec.fieldContext_FieldSearchResult_value(ctx, field)
 			case "label":
-				return ec.fieldContext_FieldValuePair_label(ctx, field)
+				return ec.fieldContext_FieldSearchResult_label(ctx, field)
 			case "isFavorite":
-				return ec.fieldContext_FieldValuePair_isFavorite(ctx, field)
+				return ec.fieldContext_FieldSearchResult_isFavorite(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type FieldValuePair", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type FieldSearchResult", field.Name)
 		},
 	}
 	return fc, nil
@@ -11775,94 +11962,6 @@ func (ec *executionContext) fieldContext_FieldValuePair_value(ctx context.Contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FieldValuePair_label(ctx context.Context, field graphql.CollectedField, obj *FieldValuePair) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FieldValuePair_label(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.FieldValuePair().Label(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FieldValuePair_label(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FieldValuePair",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FieldValuePair_isFavorite(ctx context.Context, field graphql.CollectedField, obj *FieldValuePair) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FieldValuePair_isFavorite(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.IsFavorite, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(bool)
-	fc.Result = res
-	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FieldValuePair_isFavorite(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FieldValuePair",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -36382,6 +36481,60 @@ func (ec *executionContext) _EscalationPolicyStep(ctx context.Context, sel ast.S
 	return out
 }
 
+var fieldSearchResultImplementors = []string{"FieldSearchResult"}
+
+func (ec *executionContext) _FieldSearchResult(ctx context.Context, sel ast.SelectionSet, obj *FieldSearchResult) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, fieldSearchResultImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("FieldSearchResult")
+		case "fieldID":
+			out.Values[i] = ec._FieldSearchResult_fieldID(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "value":
+			out.Values[i] = ec._FieldSearchResult_value(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "label":
+			out.Values[i] = ec._FieldSearchResult_label(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "isFavorite":
+			out.Values[i] = ec._FieldSearchResult_isFavorite(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var fieldValueConnectionImplementors = []string{"FieldValueConnection"}
 
 func (ec *executionContext) _FieldValueConnection(ctx context.Context, sel ast.SelectionSet, obj *FieldValueConnection) graphql.Marshaler {
@@ -36440,53 +36593,12 @@ func (ec *executionContext) _FieldValuePair(ctx context.Context, sel ast.Selecti
 		case "fieldID":
 			out.Values[i] = ec._FieldValuePair_fieldID(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+				out.Invalids++
 			}
 		case "value":
 			out.Values[i] = ec._FieldValuePair_value(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
-		case "label":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._FieldValuePair_label(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "isFavorite":
-			out.Values[i] = ec._FieldValuePair_isFavorite(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+				out.Invalids++
 			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -43528,6 +43640,54 @@ func (ec *executionContext) marshalNEscalationPolicyStep2ᚕgithubᚗcomᚋtarge
 				defer wg.Done()
 			}
 			ret[i] = ec.marshalNEscalationPolicyStep2githubᚗcomᚋtargetᚋgoalertᚋescalationᚐStep(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNFieldSearchResult2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldSearchResult(ctx context.Context, sel ast.SelectionSet, v FieldSearchResult) graphql.Marshaler {
+	return ec._FieldSearchResult(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNFieldSearchResult2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldSearchResultᚄ(ctx context.Context, sel ast.SelectionSet, v []FieldSearchResult) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNFieldSearchResult2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldSearchResult(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -287,16 +287,16 @@ type ComplexityRoot struct {
 		Targets          func(childComplexity int) int
 	}
 
+	FieldSearchConnection struct {
+		Nodes    func(childComplexity int) int
+		PageInfo func(childComplexity int) int
+	}
+
 	FieldSearchResult struct {
 		FieldID    func(childComplexity int) int
 		IsFavorite func(childComplexity int) int
 		Label      func(childComplexity int) int
 		Value      func(childComplexity int) int
-	}
-
-	FieldValueConnection struct {
-		Nodes    func(childComplexity int) int
-		PageInfo func(childComplexity int) int
 	}
 
 	FieldValuePair struct {
@@ -931,7 +931,7 @@ type QueryResolver interface {
 	SwoStatus(ctx context.Context) (*SWOStatus, error)
 	DestinationTypes(ctx context.Context) ([]DestinationTypeInfo, error)
 	DestinationFieldValidate(ctx context.Context, input DestinationFieldValidateInput) (bool, error)
-	DestinationFieldSearch(ctx context.Context, input DestinationFieldSearchInput) (*FieldValueConnection, error)
+	DestinationFieldSearch(ctx context.Context, input DestinationFieldSearchInput) (*FieldSearchConnection, error)
 	DestinationFieldValueName(ctx context.Context, input DestinationFieldValidateInput) (string, error)
 	DestinationDisplayInfo(ctx context.Context, input DestinationInput) (*DestinationDisplayInfo, error)
 	GqlAPIKeys(ctx context.Context) ([]GQLAPIKey, error)
@@ -1847,6 +1847,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.EscalationPolicyStep.Targets(childComplexity), true
 
+	case "FieldSearchConnection.nodes":
+		if e.complexity.FieldSearchConnection.Nodes == nil {
+			break
+		}
+
+		return e.complexity.FieldSearchConnection.Nodes(childComplexity), true
+
+	case "FieldSearchConnection.pageInfo":
+		if e.complexity.FieldSearchConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.FieldSearchConnection.PageInfo(childComplexity), true
+
 	case "FieldSearchResult.fieldID":
 		if e.complexity.FieldSearchResult.FieldID == nil {
 			break
@@ -1874,20 +1888,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.FieldSearchResult.Value(childComplexity), true
-
-	case "FieldValueConnection.nodes":
-		if e.complexity.FieldValueConnection.Nodes == nil {
-			break
-		}
-
-		return e.complexity.FieldValueConnection.Nodes(childComplexity), true
-
-	case "FieldValueConnection.pageInfo":
-		if e.complexity.FieldValueConnection.PageInfo == nil {
-			break
-		}
-
-		return e.complexity.FieldValueConnection.PageInfo(childComplexity), true
 
 	case "FieldValuePair.fieldID":
 		if e.complexity.FieldValuePair.FieldID == nil {
@@ -11599,6 +11599,110 @@ func (ec *executionContext) fieldContext_EscalationPolicyStep_actions(ctx contex
 	return fc, nil
 }
 
+func (ec *executionContext) _FieldSearchConnection_nodes(ctx context.Context, field graphql.CollectedField, obj *FieldSearchConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FieldSearchConnection_nodes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Nodes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]FieldSearchResult)
+	fc.Result = res
+	return ec.marshalNFieldSearchResult2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldSearchResultᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FieldSearchConnection_nodes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FieldSearchConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "fieldID":
+				return ec.fieldContext_FieldSearchResult_fieldID(ctx, field)
+			case "value":
+				return ec.fieldContext_FieldSearchResult_value(ctx, field)
+			case "label":
+				return ec.fieldContext_FieldSearchResult_label(ctx, field)
+			case "isFavorite":
+				return ec.fieldContext_FieldSearchResult_isFavorite(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type FieldSearchResult", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FieldSearchConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *FieldSearchConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FieldSearchConnection_pageInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FieldSearchConnection_pageInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FieldSearchConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _FieldSearchResult_fieldID(ctx context.Context, field graphql.CollectedField, obj *FieldSearchResult) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_FieldSearchResult_fieldID(ctx, field)
 	if err != nil {
@@ -11770,110 +11874,6 @@ func (ec *executionContext) fieldContext_FieldSearchResult_isFavorite(ctx contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Boolean does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FieldValueConnection_nodes(ctx context.Context, field graphql.CollectedField, obj *FieldValueConnection) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FieldValueConnection_nodes(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Nodes, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]FieldSearchResult)
-	fc.Result = res
-	return ec.marshalNFieldSearchResult2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldSearchResultᚄ(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FieldValueConnection_nodes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FieldValueConnection",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "fieldID":
-				return ec.fieldContext_FieldSearchResult_fieldID(ctx, field)
-			case "value":
-				return ec.fieldContext_FieldSearchResult_value(ctx, field)
-			case "label":
-				return ec.fieldContext_FieldSearchResult_label(ctx, field)
-			case "isFavorite":
-				return ec.fieldContext_FieldSearchResult_isFavorite(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type FieldSearchResult", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FieldValueConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *FieldValueConnection) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FieldValueConnection_pageInfo(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.PageInfo, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*PageInfo)
-	fc.Result = res
-	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐPageInfo(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FieldValueConnection_pageInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FieldValueConnection",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "endCursor":
-				return ec.fieldContext_PageInfo_endCursor(ctx, field)
-			case "hasNextPage":
-				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
 		},
 	}
 	return fc, nil
@@ -21040,9 +21040,9 @@ func (ec *executionContext) _Query_destinationFieldSearch(ctx context.Context, f
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*FieldValueConnection)
+	res := resTmp.(*FieldSearchConnection)
 	fc.Result = res
-	return ec.marshalNFieldValueConnection2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldValueConnection(ctx, field.Selections, res)
+	return ec.marshalNFieldSearchConnection2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldSearchConnection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Query_destinationFieldSearch(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -21054,11 +21054,11 @@ func (ec *executionContext) fieldContext_Query_destinationFieldSearch(ctx contex
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "nodes":
-				return ec.fieldContext_FieldValueConnection_nodes(ctx, field)
+				return ec.fieldContext_FieldSearchConnection_nodes(ctx, field)
 			case "pageInfo":
-				return ec.fieldContext_FieldValueConnection_pageInfo(ctx, field)
+				return ec.fieldContext_FieldSearchConnection_pageInfo(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type FieldValueConnection", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type FieldSearchConnection", field.Name)
 		},
 	}
 	defer func() {
@@ -36481,6 +36481,50 @@ func (ec *executionContext) _EscalationPolicyStep(ctx context.Context, sel ast.S
 	return out
 }
 
+var fieldSearchConnectionImplementors = []string{"FieldSearchConnection"}
+
+func (ec *executionContext) _FieldSearchConnection(ctx context.Context, sel ast.SelectionSet, obj *FieldSearchConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, fieldSearchConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("FieldSearchConnection")
+		case "nodes":
+			out.Values[i] = ec._FieldSearchConnection_nodes(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "pageInfo":
+			out.Values[i] = ec._FieldSearchConnection_pageInfo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var fieldSearchResultImplementors = []string{"FieldSearchResult"}
 
 func (ec *executionContext) _FieldSearchResult(ctx context.Context, sel ast.SelectionSet, obj *FieldSearchResult) graphql.Marshaler {
@@ -36509,50 +36553,6 @@ func (ec *executionContext) _FieldSearchResult(ctx context.Context, sel ast.Sele
 			}
 		case "isFavorite":
 			out.Values[i] = ec._FieldSearchResult_isFavorite(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch(ctx)
-	if out.Invalids > 0 {
-		return graphql.Null
-	}
-
-	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
-
-	for label, dfs := range deferred {
-		ec.processDeferredGroup(graphql.DeferredGroup{
-			Label:    label,
-			Path:     graphql.GetPath(ctx),
-			FieldSet: dfs,
-			Context:  ctx,
-		})
-	}
-
-	return out
-}
-
-var fieldValueConnectionImplementors = []string{"FieldValueConnection"}
-
-func (ec *executionContext) _FieldValueConnection(ctx context.Context, sel ast.SelectionSet, obj *FieldValueConnection) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, fieldValueConnectionImplementors)
-
-	out := graphql.NewFieldSet(fields)
-	deferred := make(map[string]*graphql.FieldSet)
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("FieldValueConnection")
-		case "nodes":
-			out.Values[i] = ec._FieldValueConnection_nodes(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "pageInfo":
-			out.Values[i] = ec._FieldValueConnection_pageInfo(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -43659,6 +43659,20 @@ func (ec *executionContext) marshalNEscalationPolicyStep2ᚕgithubᚗcomᚋtarge
 	return ret
 }
 
+func (ec *executionContext) marshalNFieldSearchConnection2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldSearchConnection(ctx context.Context, sel ast.SelectionSet, v FieldSearchConnection) graphql.Marshaler {
+	return ec._FieldSearchConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNFieldSearchConnection2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldSearchConnection(ctx context.Context, sel ast.SelectionSet, v *FieldSearchConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._FieldSearchConnection(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNFieldSearchResult2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldSearchResult(ctx context.Context, sel ast.SelectionSet, v FieldSearchResult) graphql.Marshaler {
 	return ec._FieldSearchResult(ctx, sel, &v)
 }
@@ -43705,20 +43719,6 @@ func (ec *executionContext) marshalNFieldSearchResult2ᚕgithubᚗcomᚋtarget�
 	}
 
 	return ret
-}
-
-func (ec *executionContext) marshalNFieldValueConnection2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldValueConnection(ctx context.Context, sel ast.SelectionSet, v FieldValueConnection) graphql.Marshaler {
-	return ec._FieldValueConnection(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNFieldValueConnection2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldValueConnection(ctx context.Context, sel ast.SelectionSet, v *FieldValueConnection) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._FieldValueConnection(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNFieldValueInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐFieldValueInput(ctx context.Context, v interface{}) (FieldValueInput, error) {

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -232,6 +232,10 @@ type ComplexityRoot struct {
 		Text        func(childComplexity int) int
 	}
 
+	DestinationDisplayInfoError struct {
+		Error func(childComplexity int) int
+	}
+
 	DestinationFieldConfig struct {
 		FieldID            func(childComplexity int) int
 		Hint               func(childComplexity int) int
@@ -787,7 +791,7 @@ type AlertMetricResolver interface {
 	TimeToClose(ctx context.Context, obj *alertmetrics.Metric) (*timeutil.ISODuration, error)
 }
 type DestinationResolver interface {
-	DisplayInfo(ctx context.Context, obj *Destination) (*DestinationDisplayInfo, error)
+	DisplayInfo(ctx context.Context, obj *Destination) (InlineDisplayInfo, error)
 }
 type EscalationPolicyResolver interface {
 	IsFavorite(ctx context.Context, obj *escalation.Policy) (bool, error)
@@ -1575,6 +1579,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.DestinationDisplayInfo.Text(childComplexity), true
+
+	case "DestinationDisplayInfoError.error":
+		if e.complexity.DestinationDisplayInfoError.Error == nil {
+			break
+		}
+
+		return e.complexity.DestinationDisplayInfoError.Error(childComplexity), true
 
 	case "DestinationFieldConfig.fieldID":
 		if e.complexity.DestinationFieldConfig.FieldID == nil {
@@ -9606,9 +9617,9 @@ func (ec *executionContext) _Destination_displayInfo(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*DestinationDisplayInfo)
+	res := resTmp.(InlineDisplayInfo)
 	fc.Result = res
-	return ec.marshalNDestinationDisplayInfo2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationDisplayInfo(ctx, field.Selections, res)
+	return ec.marshalNInlineDisplayInfo2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐInlineDisplayInfo(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Destination_displayInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -9618,17 +9629,7 @@ func (ec *executionContext) fieldContext_Destination_displayInfo(ctx context.Con
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "text":
-				return ec.fieldContext_DestinationDisplayInfo_text(ctx, field)
-			case "iconURL":
-				return ec.fieldContext_DestinationDisplayInfo_iconURL(ctx, field)
-			case "iconAltText":
-				return ec.fieldContext_DestinationDisplayInfo_iconAltText(ctx, field)
-			case "linkURL":
-				return ec.fieldContext_DestinationDisplayInfo_linkURL(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type DestinationDisplayInfo", field.Name)
+			return nil, errors.New("field of type InlineDisplayInfo does not have child fields")
 		},
 	}
 	return fc, nil
@@ -9800,6 +9801,50 @@ func (ec *executionContext) _DestinationDisplayInfo_linkURL(ctx context.Context,
 func (ec *executionContext) fieldContext_DestinationDisplayInfo_linkURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "DestinationDisplayInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DestinationDisplayInfoError_error(ctx context.Context, field graphql.CollectedField, obj *DestinationDisplayInfoError) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DestinationDisplayInfoError_error(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Error, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DestinationDisplayInfoError_error(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DestinationDisplayInfoError",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -34281,6 +34326,29 @@ func (ec *executionContext) unmarshalInputVerifyContactMethodInput(ctx context.C
 
 // region    ************************** interface.gotpl ***************************
 
+func (ec *executionContext) _InlineDisplayInfo(ctx context.Context, sel ast.SelectionSet, obj InlineDisplayInfo) graphql.Marshaler {
+	switch obj := (obj).(type) {
+	case nil:
+		return graphql.Null
+	case DestinationDisplayInfo:
+		return ec._DestinationDisplayInfo(ctx, sel, &obj)
+	case *DestinationDisplayInfo:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._DestinationDisplayInfo(ctx, sel, obj)
+	case DestinationDisplayInfoError:
+		return ec._DestinationDisplayInfoError(ctx, sel, &obj)
+	case *DestinationDisplayInfoError:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._DestinationDisplayInfoError(ctx, sel, obj)
+	default:
+		panic(fmt.Errorf("unexpected type %T", obj))
+	}
+}
+
 // endregion ************************** interface.gotpl ***************************
 
 // region    **************************** object.gotpl ****************************
@@ -35652,7 +35720,7 @@ func (ec *executionContext) _Destination(ctx context.Context, sel ast.SelectionS
 	return out
 }
 
-var destinationDisplayInfoImplementors = []string{"DestinationDisplayInfo"}
+var destinationDisplayInfoImplementors = []string{"DestinationDisplayInfo", "InlineDisplayInfo"}
 
 func (ec *executionContext) _DestinationDisplayInfo(ctx context.Context, sel ast.SelectionSet, obj *DestinationDisplayInfo) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, destinationDisplayInfoImplementors)
@@ -35680,6 +35748,45 @@ func (ec *executionContext) _DestinationDisplayInfo(ctx context.Context, sel ast
 			}
 		case "linkURL":
 			out.Values[i] = ec._DestinationDisplayInfo_linkURL(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var destinationDisplayInfoErrorImplementors = []string{"DestinationDisplayInfoError", "InlineDisplayInfo"}
+
+func (ec *executionContext) _DestinationDisplayInfoError(ctx context.Context, sel ast.SelectionSet, obj *DestinationDisplayInfoError) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, destinationDisplayInfoErrorImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DestinationDisplayInfoError")
+		case "error":
+			out.Values[i] = ec._DestinationDisplayInfoError_error(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -43774,6 +43881,16 @@ func (ec *executionContext) marshalNISOTimestamp2ᚕtimeᚐTimeᚄ(ctx context.C
 	}
 
 	return ret
+}
+
+func (ec *executionContext) marshalNInlineDisplayInfo2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐInlineDisplayInfo(ctx context.Context, sel ast.SelectionSet, v InlineDisplayInfo) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._InlineDisplayInfo(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v interface{}) (int, error) {

--- a/graphql2/graph/destinations.graphqls
+++ b/graphql2/graph/destinations.graphqls
@@ -14,7 +14,7 @@ extend type Query {
   destinationFieldValidate(input: DestinationFieldValidateInput!): Boolean!
   destinationFieldSearch(
     input: DestinationFieldSearchInput!
-  ): FieldValueConnection!
+  ): FieldSearchConnection!
   destinationFieldValueName(input: DestinationFieldValidateInput!): String!
 
   """
@@ -24,9 +24,9 @@ extend type Query {
 }
 
 """
-FieldValueConnection is a connection to a list of FieldValuePairs.
+FieldSearchConnection is a connection to a list of FieldSearchResult.
 """
-type FieldValueConnection {
+type FieldSearchConnection {
   nodes: [FieldSearchResult!]!
   pageInfo: PageInfo!
 }

--- a/graphql2/graph/destinations.graphqls
+++ b/graphql2/graph/destinations.graphqls
@@ -27,8 +27,30 @@ extend type Query {
 FieldValueConnection is a connection to a list of FieldValuePairs.
 """
 type FieldValueConnection {
-  nodes: [FieldValuePair!]!
+  nodes: [FieldSearchResult!]!
   pageInfo: PageInfo!
+}
+
+type FieldSearchResult {
+  """
+  The ID of the input field that this value is for.
+  """
+  fieldID: ID!
+
+  """
+  The value of the input field.
+  """
+  value: String!
+
+  """
+  The user-friendly text for this value of the input field (e.g., if the value is a user ID, label would be the user's name).
+  """
+  label: String!
+
+  """
+  if true, this value is a favorite for the user, only set for search results
+  """
+  isFavorite: Boolean!
 }
 
 input DestinationFieldValidateInput {
@@ -139,16 +161,6 @@ type FieldValuePair {
   The value of the input field.
   """
   value: String!
-
-  """
-  The user-friendly text for this value of the input field (e.g., if the value is a user ID, label would be the user's name).
-  """
-  label: String! @goField(forceResolver: true)
-
-  """
-  if true, this value is a favorite for the user, only set for search results
-  """
-  isFavorite: Boolean!
 }
 
 input DestinationInput {

--- a/graphql2/graph/destinations.graphqls
+++ b/graphql2/graph/destinations.graphqls
@@ -86,13 +86,22 @@ input DestinationFieldSearchInput {
   first: Int = 15
 }
 
+union InlineDisplayInfo = DestinationDisplayInfo | DestinationDisplayInfoError
+
 """
 Destination represents a destination that can be used for notifications.
 """
 type Destination {
   type: DestinationType!
   values: [FieldValuePair!]!
-  displayInfo: DestinationDisplayInfo! @goField(forceResolver: true)
+  displayInfo: InlineDisplayInfo! @goField(forceResolver: true)
+}
+
+type DestinationDisplayInfoError {
+  """
+  error message to display when the display info cannot be retrieved
+  """
+  error: String!
 }
 
 """

--- a/graphql2/graphqlapp/compat.go
+++ b/graphql2/graphqlapp/compat.go
@@ -65,18 +65,12 @@ func (a *App) CompatNCToDest(ctx context.Context, ncID uuid.UUID) (*graphql2.Des
 
 	switch nc.Type {
 	case notificationchannel.TypeSlackChan:
-		ch, err := a.SlackStore.Channel(ctx, nc.Value)
-		if err != nil {
-			return nil, err
-		}
-
 		return &graphql2.Destination{
 			Type: destSlackChan,
 			Values: []graphql2.FieldValuePair{
 				{
 					FieldID: fieldSlackChanID,
 					Value:   nc.Value,
-					Label:   ch.Name,
 				},
 			},
 		}, nil
@@ -85,14 +79,6 @@ func (a *App) CompatNCToDest(ctx context.Context, ncID uuid.UUID) (*graphql2.Des
 		if !ok {
 			return nil, fmt.Errorf("invalid slack usergroup pair: %s", nc.Value)
 		}
-		ug, err := a.SlackStore.UserGroup(ctx, ugID)
-		if err != nil {
-			return nil, err
-		}
-		ch, err := a.SlackStore.Channel(ctx, chanID)
-		if err != nil {
-			return nil, err
-		}
 
 		return &graphql2.Destination{
 			Type: destSlackUG,
@@ -100,12 +86,10 @@ func (a *App) CompatNCToDest(ctx context.Context, ncID uuid.UUID) (*graphql2.Des
 				{
 					FieldID: fieldSlackUGID,
 					Value:   ugID,
-					Label:   ug.Handle,
 				},
 				{
 					FieldID: fieldSlackChanID,
 					Value:   chanID,
-					Label:   ch.Name,
 				},
 			},
 		}, nil

--- a/graphql2/graphqlapp/compat.go
+++ b/graphql2/graphqlapp/compat.go
@@ -3,7 +3,6 @@ package graphqlapp
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/google/uuid"
@@ -94,18 +93,12 @@ func (a *App) CompatNCToDest(ctx context.Context, ncID uuid.UUID) (*graphql2.Des
 			},
 		}, nil
 	case notificationchannel.TypeWebhook:
-		u, err := url.Parse(nc.Value)
-		if err != nil {
-			return nil, err
-		}
-
 		return &graphql2.Destination{
 			Type: destWebhook,
 			Values: []graphql2.FieldValuePair{
 				{
 					FieldID: fieldWebhookURL,
 					Value:   nc.Value,
-					Label:   u.Hostname(),
 				},
 			},
 		}, nil

--- a/graphql2/graphqlapp/contactmethod.go
+++ b/graphql2/graphqlapp/contactmethod.go
@@ -29,35 +29,35 @@ func (a *ContactMethod) Dest(ctx context.Context, obj *contactmethod.ContactMeth
 		return &graphql2.Destination{
 			Type: destTwilioSMS,
 			Values: []graphql2.FieldValuePair{
-				{FieldID: fieldPhoneNumber, Value: obj.Value, Label: a.FormatDestFunc(ctx, notification.DestTypeSMS, obj.Value)},
+				{FieldID: fieldPhoneNumber, Value: obj.Value},
 			},
 		}, nil
 	case contactmethod.TypeVoice:
 		return &graphql2.Destination{
 			Type: destTwilioVoice,
 			Values: []graphql2.FieldValuePair{
-				{FieldID: fieldPhoneNumber, Value: obj.Value, Label: a.FormatDestFunc(ctx, notification.DestTypeVoice, obj.Value)},
+				{FieldID: fieldPhoneNumber, Value: obj.Value},
 			},
 		}, nil
 	case contactmethod.TypeEmail:
 		return &graphql2.Destination{
 			Type: destSMTP,
 			Values: []graphql2.FieldValuePair{
-				{FieldID: fieldEmailAddress, Value: obj.Value, Label: a.FormatDestFunc(ctx, notification.DestTypeUserEmail, obj.Value)},
+				{FieldID: fieldEmailAddress, Value: obj.Value},
 			},
 		}, nil
 	case contactmethod.TypeWebhook:
 		return &graphql2.Destination{
 			Type: destWebhook,
 			Values: []graphql2.FieldValuePair{
-				{FieldID: fieldWebhookURL, Value: obj.Value, Label: a.FormatDestFunc(ctx, notification.DestTypeUserWebhook, obj.Value)},
+				{FieldID: fieldWebhookURL, Value: obj.Value},
 			},
 		}, nil
 	case contactmethod.TypeSlackDM:
 		return &graphql2.Destination{
 			Type: destSlackDM,
 			Values: []graphql2.FieldValuePair{
-				{FieldID: fieldSlackUserID, Value: obj.Value, Label: a.FormatDestFunc(ctx, notification.ScannableDestType{CM: obj.Type}.DestType(), obj.Value)},
+				{FieldID: fieldSlackUserID, Value: obj.Value},
 			},
 		}, nil
 	}

--- a/graphql2/graphqlapp/destinationtypes.go
+++ b/graphql2/graphqlapp/destinationtypes.go
@@ -38,51 +38,6 @@ const (
 type FieldValuePair App
 type DestinationDisplayInfo App
 
-func (a *App) FieldValuePair() graphql2.FieldValuePairResolver { return (*FieldValuePair)(a) }
-
-func (a *FieldValuePair) Label(ctx context.Context, fvp *graphql2.FieldValuePair) (string, error) {
-	if fvp.Label != "" {
-		return fvp.Label, nil
-	}
-
-	app := (*App)(a)
-	switch fvp.FieldID {
-	case fieldSlackChanID:
-		ch, err := app.SlackStore.Channel(ctx, fvp.Value)
-		if err != nil {
-			return "", err
-		}
-		return ch.Name, nil
-	case fieldSlackUGID:
-		ug, err := app.SlackStore.UserGroup(ctx, fvp.Value)
-		if err != nil {
-			return "", err
-		}
-
-		return ug.Handle, nil
-	case fieldUserID:
-		u, err := app.FindOneUser(ctx, fvp.Value)
-		if err != nil {
-			return "", err
-		}
-		return u.Name, nil
-	case fieldRotationID:
-		r, err := app.FindOneRotation(ctx, fvp.Value)
-		if err != nil {
-			return "", err
-		}
-		return r.Name, nil
-	case fieldScheduleID:
-		s, err := app.FindOneSchedule(ctx, fvp.Value)
-		if err != nil {
-			return "", err
-		}
-		return s.Name, nil
-	}
-
-	return "", validation.NewGenericError("unsupported fieldID")
-}
-
 func (q *Query) DestinationFieldValueName(ctx context.Context, input graphql2.DestinationFieldValidateInput) (string, error) {
 	switch input.FieldID {
 	case fieldSlackChanID:
@@ -139,9 +94,9 @@ func (q *Query) DestinationFieldSearch(ctx context.Context, input graphql2.Desti
 			return nil, err
 		}
 
-		var nodes []graphql2.FieldValuePair
+		var nodes []graphql2.FieldSearchResult
 		for _, c := range res.Nodes {
-			nodes = append(nodes, graphql2.FieldValuePair{
+			nodes = append(nodes, graphql2.FieldSearchResult{
 				FieldID: input.FieldID,
 				Value:   c.ID,
 				Label:   c.Name,
@@ -163,9 +118,9 @@ func (q *Query) DestinationFieldSearch(ctx context.Context, input graphql2.Desti
 			return nil, err
 		}
 
-		var nodes []graphql2.FieldValuePair
+		var nodes []graphql2.FieldSearchResult
 		for _, ug := range res.Nodes {
-			nodes = append(nodes, graphql2.FieldValuePair{
+			nodes = append(nodes, graphql2.FieldSearchResult{
 				FieldID: input.FieldID,
 				Value:   ug.ID,
 				Label:   ug.Handle,
@@ -188,9 +143,9 @@ func (q *Query) DestinationFieldSearch(ctx context.Context, input graphql2.Desti
 			return nil, err
 		}
 
-		var nodes []graphql2.FieldValuePair
+		var nodes []graphql2.FieldSearchResult
 		for _, rot := range res.Nodes {
-			nodes = append(nodes, graphql2.FieldValuePair{
+			nodes = append(nodes, graphql2.FieldSearchResult{
 				FieldID:    input.FieldID,
 				Value:      rot.ID,
 				Label:      rot.Name,
@@ -214,9 +169,9 @@ func (q *Query) DestinationFieldSearch(ctx context.Context, input graphql2.Desti
 			return nil, err
 		}
 
-		var nodes []graphql2.FieldValuePair
+		var nodes []graphql2.FieldSearchResult
 		for _, sched := range res.Nodes {
-			nodes = append(nodes, graphql2.FieldValuePair{
+			nodes = append(nodes, graphql2.FieldSearchResult{
 				FieldID:    input.FieldID,
 				Value:      sched.ID,
 				Label:      sched.Name,
@@ -240,9 +195,9 @@ func (q *Query) DestinationFieldSearch(ctx context.Context, input graphql2.Desti
 			return nil, err
 		}
 
-		var nodes []graphql2.FieldValuePair
+		var nodes []graphql2.FieldSearchResult
 		for _, u := range res.Nodes {
-			nodes = append(nodes, graphql2.FieldValuePair{
+			nodes = append(nodes, graphql2.FieldSearchResult{
 				FieldID:    input.FieldID,
 				Value:      u.ID,
 				Label:      u.Name,

--- a/graphql2/graphqlapp/destinationtypes.go
+++ b/graphql2/graphqlapp/destinationtypes.go
@@ -79,7 +79,7 @@ func (q *Query) DestinationFieldValueName(ctx context.Context, input graphql2.De
 	return "", validation.NewGenericError("unsupported fieldID")
 }
 
-func (q *Query) DestinationFieldSearch(ctx context.Context, input graphql2.DestinationFieldSearchInput) (*graphql2.FieldValueConnection, error) {
+func (q *Query) DestinationFieldSearch(ctx context.Context, input graphql2.DestinationFieldSearchInput) (*graphql2.FieldSearchConnection, error) {
 	favFirst := true
 
 	switch input.FieldID {
@@ -103,7 +103,7 @@ func (q *Query) DestinationFieldSearch(ctx context.Context, input graphql2.Desti
 			})
 		}
 
-		return &graphql2.FieldValueConnection{
+		return &graphql2.FieldSearchConnection{
 			Nodes:    nodes,
 			PageInfo: res.PageInfo,
 		}, nil
@@ -127,7 +127,7 @@ func (q *Query) DestinationFieldSearch(ctx context.Context, input graphql2.Desti
 			})
 		}
 
-		return &graphql2.FieldValueConnection{
+		return &graphql2.FieldSearchConnection{
 			Nodes:    nodes,
 			PageInfo: res.PageInfo,
 		}, nil
@@ -153,7 +153,7 @@ func (q *Query) DestinationFieldSearch(ctx context.Context, input graphql2.Desti
 			})
 		}
 
-		return &graphql2.FieldValueConnection{
+		return &graphql2.FieldSearchConnection{
 			Nodes:    nodes,
 			PageInfo: res.PageInfo,
 		}, nil
@@ -179,7 +179,7 @@ func (q *Query) DestinationFieldSearch(ctx context.Context, input graphql2.Desti
 			})
 		}
 
-		return &graphql2.FieldValueConnection{
+		return &graphql2.FieldSearchConnection{
 			Nodes:    nodes,
 			PageInfo: res.PageInfo,
 		}, nil
@@ -205,7 +205,7 @@ func (q *Query) DestinationFieldSearch(ctx context.Context, input graphql2.Desti
 			})
 		}
 
-		return &graphql2.FieldValueConnection{
+		return &graphql2.FieldSearchConnection{
 			Nodes:    nodes,
 			PageInfo: res.PageInfo,
 		}, nil

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -27,6 +27,10 @@ import (
 	"github.com/target/goalert/util/timeutil"
 )
 
+type InlineDisplayInfo interface {
+	IsInlineDisplayInfo()
+}
+
 type AlertConnection struct {
 	Nodes    []alert.Alert `json:"nodes"`
 	PageInfo *PageInfo     `json:"pageInfo"`
@@ -297,9 +301,9 @@ type DebugSendSMSInput struct {
 
 // Destination represents a destination that can be used for notifications.
 type Destination struct {
-	Type        string                  `json:"type"`
-	Values      []FieldValuePair        `json:"values"`
-	DisplayInfo *DestinationDisplayInfo `json:"displayInfo"`
+	Type        string            `json:"type"`
+	Values      []FieldValuePair  `json:"values"`
+	DisplayInfo InlineDisplayInfo `json:"displayInfo"`
 }
 
 // DestinationDisplayInfo provides information for displaying a destination.
@@ -313,6 +317,15 @@ type DestinationDisplayInfo struct {
 	// URL to link to for more information about this destination
 	LinkURL string `json:"linkURL"`
 }
+
+func (DestinationDisplayInfo) IsInlineDisplayInfo() {}
+
+type DestinationDisplayInfoError struct {
+	// error message to display when the display info cannot be retrieved
+	Error string `json:"error"`
+}
+
+func (DestinationDisplayInfoError) IsInlineDisplayInfo() {}
 
 type DestinationFieldConfig struct {
 	// unique ID for the input field

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -415,6 +415,12 @@ type EscalationPolicySearchOptions struct {
 	FavoritesFirst *bool    `json:"favoritesFirst,omitempty"`
 }
 
+// FieldSearchConnection is a connection to a list of FieldSearchResult.
+type FieldSearchConnection struct {
+	Nodes    []FieldSearchResult `json:"nodes"`
+	PageInfo *PageInfo           `json:"pageInfo"`
+}
+
 type FieldSearchResult struct {
 	// The ID of the input field that this value is for.
 	FieldID string `json:"fieldID"`
@@ -424,12 +430,6 @@ type FieldSearchResult struct {
 	Label string `json:"label"`
 	// if true, this value is a favorite for the user, only set for search results
 	IsFavorite bool `json:"isFavorite"`
-}
-
-// FieldValueConnection is a connection to a list of FieldValuePairs.
-type FieldValueConnection struct {
-	Nodes    []FieldSearchResult `json:"nodes"`
-	PageInfo *PageInfo           `json:"pageInfo"`
 }
 
 type FieldValueInput struct {

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -415,10 +415,21 @@ type EscalationPolicySearchOptions struct {
 	FavoritesFirst *bool    `json:"favoritesFirst,omitempty"`
 }
 
+type FieldSearchResult struct {
+	// The ID of the input field that this value is for.
+	FieldID string `json:"fieldID"`
+	// The value of the input field.
+	Value string `json:"value"`
+	// The user-friendly text for this value of the input field (e.g., if the value is a user ID, label would be the user's name).
+	Label string `json:"label"`
+	// if true, this value is a favorite for the user, only set for search results
+	IsFavorite bool `json:"isFavorite"`
+}
+
 // FieldValueConnection is a connection to a list of FieldValuePairs.
 type FieldValueConnection struct {
-	Nodes    []FieldValuePair `json:"nodes"`
-	PageInfo *PageInfo        `json:"pageInfo"`
+	Nodes    []FieldSearchResult `json:"nodes"`
+	PageInfo *PageInfo           `json:"pageInfo"`
 }
 
 type FieldValueInput struct {
@@ -432,10 +443,6 @@ type FieldValuePair struct {
 	FieldID string `json:"fieldID"`
 	// The value of the input field.
 	Value string `json:"value"`
-	// The user-friendly text for this value of the input field (e.g., if the value is a user ID, label would be the user's name).
-	Label string `json:"label"`
-	// if true, this value is a favorite for the user, only set for search results
-	IsFavorite bool `json:"isFavorite"`
 }
 
 type GQLAPIKey struct {

--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -115,6 +115,9 @@ func (t Team) UserLink(id string) string {
 }
 
 func rootMsg(err error) string {
+	if err == nil {
+		return ""
+	}
 	unwrapped := errors.Unwrap(err)
 	if unwrapped == nil {
 		return err.Error()
@@ -126,7 +129,7 @@ func rootMsg(err error) string {
 func mapError(ctx context.Context, err error) error {
 	switch rootMsg(err) {
 	case "channel_not_found":
-		return validation.NewFieldError("ChannelID", "Invalid Slack channel ID.")
+		return validation.NewFieldError("ChannelID", "Channel does not exist, is archived, or is private (invite goalert bot).")
 	case "missing_scope", "invalid_auth", "account_inactive", "token_revoked", "not_authed":
 		log.Log(ctx, err)
 		return validation.NewFieldError("ChannelID", "Permission Denied.")
@@ -148,7 +151,7 @@ func (s *ChannelSender) ValidateChannel(ctx context.Context, id string) error {
 		res, err = s.loadChannel(ctx, id)
 		if err != nil {
 			if rootMsg(err) == "channel_not_found" {
-				return validation.NewGenericError("Channel does not exist, is private (need to invite goalert bot).")
+				return validation.NewGenericError("Channel does not exist, is archived, or is private (invite goalert bot).")
 			}
 
 			return err

--- a/notification/slack/user.go
+++ b/notification/slack/user.go
@@ -52,6 +52,9 @@ func (s *ChannelSender) User(ctx context.Context, id string) (*User, error) {
 		usr, err = c.GetUserInfoContext(ctx, id)
 		return err
 	})
+	if rootMsg(err) == "user_not_found" {
+		return nil, validation.NewGenericError("User not found.")
+	}
 	if err != nil {
 		return nil, fmt.Errorf("get user: %w", err)
 	}

--- a/web/src/app/escalation-policies/PolicyStepEditDialogDest.stories.tsx
+++ b/web/src/app/escalation-policies/PolicyStepEditDialogDest.stories.tsx
@@ -152,7 +152,11 @@ export const UpdatePolicyStep: Story = {
     await userEvent.type(delayField, '999')
     await userEvent.click(await canvas.findByText('Submit'))
 
-    await expect(await canvas.findByText('generic dialog error')).toBeVisible()
+    await waitFor(async function Error() {
+      await expect(
+        await canvas.findByText('generic dialog error'),
+      ).toBeVisible()
+    })
 
     await expect(args.onClose).not.toHaveBeenCalled() // should not close on error
 

--- a/web/src/app/escalation-policies/PolicyStepsQuery.tsx
+++ b/web/src/app/escalation-policies/PolicyStepsQuery.tsx
@@ -36,10 +36,15 @@ export const policyStepsQueryDest = gql`
         actions {
           type
           displayInfo {
-            text
-            iconURL
-            iconAltText
-            linkURL
+            ... on DestinationDisplayInfo {
+              text
+              iconURL
+              iconAltText
+              linkURL
+            }
+            ... on DestinationDisplayInfoError {
+              error
+            }
           }
         }
         targets {

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsListDest.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsListDest.tsx
@@ -10,7 +10,6 @@ import { Add } from '@mui/icons-material'
 import Error from '@mui/icons-material/Error'
 import { gql, useQuery } from 'urql'
 import {
-  DestinationDisplayInfo,
   DestinationDisplayInfoError,
   InlineDisplayInfo,
   Schedule,

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsListDest.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsListDest.tsx
@@ -9,11 +9,7 @@ import { useIsWidthDown } from '../../util/useWidth'
 import { Add } from '@mui/icons-material'
 import Error from '@mui/icons-material/Error'
 import { gql, useQuery } from 'urql'
-import {
-  DestinationDisplayInfoError,
-  InlineDisplayInfo,
-  Schedule,
-} from '../../../schema'
+import { Schedule } from '../../../schema'
 import { DestinationAvatar } from '../../util/DestinationAvatar'
 import { styles as globalStyles } from '../../styles/materialStyles'
 import makeStyles from '@mui/styles/makeStyles'

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsListDest.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsListDest.tsx
@@ -54,12 +54,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   ...globalStyles(theme),
 }))
 
-function isDisplayErr(
-  err: InlineDisplayInfo,
-): err is DestinationDisplayInfoError {
-  return (err as unknown as DestinationDisplayInfoError).error !== undefined
-}
-
 export default function ScheduleOnCallNotificationsListDest({
   scheduleID,
 }: ScheduleOnCallNotificationsListDestProps): JSX.Element {
@@ -128,7 +122,7 @@ export default function ScheduleOnCallNotificationsListDest({
               }
               items={q.data.schedule.onCallNotificationRules.map((rule) => {
                 const display = rule.dest.displayInfo
-                if (isDisplayErr(display)) {
+                if ('error' in display) {
                   return {
                     icon: <DestinationAvatar error />,
                     title: `ERROR: ${display.error}`,

--- a/web/src/app/selection/DestinationSearchSelect.stories.tsx
+++ b/web/src/app/selection/DestinationSearchSelect.stories.tsx
@@ -5,7 +5,7 @@ import { expect, userEvent, within } from '@storybook/test'
 import { handleDefaultConfig, handleExpFlags } from '../storybook/graphql'
 import { HttpResponse, graphql } from 'msw'
 import { useArgs } from '@storybook/preview-api'
-import { FieldValueConnection } from '../../schema'
+import { FieldSearchConnection } from '../../schema'
 
 const meta = {
   title: 'util/DestinationSearchSelect',
@@ -42,7 +42,7 @@ const meta = {
               data: {
                 destinationFieldSearch: {
                   nodes: [],
-                  __typename: 'FieldValueConnection',
+                  __typename: 'FieldSearchConnection',
                 },
               },
             })
@@ -68,7 +68,7 @@ const meta = {
               },
             },
           } satisfies {
-            data: { destinationFieldSearch: Partial<FieldValueConnection> }
+            data: { destinationFieldSearch: Partial<FieldSearchConnection> }
           })
         }),
         graphql.query('DestinationFieldValueName', ({ variables: vars }) => {

--- a/web/src/app/selection/DestinationSearchSelect.tsx
+++ b/web/src/app/selection/DestinationSearchSelect.tsx
@@ -3,7 +3,7 @@ import { useQuery, gql } from 'urql'
 import {
   DestinationFieldConfig,
   DestinationType,
-  FieldValueConnection,
+  FieldSearchConnection,
 } from '../../schema'
 import MaterialSelect from './MaterialSelect'
 import { FavoriteIcon } from '../util/SetFavoriteButton'
@@ -68,7 +68,7 @@ export default function DestinationSearchSelect(
 
   // check validation of the input phoneNumber through graphql
   const [{ data, fetching, error }] = useQuery<{
-    destinationFieldSearch: FieldValueConnection
+    destinationFieldSearch: FieldSearchConnection
   }>({
     query: searchOptionsQuery,
     variables: {

--- a/web/src/app/users/UserContactMethodEditDialogDest.stories.tsx
+++ b/web/src/app/users/UserContactMethodEditDialogDest.stories.tsx
@@ -6,6 +6,7 @@ import { handleDefaultConfig, handleExpFlags } from '../storybook/graphql'
 import { useArgs } from '@storybook/preview-api'
 import { HttpResponse, graphql } from 'msw'
 import { DestFieldValueError, InputFieldError } from '../util/errtypes'
+import { Destination } from '../../schema'
 
 const meta = {
   title: 'users/UserContactMethodEditDialogDest',
@@ -39,10 +40,15 @@ const meta = {
                           {
                             fieldID: 'phone-number',
                             value: '+15555555555',
-                            label: '+1 555-555-5555',
                           },
                         ],
-                      },
+                        displayInfo: {
+                          text: '+1 555-555-5555',
+                          iconAltText: 'Voice Call',
+                          iconURL: '',
+                          linkURL: '',
+                        },
+                      } satisfies Destination,
                       value: 'http://localhost:8080',
                       statusUpdates: 'DISABLED',
                       disabled: false,
@@ -56,21 +62,24 @@ const meta = {
                         values: [
                           {
                             fieldID: 'first-field',
-                            label: '+1 555-555-5555',
                             value: '+11235550123',
                           },
                           {
                             fieldID: 'second-field',
-                            label: 'email',
                             value: 'foobar@example.com',
                           },
                           {
                             fieldID: 'third-field',
-                            label: 'slack user ID',
                             value: 'slack',
                           },
                         ],
-                      },
+                        displayInfo: {
+                          text: '11235550123',
+                          iconAltText: 'Mulitple Fields Example',
+                          iconURL: '',
+                          linkURL: '',
+                        },
+                      } satisfies Destination,
                       statusUpdates: 'ENABLED',
                       disabled: false,
                       pending: false,

--- a/web/src/app/users/UserContactMethodEditDialogDest.tsx
+++ b/web/src/app/users/UserContactMethodEditDialogDest.tsx
@@ -22,7 +22,6 @@ const query = gql`
         values {
           fieldID
           value
-          label
         }
       }
       statusUpdates

--- a/web/src/app/users/UserContactMethodListDest.stories.tsx
+++ b/web/src/app/users/UserContactMethodListDest.stories.tsx
@@ -4,6 +4,7 @@ import UserContactMethodListDest from './UserContactMethodListDest'
 import { expect, within, userEvent, screen } from '@storybook/test'
 import { handleDefaultConfig, handleExpFlags } from '../storybook/graphql'
 import { HttpResponse, graphql } from 'msw'
+import { Destination } from '../../schema'
 
 const meta = {
   title: 'users/UserContactMethodListDest',
@@ -31,14 +32,15 @@ const meta = {
                               {
                                 fieldID: 'phone-number',
                                 value: '+15555555555',
-                                label: '+1 555-555-5555',
                               },
                             ],
                             displayInfo: {
                               text: '+1 555-555-5555',
                               iconAltText: 'Voice Call',
+                              iconURL: '',
+                              linkURL: '',
                             },
-                          },
+                          } satisfies Destination,
                           disabled: false,
                           pending: false,
                         },
@@ -58,24 +60,23 @@ const meta = {
                               {
                                 fieldID: 'first-field',
                                 value: 'test_user@target.com',
-                                label: 'test_user@target.com',
                               },
                               {
                                 fieldID: 'second-field',
                                 value: 'parameter-1',
-                                label: 'parameter-1',
                               },
                               {
                                 fieldID: 'third-field',
                                 value: 'parameter-2',
-                                label: 'parameter-2',
                               },
                             ],
                             displayInfo: {
                               text: 'test_user@target.com',
                               iconAltText: 'Email',
+                              iconURL: '',
+                              linkURL: '',
                             },
-                          },
+                          } satisfies Destination,
                           disabled: false,
                           pending: false,
                         },
@@ -88,14 +89,15 @@ const meta = {
                               {
                                 fieldID: 'phone-number',
                                 value: '+15555555556',
-                                label: '+1 555-555-5556',
                               },
                             ],
                             displayInfo: {
                               text: '+1 555-555-5556',
                               iconAltText: 'Voice Call',
+                              iconURL: '',
+                              linkURL: '',
                             },
-                          },
+                          } satisfies Destination,
                           disabled: false,
                           pending: false,
                         },

--- a/web/src/app/users/UserContactMethodListDest.stories.tsx
+++ b/web/src/app/users/UserContactMethodListDest.stories.tsx
@@ -34,6 +34,10 @@ const meta = {
                                 label: '+1 555-555-5555',
                               },
                             ],
+                            displayInfo: {
+                              text: '+1 555-555-5555',
+                              iconAltText: 'Voice Call',
+                            },
                           },
                           disabled: false,
                           pending: false,
@@ -53,20 +57,24 @@ const meta = {
                             values: [
                               {
                                 fieldID: 'first-field',
-                                value: '+15555555555',
-                                label: '+1 555-555-5555',
-                              },
-                              {
-                                fieldID: 'second-field',
                                 value: 'test_user@target.com',
                                 label: 'test_user@target.com',
                               },
                               {
+                                fieldID: 'second-field',
+                                value: 'parameter-1',
+                                label: 'parameter-1',
+                              },
+                              {
                                 fieldID: 'third-field',
-                                value: 'U03SM0U8TPE',
-                                label: '@TestUser',
+                                value: 'parameter-2',
+                                label: 'parameter-2',
                               },
                             ],
+                            displayInfo: {
+                              text: 'test_user@target.com',
+                              iconAltText: 'Email',
+                            },
                           },
                           disabled: false,
                           pending: false,
@@ -83,6 +91,10 @@ const meta = {
                                 label: '+1 555-555-5556',
                               },
                             ],
+                            displayInfo: {
+                              text: '+1 555-555-5556',
+                              iconAltText: 'Voice Call',
+                            },
                           },
                           disabled: false,
                           pending: false,
@@ -153,8 +165,6 @@ export const MultiContactMethods: Story = {
     ).toBeVisible()
     await expect(await canvas.findByText('+1 555-555-5556')).toBeVisible()
     await expect(await canvas.findByText('test_user@target.com')).toBeVisible()
-    // ensure has link when hint url exists
-    await expect(canvas.getByText('docs')).toHaveAttribute('href', '/docs')
     // ensure all edit icons exists
     await expect(await canvas.findAllByTestId('MoreHorizIcon')).toHaveLength(2)
   },

--- a/web/src/app/users/UserContactMethodListDest.tsx
+++ b/web/src/app/users/UserContactMethodListDest.tsx
@@ -1,14 +1,7 @@
 import React, { useState, ReactNode } from 'react'
 import { gql, useQuery } from 'urql'
 import FlatList from '../lists/FlatList'
-import {
-  Button,
-  Card,
-  CardHeader,
-  Grid,
-  IconButton,
-  Typography,
-} from '@mui/material'
+import { Button, Card, CardHeader, Grid, IconButton } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
 import { Theme } from '@mui/material/styles'
 import { Add } from '@mui/icons-material'
@@ -21,7 +14,6 @@ import UserContactMethodVerificationDialog from './UserContactMethodVerification
 import { useIsWidthDown } from '../util/useWidth'
 import { GenericError, ObjectNotFound } from '../error-pages'
 import SendTestDialog from './SendTestDialog'
-import AppLink from '../util/AppLink'
 import { styles as globalStyles } from '../styles/materialStyles'
 import { UserContactMethod } from '../../schema'
 import UserContactMethodCreateDialog from './UserContactMethodCreateDialog'

--- a/web/src/app/users/UserContactMethodListDest.tsx
+++ b/web/src/app/users/UserContactMethodListDest.tsx
@@ -184,35 +184,19 @@ export default function UserContactMethodListDest(
     )
   }
 
-  function getSubText(cm: UserContactMethod): JSX.Element {
-    return (
-      <React.Fragment>
-        {cm.dest.values.map((v) => {
-          const fieldInfo = destinationTypes
-            .find((d) => d.type === cm.dest.type)
-            ?.requiredFields.find((rf) => v.fieldID === rf.fieldID)
+  function getSubText(cm: UserContactMethod): string {
+    let cmText
+    if ('error' in cm.dest.displayInfo) {
+      cmText = `ERROR: ${cm.dest.displayInfo.error}`
+    } else {
+      cmText = cm.dest.displayInfo.text
+    }
 
-          let cmText = v.label
-          if (cm.pending) {
-            cmText = `${cmText} - this contact method will be automatically deleted if not verified`
-          }
-          if (fieldInfo?.hintURL) {
-            return (
-              <Typography component='span' key={v.toString()}>
-                {`${cmText} (`}
-                <AppLink to={fieldInfo.hintURL}>{fieldInfo.hint}</AppLink>)
-              </Typography>
-            )
-          }
+    if (cm.pending) {
+      cmText += ` - this contact method will be automatically deleted if not verified`
+    }
 
-          return (
-            <Typography component='span' key={v.toString()}>
-              {cmText}
-            </Typography>
-          )
-        })}
-      </React.Fragment>
-    )
+    return cmText
   }
 
   return (

--- a/web/src/app/users/UserContactMethodListDest.tsx
+++ b/web/src/app/users/UserContactMethodListDest.tsx
@@ -39,13 +39,17 @@ const query = gql`
           values {
             fieldID
             value
-            label
           }
           displayInfo {
-            text
-            iconURL
-            iconAltText
-            linkURL
+            ... on DestinationDisplayInfo {
+              text
+              iconURL
+              iconAltText
+              linkURL
+            }
+            ... on DestinationDisplayInfoError {
+              error
+            }
           }
         }
         disabled

--- a/web/src/app/users/UserNotificationRuleListDest.tsx
+++ b/web/src/app/users/UserNotificationRuleListDest.tsx
@@ -35,8 +35,13 @@ const query = gql`
           dest {
             type
             displayInfo {
-              text
-              iconAltText
+              ... on DestinationDisplayInfo {
+                text
+                iconAltText
+              }
+              ... on DestinationDisplayInfoError {
+                error
+              }
             }
           }
         }

--- a/web/src/app/util/DestinationChip.tsx
+++ b/web/src/app/util/DestinationChip.tsx
@@ -1,11 +1,9 @@
 import React from 'react'
 import { Chip } from '@mui/material'
-import { DestinationDisplayInfo } from '../../schema'
+import { InlineDisplayInfo } from '../../schema'
 import { DestinationAvatar } from './DestinationAvatar'
 
-export type DestinationChipProps = DestinationDisplayInfo & {
-  error?: string
-
+export type DestinationChipProps = InlineDisplayInfo & {
   // If onDelete is provided, a delete icon will be shown.
   onDelete?: () => void
 }
@@ -20,7 +18,7 @@ export type DestinationChipProps = DestinationDisplayInfo & {
 export default function DestinationChip(
   props: DestinationChipProps,
 ): React.ReactNode {
-  if (props.error) {
+  if ('error' in props) {
     return (
       <Chip
         avatar={<DestinationAvatar error />}

--- a/web/src/app/util/DestinationInputChip.tsx
+++ b/web/src/app/util/DestinationInputChip.tsx
@@ -40,13 +40,16 @@ export default function DestinationInputChip(
     context,
   })
 
+  if (error) {
+    return <DestinationChip error={error.message} onDelete={props.onDelete} />
+  }
+
   return (
     <DestinationChip
       iconAltText={data?.destinationDisplayInfo.iconAltText || ''}
       iconURL={data?.destinationDisplayInfo.iconURL || ''}
       linkURL={data?.destinationDisplayInfo.linkURL || ''}
       text={data?.destinationDisplayInfo.text || ''}
-      error={error?.message}
       onDelete={props.onDelete}
     />
   )

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -445,8 +445,15 @@ export interface EscalationPolicyStep {
   targets: Target[]
 }
 
+export interface FieldSearchResult {
+  fieldID: string
+  isFavorite: boolean
+  label: string
+  value: string
+}
+
 export interface FieldValueConnection {
-  nodes: FieldValuePair[]
+  nodes: FieldSearchResult[]
   pageInfo: PageInfo
 }
 
@@ -457,8 +464,6 @@ export interface FieldValueInput {
 
 export interface FieldValuePair {
   fieldID: string
-  isFavorite: boolean
-  label: string
   value: string
 }
 

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -344,7 +344,7 @@ export interface DebugSendSMSInput {
 }
 
 export interface Destination {
-  displayInfo: DestinationDisplayInfo
+  displayInfo: InlineDisplayInfo
   type: DestinationType
   values: FieldValuePair[]
 }
@@ -354,6 +354,10 @@ export interface DestinationDisplayInfo {
   iconURL: string
   linkURL: string
   text: string
+}
+
+export interface DestinationDisplayInfoError {
+  error: string
 }
 
 export interface DestinationFieldConfig {
@@ -500,6 +504,10 @@ export type ISODuration = string
 export type ISORInterval = string
 
 export type ISOTimestamp = string
+
+export type InlineDisplayInfo =
+  | DestinationDisplayInfo
+  | DestinationDisplayInfoError
 
 export type Int = string
 

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -445,16 +445,16 @@ export interface EscalationPolicyStep {
   targets: Target[]
 }
 
+export interface FieldSearchConnection {
+  nodes: FieldSearchResult[]
+  pageInfo: PageInfo
+}
+
 export interface FieldSearchResult {
   fieldID: string
   isFavorite: boolean
   label: string
   value: string
-}
-
-export interface FieldValueConnection {
-  nodes: FieldSearchResult[]
-  pageInfo: PageInfo
 }
 
 export interface FieldValueInput {
@@ -729,7 +729,7 @@ export interface Query {
   debugMessageStatus: DebugMessageStatusInfo
   debugMessages: DebugMessage[]
   destinationDisplayInfo: DestinationDisplayInfo
-  destinationFieldSearch: FieldValueConnection
+  destinationFieldSearch: FieldSearchConnection
   destinationFieldValidate: boolean
   destinationFieldValueName: string
   destinationTypes: DestinationTypeInfo[]


### PR DESCRIPTION
**Description:**
Fixes error handling with the new destination API. Namely, it prevents the entire page from breaking (e.g., the escalation policy details page) if any single action is invalid (e.g., archived or invalid slack channel). Instead individual chips/line items will render an error.

The purpose is to ensure in such an event, a user is able to interact with the page and take action to resolve the issue.

- gql typescript generator tool was updated to support GraphQL unions

**Screenshots:**
<details>
<summary>Escalation Policy Details</summary>

TODAY
![image](https://github.com/target/goalert/assets/595010/efdf658e-9629-4686-9524-d9b870ecbe6c)

This PR
![image](https://github.com/target/goalert/assets/595010/20c710af-4c22-46d5-ab73-ae3b76a462a7)
![image](https://github.com/target/goalert/assets/595010/3581896a-b47f-4f21-b766-bc0df03b6d2c)
</details>

<details>
<summary>User Contact Methods</summary>

TODAY
![image](https://github.com/target/goalert/assets/595010/bf0f3726-14eb-4af8-b163-8804bb8f5f4b)

This PR
![image](https://github.com/target/goalert/assets/595010/359ace28-56fc-4666-bdd9-880956342902)
</details>

<details>
<summary>Schedule On-Call Notifications</summary>

TODAY
![image](https://github.com/target/goalert/assets/595010/e09a419b-7f0f-41a6-b58c-6fa49872b8ad)

This PR
![image](https://github.com/target/goalert/assets/595010/26dca897-e883-4609-b53f-0409352ce271)
![image](https://github.com/target/goalert/assets/595010/87e08c63-969d-4c06-9537-7d966ac07d8f)
</details>

**Describe any introduced user-facing changes:**
N/A fixing broken behavior

**Describe any introduced API changes:**
!! Breaking changes to the destination's API !!

- `FieldValuePair` no longer contains `label` and `isFavorite` these were moved to `FieldSearchResult` to separate the two
- `Destination.displayInfo` return type changed from `DestinationDisplayInfo` to a union of `DestinationDisplayInfo` and `DestinationDisplayInfoError` -- rather than failing the entire query with a global error, errors are now returned inline
- `destinationFieldSearch` return type changed to `FieldSearchConnection`, which was renamed from `FieldValueConnection` to match `FieldSearchResult`

**Additional Info:**
The affected APIs are only used when the `dest-types` experimental flag is enabled.
