### PR TITLE
dev: ignore deleted files when calculating pr size

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -23,6 +23,7 @@ jobs:
           l_max_size: '500'
           xl_label: 'size/xl'
           fail_if_xl: 'true'
+          ignore_deleted: 'true'
           message_if_xl: >
             This PR exceeds the recommended size of 500 lines.
             Please make sure you are NOT addressing multiple issues with one PR.


### PR DESCRIPTION
**Description:**
Enables the `ignore_deleted` option in the labeler, this ignores the size of deleted files when calculating the size label for a PR.