### PR TITLE
engine/statusmgr: Skip status updates without an associated log entry

### DIFF
--- a/app/cmd.go
+++ b/app/cmd.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"runtime"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/pelletier/go-toml/v2"
@@ -42,6 +43,11 @@ var shutdownSignalCh = make(chan os.Signal, 2)
 var ErrDBRequired = validation.NewFieldError("db-url", "is required")
 
 func init() {
+	if testing.Testing() {
+		// Skip signal handling in tests.
+		return
+	}
+
 	signal.Notify(shutdownSignalCh, shutdownSignals...)
 }
 

--- a/engine/statusmgr/db.go
+++ b/engine/statusmgr/db.go
@@ -29,5 +29,6 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 
 	return &DB{
 		lock: lock,
+		omit: make([]int64, 0, 100), // pre-allocate for 100, needs to not be nil or the query will fail
 	}, nil
 }

--- a/engine/statusmgr/db.go
+++ b/engine/statusmgr/db.go
@@ -10,6 +10,8 @@ import (
 // DB manages outgoing status updates.
 type DB struct {
 	lock *processinglock.Lock
+
+	omit []int64
 }
 
 // Name returns the name of the module.

--- a/engine/statusmgr/queries.sql
+++ b/engine/statusmgr/queries.sql
@@ -29,7 +29,8 @@ SELECT
 FROM
     alert_status_subscriptions sub
 WHERE
-    sub.last_alert_status !=(
+    sub.id != ANY ($1::bigint[])
+    AND sub.last_alert_status !=(
         SELECT
             status
         FROM

--- a/engine/statusmgr/queries.sql
+++ b/engine/statusmgr/queries.sql
@@ -28,8 +28,7 @@ SELECT
             a.id = sub.alert_id)
 FROM
     alert_status_subscriptions sub
-WHERE
-    sub.id != ANY ($1::bigint[])
+WHERE (NOT (sub.id = ANY ($1::bigint[])))
     AND sub.last_alert_status !=(
         SELECT
             status

--- a/engine/statusmgr/update.go
+++ b/engine/statusmgr/update.go
@@ -48,6 +48,9 @@ func (db *DB) UpdateAll(ctx context.Context) error {
 
 	// Clear omit list, as we want to process all
 	// subscriptions in the next step.
+	//
+	// We don't want to assign nil to omit, as it
+	// will cause the query to fail.
 	db.omit = db.omit[:0]
 
 	// process up to 100

--- a/engine/statusmgr/update.go
+++ b/engine/statusmgr/update.go
@@ -46,6 +46,10 @@ func (db *DB) UpdateAll(ctx context.Context) error {
 		return err
 	}
 
+	// Clear omit list, as we want to process all
+	// subscriptions in the next step.
+	db.omit = db.omit[:0]
+
 	// process up to 100
 	for i := 0; i < 100; i++ {
 		err = db.lock.WithTx(ctx, db.update)
@@ -66,13 +70,17 @@ var errDone = errors.New("done")
 func (db *DB) update(ctx context.Context, tx *sql.Tx) error {
 	q := gadb.New(tx)
 
-	sub, err := q.StatusMgrNextUpdate(ctx)
+	sub, err := q.StatusMgrNextUpdate(ctx, db.omit)
 	if errors.Is(err, sql.ErrNoRows) {
 		return errDone
 	}
 	if err != nil {
 		return fmt.Errorf("query out-of-date alert status: %w", err)
 	}
+
+	// Add to omit list to prevent re-processing
+	// the same subscription in the same run.
+	db.omit = append(db.omit, sub.ID)
 
 	var eventType gadb.EnumAlertLogEvent
 	switch sub.Status {
@@ -84,23 +92,22 @@ func (db *DB) update(ctx context.Context, tx *sql.Tx) error {
 		eventType = gadb.EnumAlertLogEventClosed
 	}
 
-	var entryID sql.NullInt64
 	entry, err := q.StatusMgrLogEntry(ctx, gadb.StatusMgrLogEntryParams{
 		AlertID:   sub.AlertID,
 		EventType: eventType,
 	})
 	if errors.Is(err, sql.ErrNoRows) {
-		// log entry is best-effort, but not required
+		// no log entry, ignore
 		err = nil
 	}
 	if err != nil {
 		return fmt.Errorf("lookup latest log entry of '%s' for alert #%d: %w", eventType, sub.AlertID, err)
 	}
-	if entry.ID > 0 {
-		entryID = sql.NullInt64{Int64: int64(entry.ID), Valid: true}
-	}
 
 	switch {
+	case entry.ID == 0:
+		// no log entry, log error but continue
+		log.Log(ctx, fmt.Errorf("no log entry found for alert #%d status update (%s), skipping", sub.AlertID, eventType))
 	case sub.ContactMethodID.Valid:
 		info, err := q.StatusMgrCMInfo(ctx, sub.ContactMethodID.UUID)
 		if errors.Is(err, sql.ErrNoRows) {
@@ -121,7 +128,7 @@ func (db *DB) update(ctx context.Context, tx *sql.Tx) error {
 			CmID:    sub.ContactMethodID.UUID,
 			AlertID: sub.AlertID,
 			UserID:  info.UserID,
-			LogID:   entryID,
+			LogID:   sql.NullInt64{Int64: int64(entry.ID), Valid: true},
 		})
 		if err != nil {
 			return fmt.Errorf("send user status update message: %w", err)
@@ -131,7 +138,7 @@ func (db *DB) update(ctx context.Context, tx *sql.Tx) error {
 			ID:        uuid.New(),
 			ChannelID: sub.ChannelID.UUID,
 			AlertID:   sub.AlertID,
-			LogID:     entryID,
+			LogID:     sql.NullInt64{Int64: int64(entry.ID), Valid: true},
 		})
 		if err != nil {
 			return fmt.Errorf("send channel status update message: %w", err)

--- a/gadb/queries.sql.go
+++ b/gadb/queries.sql.go
@@ -2052,7 +2052,8 @@ SELECT
 FROM
     alert_status_subscriptions sub
 WHERE
-    sub.last_alert_status !=(
+    sub.id != ANY ($1::bigint[])
+    AND sub.last_alert_status !=(
         SELECT
             status
         FROM
@@ -2072,8 +2073,8 @@ type StatusMgrNextUpdateRow struct {
 	Status          EnumAlertStatus
 }
 
-func (q *Queries) StatusMgrNextUpdate(ctx context.Context) (StatusMgrNextUpdateRow, error) {
-	row := q.db.QueryRowContext(ctx, statusMgrNextUpdate)
+func (q *Queries) StatusMgrNextUpdate(ctx context.Context, dollar_1 []int64) (StatusMgrNextUpdateRow, error) {
+	row := q.db.QueryRowContext(ctx, statusMgrNextUpdate, pq.Array(dollar_1))
 	var i StatusMgrNextUpdateRow
 	err := row.Scan(
 		&i.ID,

--- a/gadb/queries.sql.go
+++ b/gadb/queries.sql.go
@@ -2051,8 +2051,7 @@ SELECT
             a.id = sub.alert_id)
 FROM
     alert_status_subscriptions sub
-WHERE
-    sub.id != ANY ($1::bigint[])
+WHERE (NOT (sub.id = ANY ($1::bigint[])))
     AND sub.last_alert_status !=(
         SELECT
             status

--- a/test/smoke/statusupdatesnolog_test.go
+++ b/test/smoke/statusupdatesnolog_test.go
@@ -1,0 +1,67 @@
+package smoke
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/test/smoke/harness"
+)
+
+// TestStatusUpdatesNoLog tests status updates continue to work when no logs are present.
+func TestStatusUpdatesNoLog(t *testing.T) {
+	t.Parallel()
+
+	sql := `
+	insert into escalation_policies (id, name) 
+	values
+		({{uuid "eid"}}, 'esc policy');
+	insert into escalation_policy_steps (id, escalation_policy_id) 
+	values
+		({{uuid "esid"}}, {{uuid "eid"}});
+
+	insert into notification_channels (id, type, name, value)
+	values
+		({{uuid "chan"}}, 'SLACK', '#test', {{slackChannelID "test"}});
+
+	insert into escalation_policy_actions (escalation_policy_step_id, channel_id) 
+	values 
+		({{uuid "esid"}}, {{uuid "chan"}});
+
+	insert into services (id, escalation_policy_id, name) 
+	values
+		({{uuid "sid"}}, {{uuid "eid"}}, 'service');
+`
+	h := harness.NewHarness(t, sql, "slack-user-link")
+	defer h.Close()
+
+	a := h.CreateAlertWithDetails(h.UUID("sid"), "testing", "details")
+	msg := h.Slack().Channel("test").ExpectMessage("testing")
+	msg.AssertColor("#862421")
+	msg.AssertActions()
+
+	// ensure no processing happens
+	err := h.App().Pause(context.Background())
+	require.NoError(t, err)
+	a.Ack()
+
+	_, err = h.App().DB().Exec("delete from alert_logs;")
+	require.NoError(t, err)
+
+	h.IgnoreErrorsWith("no log entry found for alert #1 status update (acknowledged), skipping")
+
+	err = h.App().Resume(context.Background())
+	require.NoError(t, err)
+
+	h.Trigger()
+	// first update should be skipped
+
+	a.Close()
+
+	updated := msg.ExpectUpdate()
+	updated.AssertText("Closed", "testing")
+	updated.AssertNotText("details")
+	updated.AssertColor("#218626")
+
+	updated.AssertActions() // no actions
+}


### PR DESCRIPTION
**Description:**
This PR introduces logic to "skip" status updates that are missing log entries.

Currently, these updates will result in _all_ status updates failing indefinitely, or until the alert has no changes for 7 days.

The new behavior has the following properties:
- If a log entry is missing for any reason, an error is logged, the status update is skipped, and the status subscription is updated. This means future updates will still be attempted.
- Since only log entries from the last hour are considered, that means 1 hour is the max possible delay for a status update (currently, it is indefinite)
- An "omit" list is kept during each engine cycle, ensuring each subscription is attempted at most once per engine cycle. If a status update fails today, it will be retried 100 times, blocking all others.

**Which issue(s) this PR fixes:**
Closes #3783 

**Additional Info:**
- As per testing this, a dev bug was fixed where CTRL+C would fail to cancel unit tests or smoke tests.
