### PR TITLE
webworker: add check on worker method name

### DIFF
--- a/web/src/app/worker/worker.ts
+++ b/web/src/app/worker/worker.ts
@@ -2,6 +2,13 @@ import methods from './methods'
 
 self.onmessage = (e) => {
   const method = e.data.method as keyof typeof methods
+
+  if (!(method in methods)) {
+    // Shouldn't happen, but ensures that we can't unknowingly
+    // call a method that doesn't exist, or is on the prototype.
+    throw new Error('Invalid method')
+  }
+
   const result = methods[method](e.data.arg)
   self.postMessage(result)
 }


### PR DESCRIPTION
**Description:**
It adds a check that the method name sent to the web worker is one of the expected/defined ones, and it prevents any unknown values from matching, e.g., the prototype.
