### PR TITLE
ui/config: always request dest types

### DIFF
--- a/web/src/app/selection/DestinationInputDirect.tsx
+++ b/web/src/app/selection/DestinationInputDirect.tsx
@@ -119,6 +119,7 @@ export default function DestinationInputDirect(
   return (
     <TextField
       fullWidth
+      name={props.fieldID}
       disabled={props.disabled}
       InputProps={iprops}
       type={props.inputType}

--- a/web/src/app/selection/DestinationSearchSelect.tsx
+++ b/web/src/app/selection/DestinationSearchSelect.tsx
@@ -125,6 +125,7 @@ export default function DestinationSearchSelect(
 
   return (
     <MaterialSelect
+      name={props.fieldID}
       isLoading={fetching}
       multiple={false}
       noOptionsText='No options'

--- a/web/src/app/util/RequireConfig.tsx
+++ b/web/src/app/util/RequireConfig.tsx
@@ -8,7 +8,6 @@ import {
   DestinationTypeInfo,
   DestinationType,
 } from '../../schema'
-import { useExpFlag } from './useExpFlag'
 
 type Value = boolean | number | string | string[] | null
 export type ConfigData = Record<ConfigID, Value>
@@ -24,29 +23,6 @@ const ConfigContext = React.createContext({
 ConfigContext.displayName = 'ConfigContext'
 
 const query = gql`
-  query RequireConfig {
-    user {
-      id
-      name
-      role
-    }
-    config {
-      id
-      type
-      value
-    }
-    integrationKeyTypes {
-      id
-      name
-      label
-      enabled
-    }
-  }
-`
-
-// expDestQuery will be used when "dest-types" experimental flag is enabled.
-// expDestQuery should replace "query" when new components have been fully integrated into master branch for https://github.com/target/goalert/issues/2639
-const expDestQuery = gql`
   query RequireConfig {
     user {
       id
@@ -96,9 +72,8 @@ type ConfigProviderProps = {
 }
 
 export function ConfigProvider(props: ConfigProviderProps): React.ReactNode {
-  const hasDestTypesFlag = useExpFlag('dest-types')
   const [{ data }] = useQuery({
-    query: hasDestTypesFlag ? expDestQuery : query,
+    query,
   })
 
   return (


### PR DESCRIPTION
**Description:**
Updates the RequireConfig component to always request `destinationTypes` -- the API is no longer under the experimental flag.

- A missing `name` prop was also added to the `DestinationInputDirect` and `DestinationSearchSelect` components