### PR TITLE
service maint: allow specifying a custom end time

### DIFF
--- a/web/src/app/services/ServiceMaintenanceDialog.tsx
+++ b/web/src/app/services/ServiceMaintenanceDialog.tsx
@@ -45,9 +45,10 @@ function ServiceMaintenanceForm(props: {
         <FormControlLabel value={1} control={<Radio />} label={label(1)} />
         <FormControlLabel value={2} control={<Radio />} label={label(2)} />
         <FormControlLabel value={4} control={<Radio />} label={label(4)} />
-        <FormControlLabel value={-1} control={<Radio />} label='Specify' />
+        <FormControlLabel value={-1} control={<Radio />} label='Until...' />
       </RadioGroup>
       <ISODateTimePicker
+        label='Select a date'
         value={props.value.toISO()}
         disabled={selectedOption !== -1}
         onChange={(iso) => props.onChange(DateTime.fromISO(iso))}

--- a/web/src/app/services/ServiceMaintenanceDialog.tsx
+++ b/web/src/app/services/ServiceMaintenanceDialog.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { gql, useMutation } from 'urql'
-import { RadioGroup, Radio } from '@mui/material'
-
+import { RadioGroup, Radio, Typography } from '@mui/material'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import FormControl from '@mui/material/FormControl'
 import FormDialog from '../dialogs/FormDialog'
@@ -19,7 +18,7 @@ interface Props {
 function label(hours: number): JSX.Element {
   return (
     <span>
-      For <Time duration={{ hours }} /> (
+      <Time duration={{ hours }} /> (
       <Time prefix='ends ' time={DateTime.local().plus({ hours }).toISO()} />)
     </span>
   )
@@ -54,6 +53,10 @@ function ServiceMaintenanceForm(props: {
         onChange={(iso) => props.onChange(DateTime.fromISO(iso))}
         min={DateTime.local().plus({ hours: 1 }).toISO()}
         max={DateTime.local().plus({ hours: 24 }).toISO()}
+        sx={{
+          marginLeft: (theme) => theme.spacing(3.75),
+          marginTop: (theme) => theme.spacing(1),
+        }}
       />
     </FormControl>
   )
@@ -81,7 +84,7 @@ export default function ServiceMaintenanceModeDialog(
       maxWidth='sm'
       title='Set Maintenance Mode'
       subTitle={
-        <React.Fragment>
+        <Typography>
           Pause all outgoing notifications and escalations for{' '}
           <Time
             duration={{
@@ -90,7 +93,7 @@ export default function ServiceMaintenanceModeDialog(
           />
           . Incoming alerts will still be created and will continue as normal
           after maintenance mode ends.
-        </React.Fragment>
+        </Typography>
       }
       loading={updateServiceStatus.fetching}
       errors={nonFieldErrors(updateServiceStatus.error)}

--- a/web/src/app/services/ServiceMaintenanceDialog.tsx
+++ b/web/src/app/services/ServiceMaintenanceDialog.tsx
@@ -8,6 +8,7 @@ import FormDialog from '../dialogs/FormDialog'
 import { nonFieldErrors } from '../util/errutil'
 import { DateTime } from 'luxon'
 import { Time } from '../util/Time'
+import { ISODateTimePicker } from '../util/ISOPickers'
 
 interface Props {
   serviceID: string
@@ -25,19 +26,35 @@ function label(hours: number): JSX.Element {
 }
 
 function ServiceMaintenanceForm(props: {
-  onChange: (val: number) => void
-  selectedIndex: number
+  value: DateTime
+  onChange: (val: DateTime) => void
 }): JSX.Element {
+  const [selectedOption, setSelectedOption] = useState(1)
+
+  function handleOption(value: number): void {
+    setSelectedOption(value)
+    if (value === -1) return
+    props.onChange(DateTime.local().plus({ hours: value }))
+  }
+
   return (
     <FormControl>
       <RadioGroup
-        value={props.selectedIndex}
-        onChange={(e) => props.onChange(parseInt(e.target.value, 10))}
+        value={selectedOption}
+        onChange={(e) => handleOption(parseInt(e.target.value, 10))}
       >
         <FormControlLabel value={1} control={<Radio />} label={label(1)} />
         <FormControlLabel value={2} control={<Radio />} label={label(2)} />
         <FormControlLabel value={4} control={<Radio />} label={label(4)} />
+        <FormControlLabel value={-1} control={<Radio />} label='Specify' />
       </RadioGroup>
+      <ISODateTimePicker
+        value={props.value.toISO()}
+        disabled={selectedOption !== -1}
+        onChange={(iso) => props.onChange(DateTime.fromISO(iso))}
+        min={DateTime.local().plus({ hours: 1 }).toISO()}
+        max={DateTime.local().plus({ hours: 24 }).toISO()}
+      />
     </FormControl>
   )
 }
@@ -51,7 +68,7 @@ const mutation = gql`
 export default function ServiceMaintenanceModeDialog(
   props: Props,
 ): JSX.Element {
-  const [selectedHours, setSelectedHours] = useState(1)
+  const [endTime, setEndTime] = useState(DateTime.local().plus({ hours: 1 }))
   const [updateServiceStatus, updateService] = useMutation(mutation)
 
   useEffect(() => {
@@ -66,9 +83,13 @@ export default function ServiceMaintenanceModeDialog(
       subTitle={
         <React.Fragment>
           Pause all outgoing notifications and escalations for{' '}
-          <Time duration={{ hours: selectedHours }} />. Incoming alerts will
-          still be created and will continue as normal after maintenance mode
-          ends.
+          <Time
+            duration={{
+              hours: Math.ceil(endTime.diffNow('hours').hours),
+            }}
+          />
+          . Incoming alerts will still be created and will continue as normal
+          after maintenance mode ends.
         </React.Fragment>
       }
       loading={updateServiceStatus.fetching}
@@ -79,9 +100,7 @@ export default function ServiceMaintenanceModeDialog(
           {
             input: {
               id: props.serviceID,
-              maintenanceExpiresAt: DateTime.local()
-                .plus({ hours: selectedHours })
-                .toISO(),
+              maintenanceExpiresAt: endTime.toISO(),
             },
           },
           {
@@ -91,8 +110,8 @@ export default function ServiceMaintenanceModeDialog(
       }
       form={
         <ServiceMaintenanceForm
-          onChange={(value) => setSelectedHours(value)}
-          selectedIndex={selectedHours}
+          onChange={(value) => setEndTime(value)}
+          value={endTime}
         />
       }
     />

--- a/web/src/app/services/ServiceMaintenanceDialog.tsx
+++ b/web/src/app/services/ServiceMaintenanceDialog.tsx
@@ -49,6 +49,7 @@ function ServiceMaintenanceForm(props: {
       </RadioGroup>
       <ISODateTimePicker
         label='Select a date'
+        helperText='Within 24 hours'
         value={props.value.toISO()}
         disabled={selectedOption !== -1}
         onChange={(iso) => props.onChange(DateTime.fromISO(iso))}

--- a/web/src/app/util/ISOPickers.tsx
+++ b/web/src/app/util/ISOPickers.tsx
@@ -29,6 +29,9 @@ interface ISOPickerProps extends ISOTextFieldProps {
 type ISOTextFieldProps = Partial<Omit<TextFieldProps, 'value' | 'onChange'>> & {
   value?: string
   onChange: (value: string) => void
+
+  min?: string
+  max?: string
 }
 
 function ISOPicker(props: ISOPickerProps): JSX.Element {


### PR DESCRIPTION
**Description:**
Updates the maintenance dialog to allow specifying a custom end time up to 24 hours in the future.

**Which issue(s) this PR fixes:**
Closes #3681 

**Screenshots:**
![Screenshot 2024-04-15 at 10 28 04 AM](https://github.com/target/goalert/assets/11381794/8749d42b-402c-4e63-b75e-d2028d990442)

**Describe any introduced user-facing changes:**
- A 4th option in the dialog allows specifying an exact end time.

**Describe any introduced API changes:**
N/A
