### PR TITLE
playwright: Fix tooltip hover check

### DIFF
--- a/test/integration/schedules.spec.ts
+++ b/test/integration/schedules.spec.ts
@@ -28,7 +28,7 @@ test.afterEach(async ({ page }) => {
   await page.click('button:has-text("Confirm")')
 })
 
-test('local time hover', async ({ page, isMobile }) => {
+test('local time hover', async ({ page }) => {
   // change schedule tz to Europe/Amsterdam
   await page.click('[aria-label="Edit"]')
   await page.fill('input[name=time-zone]', 'Europe/Amsterdam')
@@ -36,31 +36,6 @@ test('local time hover', async ({ page, isMobile }) => {
   await page.getByRole('button', { name: 'Submit' }).click()
 
   await page.goto(`${baseURL}/schedules/${scheduleID}/shifts`)
-
-  // add user override
-  if (!isMobile) {
-    await page.click('button:has-text("Create Override")')
-    await page.keyboard.press('Tab')
-    await page.keyboard.press('ArrowDown')
-    await page.keyboard.press('ArrowDown')
-    await page.keyboard.press('Enter')
-  } else {
-    await page.click('[data-testid="AddIcon"]')
-    await page.keyboard.press('Tab')
-    await page.keyboard.press('Tab')
-    await page.keyboard.press('ArrowDown')
-    await page.keyboard.press('ArrowDown')
-    await page.keyboard.press('Enter')
-  }
-
-  // should display schedule timezone in form
-  await expect(page.locator('form[id=dialog-form]')).toContainText(
-    'Times shown in schedule timezone (Europe/Amsterdam)',
-  )
-  await page.locator('input[name=addUserID]').fill('Admin McIntegrationFace')
-
-  await page.click('li:has-text("Admin McIntegrationFace")')
-  await page.locator('button[type=submit]').click()
 
   // should display schedule tz on hover
   await page.hover(`[data-testid="shift-details"]`)

--- a/web/src/app/schedules/ScheduleShiftList.tsx
+++ b/web/src/app/schedules/ScheduleShiftList.tsx
@@ -178,10 +178,11 @@ function ScheduleShiftList({
       const scheduleTZDetails = `From ${schedStartTime} to ${schedEndTime} ${tzAbbr}`
       const localTZDetails = `From ${localStartTime} to ${localEndTime} ${localTzAbbr}`
       return (
-        <Tooltip title={scheduleTZDetails} placement='right'>
-          <span data-cy='shift-details' data-testid='shift-details'>
-            {localTZDetails}
-          </span>
+        <Tooltip
+          title={<span data-testid='shift-tooltip'>{scheduleTZDetails}</span>}
+          placement='right'
+        >
+          <span data-testid='shift-details'>{localTZDetails}</span>
         </Tooltip>
       )
     }
@@ -194,8 +195,11 @@ function ScheduleShiftList({
         s.truncated ? ' at least' : ''
       } ${localEndTime} ${localTzAbbr}`
       return (
-        <Tooltip title={scheduleTZDetails} placement='right'>
-          <span>{localTZDetails}</span>
+        <Tooltip
+          title={<span data-testid='shift-tooltip'>{scheduleTZDetails}</span>}
+          placement='right'
+        >
+          <span data-testid='shift-details'>{localTZDetails}</span>
         </Tooltip>
       )
     }
@@ -205,14 +209,10 @@ function ScheduleShiftList({
     const localTZDetails = `Active after ${localStartTime} ${localTzAbbr}`
     return (
       <Tooltip
-        title={scheduleTZDetails}
+        title={<span data-testid='shift-tooltip'>{scheduleTZDetails}</span>}
         placement='right'
-        PopperProps={{
-          // @ts-expect-error test id
-          'data-testid': 'shift-tooltip',
-        }}
       >
-        <span>{localTZDetails}</span>
+        <span data-testid='shift-details'>{localTZDetails}</span>
       </Tooltip>
     )
   }


### PR DESCRIPTION
**Description:**
Fixes a flaky playwright test that would fail to find the tooltip selector.

- Creating an override is no longer necessary as by default the user that creates a schedule is assigned as on-call
