### PR TITLE
intkey: update old code to use API-driven key types

### DIFF
--- a/web/src/app/admin/admin-service-metrics/AdminServiceFilter.tsx
+++ b/web/src/app/admin/admin-service-metrics/AdminServiceFilter.tsx
@@ -20,6 +20,7 @@ import {
 } from '@mui/material'
 import { LabelKeySelect } from '../../selection'
 import { LabelValueSelect } from '../../selection/LabelValueSelect'
+import { useFeatures } from '../../util/RequireConfig'
 
 function AdminServiceFilter(): JSX.Element {
   const [open, setOpen] = useState<boolean>(false)
@@ -37,6 +38,7 @@ function AdminServiceFilter(): JSX.Element {
     'labelKey',
     'labelValue',
   )
+  const intKeyTypes = useFeatures().integrationKeyTypes.map((t) => t.id)
 
   const removeFilter = (filterName: string): void => {
     if (filterName === 'labelKey') {
@@ -133,13 +135,7 @@ function AdminServiceFilter(): JSX.Element {
                   multiple
                   fullWidth
                   id='int-key-targets'
-                  options={[
-                    'generic',
-                    'grafana',
-                    'site24x7',
-                    'prometheusAlertmanager',
-                    'email',
-                  ]}
+                  options={intKeyTypes}
                   value={params.intKeyTgts}
                   onChange={(_, value) =>
                     setParams({ ...params, intKeyTgts: value })

--- a/web/src/app/wizard/WizardForm.jsx
+++ b/web/src/app/wizard/WizardForm.jsx
@@ -16,6 +16,7 @@ import makeStyles from '@mui/styles/makeStyles'
 import * as _ from 'lodash'
 import { useIsWidthDown } from '../util/useWidth'
 import MaterialSelect from '../selection/MaterialSelect'
+import { useFeatures } from '../util/RequireConfig'
 
 const useStyles = makeStyles({
   fieldItem: {
@@ -31,6 +32,8 @@ export default function WizardForm(props) {
   const { onChange, value } = props
   const fullScreen = useIsWidthDown('md')
   const classes = useStyles()
+
+  const keyTypes = useFeatures().integrationKeyTypes
 
   const handleSecondaryScheduleToggle = (e) => {
     const newVal = _.cloneDeep(value)
@@ -167,28 +170,10 @@ export default function WizardForm(props) {
             formLabel
             fullWidth={fullScreen}
             required
-            options={[
-              {
-                label: 'Generic API',
-                value: 'generic',
-              },
-              {
-                label: 'Grafana Webhook URL',
-                value: 'grafana',
-              },
-              {
-                label: 'Site24x7 Webhook URL',
-                value: 'site24x7',
-              },
-              {
-                label: 'Prometheus Alertmanager Webhook URL',
-                value: 'prometheusAlertmanager',
-              },
-              {
-                label: 'Email',
-                value: 'email',
-              },
-            ]}
+            options={keyTypes.map((k) => ({
+              label: k.name,
+              value: k.id,
+            }))}
           />
         </Grid>
       </Grid>


### PR DESCRIPTION
**Description:**
Updates a couple of places that were never migrated to use the integration key types query.

- AdminServiceFilter (Admin -> Service Metrics)
- WizardForm (Setup Wizard)
