### PR TITLE
ui: add route for universal integration keys

### DIFF
--- a/web/src/app/main/AppRoutes.tsx
+++ b/web/src/app/main/AppRoutes.tsx
@@ -42,6 +42,7 @@ import { useSessionInfo } from '../util/RequireConfig'
 import WizardRouter from '../wizard/WizardRouter'
 import LocalDev from '../localdev/LocalDev'
 import AdminSwitchoverGuide from '../admin/switchover/AdminSwitchoverGuide'
+import UniversalKeyPage from '../services/UniversalKey/UniversalKeyPage'
 
 // ParamRoute will pass route parameters as props to the route's child.
 function ParamRoute(props: RouteProps): JSX.Element {
@@ -100,6 +101,7 @@ export const routes: Record<string, JSXElementConstructor<any>> = {
   '/services/:serviceID/alerts/:alertID': AlertDetailPage,
   '/services/:serviceID/heartbeat-monitors': HeartbeatMonitorList,
   '/services/:serviceID/integration-keys': IntegrationKeyList,
+  '/services/:serviceID/integration-keys/:keyID': UniversalKeyPage,
   '/services/:serviceID/labels': ServiceLabelList,
   '/services/:serviceID/alert-metrics': AlertMetrics,
 

--- a/web/src/app/main/components/ToolbarPageTitle.tsx
+++ b/web/src/app/main/components/ToolbarPageTitle.tsx
@@ -123,7 +123,8 @@ function useBreadcrumbs(): [string, JSX.Element[] | JSX.Element] {
   const crumbs: Array<JSX.Element> = []
   const parts = path.split('/')
   const name = useName(parts[1], parts[2])
-  parts.slice(1).forEach((part, i) => {
+  parts.slice(1).forEach((p, i) => {
+    const part = decodeURIComponent(p)
     title = i === 1 ? name : toTitleCase(part)
     if (parts[1] === 'admin') {
       // admin doesn't have IDs to lookup

--- a/web/src/app/services/IntegrationKeyList.tsx
+++ b/web/src/app/services/IntegrationKeyList.tsx
@@ -120,6 +120,7 @@ export default function IntegrationKeyList(props: {
     .map(
       (key: IntegrationKey): FlatListListItem => ({
         title: key.name,
+        url: key.type === 'universal' ? key.name : undefined,
         subText: (
           <IntegrationKeyDetails
             key={key.id}

--- a/web/src/app/services/UniversalKey/UniversalKeyPage.tsx
+++ b/web/src/app/services/UniversalKey/UniversalKeyPage.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+interface UniversalKeyPageProps {
+  serviceID: string
+  keyID: string
+}
+
+export default function UniversalKeyPage({
+  serviceID,
+  keyID,
+}: UniversalKeyPageProps): JSX.Element {
+  return <div />
+}


### PR DESCRIPTION
**Description:**
Adds a dynamic route for new universal integration keys, where the url is defined by the name

**Which issue(s) this PR fixes:**
Part of -

**Out of Scope:**
Rest of page from demo branch

**Screenshots:**
![Screenshot 2024-05-03 at 9 28 13 AM](https://github.com/target/goalert/assets/11381794/00460449-4bc4-4016-bfc9-01b048b34a73)