### PR TITLE
ui: update breadcrumbs to handle doubly nested routes

### DIFF
--- a/web/src/app/main/components/BreadCrumb.tsx
+++ b/web/src/app/main/components/BreadCrumb.tsx
@@ -1,0 +1,129 @@
+import React from 'react'
+import { Theme, Typography } from '@mui/material'
+import AppLink from '../../util/AppLink'
+import { camelCase, startCase } from 'lodash'
+import { useQuery } from 'urql'
+
+interface BreadCrumbProps {
+  crumb: Routes | string
+  urlParts: string[]
+  index: number
+  link?: string
+}
+
+type Routes =
+  | 'alerts'
+  | 'schedules'
+  | 'rotations'
+  | 'users'
+  | 'escalation-policies'
+  | 'services'
+  | 'integration-keys'
+
+// todo: not needed once appbar is using same color prop for dark/light modes
+const getContrastColor = (theme: Theme): string => {
+  return theme.palette.getContrastText(
+    theme.palette.mode === 'dark'
+      ? theme.palette.background.paper
+      : theme.palette.primary.main,
+  )
+}
+
+const typeMap: { [key: string]: string } = {
+  alerts: 'Alert',
+  schedules: 'Schedule',
+  'escalation-policies': 'Escalation Policy',
+  rotations: 'Rotation',
+  users: 'User',
+  services: 'Service',
+  'integration-keys': 'IntegrationKey',
+}
+
+const toTitleCase = (str: string): string =>
+  startCase(str)
+    .replace(/^Wizard/, 'Setup Wizard')
+    .replace('On Call', 'On-Call')
+    .replace('Docs', 'Documentation')
+    .replace('Limits', 'System Limits')
+    .replace('Admin ', 'Admin: ')
+    .replace(/Config$/, 'Configuration')
+    .replace('Api', 'API')
+
+export function useName(crumb: string, index: number, parts: string[]): string {
+  const isUUID =
+    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(crumb)
+
+  let type = typeMap[crumb]
+  let queryName = 'skipping'
+  if (isUUID) {
+    type = parts[index - 1] // if uuid, grab type from previous crumb
+    queryName = camelCase(typeMap[parts[index - 1]])
+  }
+
+  // query for details page name if on a subpage
+  // skip if not a uuid - use type
+  const [result] = useQuery({
+    query: `query ($id: ID!) {
+        data: ${queryName}(id: $id) {
+          id
+          name
+        }
+      }`,
+    variables: { id: crumb },
+    pause: !isUUID,
+  })
+
+  if (type && isUUID && result?.data?.data?.name) {
+    return result.data.data.name
+  }
+
+  return toTitleCase(crumb)
+}
+
+export default function BreadCrumb(props: BreadCrumbProps): JSX.Element {
+  const { index, crumb, link, urlParts } = props
+
+  const name = useName(crumb, index, urlParts)
+
+  const text = (
+    <Typography
+      data-cy={`breadcrumb-${index}`}
+      noWrap
+      key={index}
+      component='h6'
+      sx={{
+        padding: '0 4px 0 4px',
+        fontSize: '1.25rem',
+        color: getContrastColor,
+      }}
+    >
+      {name}
+    </Typography>
+  )
+
+  if (!link) {
+    return text
+  }
+
+  return (
+    <AppLink
+      key={link}
+      to={link}
+      underline='hover'
+      color='inherit'
+      sx={{
+        '&:hover': {
+          textDecoration: 'none',
+        },
+        '&:hover > h6': {
+          cursor: 'pointer',
+          backgroundColor: 'rgba(255, 255, 255, 0.2)',
+          borderRadius: '6px',
+          padding: '4px',
+        },
+      }}
+    >
+      {text}
+    </AppLink>
+  )
+}

--- a/web/src/app/main/components/ToolbarPageTitle.tsx
+++ b/web/src/app/main/components/ToolbarPageTitle.tsx
@@ -1,42 +1,16 @@
 import * as React from 'react'
-import Typography from '@mui/material/Typography'
 import Breadcrumbs from '@mui/material/Breadcrumbs'
 import { ChevronRight } from '@mui/icons-material'
-import { useQuery } from 'urql'
 import { useLocation } from 'wouter'
 import { Theme } from '@mui/material'
-import { startCase, camelCase } from 'lodash'
-import { applicationName as appName } from '../../env'
-import { routes } from '../AppRoutes'
-import { useConfigValue } from '../../util/RequireConfig'
-import AppLink from '../../util/AppLink'
+import BreadCrumb from './BreadCrumb'
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore type definition is broken for this file
-import makeMatcher from 'wouter/matcher'
 import { useIsWidthDown } from '../../util/useWidth'
 
-const typeMap: { [key: string]: string } = {
-  alerts: 'Alert',
-  schedules: 'Schedule',
-  'escalation-policies': 'Escalation Policy',
-  rotations: 'Rotation',
-  users: 'User',
-  services: 'Service',
-  'integration-keys': 'IntegrationKey',
-}
-const toTitleCase = (str: string): string =>
-  startCase(str)
-    .replace(/^Wizard/, 'Setup Wizard')
-    .replace('On Call', 'On-Call')
-    .replace('Docs', 'Documentation')
-    .replace('Limits', 'System Limits')
-    .replace('Admin ', 'Admin: ')
-    .replace(/Config$/, 'Configuration')
-    .replace('Api', 'API')
-
 // todo: not needed once appbar is using same color prop for dark/light modes
-const getContrastColor = (theme: Theme): string => {
+export const getContrastColor = (theme: Theme): string => {
   return theme.palette.getContrastText(
     theme.palette.mode === 'dark'
       ? theme.palette.background.paper
@@ -44,122 +18,11 @@ const getContrastColor = (theme: Theme): string => {
   )
 }
 
-const renderCrumb = (
-  index: number,
-  title: string,
-  link?: string,
-): JSX.Element => {
-  const text = (
-    <Typography
-      data-cy={`breadcrumb-${index}`}
-      noWrap
-      key={index}
-      component='h6'
-      sx={{
-        padding: '0 4px 0 4px',
-        fontSize: '1.25rem',
-        color: getContrastColor,
-      }}
-    >
-      {title}
-    </Typography>
-  )
-
-  if (!link) {
-    return text
-  }
-
-  return (
-    <AppLink
-      key={link}
-      to={link}
-      underline='hover'
-      color='inherit'
-      sx={{
-        '&:hover': {
-          textDecoration: 'none',
-        },
-        '&:hover > h6': {
-          cursor: 'pointer',
-          backgroundColor: 'rgba(255, 255, 255, 0.2)',
-          borderRadius: '6px',
-          padding: '4px',
-        },
-      }}
-    >
-      {text}
-    </AppLink>
-  )
-}
-
-const matchPath = makeMatcher()
-
-function useName(type = '', id = ''): string {
-  const queryName = camelCase(typeMap[type] ?? 'skipping')
-  const isUUID =
-    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(id)
-  // query for details page name if on a subpage
-  const [result] = useQuery({
-    query: `query ($id: ID!) {
-        data: ${queryName}(id: $id) {
-          id
-          name
-        }
-      }`,
-    variables: { id },
-    pause: !type || !isUUID,
-  })
-
-  if (type && isUUID && result?.data?.data?.name) {
-    return result.data.data.name
-  }
-
-  return toTitleCase(isUUID ? typeMap[type] ?? type : id)
-}
-
-function useBreadcrumbs(): [string, JSX.Element[] | JSX.Element] {
-  const [path] = useLocation()
-
-  let title = ''
-  const crumbs: Array<JSX.Element> = []
-  const parts = path.split('/')
-  const name = useName(parts[1], parts[2])
-  parts.slice(1).forEach((p, i) => {
-    const part = decodeURIComponent(p)
-    title = i === 1 ? name : toTitleCase(part)
-    if (parts[1] === 'admin') {
-      // admin doesn't have IDs to lookup
-      // and instead just has fixed sub-page names
-      title = toTitleCase(part)
-    }
-    crumbs.push(renderCrumb(i, title, parts.slice(0, i + 2).join('/')))
-  })
-
-  const isValidRoute = Object.keys(routes).some((pattern) => {
-    const [match] = matchPath(pattern, path)
-    return match
-  })
-
-  if (!isValidRoute) {
-    const title = toTitleCase('page-not-found')
-    return [title, renderCrumb(0, title)]
-  }
-
-  if (/^\d+$/.test(title)) {
-    title = 'Alert ' + title
-  }
-
-  return [title, crumbs]
-}
-
 export default function ToolbarPageTitle(): JSX.Element {
-  const [title, crumbs] = useBreadcrumbs()
-  const [applicationName] = useConfigValue('General.ApplicationName')
   const isMobile = useIsWidthDown('md')
 
-  React.useLayoutEffect(() => {
-    document.title = `${applicationName || appName} - ${title}`
-  }, [title, applicationName])
+  const [path] = useLocation()
+  const parts = React.useMemo(() => path.split('/').slice(1), [path])
 
   return (
     <Breadcrumbs
@@ -172,7 +35,18 @@ export default function ToolbarPageTitle(): JSX.Element {
         />
       }
     >
-      {crumbs}
+      {parts.map((part, idx) => (
+        <BreadCrumb
+          key={part + idx}
+          crumb={part}
+          urlParts={parts}
+          index={idx}
+          link={path
+            .split('/')
+            .slice(0, idx + 2)
+            .join('/')}
+        />
+      ))}
     </Breadcrumbs>
   )
 }

--- a/web/src/app/util/AppLink.tsx
+++ b/web/src/app/util/AppLink.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, ForwardRefRenderFunction } from 'react'
+import React, { forwardRef } from 'react'
 import { LinkProps } from '@mui/material'
 import MUILink from '@mui/material/Link'
 
@@ -32,35 +32,35 @@ const WrapLink = forwardRef(function WrapLink(
   )
 })
 
-const AppLink: ForwardRefRenderFunction<HTMLAnchorElement, AppLinkProps> =
-  function AppLink(props, ref): JSX.Element {
-    let { to, newTab, ...other } = props
-    const [location] = useLocation()
+const AppLink = forwardRef<HTMLAnchorElement, AppLinkProps>((props, ref) => {
+  let { to, newTab, ...other } = props
+  const [location] = useLocation()
 
-    if (newTab) {
-      other.target = '_blank'
-      other.rel = 'noopener noreferrer'
-    }
-
-    const external = /^(tel:|mailto:|blob:|https?:\/\/)/.test(to)
-
-    // handle relative URLs
-    if (!external && !to.startsWith('/')) {
-      to = joinURL(location, to)
-    }
-
-    return (
-      <MUILink
-        ref={ref}
-        to={to}
-        href={to}
-        component={external || newTab ? 'a' : WrapLink}
-        {...other}
-      />
-    )
+  if (newTab) {
+    other.target = '_blank'
+    other.rel = 'noopener noreferrer'
   }
 
-export default forwardRef(AppLink)
+  const external = /^(tel:|mailto:|blob:|https?:\/\/)/.test(to)
+
+  // handle relative URLs
+  if (!external && !to.startsWith('/')) {
+    to = joinURL(location, to)
+  }
+
+  return (
+    <MUILink
+      ref={ref}
+      to={to}
+      href={to}
+      component={external || newTab ? 'a' : WrapLink}
+      {...other}
+    />
+  )
+})
+
+AppLink.displayName = 'AppLink'
+export default AppLink
 
 export const AppLinkListItem = forwardRef<HTMLAnchorElement, AppLinkProps>(
   (props, ref) => (


### PR DESCRIPTION
This PR updates the breadcrumbs component to work on double nested routes (which haven't existed until now for universal integration keys)

![Screenshot 2024-05-06 at 12 52 38 PM](https://github.com/target/goalert/assets/11381794/45f79eee-c9ad-401e-946c-a959e41169af)

Also fixes an issue with ref forwarding inside of AppLink.