### PR TITLE
uik: add bounds/limits on int key config

### DIFF
--- a/validation/validate/range.go
+++ b/validation/validate/range.go
@@ -1,9 +1,32 @@
 package validate
 
 import (
-	"github.com/target/goalert/validation"
 	"strconv"
+
+	"github.com/target/goalert/validation"
 )
+
+// Len will ensure a slice has at least min and at most max items.
+func Len[T any](fname string, val []T, min, max int) error {
+	if len(val) < min {
+		return validation.NewFieldError(fname, "must have at least "+strconv.Itoa(min)+" items")
+	}
+	if len(val) > max {
+		return validation.NewFieldError(fname, "must have at most "+strconv.Itoa(max)+" items")
+	}
+	return nil
+}
+
+// MapLen will ensure a map has at least min and at most max items.
+func MapLen[K comparable, V any](fname string, val map[K]V, min, max int) error {
+	if len(val) < min {
+		return validation.NewFieldError(fname, "must have at least "+strconv.Itoa(min)+" items")
+	}
+	if len(val) > max {
+		return validation.NewFieldError(fname, "must have at most "+strconv.Itoa(max)+" items")
+	}
+	return nil
+}
 
 // Range will ensure a value is between min and max (inclusive).
 // A FieldError is returned otherwise.


### PR DESCRIPTION
**Description:**
Adds some initial validation and limits to integration key configuration.

Most notable:
- max 100 rules
- max 10 actions per rule
- max 10 parameters per action
