### PR TITLE
urql: move admin message logs to ListPageControls

### DIFF
--- a/web/src/app/admin/admin-message-logs/AdminMessageLogsLayout.tsx
+++ b/web/src/app/admin/admin-message-logs/AdminMessageLogsLayout.tsx
@@ -122,8 +122,8 @@ export default function AdminMessageLogsLayout(): JSX.Element {
           </Grid>
         </Grid>
       ),
-      action: (
-        <Typography variant='body2' color='textSecondary'>
+      secondaryAction: (
+        <Typography variant='body2' component='div' color='textSecondary'>
           {DateTime.fromISO(log.createdAt).toFormat('fff')}
         </Typography>
       ),

--- a/web/src/app/admin/admin-message-logs/AdminMessageLogsLayout.tsx
+++ b/web/src/app/admin/admin-message-logs/AdminMessageLogsLayout.tsx
@@ -3,15 +3,15 @@ import { Chip, Grid, Typography } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
 import { Theme } from '@mui/material/styles'
 import { DateTime } from 'luxon'
-import { gql } from 'urql'
+import { gql, useQuery } from 'urql'
 import AdminMessageLogsControls from './AdminMessageLogsControls'
 import AdminMessageLogDrawer from './AdminMessageLogDrawer'
-import { DebugMessage } from '../../../schema'
+import { DebugMessage, MessageLogConnection } from '../../../schema'
 import AdminMessageLogsGraph from './AdminMessageLogsGraph'
 import toTitleCase from '../../util/toTitleCase'
-import QueryList from '../../lists/QueryList'
-import { PaginatedListItemProps } from '../../lists/PaginatedList'
 import { useMessageLogsParams } from './util'
+import ListPageControls from '../../lists/ListPageControls'
+import FlatList, { FlatListListItem } from '../../lists/FlatList'
 
 const query = gql`
   query messageLogsQuery($input: MessageLogSearchOptions) {
@@ -54,19 +54,32 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }))
 
+const context = { suspense: false }
+
 export default function AdminMessageLogsLayout(): JSX.Element {
   const classes = useStyles()
   const [selectedLog, setSelectedLog] = useState<DebugMessage | null>(null)
 
   const [{ search, start, end }] = useMessageLogsParams()
+  const [cursor, setCursor] = useState('')
 
   const logsInput = {
     search,
     createdAfter: start,
     createdBefore: end,
+    after: cursor,
   }
 
-  function mapLogToListItem(log: DebugMessage): PaginatedListItemProps {
+  const [q] = useQuery<{ messageLogs: MessageLogConnection }>({
+    query,
+    variables: { input: logsInput },
+    context,
+  })
+  const nextCursor = q.data?.messageLogs.pageInfo.hasNextPage
+    ? q.data?.messageLogs.pageInfo.endCursor
+    : ''
+
+  function mapLogToListItem(log: DebugMessage): FlatListListItem {
     const status = toTitleCase(log.status)
     const statusDict = {
       success: {
@@ -96,8 +109,8 @@ export default function AdminMessageLogsLayout(): JSX.Element {
     if (s.includes('pend')) statusStyles = statusDict.info
 
     return {
-      onClick: () => setSelectedLog(log as DebugMessage),
-      selected: (log as DebugMessage).id === selectedLog?.id,
+      onClick: () => setSelectedLog(log),
+      selected: log.id === selectedLog?.id,
       title: `${log.type} Notification`,
       subText: (
         <Grid container spacing={2} direction='column'>
@@ -137,11 +150,18 @@ export default function AdminMessageLogsLayout(): JSX.Element {
         <AdminMessageLogsGraph />
 
         <Grid item xs={12}>
-          <QueryList
-            query={query}
-            variables={{ input: { ...logsInput } }}
-            noSearch
-            mapDataNode={(n) => mapLogToListItem(n as DebugMessage)}
+          <ListPageControls
+            nextCursor={nextCursor}
+            onCursorChange={setCursor}
+            loading={q.fetching}
+            slots={{
+              list: (
+                <FlatList
+                  emptyMessage='No results'
+                  items={q.data?.messageLogs.nodes.map(mapLogToListItem) || []}
+                />
+              ),
+            }}
           />
         </Grid>
       </Grid>

--- a/web/src/app/lists/ListPageControls.tsx
+++ b/web/src/app/lists/ListPageControls.tsx
@@ -98,7 +98,7 @@ export default function ListPageControls(
       </Grid>
 
       <Grid item xs={12}>
-        <Card>{props.slots.list}</Card>
+        <Card data-cy='paginated-list'>{props.slots.list}</Card>
       </Grid>
 
       <Grid

--- a/web/src/cypress/e2e/admin.cy.ts
+++ b/web/src/cypress/e2e/admin.cy.ts
@@ -5,247 +5,247 @@ import { testScreen, login, Config, pathPrefix } from '../support/e2e'
 const c = new Chance()
 
 function testAdmin(): void {
-  describe('Admin System Limits Page', () => {
-    let limits: Limits = new Map()
-    beforeEach(() => {
-      cy.getLimits().then((l: Limits) => {
-        limits = l
-        return cy.visit('/admin/limits')
-      })
-    })
+  // describe('Admin System Limits Page', () => {
+  //   let limits: Limits = new Map()
+  //   beforeEach(() => {
+  //     cy.getLimits().then((l: Limits) => {
+  //       limits = l
+  //       return cy.visit('/admin/limits')
+  //     })
+  //   })
 
-    it('should allow updating system limits values', () => {
-      cy.get('nav li').contains('System Limits').should('be.visible')
+  //   it('should allow updating system limits values', () => {
+  //     cy.get('nav li').contains('System Limits').should('be.visible')
 
-      const newContactMethods = c.integer({ min: 15, max: 1000 }).toString()
-      const newEPActions = c.integer({ min: 15, max: 1000 }).toString()
+  //     const newContactMethods = c.integer({ min: 15, max: 1000 }).toString()
+  //     const newEPActions = c.integer({ min: 15, max: 1000 }).toString()
 
-      const ContactMethodsPerUser = limits.get(
-        'ContactMethodsPerUser',
-      ) as SystemLimits
-      const EPActionsPerStep = limits.get('EPActionsPerStep') as SystemLimits
+  //     const ContactMethodsPerUser = limits.get(
+  //       'ContactMethodsPerUser',
+  //     ) as SystemLimits
+  //     const EPActionsPerStep = limits.get('EPActionsPerStep') as SystemLimits
 
-      cy.form({
-        ContactMethodsPerUser: newContactMethods,
-        EPActionsPerStep: newEPActions,
-      })
+  //     cy.form({
+  //       ContactMethodsPerUser: newContactMethods,
+  //       EPActionsPerStep: newEPActions,
+  //     })
 
-      cy.get('button[data-cy=save]').click()
-      cy.dialogTitle('Apply Configuration Changes?')
+  //     cy.get('button[data-cy=save]').click()
+  //     cy.dialogTitle('Apply Configuration Changes?')
 
-      cy.dialogContains('-' + ContactMethodsPerUser.value)
-      cy.dialogContains('-' + EPActionsPerStep.value)
-      cy.dialogContains('+' + newContactMethods)
-      cy.dialogContains('+' + newEPActions)
-      cy.dialogFinish('Confirm')
+  //     cy.dialogContains('-' + ContactMethodsPerUser.value)
+  //     cy.dialogContains('-' + EPActionsPerStep.value)
+  //     cy.dialogContains('+' + newContactMethods)
+  //     cy.dialogContains('+' + newEPActions)
+  //     cy.dialogFinish('Confirm')
 
-      cy.get('input[name="EPActionsPerStep"]').should(
-        'have.value',
-        newEPActions,
-      )
-      cy.get('input[name="ContactMethodsPerUser"]').should(
-        'have.value',
-        newContactMethods,
-      )
-    })
+  //     cy.get('input[name="EPActionsPerStep"]').should(
+  //       'have.value',
+  //       newEPActions,
+  //     )
+  //     cy.get('input[name="ContactMethodsPerUser"]').should(
+  //       'have.value',
+  //       newContactMethods,
+  //     )
+  //   })
 
-    it('should reset pending system limit value changes', () => {
-      const ContactMethodsPerUser = limits.get(
-        'ContactMethodsPerUser',
-      ) as SystemLimits
-      const EPActionsPerStep = limits.get('EPActionsPerStep') as SystemLimits
+  //   it('should reset pending system limit value changes', () => {
+  //     const ContactMethodsPerUser = limits.get(
+  //       'ContactMethodsPerUser',
+  //     ) as SystemLimits
+  //     const EPActionsPerStep = limits.get('EPActionsPerStep') as SystemLimits
 
-      cy.form({
-        ContactMethodsPerUser: c.integer({ min: 0, max: 1000 }).toString(),
-        EPActionsPerStep: c.integer({ min: 0, max: 1000 }).toString(),
-      })
+  //     cy.form({
+  //       ContactMethodsPerUser: c.integer({ min: 0, max: 1000 }).toString(),
+  //       EPActionsPerStep: c.integer({ min: 0, max: 1000 }).toString(),
+  //     })
 
-      cy.get('button[data-cy="reset"]').click()
+  //     cy.get('button[data-cy="reset"]').click()
 
-      cy.get('input[name="ContactMethodsPerUser"]').should(
-        'have.value',
-        ContactMethodsPerUser.value.toString(),
-      )
-      cy.get('input[name="EPActionsPerStep"]').should(
-        'have.value',
-        EPActionsPerStep.value.toString(),
-      )
-    })
-  })
+  //     cy.get('input[name="ContactMethodsPerUser"]').should(
+  //       'have.value',
+  //       ContactMethodsPerUser.value.toString(),
+  //     )
+  //     cy.get('input[name="EPActionsPerStep"]').should(
+  //       'have.value',
+  //       EPActionsPerStep.value.toString(),
+  //     )
+  //   })
+  // })
 
-  describe('Admin Config Page', () => {
-    let cfg: Config
-    beforeEach(() => {
-      return cy
-        .resetConfig()
-        .updateConfig({
-          Mailgun: {
-            APIKey: 'key-' + c.string({ length: 32, pool: '0123456789abcdef' }),
-            EmailDomain: '',
-          },
-          Twilio: {
-            Enable: true,
-            AccountSID:
-              'AC' + c.string({ length: 32, pool: '0123456789abcdef' }),
-            AuthToken: c.string({ length: 32, pool: '0123456789abcdef' }),
-            FromNumber: '+17633' + c.string({ length: 6, pool: '0123456789' }),
-          },
-        })
-        .then((curCfg: Config) => {
-          cfg = curCfg
-          return cy.visit('/admin').get('button[data-cy=save]').should('exist')
-        })
-    })
+  // describe('Admin Config Page', () => {
+  //   let cfg: Config
+  //   beforeEach(() => {
+  //     return cy
+  //       .resetConfig()
+  //       .updateConfig({
+  //         Mailgun: {
+  //           APIKey: 'key-' + c.string({ length: 32, pool: '0123456789abcdef' }),
+  //           EmailDomain: '',
+  //         },
+  //         Twilio: {
+  //           Enable: true,
+  //           AccountSID:
+  //             'AC' + c.string({ length: 32, pool: '0123456789abcdef' }),
+  //           AuthToken: c.string({ length: 32, pool: '0123456789abcdef' }),
+  //           FromNumber: '+17633' + c.string({ length: 6, pool: '0123456789' }),
+  //         },
+  //       })
+  //       .then((curCfg: Config) => {
+  //         cfg = curCfg
+  //         return cy.visit('/admin').get('button[data-cy=save]').should('exist')
+  //       })
+  //   })
 
-    it('should allow updating config values', () => {
-      const newURL = 'http://' + c.domain()
-      const newDomain = c.domain()
-      const newAPIKey =
-        'key-' + c.string({ length: 32, pool: '0123456789abcdef' })
+  //   it('should allow updating config values', () => {
+  //     const newURL = 'http://' + c.domain()
+  //     const newDomain = c.domain()
+  //     const newAPIKey =
+  //       'key-' + c.string({ length: 32, pool: '0123456789abcdef' })
 
-      cy.form({
-        'General.PublicURL': newURL,
-        'Mailgun.EmailDomain': newDomain,
-        'Twilio.FromNumber': '',
-        'Mailgun.APIKey': newAPIKey,
-        'Twilio.Enable': false,
-      })
-      cy.get('button[data-cy=save]').click()
+  //     cy.form({
+  //       'General.PublicURL': newURL,
+  //       'Mailgun.EmailDomain': newDomain,
+  //       'Twilio.FromNumber': '',
+  //       'Mailgun.APIKey': newAPIKey,
+  //       'Twilio.Enable': false,
+  //     })
+  //     cy.get('button[data-cy=save]').click()
 
-      cy.dialogTitle('Apply Configuration Changes?')
-      cy.dialogFinish('Cancel')
+  //     cy.dialogTitle('Apply Configuration Changes?')
+  //     cy.dialogFinish('Cancel')
 
-      cy.get('button[data-cy=save]').click()
-      cy.dialogTitle('Apply Configuration Changes?')
-      cy.dialogContains('-' + cfg.General.PublicURL)
-      cy.dialogContains('-' + cfg.Twilio.FromNumber)
-      cy.dialogContains('-' + cfg.Mailgun.APIKey)
-      cy.dialogContains('-true')
-      cy.dialogContains('+false')
-      cy.dialogContains('+' + newURL)
-      cy.dialogContains('+' + newDomain)
-      cy.dialogContains('+' + newAPIKey)
-      cy.dialogFinish('Confirm')
+  //     cy.get('button[data-cy=save]').click()
+  //     cy.dialogTitle('Apply Configuration Changes?')
+  //     cy.dialogContains('-' + cfg.General.PublicURL)
+  //     cy.dialogContains('-' + cfg.Twilio.FromNumber)
+  //     cy.dialogContains('-' + cfg.Mailgun.APIKey)
+  //     cy.dialogContains('-true')
+  //     cy.dialogContains('+false')
+  //     cy.dialogContains('+' + newURL)
+  //     cy.dialogContains('+' + newDomain)
+  //     cy.dialogContains('+' + newAPIKey)
+  //     cy.dialogFinish('Confirm')
 
-      cy.get('input[name="General.PublicURL"]').should('have.value', newURL)
-      cy.get('input[name="Mailgun.EmailDomain"]').should(
-        'have.value',
-        newDomain,
-      )
-      cy.get('input[name="Twilio.FromNumber"]').should('have.value', '')
-      cy.get('input[name="Mailgun.APIKey"]').should('have.value', newAPIKey)
-      cy.get('input[name="Twilio.Enable"]').should('not.be.checked')
-    })
+  //     cy.get('input[name="General.PublicURL"]').should('have.value', newURL)
+  //     cy.get('input[name="Mailgun.EmailDomain"]').should(
+  //       'have.value',
+  //       newDomain,
+  //     )
+  //     cy.get('input[name="Twilio.FromNumber"]').should('have.value', '')
+  //     cy.get('input[name="Mailgun.APIKey"]').should('have.value', newAPIKey)
+  //     cy.get('input[name="Twilio.Enable"]').should('not.be.checked')
+  //   })
 
-    it('should reset pending config value changes', () => {
-      const domain1 = c.domain()
-      const domain2 = c.domain()
+  //   it('should reset pending config value changes', () => {
+  //     const domain1 = c.domain()
+  //     const domain2 = c.domain()
 
-      cy.form({
-        'General.PublicURL': domain1,
-        'Mailgun.EmailDomain': domain2,
-      })
+  //     cy.form({
+  //       'General.PublicURL': domain1,
+  //       'Mailgun.EmailDomain': domain2,
+  //     })
 
-      cy.get('button[data-cy="reset"]').click()
+  //     cy.get('button[data-cy="reset"]').click()
 
-      cy.get('input[name="General.PublicURL"]').should(
-        'have.value',
-        cfg.General.PublicURL,
-      )
-      cy.get('input[name="Mailgun.EmailDomain"]').should('have.value', '')
-    })
+  //     cy.get('input[name="General.PublicURL"]').should(
+  //       'have.value',
+  //       cfg.General.PublicURL,
+  //     )
+  //     cy.get('input[name="Mailgun.EmailDomain"]').should('have.value', '')
+  //   })
 
-    it('should update a string list field', () => {
-      const domain1 = 'http://' + c.domain()
-      const domain2 = 'http://' + c.domain()
-      const domain3 = cfg.General.PublicURL
+  //   it('should update a string list field', () => {
+  //     const domain1 = 'http://' + c.domain()
+  //     const domain2 = 'http://' + c.domain()
+  //     const domain3 = cfg.General.PublicURL
 
-      cy.form({ 'Auth.RefererURLs-new-item': domain1 })
-      cy.form({ 'Auth.RefererURLs-new-item': domain2 })
-      cy.form({ 'Auth.RefererURLs-new-item': domain3 })
+  //     cy.form({ 'Auth.RefererURLs-new-item': domain1 })
+  //     cy.form({ 'Auth.RefererURLs-new-item': domain2 })
+  //     cy.form({ 'Auth.RefererURLs-new-item': domain3 })
 
-      cy.get('button[data-cy=save]').click()
-      cy.dialogFinish('Confirm')
+  //     cy.get('button[data-cy=save]').click()
+  //     cy.dialogFinish('Confirm')
 
-      cy.get('input[name="Auth.RefererURLs-0"]').should('have.value', domain1)
-      cy.get('input[name="Auth.RefererURLs-1"]').should('have.value', domain2)
-      cy.get('input[name="Auth.RefererURLs-2"]').should('have.value', domain3)
-      cy.get('input[name="Auth.RefererURLs-new-item"]').should('have.value', '')
-    })
+  //     cy.get('input[name="Auth.RefererURLs-0"]').should('have.value', domain1)
+  //     cy.get('input[name="Auth.RefererURLs-1"]').should('have.value', domain2)
+  //     cy.get('input[name="Auth.RefererURLs-2"]').should('have.value', domain3)
+  //     cy.get('input[name="Auth.RefererURLs-new-item"]').should('have.value', '')
+  //   })
 
-    it('should generate a slack manifest', () => {
-      const publicURL = cfg.General.PublicURL
-      cy.get('[id="accordion-Slack"]').click()
-      cy.get('button').contains('App Manifest').click()
-      cy.dialogTitle('App Manifest')
+  //   it('should generate a slack manifest', () => {
+  //     const publicURL = cfg.General.PublicURL
+  //     cy.get('[id="accordion-Slack"]').click()
+  //     cy.get('button').contains('App Manifest').click()
+  //     cy.dialogTitle('App Manifest')
 
-      // verify data integrity from pulled values
-      cy.dialogContains("name: 'GoAlert'")
-      cy.dialogContains(
-        `request_url: '${publicURL}/api/v2/slack/message-action'`,
-      )
-      cy.dialogContains(
-        `message_menu_options_url: '${publicURL}/api/v2/slack/menu-options'`,
-      )
-      cy.dialogContains(
-        `'${publicURL}/api/v2/identity/providers/oidc/callback'`,
-      )
-      cy.dialogContains("display_name: 'GoAlert'")
+  //     // verify data integrity from pulled values
+  //     cy.dialogContains("name: 'GoAlert'")
+  //     cy.dialogContains(
+  //       `request_url: '${publicURL}/api/v2/slack/message-action'`,
+  //     )
+  //     cy.dialogContains(
+  //       `message_menu_options_url: '${publicURL}/api/v2/slack/menu-options'`,
+  //     )
+  //     cy.dialogContains(
+  //       `'${publicURL}/api/v2/identity/providers/oidc/callback'`,
+  //     )
+  //     cy.dialogContains("display_name: 'GoAlert'")
 
-      // verify button routing to slack config page
-      cy.get('[data-cy="configure-in-slack"]')
-        .should('have.attr', 'href')
-        .and('contain', 'https://api.slack.com/apps?new_app=1&manifest_yaml=')
-    })
-  })
+  //     // verify button routing to slack config page
+  //     cy.get('[data-cy="configure-in-slack"]')
+  //       .should('have.attr', 'href')
+  //       .and('contain', 'https://api.slack.com/apps?new_app=1&manifest_yaml=')
+  //   })
+  // })
 
-  describe('Admin Alert Count Page', () => {
-    let svc1: Service
-    let svc2: Service
+  // describe('Admin Alert Count Page', () => {
+  //   let svc1: Service
+  //   let svc2: Service
 
-    beforeEach(() => {
-      cy.setTimeSpeed(0)
-      cy.fastForward('-21h')
+  //   beforeEach(() => {
+  //     cy.setTimeSpeed(0)
+  //     cy.fastForward('-21h')
 
-      cy.createService().then((s1: Service) => {
-        svc1 = s1
-        cy.createAlert({ serviceID: s1.id })
-      })
-      cy.createService().then((s2: Service) => {
-        svc2 = s2
-        cy.createAlert({ serviceID: s2.id })
-        cy.createAlert({ serviceID: s2.id })
-      })
+  //     cy.createService().then((s1: Service) => {
+  //       svc1 = s1
+  //       cy.createAlert({ serviceID: s1.id })
+  //     })
+  //     cy.createService().then((s2: Service) => {
+  //       svc2 = s2
+  //       cy.createAlert({ serviceID: s2.id })
+  //       cy.createAlert({ serviceID: s2.id })
+  //     })
 
-      cy.fastForward('21h')
-      cy.setTimeSpeed(1) // resume the flow of time
+  //     cy.fastForward('21h')
+  //     cy.setTimeSpeed(1) // resume the flow of time
 
-      return cy.visit('/admin/alert-counts')
-    })
+  //     return cy.visit('/admin/alert-counts')
+  //   })
 
-    it('should display alert counts', () => {
-      const now = DateTime.local()
-        .minus({ hours: 21 })
-        .set({ minute: 0 })
-        .toLocaleString({
-          year: 'numeric',
-          month: 'short',
-          day: 'numeric',
-          hour: 'numeric',
-          minute: 'numeric',
-        })
+  //   it('should display alert counts', () => {
+  //     const now = DateTime.local()
+  //       .minus({ hours: 21 })
+  //       .set({ minute: 0 })
+  //       .toLocaleString({
+  //         year: 'numeric',
+  //         month: 'short',
+  //         day: 'numeric',
+  //         hour: 'numeric',
+  //         minute: 'numeric',
+  //       })
 
-      cy.get(`.recharts-line-dots circle[r=3]`).last().trigger('mouseover')
-      cy.get('[data-cy=alert-count-graph]')
-        .should('contain', now)
-        .should('contain', `${svc1.name}: 1`)
-        .should('contain', `${svc2.name}: 2`)
+  //     cy.get(`.recharts-line-dots circle[r=3]`).last().trigger('mouseover')
+  //     cy.get('[data-cy=alert-count-graph]')
+  //       .should('contain', now)
+  //       .should('contain', `${svc1.name}: 1`)
+  //       .should('contain', `${svc2.name}: 2`)
 
-      cy.get('[data-cy=alert-count-table]')
-        .should('contain', svc1.name)
-        .should('contain', svc2.name)
-    })
-  })
+  //     cy.get('[data-cy=alert-count-table]')
+  //       .should('contain', svc1.name)
+  //       .should('contain', svc2.name)
+  //   })
+  // })
 
   describe('Admin Message Logs Page', () => {
     let debugMessage: DebugMessage
@@ -297,11 +297,10 @@ function testAdmin(): void {
     })
 
     it('should select and view a logs details', () => {
-      cy.get('[data-cy="paginated-list"]')
-        .as('list')
-        .should('have.length', 1, { timeout: 30000 })
-      cy.get('@list').eq(0).should('be.visible', { timeout: 30000 }).click()
-      cy.get('[data-cy="debug-message-details"').as('details').should('exist')
+      cy.get('[data-cy="paginated-list"] > ul > li').as('list').scrollIntoView()
+      cy.get('[data-cy="list-empty-message"]').should('not.exist')
+      cy.get('@list').first().click()
+      cy.get('[data-cy="debug-message-details"').as('details')
 
       // todo: not asserting updatedAt, destination, or providerID
       cy.get('@details').should('contain.text', 'ID')
@@ -330,10 +329,9 @@ function testAdmin(): void {
     })
 
     it('should verify user link from a logs details', () => {
-      cy.get('[data-cy="paginated-list"]')
-        .eq(0)
-        .should('be.visible', { timeout: 30000 })
-        .click()
+      cy.get('[data-cy="paginated-list"] > ul > li').as('list').scrollIntoView()
+      cy.get('[data-cy="list-empty-message"]').should('not.exist')
+      cy.get('@list').first().click()
       cy.get('[data-cy="debug-message-details"')
         .find('a')
         .contains(debugMessage?.userName ?? '')
@@ -347,10 +345,9 @@ function testAdmin(): void {
     })
 
     it('should verify service link from a logs details', () => {
-      cy.get('[data-cy="paginated-list"]')
-        .eq(0)
-        .should('be.visible', { timeout: 30000 })
-        .click()
+      cy.get('[data-cy="paginated-list"] > ul > li').as('list').scrollIntoView()
+      cy.get('[data-cy="list-empty-message"]').should('not.exist')
+      cy.get('@list').first().click()
       cy.get('[data-cy="debug-message-details"')
         .find('a')
         .contains(debugMessage?.serviceName ?? '')

--- a/web/src/cypress/e2e/admin.cy.ts
+++ b/web/src/cypress/e2e/admin.cy.ts
@@ -5,247 +5,247 @@ import { testScreen, login, Config, pathPrefix } from '../support/e2e'
 const c = new Chance()
 
 function testAdmin(): void {
-  // describe('Admin System Limits Page', () => {
-  //   let limits: Limits = new Map()
-  //   beforeEach(() => {
-  //     cy.getLimits().then((l: Limits) => {
-  //       limits = l
-  //       return cy.visit('/admin/limits')
-  //     })
-  //   })
+  describe('Admin System Limits Page', () => {
+    let limits: Limits = new Map()
+    beforeEach(() => {
+      cy.getLimits().then((l: Limits) => {
+        limits = l
+        return cy.visit('/admin/limits')
+      })
+    })
 
-  //   it('should allow updating system limits values', () => {
-  //     cy.get('nav li').contains('System Limits').should('be.visible')
+    it('should allow updating system limits values', () => {
+      cy.get('nav li').contains('System Limits').should('be.visible')
 
-  //     const newContactMethods = c.integer({ min: 15, max: 1000 }).toString()
-  //     const newEPActions = c.integer({ min: 15, max: 1000 }).toString()
+      const newContactMethods = c.integer({ min: 15, max: 1000 }).toString()
+      const newEPActions = c.integer({ min: 15, max: 1000 }).toString()
 
-  //     const ContactMethodsPerUser = limits.get(
-  //       'ContactMethodsPerUser',
-  //     ) as SystemLimits
-  //     const EPActionsPerStep = limits.get('EPActionsPerStep') as SystemLimits
+      const ContactMethodsPerUser = limits.get(
+        'ContactMethodsPerUser',
+      ) as SystemLimits
+      const EPActionsPerStep = limits.get('EPActionsPerStep') as SystemLimits
 
-  //     cy.form({
-  //       ContactMethodsPerUser: newContactMethods,
-  //       EPActionsPerStep: newEPActions,
-  //     })
+      cy.form({
+        ContactMethodsPerUser: newContactMethods,
+        EPActionsPerStep: newEPActions,
+      })
 
-  //     cy.get('button[data-cy=save]').click()
-  //     cy.dialogTitle('Apply Configuration Changes?')
+      cy.get('button[data-cy=save]').click()
+      cy.dialogTitle('Apply Configuration Changes?')
 
-  //     cy.dialogContains('-' + ContactMethodsPerUser.value)
-  //     cy.dialogContains('-' + EPActionsPerStep.value)
-  //     cy.dialogContains('+' + newContactMethods)
-  //     cy.dialogContains('+' + newEPActions)
-  //     cy.dialogFinish('Confirm')
+      cy.dialogContains('-' + ContactMethodsPerUser.value)
+      cy.dialogContains('-' + EPActionsPerStep.value)
+      cy.dialogContains('+' + newContactMethods)
+      cy.dialogContains('+' + newEPActions)
+      cy.dialogFinish('Confirm')
 
-  //     cy.get('input[name="EPActionsPerStep"]').should(
-  //       'have.value',
-  //       newEPActions,
-  //     )
-  //     cy.get('input[name="ContactMethodsPerUser"]').should(
-  //       'have.value',
-  //       newContactMethods,
-  //     )
-  //   })
+      cy.get('input[name="EPActionsPerStep"]').should(
+        'have.value',
+        newEPActions,
+      )
+      cy.get('input[name="ContactMethodsPerUser"]').should(
+        'have.value',
+        newContactMethods,
+      )
+    })
 
-  //   it('should reset pending system limit value changes', () => {
-  //     const ContactMethodsPerUser = limits.get(
-  //       'ContactMethodsPerUser',
-  //     ) as SystemLimits
-  //     const EPActionsPerStep = limits.get('EPActionsPerStep') as SystemLimits
+    it('should reset pending system limit value changes', () => {
+      const ContactMethodsPerUser = limits.get(
+        'ContactMethodsPerUser',
+      ) as SystemLimits
+      const EPActionsPerStep = limits.get('EPActionsPerStep') as SystemLimits
 
-  //     cy.form({
-  //       ContactMethodsPerUser: c.integer({ min: 0, max: 1000 }).toString(),
-  //       EPActionsPerStep: c.integer({ min: 0, max: 1000 }).toString(),
-  //     })
+      cy.form({
+        ContactMethodsPerUser: c.integer({ min: 0, max: 1000 }).toString(),
+        EPActionsPerStep: c.integer({ min: 0, max: 1000 }).toString(),
+      })
 
-  //     cy.get('button[data-cy="reset"]').click()
+      cy.get('button[data-cy="reset"]').click()
 
-  //     cy.get('input[name="ContactMethodsPerUser"]').should(
-  //       'have.value',
-  //       ContactMethodsPerUser.value.toString(),
-  //     )
-  //     cy.get('input[name="EPActionsPerStep"]').should(
-  //       'have.value',
-  //       EPActionsPerStep.value.toString(),
-  //     )
-  //   })
-  // })
+      cy.get('input[name="ContactMethodsPerUser"]').should(
+        'have.value',
+        ContactMethodsPerUser.value.toString(),
+      )
+      cy.get('input[name="EPActionsPerStep"]').should(
+        'have.value',
+        EPActionsPerStep.value.toString(),
+      )
+    })
+  })
 
-  // describe('Admin Config Page', () => {
-  //   let cfg: Config
-  //   beforeEach(() => {
-  //     return cy
-  //       .resetConfig()
-  //       .updateConfig({
-  //         Mailgun: {
-  //           APIKey: 'key-' + c.string({ length: 32, pool: '0123456789abcdef' }),
-  //           EmailDomain: '',
-  //         },
-  //         Twilio: {
-  //           Enable: true,
-  //           AccountSID:
-  //             'AC' + c.string({ length: 32, pool: '0123456789abcdef' }),
-  //           AuthToken: c.string({ length: 32, pool: '0123456789abcdef' }),
-  //           FromNumber: '+17633' + c.string({ length: 6, pool: '0123456789' }),
-  //         },
-  //       })
-  //       .then((curCfg: Config) => {
-  //         cfg = curCfg
-  //         return cy.visit('/admin').get('button[data-cy=save]').should('exist')
-  //       })
-  //   })
+  describe('Admin Config Page', () => {
+    let cfg: Config
+    beforeEach(() => {
+      return cy
+        .resetConfig()
+        .updateConfig({
+          Mailgun: {
+            APIKey: 'key-' + c.string({ length: 32, pool: '0123456789abcdef' }),
+            EmailDomain: '',
+          },
+          Twilio: {
+            Enable: true,
+            AccountSID:
+              'AC' + c.string({ length: 32, pool: '0123456789abcdef' }),
+            AuthToken: c.string({ length: 32, pool: '0123456789abcdef' }),
+            FromNumber: '+17633' + c.string({ length: 6, pool: '0123456789' }),
+          },
+        })
+        .then((curCfg: Config) => {
+          cfg = curCfg
+          return cy.visit('/admin').get('button[data-cy=save]').should('exist')
+        })
+    })
 
-  //   it('should allow updating config values', () => {
-  //     const newURL = 'http://' + c.domain()
-  //     const newDomain = c.domain()
-  //     const newAPIKey =
-  //       'key-' + c.string({ length: 32, pool: '0123456789abcdef' })
+    it('should allow updating config values', () => {
+      const newURL = 'http://' + c.domain()
+      const newDomain = c.domain()
+      const newAPIKey =
+        'key-' + c.string({ length: 32, pool: '0123456789abcdef' })
 
-  //     cy.form({
-  //       'General.PublicURL': newURL,
-  //       'Mailgun.EmailDomain': newDomain,
-  //       'Twilio.FromNumber': '',
-  //       'Mailgun.APIKey': newAPIKey,
-  //       'Twilio.Enable': false,
-  //     })
-  //     cy.get('button[data-cy=save]').click()
+      cy.form({
+        'General.PublicURL': newURL,
+        'Mailgun.EmailDomain': newDomain,
+        'Twilio.FromNumber': '',
+        'Mailgun.APIKey': newAPIKey,
+        'Twilio.Enable': false,
+      })
+      cy.get('button[data-cy=save]').click()
 
-  //     cy.dialogTitle('Apply Configuration Changes?')
-  //     cy.dialogFinish('Cancel')
+      cy.dialogTitle('Apply Configuration Changes?')
+      cy.dialogFinish('Cancel')
 
-  //     cy.get('button[data-cy=save]').click()
-  //     cy.dialogTitle('Apply Configuration Changes?')
-  //     cy.dialogContains('-' + cfg.General.PublicURL)
-  //     cy.dialogContains('-' + cfg.Twilio.FromNumber)
-  //     cy.dialogContains('-' + cfg.Mailgun.APIKey)
-  //     cy.dialogContains('-true')
-  //     cy.dialogContains('+false')
-  //     cy.dialogContains('+' + newURL)
-  //     cy.dialogContains('+' + newDomain)
-  //     cy.dialogContains('+' + newAPIKey)
-  //     cy.dialogFinish('Confirm')
+      cy.get('button[data-cy=save]').click()
+      cy.dialogTitle('Apply Configuration Changes?')
+      cy.dialogContains('-' + cfg.General.PublicURL)
+      cy.dialogContains('-' + cfg.Twilio.FromNumber)
+      cy.dialogContains('-' + cfg.Mailgun.APIKey)
+      cy.dialogContains('-true')
+      cy.dialogContains('+false')
+      cy.dialogContains('+' + newURL)
+      cy.dialogContains('+' + newDomain)
+      cy.dialogContains('+' + newAPIKey)
+      cy.dialogFinish('Confirm')
 
-  //     cy.get('input[name="General.PublicURL"]').should('have.value', newURL)
-  //     cy.get('input[name="Mailgun.EmailDomain"]').should(
-  //       'have.value',
-  //       newDomain,
-  //     )
-  //     cy.get('input[name="Twilio.FromNumber"]').should('have.value', '')
-  //     cy.get('input[name="Mailgun.APIKey"]').should('have.value', newAPIKey)
-  //     cy.get('input[name="Twilio.Enable"]').should('not.be.checked')
-  //   })
+      cy.get('input[name="General.PublicURL"]').should('have.value', newURL)
+      cy.get('input[name="Mailgun.EmailDomain"]').should(
+        'have.value',
+        newDomain,
+      )
+      cy.get('input[name="Twilio.FromNumber"]').should('have.value', '')
+      cy.get('input[name="Mailgun.APIKey"]').should('have.value', newAPIKey)
+      cy.get('input[name="Twilio.Enable"]').should('not.be.checked')
+    })
 
-  //   it('should reset pending config value changes', () => {
-  //     const domain1 = c.domain()
-  //     const domain2 = c.domain()
+    it('should reset pending config value changes', () => {
+      const domain1 = c.domain()
+      const domain2 = c.domain()
 
-  //     cy.form({
-  //       'General.PublicURL': domain1,
-  //       'Mailgun.EmailDomain': domain2,
-  //     })
+      cy.form({
+        'General.PublicURL': domain1,
+        'Mailgun.EmailDomain': domain2,
+      })
 
-  //     cy.get('button[data-cy="reset"]').click()
+      cy.get('button[data-cy="reset"]').click()
 
-  //     cy.get('input[name="General.PublicURL"]').should(
-  //       'have.value',
-  //       cfg.General.PublicURL,
-  //     )
-  //     cy.get('input[name="Mailgun.EmailDomain"]').should('have.value', '')
-  //   })
+      cy.get('input[name="General.PublicURL"]').should(
+        'have.value',
+        cfg.General.PublicURL,
+      )
+      cy.get('input[name="Mailgun.EmailDomain"]').should('have.value', '')
+    })
 
-  //   it('should update a string list field', () => {
-  //     const domain1 = 'http://' + c.domain()
-  //     const domain2 = 'http://' + c.domain()
-  //     const domain3 = cfg.General.PublicURL
+    it('should update a string list field', () => {
+      const domain1 = 'http://' + c.domain()
+      const domain2 = 'http://' + c.domain()
+      const domain3 = cfg.General.PublicURL
 
-  //     cy.form({ 'Auth.RefererURLs-new-item': domain1 })
-  //     cy.form({ 'Auth.RefererURLs-new-item': domain2 })
-  //     cy.form({ 'Auth.RefererURLs-new-item': domain3 })
+      cy.form({ 'Auth.RefererURLs-new-item': domain1 })
+      cy.form({ 'Auth.RefererURLs-new-item': domain2 })
+      cy.form({ 'Auth.RefererURLs-new-item': domain3 })
 
-  //     cy.get('button[data-cy=save]').click()
-  //     cy.dialogFinish('Confirm')
+      cy.get('button[data-cy=save]').click()
+      cy.dialogFinish('Confirm')
 
-  //     cy.get('input[name="Auth.RefererURLs-0"]').should('have.value', domain1)
-  //     cy.get('input[name="Auth.RefererURLs-1"]').should('have.value', domain2)
-  //     cy.get('input[name="Auth.RefererURLs-2"]').should('have.value', domain3)
-  //     cy.get('input[name="Auth.RefererURLs-new-item"]').should('have.value', '')
-  //   })
+      cy.get('input[name="Auth.RefererURLs-0"]').should('have.value', domain1)
+      cy.get('input[name="Auth.RefererURLs-1"]').should('have.value', domain2)
+      cy.get('input[name="Auth.RefererURLs-2"]').should('have.value', domain3)
+      cy.get('input[name="Auth.RefererURLs-new-item"]').should('have.value', '')
+    })
 
-  //   it('should generate a slack manifest', () => {
-  //     const publicURL = cfg.General.PublicURL
-  //     cy.get('[id="accordion-Slack"]').click()
-  //     cy.get('button').contains('App Manifest').click()
-  //     cy.dialogTitle('App Manifest')
+    it('should generate a slack manifest', () => {
+      const publicURL = cfg.General.PublicURL
+      cy.get('[id="accordion-Slack"]').click()
+      cy.get('button').contains('App Manifest').click()
+      cy.dialogTitle('App Manifest')
 
-  //     // verify data integrity from pulled values
-  //     cy.dialogContains("name: 'GoAlert'")
-  //     cy.dialogContains(
-  //       `request_url: '${publicURL}/api/v2/slack/message-action'`,
-  //     )
-  //     cy.dialogContains(
-  //       `message_menu_options_url: '${publicURL}/api/v2/slack/menu-options'`,
-  //     )
-  //     cy.dialogContains(
-  //       `'${publicURL}/api/v2/identity/providers/oidc/callback'`,
-  //     )
-  //     cy.dialogContains("display_name: 'GoAlert'")
+      // verify data integrity from pulled values
+      cy.dialogContains("name: 'GoAlert'")
+      cy.dialogContains(
+        `request_url: '${publicURL}/api/v2/slack/message-action'`,
+      )
+      cy.dialogContains(
+        `message_menu_options_url: '${publicURL}/api/v2/slack/menu-options'`,
+      )
+      cy.dialogContains(
+        `'${publicURL}/api/v2/identity/providers/oidc/callback'`,
+      )
+      cy.dialogContains("display_name: 'GoAlert'")
 
-  //     // verify button routing to slack config page
-  //     cy.get('[data-cy="configure-in-slack"]')
-  //       .should('have.attr', 'href')
-  //       .and('contain', 'https://api.slack.com/apps?new_app=1&manifest_yaml=')
-  //   })
-  // })
+      // verify button routing to slack config page
+      cy.get('[data-cy="configure-in-slack"]')
+        .should('have.attr', 'href')
+        .and('contain', 'https://api.slack.com/apps?new_app=1&manifest_yaml=')
+    })
+  })
 
-  // describe('Admin Alert Count Page', () => {
-  //   let svc1: Service
-  //   let svc2: Service
+  describe('Admin Alert Count Page', () => {
+    let svc1: Service
+    let svc2: Service
 
-  //   beforeEach(() => {
-  //     cy.setTimeSpeed(0)
-  //     cy.fastForward('-21h')
+    beforeEach(() => {
+      cy.setTimeSpeed(0)
+      cy.fastForward('-21h')
 
-  //     cy.createService().then((s1: Service) => {
-  //       svc1 = s1
-  //       cy.createAlert({ serviceID: s1.id })
-  //     })
-  //     cy.createService().then((s2: Service) => {
-  //       svc2 = s2
-  //       cy.createAlert({ serviceID: s2.id })
-  //       cy.createAlert({ serviceID: s2.id })
-  //     })
+      cy.createService().then((s1: Service) => {
+        svc1 = s1
+        cy.createAlert({ serviceID: s1.id })
+      })
+      cy.createService().then((s2: Service) => {
+        svc2 = s2
+        cy.createAlert({ serviceID: s2.id })
+        cy.createAlert({ serviceID: s2.id })
+      })
 
-  //     cy.fastForward('21h')
-  //     cy.setTimeSpeed(1) // resume the flow of time
+      cy.fastForward('21h')
+      cy.setTimeSpeed(1) // resume the flow of time
 
-  //     return cy.visit('/admin/alert-counts')
-  //   })
+      return cy.visit('/admin/alert-counts')
+    })
 
-  //   it('should display alert counts', () => {
-  //     const now = DateTime.local()
-  //       .minus({ hours: 21 })
-  //       .set({ minute: 0 })
-  //       .toLocaleString({
-  //         year: 'numeric',
-  //         month: 'short',
-  //         day: 'numeric',
-  //         hour: 'numeric',
-  //         minute: 'numeric',
-  //       })
+    it('should display alert counts', () => {
+      const now = DateTime.local()
+        .minus({ hours: 21 })
+        .set({ minute: 0 })
+        .toLocaleString({
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          hour: 'numeric',
+          minute: 'numeric',
+        })
 
-  //     cy.get(`.recharts-line-dots circle[r=3]`).last().trigger('mouseover')
-  //     cy.get('[data-cy=alert-count-graph]')
-  //       .should('contain', now)
-  //       .should('contain', `${svc1.name}: 1`)
-  //       .should('contain', `${svc2.name}: 2`)
+      cy.get(`.recharts-line-dots circle[r=3]`).last().trigger('mouseover')
+      cy.get('[data-cy=alert-count-graph]')
+        .should('contain', now)
+        .should('contain', `${svc1.name}: 1`)
+        .should('contain', `${svc2.name}: 2`)
 
-  //     cy.get('[data-cy=alert-count-table]')
-  //       .should('contain', svc1.name)
-  //       .should('contain', svc2.name)
-  //   })
-  // })
+      cy.get('[data-cy=alert-count-table]')
+        .should('contain', svc1.name)
+        .should('contain', svc2.name)
+    })
+  })
 
   describe('Admin Message Logs Page', () => {
     let debugMessage: DebugMessage

--- a/web/src/cypress/e2e/admin.cy.ts
+++ b/web/src/cypress/e2e/admin.cy.ts
@@ -299,7 +299,9 @@ function testAdmin(): void {
     it('should select and view a logs details', () => {
       cy.get('[data-cy="paginated-list"] > ul > li').as('list').scrollIntoView()
       cy.get('[data-cy="list-empty-message"]').should('not.exist')
-      cy.get('@list').first().click()
+
+      // { force: true } needed for mobile view as the button is hidden under another div
+      cy.get('@list').children().first().click({ force: true })
       cy.get('[data-cy="debug-message-details"').as('details')
 
       // todo: not asserting updatedAt, destination, or providerID
@@ -331,7 +333,7 @@ function testAdmin(): void {
     it('should verify user link from a logs details', () => {
       cy.get('[data-cy="paginated-list"] > ul > li').as('list').scrollIntoView()
       cy.get('[data-cy="list-empty-message"]').should('not.exist')
-      cy.get('@list').first().click()
+      cy.get('@list').children().first().click({ force: true })
       cy.get('[data-cy="debug-message-details"')
         .find('a')
         .contains(debugMessage?.userName ?? '')
@@ -347,7 +349,7 @@ function testAdmin(): void {
     it('should verify service link from a logs details', () => {
       cy.get('[data-cy="paginated-list"] > ul > li').as('list').scrollIntoView()
       cy.get('[data-cy="list-empty-message"]').should('not.exist')
-      cy.get('@list').first().click()
+      cy.get('@list').children().first().click({ force: true })
       cy.get('[data-cy="debug-message-details"')
         .find('a')
         .contains(debugMessage?.serviceName ?? '')

--- a/web/src/cypress/e2e/admin.cy.ts
+++ b/web/src/cypress/e2e/admin.cy.ts
@@ -297,7 +297,10 @@ function testAdmin(): void {
     })
 
     it('should select and view a logs details', () => {
-      cy.get('[data-cy="paginated-list"]').eq(0).click()
+      cy.get('[data-cy="paginated-list"]')
+        .as('list')
+        .should('have.length', 1, { timeout: 30000 })
+      cy.get('@list').eq(0).should('be.visible', { timeout: 30000 }).click()
       cy.get('[data-cy="debug-message-details"').as('details').should('exist')
 
       // todo: not asserting updatedAt, destination, or providerID
@@ -327,7 +330,10 @@ function testAdmin(): void {
     })
 
     it('should verify user link from a logs details', () => {
-      cy.get('[data-cy="paginated-list"]').eq(0).click()
+      cy.get('[data-cy="paginated-list"]')
+        .eq(0)
+        .should('be.visible', { timeout: 30000 })
+        .click()
       cy.get('[data-cy="debug-message-details"')
         .find('a')
         .contains(debugMessage?.userName ?? '')
@@ -341,7 +347,10 @@ function testAdmin(): void {
     })
 
     it('should verify service link from a logs details', () => {
-      cy.get('[data-cy="paginated-list"]').eq(0).click()
+      cy.get('[data-cy="paginated-list"]')
+        .eq(0)
+        .should('be.visible', { timeout: 30000 })
+        .click()
       cy.get('[data-cy="debug-message-details"')
         .find('a')
         .contains(debugMessage?.serviceName ?? '')


### PR DESCRIPTION
**Description:**
Updates AdminMessageLogsLayout to use ListPageControls instead of QueryList

**Which issue(s) this PR fixes:**
Part of https://github.com/target/goalert/issues/3240
