### PR TITLE
profile: optimize on-call query

### DIFF
--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -508,6 +508,19 @@ type ComplexityRoot struct {
 		WeekdayFilter func(childComplexity int) int
 	}
 
+	OnCallOverview struct {
+		ServiceAssignments func(childComplexity int) int
+		ServiceCount       func(childComplexity int) int
+	}
+
+	OnCallServiceAssignment struct {
+		EscalationPolicyID   func(childComplexity int) int
+		EscalationPolicyName func(childComplexity int) int
+		ServiceID            func(childComplexity int) int
+		ServiceName          func(childComplexity int) int
+		StepNumber           func(childComplexity int) int
+	}
+
 	OnCallShift struct {
 		End       func(childComplexity int) int
 		Start     func(childComplexity int) int
@@ -758,6 +771,7 @@ type ComplexityRoot struct {
 		IsFavorite            func(childComplexity int) int
 		Name                  func(childComplexity int) int
 		NotificationRules     func(childComplexity int) int
+		OnCallOverview        func(childComplexity int) int
 		OnCallSteps           func(childComplexity int) int
 		Role                  func(childComplexity int) int
 		Sessions              func(childComplexity int) int
@@ -1048,6 +1062,7 @@ type UserResolver interface {
 	AuthSubjects(ctx context.Context, obj *user.User) ([]user.AuthSubject, error)
 	Sessions(ctx context.Context, obj *user.User) ([]UserSession, error)
 	OnCallSteps(ctx context.Context, obj *user.User) ([]escalation.Step, error)
+	OnCallOverview(ctx context.Context, obj *user.User) (*OnCallOverview, error)
 	IsFavorite(ctx context.Context, obj *user.User) (bool, error)
 	AssignedSchedules(ctx context.Context, obj *user.User) ([]schedule.Schedule, error)
 }
@@ -3177,6 +3192,55 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.OnCallNotificationRule.WeekdayFilter(childComplexity), true
 
+	case "OnCallOverview.serviceAssignments":
+		if e.complexity.OnCallOverview.ServiceAssignments == nil {
+			break
+		}
+
+		return e.complexity.OnCallOverview.ServiceAssignments(childComplexity), true
+
+	case "OnCallOverview.serviceCount":
+		if e.complexity.OnCallOverview.ServiceCount == nil {
+			break
+		}
+
+		return e.complexity.OnCallOverview.ServiceCount(childComplexity), true
+
+	case "OnCallServiceAssignment.escalationPolicyID":
+		if e.complexity.OnCallServiceAssignment.EscalationPolicyID == nil {
+			break
+		}
+
+		return e.complexity.OnCallServiceAssignment.EscalationPolicyID(childComplexity), true
+
+	case "OnCallServiceAssignment.escalationPolicyName":
+		if e.complexity.OnCallServiceAssignment.EscalationPolicyName == nil {
+			break
+		}
+
+		return e.complexity.OnCallServiceAssignment.EscalationPolicyName(childComplexity), true
+
+	case "OnCallServiceAssignment.serviceID":
+		if e.complexity.OnCallServiceAssignment.ServiceID == nil {
+			break
+		}
+
+		return e.complexity.OnCallServiceAssignment.ServiceID(childComplexity), true
+
+	case "OnCallServiceAssignment.serviceName":
+		if e.complexity.OnCallServiceAssignment.ServiceName == nil {
+			break
+		}
+
+		return e.complexity.OnCallServiceAssignment.ServiceName(childComplexity), true
+
+	case "OnCallServiceAssignment.stepNumber":
+		if e.complexity.OnCallServiceAssignment.StepNumber == nil {
+			break
+		}
+
+		return e.complexity.OnCallServiceAssignment.StepNumber(childComplexity), true
+
 	case "OnCallShift.end":
 		if e.complexity.OnCallShift.End == nil {
 			break
@@ -4562,6 +4626,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.User.NotificationRules(childComplexity), true
+
+	case "User.onCallOverview":
+		if e.complexity.User.OnCallOverview == nil {
+			break
+		}
+
+		return e.complexity.User.OnCallOverview(childComplexity), true
 
 	case "User.onCallSteps":
 		if e.complexity.User.OnCallSteps == nil {
@@ -13272,6 +13343,8 @@ func (ec *executionContext) fieldContext_GQLAPIKey_createdBy(_ context.Context, 
 				return ec.fieldContext_User_sessions(ctx, field)
 			case "onCallSteps":
 				return ec.fieldContext_User_onCallSteps(ctx, field)
+			case "onCallOverview":
+				return ec.fieldContext_User_onCallOverview(ctx, field)
 			case "isFavorite":
 				return ec.fieldContext_User_isFavorite(ctx, field)
 			case "assignedSchedules":
@@ -13385,6 +13458,8 @@ func (ec *executionContext) fieldContext_GQLAPIKey_updatedBy(_ context.Context, 
 				return ec.fieldContext_User_sessions(ctx, field)
 			case "onCallSteps":
 				return ec.fieldContext_User_onCallSteps(ctx, field)
+			case "onCallOverview":
+				return ec.fieldContext_User_onCallOverview(ctx, field)
 			case "isFavorite":
 				return ec.fieldContext_User_isFavorite(ctx, field)
 			case "assignedSchedules":
@@ -17583,6 +17658,8 @@ func (ec *executionContext) fieldContext_Mutation_createUser(ctx context.Context
 				return ec.fieldContext_User_sessions(ctx, field)
 			case "onCallSteps":
 				return ec.fieldContext_User_onCallSteps(ctx, field)
+			case "onCallOverview":
+				return ec.fieldContext_User_onCallOverview(ctx, field)
 			case "isFavorite":
 				return ec.fieldContext_User_isFavorite(ctx, field)
 			case "assignedSchedules":
@@ -19346,6 +19423,326 @@ func (ec *executionContext) fieldContext_OnCallNotificationRule_weekdayFilter(_ 
 	return fc, nil
 }
 
+func (ec *executionContext) _OnCallOverview_serviceCount(ctx context.Context, field graphql.CollectedField, obj *OnCallOverview) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OnCallOverview_serviceCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ServiceCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OnCallOverview_serviceCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OnCallOverview",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OnCallOverview_serviceAssignments(ctx context.Context, field graphql.CollectedField, obj *OnCallOverview) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OnCallOverview_serviceAssignments(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ServiceAssignments, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]OnCallServiceAssignment)
+	fc.Result = res
+	return ec.marshalNOnCallServiceAssignment2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐOnCallServiceAssignmentᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OnCallOverview_serviceAssignments(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OnCallOverview",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "stepNumber":
+				return ec.fieldContext_OnCallServiceAssignment_stepNumber(ctx, field)
+			case "escalationPolicyID":
+				return ec.fieldContext_OnCallServiceAssignment_escalationPolicyID(ctx, field)
+			case "escalationPolicyName":
+				return ec.fieldContext_OnCallServiceAssignment_escalationPolicyName(ctx, field)
+			case "serviceID":
+				return ec.fieldContext_OnCallServiceAssignment_serviceID(ctx, field)
+			case "serviceName":
+				return ec.fieldContext_OnCallServiceAssignment_serviceName(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type OnCallServiceAssignment", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OnCallServiceAssignment_stepNumber(ctx context.Context, field graphql.CollectedField, obj *OnCallServiceAssignment) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OnCallServiceAssignment_stepNumber(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.StepNumber, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OnCallServiceAssignment_stepNumber(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OnCallServiceAssignment",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OnCallServiceAssignment_escalationPolicyID(ctx context.Context, field graphql.CollectedField, obj *OnCallServiceAssignment) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OnCallServiceAssignment_escalationPolicyID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.EscalationPolicyID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OnCallServiceAssignment_escalationPolicyID(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OnCallServiceAssignment",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OnCallServiceAssignment_escalationPolicyName(ctx context.Context, field graphql.CollectedField, obj *OnCallServiceAssignment) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OnCallServiceAssignment_escalationPolicyName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.EscalationPolicyName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OnCallServiceAssignment_escalationPolicyName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OnCallServiceAssignment",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OnCallServiceAssignment_serviceID(ctx context.Context, field graphql.CollectedField, obj *OnCallServiceAssignment) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OnCallServiceAssignment_serviceID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ServiceID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OnCallServiceAssignment_serviceID(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OnCallServiceAssignment",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _OnCallServiceAssignment_serviceName(ctx context.Context, field graphql.CollectedField, obj *OnCallServiceAssignment) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_OnCallServiceAssignment_serviceName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ServiceName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_OnCallServiceAssignment_serviceName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "OnCallServiceAssignment",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _OnCallShift_userID(ctx context.Context, field graphql.CollectedField, obj *oncall.Shift) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_OnCallShift_userID(ctx, field)
 	if err != nil {
@@ -19448,6 +19845,8 @@ func (ec *executionContext) fieldContext_OnCallShift_user(_ context.Context, fie
 				return ec.fieldContext_User_sessions(ctx, field)
 			case "onCallSteps":
 				return ec.fieldContext_User_onCallSteps(ctx, field)
+			case "onCallOverview":
+				return ec.fieldContext_User_onCallOverview(ctx, field)
 			case "isFavorite":
 				return ec.fieldContext_User_isFavorite(ctx, field)
 			case "assignedSchedules":
@@ -20258,6 +20657,8 @@ func (ec *executionContext) fieldContext_Query_user(ctx context.Context, field g
 				return ec.fieldContext_User_sessions(ctx, field)
 			case "onCallSteps":
 				return ec.fieldContext_User_onCallSteps(ctx, field)
+			case "onCallOverview":
+				return ec.fieldContext_User_onCallOverview(ctx, field)
 			case "isFavorite":
 				return ec.fieldContext_User_isFavorite(ctx, field)
 			case "assignedSchedules":
@@ -23638,6 +24039,8 @@ func (ec *executionContext) fieldContext_Rotation_users(_ context.Context, field
 				return ec.fieldContext_User_sessions(ctx, field)
 			case "onCallSteps":
 				return ec.fieldContext_User_onCallSteps(ctx, field)
+			case "onCallOverview":
+				return ec.fieldContext_User_onCallOverview(ctx, field)
 			case "isFavorite":
 				return ec.fieldContext_User_isFavorite(ctx, field)
 			case "assignedSchedules":
@@ -28364,6 +28767,56 @@ func (ec *executionContext) fieldContext_User_onCallSteps(_ context.Context, fie
 	return fc, nil
 }
 
+func (ec *executionContext) _User_onCallOverview(ctx context.Context, field graphql.CollectedField, obj *user.User) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_User_onCallOverview(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.User().OnCallOverview(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*OnCallOverview)
+	fc.Result = res
+	return ec.marshalNOnCallOverview2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐOnCallOverview(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_User_onCallOverview(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "serviceCount":
+				return ec.fieldContext_OnCallOverview_serviceCount(ctx, field)
+			case "serviceAssignments":
+				return ec.fieldContext_OnCallOverview_serviceAssignments(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type OnCallOverview", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _User_isFavorite(ctx context.Context, field graphql.CollectedField, obj *user.User) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_User_isFavorite(ctx, field)
 	if err != nil {
@@ -28951,6 +29404,8 @@ func (ec *executionContext) fieldContext_UserConnection_nodes(_ context.Context,
 				return ec.fieldContext_User_sessions(ctx, field)
 			case "onCallSteps":
 				return ec.fieldContext_User_onCallSteps(ctx, field)
+			case "onCallOverview":
+				return ec.fieldContext_User_onCallOverview(ctx, field)
 			case "isFavorite":
 				return ec.fieldContext_User_isFavorite(ctx, field)
 			case "assignedSchedules":
@@ -30029,6 +30484,8 @@ func (ec *executionContext) fieldContext_UserOverride_addUser(_ context.Context,
 				return ec.fieldContext_User_sessions(ctx, field)
 			case "onCallSteps":
 				return ec.fieldContext_User_onCallSteps(ctx, field)
+			case "onCallOverview":
+				return ec.fieldContext_User_onCallOverview(ctx, field)
 			case "isFavorite":
 				return ec.fieldContext_User_isFavorite(ctx, field)
 			case "assignedSchedules":
@@ -30098,6 +30555,8 @@ func (ec *executionContext) fieldContext_UserOverride_removeUser(_ context.Conte
 				return ec.fieldContext_User_sessions(ctx, field)
 			case "onCallSteps":
 				return ec.fieldContext_User_onCallSteps(ctx, field)
+			case "onCallOverview":
+				return ec.fieldContext_User_onCallOverview(ctx, field)
 			case "isFavorite":
 				return ec.fieldContext_User_isFavorite(ctx, field)
 			case "assignedSchedules":
@@ -40637,6 +41096,109 @@ func (ec *executionContext) _OnCallNotificationRule(ctx context.Context, sel ast
 	return out
 }
 
+var onCallOverviewImplementors = []string{"OnCallOverview"}
+
+func (ec *executionContext) _OnCallOverview(ctx context.Context, sel ast.SelectionSet, obj *OnCallOverview) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, onCallOverviewImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("OnCallOverview")
+		case "serviceCount":
+			out.Values[i] = ec._OnCallOverview_serviceCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "serviceAssignments":
+			out.Values[i] = ec._OnCallOverview_serviceAssignments(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var onCallServiceAssignmentImplementors = []string{"OnCallServiceAssignment"}
+
+func (ec *executionContext) _OnCallServiceAssignment(ctx context.Context, sel ast.SelectionSet, obj *OnCallServiceAssignment) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, onCallServiceAssignmentImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("OnCallServiceAssignment")
+		case "stepNumber":
+			out.Values[i] = ec._OnCallServiceAssignment_stepNumber(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "escalationPolicyID":
+			out.Values[i] = ec._OnCallServiceAssignment_escalationPolicyID(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "escalationPolicyName":
+			out.Values[i] = ec._OnCallServiceAssignment_escalationPolicyName(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "serviceID":
+			out.Values[i] = ec._OnCallServiceAssignment_serviceID(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "serviceName":
+			out.Values[i] = ec._OnCallServiceAssignment_serviceName(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var onCallShiftImplementors = []string{"OnCallShift"}
 
 func (ec *executionContext) _OnCallShift(ctx context.Context, sel ast.SelectionSet, obj *oncall.Shift) graphql.Marshaler {
@@ -44172,6 +44734,42 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "onCallOverview":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_onCallOverview(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "isFavorite":
 			field := field
 
@@ -47535,6 +48133,68 @@ func (ec *executionContext) unmarshalNOnCallNotificationRuleInput2ᚕgithubᚗco
 		}
 	}
 	return res, nil
+}
+
+func (ec *executionContext) marshalNOnCallOverview2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐOnCallOverview(ctx context.Context, sel ast.SelectionSet, v OnCallOverview) graphql.Marshaler {
+	return ec._OnCallOverview(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNOnCallOverview2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐOnCallOverview(ctx context.Context, sel ast.SelectionSet, v *OnCallOverview) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._OnCallOverview(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNOnCallServiceAssignment2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐOnCallServiceAssignment(ctx context.Context, sel ast.SelectionSet, v OnCallServiceAssignment) graphql.Marshaler {
+	return ec._OnCallServiceAssignment(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNOnCallServiceAssignment2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐOnCallServiceAssignmentᚄ(ctx context.Context, sel ast.SelectionSet, v []OnCallServiceAssignment) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNOnCallServiceAssignment2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐOnCallServiceAssignment(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalNOnCallShift2githubᚗcomᚋtargetᚋgoalertᚋoncallᚐShift(ctx context.Context, sel ast.SelectionSet, v oncall.Shift) graphql.Marshaler {

--- a/graphql2/graphqlapp/queries.sql
+++ b/graphql2/graphqlapp/queries.sql
@@ -16,3 +16,18 @@ WHERE
         OR (om.message_type = 'alert_notification_bundle'
             AND om.service_id = @service_id::uuid));
 
+-- name: GQLUserOnCallOverview :many
+SELECT
+    svc.id AS service_id,
+    svc.name AS service_name,
+    ep.id AS policy_id,
+    ep.name AS policy_name,
+    step.step_number
+FROM
+    ep_step_on_call_users oc
+    JOIN escalation_policy_steps step ON step.id = oc.ep_step_id
+    JOIN escalation_policies ep ON ep.id = step.escalation_policy_id
+    JOIN services svc ON svc.escalation_policy_id = ep.id
+WHERE
+    oc.user_id = $1;
+

--- a/graphql2/graphqlapp/user.go
+++ b/graphql2/graphqlapp/user.go
@@ -53,7 +53,7 @@ func (a *User) OnCallOverview(ctx context.Context, obj *user.User) (*graphql2.On
 	for _, svc := range data {
 		svcCount[svc.ServiceID] = struct{}{}
 		overview.ServiceAssignments = append(overview.ServiceAssignments, graphql2.OnCallServiceAssignment{
-			StepNumber:           int(svc.StepNumber) + 1,
+			StepNumber:           int(svc.StepNumber),
 			EscalationPolicyID:   svc.PolicyID.String(),
 			EscalationPolicyName: svc.PolicyName,
 			ServiceID:            svc.ServiceID.String(),

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -645,6 +645,19 @@ type NotificationState struct {
 	FormattedSrcValue string              `json:"formattedSrcValue"`
 }
 
+type OnCallOverview struct {
+	ServiceCount       int                       `json:"serviceCount"`
+	ServiceAssignments []OnCallServiceAssignment `json:"serviceAssignments"`
+}
+
+type OnCallServiceAssignment struct {
+	StepNumber           int    `json:"stepNumber"`
+	EscalationPolicyID   string `json:"escalationPolicyID"`
+	EscalationPolicyName string `json:"escalationPolicyName"`
+	ServiceID            string `json:"serviceID"`
+	ServiceName          string `json:"serviceName"`
+}
+
 type PageInfo struct {
 	EndCursor   *string `json:"endCursor,omitempty"`
 	HasNextPage bool    `json:"hasNextPage"`

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -651,7 +651,7 @@ type OnCallOverview struct {
 }
 
 type OnCallServiceAssignment struct {
-	// stepNumber is the escalation step this assignment is from (begining with 0).
+	// stepNumber is the escalation step this assignment is from (beginning with 0).
 	StepNumber           int    `json:"stepNumber"`
 	EscalationPolicyID   string `json:"escalationPolicyID"`
 	EscalationPolicyName string `json:"escalationPolicyName"`

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -651,6 +651,7 @@ type OnCallOverview struct {
 }
 
 type OnCallServiceAssignment struct {
+	// stepNumber is the escalation step this assignment is from (begining with 0).
 	StepNumber           int    `json:"stepNumber"`
 	EscalationPolicyID   string `json:"escalationPolicyID"`
 	EscalationPolicyName string `json:"escalationPolicyName"`

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -1210,7 +1210,7 @@ type OnCallOverview {
 
 type OnCallServiceAssignment {
   """
-  stepNumber is the escalation step this assignment is from (begining with 0).
+  stepNumber is the escalation step this assignment is from (beginning with 0).
   """
   stepNumber: Int!
 

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -1209,6 +1209,9 @@ type OnCallOverview {
 }
 
 type OnCallServiceAssignment {
+  """
+  stepNumber is the escalation step this assignment is from (begining with 0).
+  """
   stepNumber: Int!
 
   escalationPolicyID: ID!

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -1178,6 +1178,9 @@ type User {
   sessions: [UserSession!]!
 
   onCallSteps: [EscalationPolicyStep!]!
+    @deprecated(reason: "Use `onCallOverview` instead.")
+
+  onCallOverview: OnCallOverview!
 
   isFavorite: Boolean!
 
@@ -1198,6 +1201,21 @@ type UserNotificationRule {
 
   contactMethodID: ID!
   contactMethod: UserContactMethod
+}
+
+type OnCallOverview {
+  serviceCount: Int!
+  serviceAssignments: [OnCallServiceAssignment!]!
+}
+
+type OnCallServiceAssignment {
+  stepNumber: Int!
+
+  escalationPolicyID: ID!
+  escalationPolicyName: String!
+
+  serviceID: ID!
+  serviceName: String!
 }
 
 enum ContactMethodType {

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -805,6 +805,19 @@ export interface OnCallNotificationRuleInput {
   weekdayFilter?: null | WeekdayFilter
 }
 
+export interface OnCallOverview {
+  serviceAssignments: OnCallServiceAssignment[]
+  serviceCount: number
+}
+
+export interface OnCallServiceAssignment {
+  escalationPolicyID: string
+  escalationPolicyName: string
+  serviceID: string
+  serviceName: string
+  stepNumber: number
+}
+
 export interface OnCallShift {
   end: ISOTimestamp
   start: ISOTimestamp
@@ -1337,6 +1350,7 @@ export interface User {
   isFavorite: boolean
   name: string
   notificationRules: UserNotificationRule[]
+  onCallOverview: OnCallOverview
   onCallSteps: EscalationPolicyStep[]
   role: UserRole
   sessions: UserSession[]


### PR DESCRIPTION
**Description:**
Makes a single DB call for on-call assignments instead of the recursive resolvers it previously used.

**Which issue(s) this PR fixes:**
Fixes #3870

**Describe any introduced user-facing changes:**
If introducing any user-facing changes, provide a clear description of them.

**Describe any introduced API changes:**
- Added `onCallOverview` to the User type
- Deprecated `onCallSteps`
