### PR TITLE
uik: add deleteSecondaryToken mutation

### DIFF
--- a/gadb/queries.sql.go
+++ b/gadb/queries.sql.go
@@ -1493,6 +1493,21 @@ func (q *Queries) IntKeyDeleteConfig(ctx context.Context, id uuid.UUID) error {
 	return err
 }
 
+const intKeyDeleteSecondaryToken = `-- name: IntKeyDeleteSecondaryToken :exec
+UPDATE
+    uik_config
+SET
+    secondary_token = NULL,
+    secondary_token_hint = NULL
+WHERE
+    id = $1
+`
+
+func (q *Queries) IntKeyDeleteSecondaryToken(ctx context.Context, id uuid.UUID) error {
+	_, err := q.db.ExecContext(ctx, intKeyDeleteSecondaryToken, id)
+	return err
+}
+
 const intKeyFindByService = `-- name: IntKeyFindByService :many
 SELECT
     id,

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -457,6 +457,7 @@ type ComplexityRoot struct {
 		DeleteAll                          func(childComplexity int, input []assignment.RawTarget) int
 		DeleteAuthSubject                  func(childComplexity int, input user.AuthSubject) int
 		DeleteGQLAPIKey                    func(childComplexity int, id string) int
+		DeleteSecondaryToken               func(childComplexity int, id string) int
 		EndAllAuthSessionsByCurrentUser    func(childComplexity int) int
 		EscalateAlerts                     func(childComplexity int, input []int) int
 		GenerateKeyToken                   func(childComplexity int, id string) int
@@ -965,6 +966,7 @@ type MutationResolver interface {
 	DeleteGQLAPIKey(ctx context.Context, id string) (bool, error)
 	UpdateKeyConfig(ctx context.Context, input UpdateKeyConfigInput) (bool, error)
 	PromoteSecondaryToken(ctx context.Context, id string) (bool, error)
+	DeleteSecondaryToken(ctx context.Context, id string) (bool, error)
 	GenerateKeyToken(ctx context.Context, id string) (string, error)
 }
 type OnCallNotificationRuleResolver interface {
@@ -2777,6 +2779,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.DeleteGQLAPIKey(childComplexity, args["id"].(string)), true
+
+	case "Mutation.deleteSecondaryToken":
+		if e.complexity.Mutation.DeleteSecondaryToken == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteSecondaryToken_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteSecondaryToken(childComplexity, args["id"].(string)), true
 
 	case "Mutation.endAllAuthSessionsByCurrentUser":
 		if e.complexity.Mutation.EndAllAuthSessionsByCurrentUser == nil {
@@ -5641,6 +5655,21 @@ func (ec *executionContext) field_Mutation_deleteAuthSubject_args(ctx context.Co
 }
 
 func (ec *executionContext) field_Mutation_deleteGQLAPIKey_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+		arg0, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteSecondaryToken_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 string
@@ -19169,6 +19198,85 @@ func (ec *executionContext) fieldContext_Mutation_promoteSecondaryToken(ctx cont
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_promoteSecondaryToken_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteSecondaryToken(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteSecondaryToken(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Mutation().DeleteSecondaryToken(rctx, fc.Args["id"].(string))
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			flagName, err := ec.unmarshalNString2string(ctx, "univ-keys")
+			if err != nil {
+				return nil, err
+			}
+			if ec.directives.Experimental == nil {
+				return nil, errors.New("directive experimental is not implemented")
+			}
+			return ec.directives.Experimental(ctx, nil, directive0, flagName)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(bool); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be bool`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteSecondaryToken(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteSecondaryToken_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -41316,6 +41424,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "promoteSecondaryToken":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_promoteSecondaryToken(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteSecondaryToken":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteSecondaryToken(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/graphql2/graph/univkeys.graphqls
+++ b/graphql2/graph/univkeys.graphqls
@@ -32,6 +32,11 @@ extend type Mutation {
   promoteSecondaryToken(id: ID!): Boolean! @experimental(flagName: "univ-keys")
 
   """
+  deleteSecondaryToken deletes the secondary token.
+  """
+  deleteSecondaryToken(id: ID!): Boolean! @experimental(flagName: "univ-keys")
+
+  """
   generateKeyToken generates a new token for an integration key.
 
   If the integration key already has a primary token, the new token will be the secondary token.

--- a/graphql2/graphqlapp/integrationkey.go
+++ b/graphql2/graphqlapp/integrationkey.go
@@ -29,6 +29,20 @@ func (m *Mutation) GenerateKeyToken(ctx context.Context, keyID string) (string, 
 	return m.IntKeyStore.GenerateToken(ctx, m.DB, id)
 }
 
+func (m *Mutation) DeleteSecondaryToken(ctx context.Context, keyID string) (bool, error) {
+	id, err := validate.ParseUUID("ID", keyID)
+	if err != nil {
+		return false, err
+	}
+
+	err = m.IntKeyStore.DeleteSecondaryToken(ctx, m.DB, id)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
 func (m *Mutation) PromoteSecondaryToken(ctx context.Context, keyID string) (bool, error) {
 	id, err := validate.ParseUUID("ID", keyID)
 	if err != nil {

--- a/integrationkey/queries.sql
+++ b/integrationkey/queries.sql
@@ -114,3 +114,12 @@ WHERE
 RETURNING
     id;
 
+-- name: IntKeyDeleteSecondaryToken :exec
+UPDATE
+    uik_config
+SET
+    secondary_token = NULL,
+    secondary_token_hint = NULL
+WHERE
+    id = $1;
+

--- a/integrationkey/uik.go
+++ b/integrationkey/uik.go
@@ -131,3 +131,17 @@ func (s *Store) PromoteSecondaryToken(ctx context.Context, db gadb.DBTX, id uuid
 
 	return nil
 }
+
+func (s *Store) DeleteSecondaryToken(ctx context.Context, db gadb.DBTX, id uuid.UUID) error {
+	err := permission.LimitCheckAny(ctx, permission.User)
+	if err != nil {
+		return err
+	}
+
+	err = gadb.New(db).IntKeyDeleteSecondaryToken(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -742,6 +742,7 @@ export interface Mutation {
   deleteAll: boolean
   deleteAuthSubject: boolean
   deleteGQLAPIKey: boolean
+  deleteSecondaryToken: boolean
   endAllAuthSessionsByCurrentUser: boolean
   escalateAlerts?: null | Alert[]
   generateKeyToken: string


### PR DESCRIPTION
**Description:**
This PR adds a way to delete a secondary token so that users aren't forced to promote/delete the primary in the event the secondary token is lost/cant be used.

**Describe any introduced API changes:**
- added `deleteSecondaryToken` mutation
