### PR TITLE
uik: add methods of updating single rules

### DIFF
--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -395,6 +395,7 @@ type ComplexityRoot struct {
 
 	KeyConfig struct {
 		DefaultActions  func(childComplexity int) int
+		OneRule         func(childComplexity int, id string) int
 		Rules           func(childComplexity int) int
 		StopAtFirstRule func(childComplexity int) int
 	}
@@ -2370,6 +2371,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.KeyConfig.DefaultActions(childComplexity), true
+
+	case "KeyConfig.oneRule":
+		if e.complexity.KeyConfig.OneRule == nil {
+			break
+		}
+
+		args, err := ec.field_KeyConfig_oneRule_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.KeyConfig.OneRule(childComplexity, args["id"].(string)), true
 
 	case "KeyConfig.rules":
 		if e.complexity.KeyConfig.Rules == nil {
@@ -5292,6 +5305,21 @@ func (ec *executionContext) field_Expr_exprToCondition_args(ctx context.Context,
 		}
 	}
 	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_KeyConfig_oneRule_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+		arg0, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["id"] = arg0
 	return args, nil
 }
 
@@ -14547,6 +14575,8 @@ func (ec *executionContext) fieldContext_IntegrationKey_config(_ context.Context
 				return ec.fieldContext_KeyConfig_stopAtFirstRule(ctx, field)
 			case "rules":
 				return ec.fieldContext_KeyConfig_rules(ctx, field)
+			case "oneRule":
+				return ec.fieldContext_KeyConfig_oneRule(ctx, field)
 			case "defaultActions":
 				return ec.fieldContext_KeyConfig_defaultActions(ctx, field)
 			}
@@ -15014,6 +15044,70 @@ func (ec *executionContext) fieldContext_KeyConfig_rules(_ context.Context, fiel
 			}
 			return nil, fmt.Errorf("no field named %q was found under type KeyRule", field.Name)
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _KeyConfig_oneRule(ctx context.Context, field graphql.CollectedField, obj *KeyConfig) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_KeyConfig_oneRule(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OneRule, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*KeyRule)
+	fc.Result = res
+	return ec.marshalOKeyRule2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐKeyRule(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_KeyConfig_oneRule(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "KeyConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_KeyRule_id(ctx, field)
+			case "name":
+				return ec.fieldContext_KeyRule_name(ctx, field)
+			case "description":
+				return ec.fieldContext_KeyRule_description(ctx, field)
+			case "conditionExpr":
+				return ec.fieldContext_KeyRule_conditionExpr(ctx, field)
+			case "actions":
+				return ec.fieldContext_KeyRule_actions(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type KeyRule", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_KeyConfig_oneRule_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -36704,7 +36798,7 @@ func (ec *executionContext) unmarshalInputUpdateKeyConfigInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"keyID", "stopAtFirstRule", "rules", "defaultActions"}
+	fieldsInOrder := [...]string{"keyID", "stopAtFirstRule", "rules", "setRule", "deleteRule", "defaultActions"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -36732,6 +36826,20 @@ func (ec *executionContext) unmarshalInputUpdateKeyConfigInput(ctx context.Conte
 				return it, err
 			}
 			it.Rules = data
+		case "setRule":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("setRule"))
+			data, err := ec.unmarshalOKeyRuleInput2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐKeyRuleInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SetRule = data
+		case "deleteRule":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deleteRule"))
+			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeleteRule = data
 		case "defaultActions":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("defaultActions"))
 			data, err := ec.unmarshalOActionInput2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐActionInputᚄ(ctx, v)
@@ -40610,6 +40718,8 @@ func (ec *executionContext) _KeyConfig(ctx context.Context, sel ast.SelectionSet
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "oneRule":
+			out.Values[i] = ec._KeyConfig_oneRule(ctx, field, obj)
 		case "defaultActions":
 			out.Values[i] = ec._KeyConfig_defaultActions(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -51194,6 +51304,13 @@ func (ec *executionContext) unmarshalOIntegrationKeySearchOptions2ᚖgithubᚗco
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) marshalOKeyRule2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐKeyRule(ctx context.Context, sel ast.SelectionSet, v *KeyRule) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._KeyRule(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalOKeyRuleInput2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐKeyRuleInputᚄ(ctx context.Context, v interface{}) ([]KeyRuleInput, error) {
 	if v == nil {
 		return nil, nil
@@ -51212,6 +51329,14 @@ func (ec *executionContext) unmarshalOKeyRuleInput2ᚕgithubᚗcomᚋtargetᚋgo
 		}
 	}
 	return res, nil
+}
+
+func (ec *executionContext) unmarshalOKeyRuleInput2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐKeyRuleInput(ctx context.Context, v interface{}) (*KeyRuleInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputKeyRuleInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalOLabelKeySearchOptions2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐLabelKeySearchOptions(ctx context.Context, v interface{}) (*LabelKeySearchOptions, error) {

--- a/graphql2/graph/univkeys.graphqls
+++ b/graphql2/graph/univkeys.graphqls
@@ -52,6 +52,11 @@ type KeyConfig {
   rules: [KeyRule!]!
 
   """
+  Get a single rule by ID.
+  """
+  oneRule(id: ID!): KeyRule
+
+  """
   defaultAction is the action to take if no rules match the request.
   """
   defaultActions: [Action!]!
@@ -80,6 +85,16 @@ input UpdateKeyConfigInput {
   stopAtFirstRule: Boolean
 
   rules: [KeyRuleInput!]
+
+  """
+  setRule allows you to set a single rule. If ID is provided, the rule with that ID will be updated. If ID is not provided, a new rule will be created and appended to the list of rules.
+  """
+  setRule: KeyRuleInput
+
+  """
+  deleteRule allows you to delete a single rule by ID.
+  """
+  deleteRule: ID
 
   """
   defaultAction is the action to take if no rules match the request.

--- a/graphql2/graph/univkeys.graphqls
+++ b/graphql2/graph/univkeys.graphqls
@@ -54,7 +54,7 @@ type KeyConfig {
   """
   Get a single rule by ID.
   """
-  oneRule(id: ID!): KeyRule
+  oneRule(id: ID!): KeyRule @goField(forceResolver: true)
 
   """
   defaultAction is the action to take if no rules match the request.

--- a/graphql2/graphqlapp/integrationkey.go
+++ b/graphql2/graphqlapp/integrationkey.go
@@ -16,7 +16,20 @@ import (
 
 type IntegrationKey App
 
+type KeyConfig App
+
 func (a *App) IntegrationKey() graphql2.IntegrationKeyResolver { return (*IntegrationKey)(a) }
+func (a *App) KeyConfig() graphql2.KeyConfigResolver           { return (*KeyConfig)(a) }
+
+func (k *KeyConfig) OneRule(ctx context.Context, key *graphql2.KeyConfig, ruleID string) (*graphql2.KeyRule, error) {
+	for _, r := range key.Rules {
+		if r.ID == ruleID {
+			return &r, nil
+		}
+	}
+
+	return nil, validation.NewFieldError("RuleID", "not found")
+}
 
 func (q *Query) IntegrationKey(ctx context.Context, id string) (*integrationkey.IntegrationKey, error) {
 	return q.IntKeyStore.FindOne(ctx, id)

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -564,6 +564,8 @@ type KeyConfig struct {
 	// Stop evaluating rules after the first rule that matches.
 	StopAtFirstRule bool      `json:"stopAtFirstRule"`
 	Rules           []KeyRule `json:"rules"`
+	// Get a single rule by ID.
+	OneRule *KeyRule `json:"oneRule,omitempty"`
 	// defaultAction is the action to take if no rules match the request.
 	DefaultActions []Action `json:"defaultActions"`
 }
@@ -923,6 +925,10 @@ type UpdateKeyConfigInput struct {
 	// Stop evaluating rules after the first rule that matches.
 	StopAtFirstRule *bool          `json:"stopAtFirstRule,omitempty"`
 	Rules           []KeyRuleInput `json:"rules,omitempty"`
+	// setRule allows you to set a single rule. If ID is provided, the rule with that ID will be updated. If ID is not provided, a new rule will be created and appended to the list of rules.
+	SetRule *KeyRuleInput `json:"setRule,omitempty"`
+	// deleteRule allows you to delete a single rule by ID.
+	DeleteRule *string `json:"deleteRule,omitempty"`
 	// defaultAction is the action to take if no rules match the request.
 	DefaultActions []ActionInput `json:"defaultActions,omitempty"`
 }

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -640,6 +640,7 @@ export interface IntegrationKeyTypeInfo {
 
 export interface KeyConfig {
   defaultActions: Action[]
+  oneRule?: null | KeyRule
   rules: KeyRule[]
   stopAtFirstRule: boolean
 }
@@ -1285,8 +1286,10 @@ export interface UpdateHeartbeatMonitorInput {
 
 export interface UpdateKeyConfigInput {
   defaultActions?: null | ActionInput[]
+  deleteRule?: null | string
   keyID: string
   rules?: null | KeyRuleInput[]
+  setRule?: null | KeyRuleInput
   stopAtFirstRule?: null | boolean
 }
 


### PR DESCRIPTION
**Description:**
Adds fields for CRUD on single rules

**Describe any introduced API changes:**
- Added `KeyConfig.oneRule(id: ID!)` for reading a single rule (e.g., edit or delete dialog)
- Added `KeyConfigInput.setRule` for creating or updating a single rule
- Added `keyConfigInput.deleteRule` for deleting a single rule from config
