### PR TITLE
ui/on-call notifications: always show quick link, show error on no days

### DIFF
--- a/web/src/app/schedules/ScheduleDetails.tsx
+++ b/web/src/app/schedules/ScheduleDetails.tsx
@@ -13,7 +13,6 @@ import { ObjectNotFound, GenericError } from '../error-pages'
 import TempSchedDialog from './temp-sched/TempSchedDialog'
 import TempSchedDeleteConfirmation from './temp-sched/TempSchedDeleteConfirmation'
 import { ScheduleAvatar } from '../util/avatars'
-import { useConfigValue } from '../util/RequireConfig'
 import ScheduleOverrideDialog from './ScheduleOverrideDialog'
 import { useIsWidthDown } from '../util/useWidth'
 import { TempSchedValue, defaultTempSchedValue } from './temp-sched/sharedUtils'
@@ -73,9 +72,6 @@ export default function ScheduleDetails({
   const [showDelete, setShowDelete] = useState(false)
 
   const isMobile = useIsWidthDown('md')
-
-  const [slackEnabled] = useConfigValue('Slack.Enable')
-  const [webhookEnabled] = useConfigValue('Webhook.Enable')
 
   const [editTempSched, setEditTempSched] = useState(false)
 
@@ -214,18 +210,12 @@ export default function ScheduleDetails({
             url: 'shifts',
             subText: 'Review a list of past and future on-call shifts',
           },
-        ].concat(
-          // only slack/webhook supported atm, so hide the link if disabled
-          slackEnabled || webhookEnabled
-            ? [
-                {
-                  label: 'On-Call Notifications',
-                  url: 'on-call-notifications',
-                  subText: 'Set up notifications to know who is on-call',
-                },
-              ]
-            : [],
-        )}
+          {
+            label: 'On-Call Notifications',
+            url: 'on-call-notifications',
+            subText: 'Set up notifications to know who is on-call',
+          },
+        ]}
       />
     </React.Fragment>
   )


### PR DESCRIPTION
This PR makes a couple small changes to the Schedule On-Call Notifications experience:

- The quick link from the Schedule page should always show now. This was previously conditionally rendered if slack or webhooks were enabled in the config
- Shows an error and disables the user from submitting if "Specify at time and day of week" is enabled, but all days are unchecked, saying that at least one day is required. Right now, nothing happens and the dialog closes.