### PR TITLE
ui/chore: remove "Dest" suffix from relevant UI files

### DIFF
--- a/web/src/app/escalation-policies/PolicyStepCreateDialog.stories.tsx
+++ b/web/src/app/escalation-policies/PolicyStepCreateDialog.stories.tsx
@@ -1,23 +1,20 @@
 import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
-import PolicyStepEditDialogDest from './PolicyStepEditDialogDest'
+import PolicyStepCreateDialog from './PolicyStepCreateDialog'
 import { expect, fn, userEvent, waitFor, within } from '@storybook/test'
 import { handleDefaultConfig } from '../storybook/graphql'
 import { HttpResponse, graphql } from 'msw'
 import { DestFieldValueError } from '../util/errtypes'
-import { EscalationPolicyStep } from '../../schema'
 
 const meta = {
-  title: 'Escalation Policies/Steps/Edit Dialog',
-  component: PolicyStepEditDialogDest,
+  title: 'Escalation Policies/Steps/Create Dialog',
+  component: PolicyStepCreateDialog,
   render: function Component(args) {
-    return <PolicyStepEditDialogDest {...args} disablePortal />
+    return <PolicyStepCreateDialog {...args} disablePortal />
   },
   tags: ['autodocs'],
   args: {
     onClose: fn(),
-    escalationPolicyID: 'policy1',
-    stepID: 'step1',
   },
   parameters: {
     docs: {
@@ -64,52 +61,31 @@ const meta = {
           })
         }),
 
-        graphql.query('GetEPStep', () => {
-          return HttpResponse.json({
-            data: {
-              escalationPolicy: {
-                id: 'policy1',
-                steps: [
-                  {
-                    id: 'step1',
-                    delayMinutes: 17,
-                    actions: [
-                      {
-                        type: 'single-field',
-                        values: [
-                          { fieldID: 'phone-number', value: '+19995550123' },
-                        ],
-                      },
-                    ],
-                  } as EscalationPolicyStep,
-                ],
-              },
-            },
-          })
-        }),
+        graphql.mutation(
+          'createEscalationPolicyStep',
+          ({ variables: vars }) => {
+            if (vars.input.delayMinutes === 999) {
+              return HttpResponse.json({
+                errors: [{ message: 'generic dialog error' }],
+              })
+            }
 
-        graphql.mutation('UpdateEPStep', ({ variables: vars }) => {
-          if (vars.input.delayMinutes === 999) {
             return HttpResponse.json({
-              errors: [{ message: 'generic dialog error' }],
+              data: {
+                createEscalationPolicyStep: { id: '1' },
+              },
             })
-          }
-
-          return HttpResponse.json({
-            data: {
-              updateEscalationPolicyStep: true,
-            },
-          })
-        }),
+          },
+        ),
       ],
     },
   },
-} satisfies Meta<typeof PolicyStepEditDialogDest>
+} satisfies Meta<typeof PolicyStepCreateDialog>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const UpdatePolicyStep: Story = {
+export const CreatePolicyStep: Story = {
   argTypes: {
     onClose: { action: 'onClose' },
   },
@@ -118,18 +94,6 @@ export const UpdatePolicyStep: Story = {
   },
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement)
-
-    // validate existing step data
-    // 1. delay should be 17
-    // 2. phone number should be +19995550123
-
-    await waitFor(async function ExistingChip() {
-      await expect(await canvas.findByLabelText('Delay (minutes)')).toHaveValue(
-        17,
-      )
-      await expect(await canvas.findByText('+19995550123')).toBeVisible()
-    })
-
     const phoneInput = await canvas.findByLabelText('Phone Number')
     await userEvent.clear(phoneInput)
     await userEvent.type(phoneInput, '1222')
@@ -151,11 +115,7 @@ export const UpdatePolicyStep: Story = {
     await userEvent.type(delayField, '999')
     await userEvent.click(await canvas.findByText('Submit'))
 
-    await waitFor(async function Error() {
-      await expect(
-        await canvas.findByText('generic dialog error'),
-      ).toBeVisible()
-    })
+    await expect(await canvas.findByText('generic dialog error')).toBeVisible()
 
     await expect(args.onClose).not.toHaveBeenCalled() // should not close on error
 

--- a/web/src/app/escalation-policies/PolicyStepCreateDialog.tsx
+++ b/web/src/app/escalation-policies/PolicyStepCreateDialog.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from 'react'
 import { CombinedError, gql, useMutation } from 'urql'
 import { splitErrorsByPath } from '../util/errutil'
 import FormDialog from '../dialogs/FormDialog'
-import PolicyStepFormDest, { FormValue } from './PolicyStepFormDest'
-import { errorPaths } from '../users/UserContactMethodFormDest'
+import PolicyStepForm, { FormValue } from './PolicyStepForm'
+import { errorPaths } from '../users/UserContactMethodForm'
 
 const mutation = gql`
   mutation createEscalationPolicyStep(
@@ -15,7 +15,7 @@ const mutation = gql`
   }
 `
 
-function PolicyStepCreateDialogDest(props: {
+export default function PolicyStepCreateDialog(props: {
   escalationPolicyID: string
   disablePortal?: boolean
   onClose: () => void
@@ -66,7 +66,7 @@ function PolicyStepCreateDialogDest(props: {
         })
       }}
       form={
-        <PolicyStepFormDest
+        <PolicyStepForm
           errors={formErrors}
           disabled={createStepStatus.fetching}
           value={value}
@@ -76,5 +76,3 @@ function PolicyStepCreateDialogDest(props: {
     />
   )
 }
-
-export default PolicyStepCreateDialogDest

--- a/web/src/app/escalation-policies/PolicyStepDeleteDialog.tsx
+++ b/web/src/app/escalation-policies/PolicyStepDeleteDialog.tsx
@@ -23,7 +23,7 @@ const mutation = gql`
   }
 `
 
-function PolicyStepDeleteDialog(props: {
+export default function PolicyStepDeleteDialog(props: {
   escalationPolicyID: string
   stepID: string
   onClose: () => void
@@ -76,5 +76,3 @@ function PolicyStepDeleteDialog(props: {
     />
   )
 }
-
-export default PolicyStepDeleteDialog

--- a/web/src/app/escalation-policies/PolicyStepEditDialog.tsx
+++ b/web/src/app/escalation-policies/PolicyStepEditDialog.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { gql, useMutation, useQuery } from 'urql'
 import { splitErrorsByPath } from '../util/errutil'
 import FormDialog from '../dialogs/FormDialog'
-import PolicyStepFormDest, { FormValue } from './PolicyStepFormDest'
+import PolicyStepForm, { FormValue } from './PolicyStepForm'
 import {
   Destination,
   EscalationPolicy,
@@ -10,7 +10,7 @@ import {
   UpdateEscalationPolicyStepInput,
 } from '../../schema'
 
-interface PolicyStepEditDialogDestProps {
+interface PolicyStepEditDialogProps {
   escalationPolicyID: string
   onClose: () => void
   stepID: string
@@ -42,8 +42,8 @@ const query = gql`
   }
 `
 
-function PolicyStepEditDialogDest(
-  props: PolicyStepEditDialogDestProps,
+export default function PolicyStepEditDialog(
+  props: PolicyStepEditDialogProps,
 ): React.ReactNode {
   const [stepQ] = useQuery<{ escalationPolicy: EscalationPolicy }>({
     query,
@@ -98,7 +98,7 @@ function PolicyStepEditDialogDest(
         })
       }
       form={
-        <PolicyStepFormDest
+        <PolicyStepForm
           disabled={editStepStatus.fetching}
           value={value}
           onChange={(value: FormValue) => setValue(value)}
@@ -107,5 +107,3 @@ function PolicyStepEditDialogDest(
     />
   )
 }
-
-export default PolicyStepEditDialogDest

--- a/web/src/app/escalation-policies/PolicyStepForm.stories.tsx
+++ b/web/src/app/escalation-policies/PolicyStepForm.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
-import PolicyStepFormDest, { FormValue } from './PolicyStepFormDest'
+import PolicyStepForm, { FormValue } from './PolicyStepForm'
 import { expect, userEvent, waitFor, within, fn } from '@storybook/test'
 import { handleDefaultConfig } from '../storybook/graphql'
 import { HttpResponse, graphql } from 'msw'
@@ -13,7 +13,7 @@ const INVALID_PHONE = '+15555'
 
 const meta = {
   title: 'Escalation Policies/Steps/Form',
-  component: PolicyStepFormDest,
+  component: PolicyStepForm,
   args: {
     onChange: fn(),
   },
@@ -23,7 +23,7 @@ const meta = {
       if (args.onChange) args.onChange(newValue)
       setArgs({ value: newValue })
     }
-    return <PolicyStepFormDest {...args} onChange={onChange} />
+    return <PolicyStepForm {...args} onChange={onChange} />
   },
   tags: ['autodocs'],
   parameters: {
@@ -74,7 +74,7 @@ const meta = {
       ],
     },
   },
-} satisfies Meta<typeof PolicyStepFormDest>
+} satisfies Meta<typeof PolicyStepForm>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/web/src/app/escalation-policies/PolicyStepForm.tsx
+++ b/web/src/app/escalation-policies/PolicyStepForm.tsx
@@ -33,7 +33,7 @@ export type FormValue = {
   actions: DestinationInput[]
 }
 
-export type PolicyStepFormDestProps = {
+export type PolicyStepFormProps = {
   value: FormValue
   errors?: (KnownError | DestFieldValueError)[]
   disabled?: boolean
@@ -51,9 +51,7 @@ const query = gql`
   }
 `
 
-export default function PolicyStepFormDest(
-  props: PolicyStepFormDestProps,
-): ReactNode {
+export default function PolicyStepForm(props: PolicyStepFormProps): ReactNode {
   const types = useEPTargetTypes()
   const classes = useStyles()
   const [destType, setDestType] = useState(types[0].type)

--- a/web/src/app/escalation-policies/PolicyStepsCard.tsx
+++ b/web/src/app/escalation-policies/PolicyStepsCard.tsx
@@ -8,14 +8,14 @@ import { Add } from '@mui/icons-material'
 import { gql, useMutation } from 'urql'
 import FlatList from '../lists/FlatList'
 import CreateFAB from '../lists/CreateFAB'
-import PolicyStepCreateDialogDest from './PolicyStepCreateDialogDest'
+import PolicyStepCreateDialog from './PolicyStepCreateDialog'
 import { useResetURLParams, useURLParam } from '../actions'
 import DialogTitleWrapper from '../dialogs/components/DialogTitleWrapper'
 import DialogContentError from '../dialogs/components/DialogContentError'
 import { useIsWidthDown } from '../util/useWidth'
 import { reorderList } from '../rotations/util'
 import PolicyStepDeleteDialog from './PolicyStepDeleteDialog'
-import PolicyStepEditDialogDest from './PolicyStepEditDialogDest'
+import PolicyStepEditDialog from './PolicyStepEditDialog'
 import OtherActions from '../util/OtherActions'
 import { renderChipsDest, renderDelayMessage } from './stepUtil'
 import { Destination } from '../../schema'
@@ -116,7 +116,7 @@ export default function PolicyStepsCard(
       )}
       {createStep && (
         <React.Fragment>
-          <PolicyStepCreateDialogDest
+          <PolicyStepCreateDialog
             escalationPolicyID={props.escalationPolicyID}
             onClose={resetCreateStep}
           />
@@ -191,7 +191,7 @@ export default function PolicyStepsCard(
       <Suspense>
         {editStep && (
           <React.Fragment>
-            <PolicyStepEditDialogDest
+            <PolicyStepEditDialog
               escalationPolicyID={props.escalationPolicyID}
               onClose={resetEditStep}
               stepID={editStep.id}

--- a/web/src/app/main/AppRoutes.tsx
+++ b/web/src/app/main/AppRoutes.tsx
@@ -19,7 +19,7 @@ import PolicyServicesQuery from '../escalation-policies/PolicyServicesQuery'
 import Spinner from '../loading/components/Spinner'
 import RotationDetails from '../rotations/RotationDetails'
 import RotationList from '../rotations/RotationList'
-import ScheduleOnCallNotificationsListDest from '../schedules/on-call-notifications/ScheduleOnCallNotificationsListDest'
+import ScheduleOnCallNotificationsList from '../schedules/on-call-notifications/ScheduleOnCallNotificationsList'
 import ScheduleAssignedToList from '../schedules/ScheduleAssignedToList'
 import ScheduleDetails from '../schedules/ScheduleDetails'
 import ScheduleList from '../schedules/ScheduleList'
@@ -90,7 +90,7 @@ export const routes: Record<string, JSXElementConstructor<any>> = {
   '/schedules/:scheduleID/overrides': ScheduleOverrideList,
   '/schedules/:scheduleID/shifts': ScheduleShiftList,
   '/schedules/:scheduleID/on-call-notifications':
-    ScheduleOnCallNotificationsListDest,
+    ScheduleOnCallNotificationsList,
 
   '/escalation-policies': PolicyList,
   '/escalation-policies/:policyID': PolicyDetails,

--- a/web/src/app/main/components/NewUserSetup.tsx
+++ b/web/src/app/main/components/NewUserSetup.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import UserContactMethodVerificationDialog from '../../users/UserContactMethodVerificationDialog'
 import { useSessionInfo } from '../../util/RequireConfig'
 import { useResetURLParams, useURLParam } from '../../actions'
-import UserContactMethodCreateDialogDest from '../../users/UserContactMethodCreateDialogDest'
+import UserContactMethodCreateDialog from '../../users/UserContactMethodCreateDialog'
 
 export default function NewUserSetup(): JSX.Element {
   const [isFirstLogin] = useURLParam('isFirstLogin', '')
@@ -23,7 +23,7 @@ export default function NewUserSetup(): JSX.Element {
   }
 
   return (
-    <UserContactMethodCreateDialogDest
+    <UserContactMethodCreateDialog
       title='Welcome to GoAlert!'
       subtitle='To get started, please enter a contact method.'
       userID={userID}

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsCreateDialog.stories.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsCreateDialog.stories.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
 import { expect, fn, userEvent, waitFor, within } from '@storybook/test'
-import ScheduleOnCallNotificationsCreateDialogDest from './ScheduleOnCallNotificationsCreateDialogDest'
+import ScheduleOnCallNotificationsCreateDialog from './ScheduleOnCallNotificationsCreateDialog'
 import { HttpResponse, graphql } from 'msw'
 import { handleDefaultConfig } from '../../storybook/graphql'
 import { BaseError, DestFieldValueError } from '../../util/errtypes'
 
 const meta = {
   title: 'schedules/on-call-notifications/CreateDialogDest',
-  component: ScheduleOnCallNotificationsCreateDialogDest,
+  component: ScheduleOnCallNotificationsCreateDialog,
   argTypes: {},
   args: {
     scheduleID: 'create-test',
@@ -86,11 +86,9 @@ const meta = {
   },
   tags: ['autodocs'],
   render: function Component(args) {
-    return (
-      <ScheduleOnCallNotificationsCreateDialogDest {...args} disablePortal />
-    )
+    return <ScheduleOnCallNotificationsCreateDialog {...args} disablePortal />
   },
-} satisfies Meta<typeof ScheduleOnCallNotificationsCreateDialogDest>
+} satisfies Meta<typeof ScheduleOnCallNotificationsCreateDialog>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsCreateDialog.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsCreateDialog.tsx
@@ -3,7 +3,7 @@ import FormDialog from '../../dialogs/FormDialog'
 import ScheduleOnCallNotificationsForm, {
   Value,
   errorPaths,
-} from './ScheduleOnCallNotificationsFormDest'
+} from './ScheduleOnCallNotificationsForm'
 import { NO_DAY } from './util'
 import { useSchedOnCallNotifyTypes } from '../../util/RequireConfig'
 import { splitErrorsByPath } from '../../util/errutil'

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsEditDialog.stories.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsEditDialog.stories.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
 import { expect, fn, userEvent, waitFor, within } from '@storybook/test'
-import ScheduleOnCallNotificationsEditDialogDest from './ScheduleOnCallNotificationsEditDialogDest'
+import ScheduleOnCallNotificationsEditDialog from './ScheduleOnCallNotificationsEditDialog'
 import { HttpResponse, graphql } from 'msw'
 import { handleDefaultConfig } from '../../storybook/graphql'
 import { BaseError, DestFieldValueError } from '../../util/errtypes'
 
 const meta = {
   title: 'schedules/on-call-notifications/EditDialogDest',
-  component: ScheduleOnCallNotificationsEditDialogDest,
+  component: ScheduleOnCallNotificationsEditDialog,
   argTypes: {},
   args: {
     scheduleID: 'create-test',
@@ -100,9 +100,9 @@ const meta = {
   },
   tags: ['autodocs'],
   render: function Component(args) {
-    return <ScheduleOnCallNotificationsEditDialogDest {...args} disablePortal />
+    return <ScheduleOnCallNotificationsEditDialog {...args} disablePortal />
   },
-} satisfies Meta<typeof ScheduleOnCallNotificationsEditDialogDest>
+} satisfies Meta<typeof ScheduleOnCallNotificationsEditDialog>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsEditDialog.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsEditDialog.tsx
@@ -3,7 +3,7 @@ import FormDialog from '../../dialogs/FormDialog'
 import ScheduleOnCallNotificationsForm, {
   Value,
   errorPaths,
-} from './ScheduleOnCallNotificationsFormDest'
+} from './ScheduleOnCallNotificationsForm'
 import { NO_DAY } from './util'
 import { splitErrorsByPath } from '../../util/errutil'
 import { CombinedError, gql, useMutation, useQuery } from 'urql'

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsForm.stories.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsForm.stories.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
-import ScheduleOnCallNotificationsFormDest, {
+import ScheduleOnCallNotificationsForm, {
   Value,
-} from './ScheduleOnCallNotificationsFormDest'
+} from './ScheduleOnCallNotificationsForm'
 import { useArgs } from '@storybook/preview-api'
 import { expect, fn, userEvent, within } from '@storybook/test'
 
 const meta = {
   title: 'schedules/on-call-notifications/FormDest',
-  component: ScheduleOnCallNotificationsFormDest,
+  component: ScheduleOnCallNotificationsForm,
   argTypes: {},
   args: {
     scheduleID: '',
@@ -29,9 +29,9 @@ const meta = {
       if (args.onChange) args.onChange(newValue)
       setArgs({ value: newValue })
     }
-    return <ScheduleOnCallNotificationsFormDest {...args} onChange={onChange} />
+    return <ScheduleOnCallNotificationsForm {...args} onChange={onChange} />
   },
-} satisfies Meta<typeof ScheduleOnCallNotificationsFormDest>
+} satisfies Meta<typeof ScheduleOnCallNotificationsForm>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsForm.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsForm.tsx
@@ -55,7 +55,7 @@ export const errorPaths = (prefix = '*'): string[] => [
   `${prefix}.dest`,
 ]
 
-export default function ScheduleOnCallNotificationsFormDest(
+export default function ScheduleOnCallNotificationsForm(
   props: ScheduleOnCallNotificationsFormProps,
 ): JSX.Element {
   const { scheduleID, ...formProps } = props

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsList.stories.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsList.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import ScheduleOnCallNotificationsListDest from './ScheduleOnCallNotificationsListDest'
+import ScheduleOnCallNotificationsList from './ScheduleOnCallNotificationsList'
 import { handleDefaultConfig } from '../../storybook/graphql'
 import { HttpResponse, graphql } from 'msw'
 
@@ -9,7 +9,7 @@ const manyNotificationsScheduleID = '22222222-2222-2222-2222-222222222222'
 
 const meta = {
   title: 'schedules/on-call-notifications/ListDest',
-  component: ScheduleOnCallNotificationsListDest,
+  component: ScheduleOnCallNotificationsList,
   argTypes: {},
   parameters: {
     msw: {
@@ -93,7 +93,7 @@ const meta = {
     },
   },
   tags: ['autodocs'],
-} satisfies Meta<typeof ScheduleOnCallNotificationsListDest>
+} satisfies Meta<typeof ScheduleOnCallNotificationsList>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsList.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsList.tsx
@@ -13,10 +13,10 @@ import { Schedule } from '../../../schema'
 import { DestinationAvatar } from '../../util/DestinationAvatar'
 import { styles as globalStyles } from '../../styles/materialStyles'
 import makeStyles from '@mui/styles/makeStyles'
-import ScheduleOnCallNotificationsCreateDialogDest from './ScheduleOnCallNotificationsCreateDialogDest'
-import ScheduleOnCallNotificationsEditDialogDest from './ScheduleOnCallNotificationsEditDialogDest'
+import ScheduleOnCallNotificationsCreateDialog from './ScheduleOnCallNotificationsCreateDialog'
+import ScheduleOnCallNotificationsEditDialog from './ScheduleOnCallNotificationsEditDialog'
 
-export type ScheduleOnCallNotificationsListDestProps = {
+export type ScheduleOnCallNotificationsListProps = {
   scheduleID: string
 }
 
@@ -50,9 +50,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   ...globalStyles(theme),
 }))
 
-export default function ScheduleOnCallNotificationsListDest({
+export default function ScheduleOnCallNotificationsList({
   scheduleID,
-}: ScheduleOnCallNotificationsListDestProps): JSX.Element {
+}: ScheduleOnCallNotificationsListProps): JSX.Element {
   const [createRule, setCreateRule] = useState(false)
   const [editRuleID, setEditRuleID] = useState('')
   const [deleteRuleID, setDeleteRuleID] = useState('')
@@ -177,13 +177,13 @@ export default function ScheduleOnCallNotificationsListDest({
       )}
       <Suspense>
         {createRule && (
-          <ScheduleOnCallNotificationsCreateDialogDest
+          <ScheduleOnCallNotificationsCreateDialog
             scheduleID={scheduleID}
             onClose={() => setCreateRule(false)}
           />
         )}
         {editRuleID && (
-          <ScheduleOnCallNotificationsEditDialogDest
+          <ScheduleOnCallNotificationsEditDialog
             scheduleID={scheduleID}
             ruleID={editRuleID}
             onClose={() => setEditRuleID('')}

--- a/web/src/app/users/UserContactMethodCreateDialog.stories.tsx
+++ b/web/src/app/users/UserContactMethodCreateDialog.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
-import UserContactMethodCreateDialogDest from './UserContactMethodCreateDialogDest'
+import UserContactMethodCreateDialog from './UserContactMethodCreateDialog'
 import { expect, fn, userEvent, waitFor, within } from '@storybook/test'
 import { handleDefaultConfig, defaultConfig } from '../storybook/graphql'
 import { useArgs } from '@storybook/preview-api'
@@ -8,8 +8,8 @@ import { HttpResponse, graphql } from 'msw'
 import { DestFieldValueError, InputFieldError } from '../util/errtypes'
 
 const meta = {
-  title: 'users/UserContactMethodCreateDialogDest',
-  component: UserContactMethodCreateDialogDest,
+  title: 'users/UserContactMethodCreateDialog',
+  component: UserContactMethodCreateDialog,
   tags: ['autodocs'],
   args: {
     onClose: fn(),
@@ -88,14 +88,14 @@ const meta = {
       setArgs({ value: contactMethodID })
     }
     return (
-      <UserContactMethodCreateDialogDest
+      <UserContactMethodCreateDialog
         {...args}
         disablePortal
         onClose={onClose}
       />
     )
   },
-} satisfies Meta<typeof UserContactMethodCreateDialogDest>
+} satisfies Meta<typeof UserContactMethodCreateDialog>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/web/src/app/users/UserContactMethodCreateDialog.tsx
+++ b/web/src/app/users/UserContactMethodCreateDialog.tsx
@@ -3,7 +3,7 @@ import { useMutation, gql, CombinedError } from 'urql'
 
 import { splitErrorsByPath } from '../util/errutil'
 import FormDialog from '../dialogs/FormDialog'
-import UserContactMethodForm, { errorPaths } from './UserContactMethodFormDest'
+import UserContactMethodForm, { errorPaths } from './UserContactMethodForm'
 import { useContactMethodTypes } from '../util/RequireConfig'
 import { Dialog, DialogTitle, DialogActions, Button } from '@mui/material'
 import DialogContentError from '../dialogs/components/DialogContentError'
@@ -23,7 +23,7 @@ const createMutation = gql`
   }
 `
 
-export default function UserContactMethodCreateDialogDest(props: {
+export default function UserContactMethodCreateDialog(props: {
   userID: string
   onClose: (contactMethodID?: string) => void
   title?: string

--- a/web/src/app/users/UserContactMethodEditDialog.stories.tsx
+++ b/web/src/app/users/UserContactMethodEditDialog.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
-import UserContactMethodEditDialogDest from './UserContactMethodEditDialogDest'
+import UserContactMethodEditDialog from './UserContactMethodEditDialog'
 import { expect, fn, userEvent, waitFor, within } from '@storybook/test'
 import { handleDefaultConfig } from '../storybook/graphql'
 import { useArgs } from '@storybook/preview-api'
@@ -9,8 +9,8 @@ import { DestFieldValueError, InputFieldError } from '../util/errtypes'
 import { Destination } from '../../schema'
 
 const meta = {
-  title: 'users/UserContactMethodEditDialogDest',
-  component: UserContactMethodEditDialogDest,
+  title: 'users/UserContactMethodEditDialog',
+  component: UserContactMethodEditDialog,
   tags: ['autodocs'],
   args: {
     onClose: fn(),
@@ -147,14 +147,10 @@ const meta = {
       setArgs({ value: contactMethodID })
     }
     return (
-      <UserContactMethodEditDialogDest
-        {...args}
-        disablePortal
-        onClose={onClose}
-      />
+      <UserContactMethodEditDialog {...args} disablePortal onClose={onClose} />
     )
   },
-} satisfies Meta<typeof UserContactMethodEditDialogDest>
+} satisfies Meta<typeof UserContactMethodEditDialog>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/web/src/app/users/UserContactMethodEditDialog.tsx
+++ b/web/src/app/users/UserContactMethodEditDialog.tsx
@@ -3,7 +3,7 @@ import { useMutation, gql, CombinedError, useQuery } from 'urql'
 
 import { splitErrorsByPath } from '../util/errutil'
 import FormDialog from '../dialogs/FormDialog'
-import UserContactMethodForm, { errorPaths } from './UserContactMethodFormDest'
+import UserContactMethodForm, { errorPaths } from './UserContactMethodForm'
 import { DestinationInput } from '../../schema'
 
 type Value = {
@@ -35,7 +35,7 @@ const mutation = gql`
   }
 `
 
-export default function UserContactMethodEditDialogDest(props: {
+export default function UserContactMethodEditDialog(props: {
   onClose: (contactMethodID?: string) => void
   contactMethodID: string
 

--- a/web/src/app/users/UserContactMethodForm.stories.tsx
+++ b/web/src/app/users/UserContactMethodForm.stories.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
-import UserContactMethodFormDest, { Value } from './UserContactMethodFormDest'
+import UserContactMethodForm, { Value } from './UserContactMethodForm'
 import { expect, within, userEvent, waitFor } from '@storybook/test'
 import { handleDefaultConfig } from '../storybook/graphql'
 import { useArgs } from '@storybook/preview-api'
 import { HttpResponse, graphql } from 'msw'
 
 const meta = {
-  title: 'users/UserContactMethodFormDest',
-  component: UserContactMethodFormDest,
+  title: 'users/UserContactMethodForm',
+  component: UserContactMethodForm,
   tags: ['autodocs'],
   parameters: {
     msw: {
@@ -30,9 +30,9 @@ const meta = {
       if (args.onChange) args.onChange(newValue)
       setArgs({ value: newValue })
     }
-    return <UserContactMethodFormDest {...args} onChange={onChange} />
+    return <UserContactMethodForm {...args} onChange={onChange} />
   },
-} satisfies Meta<typeof UserContactMethodFormDest>
+} satisfies Meta<typeof UserContactMethodForm>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/web/src/app/users/UserContactMethodForm.tsx
+++ b/web/src/app/users/UserContactMethodForm.tsx
@@ -39,7 +39,7 @@ export const errorPaths = (prefix = '*'): string[] => [
   `${prefix}.dest`,
 ]
 
-export default function UserContactMethodFormDest(
+export default function UserContactMethodForm(
   props: UserContactMethodFormProps,
 ): JSX.Element {
   const { value, edit = false, errors = [], ...other } = props

--- a/web/src/app/users/UserContactMethodList.stories.tsx
+++ b/web/src/app/users/UserContactMethodList.stories.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
-import UserContactMethodListDest from './UserContactMethodListDest'
+import UserContactMethodList from './UserContactMethodList'
 import { expect, within, userEvent, screen } from '@storybook/test'
 import { handleDefaultConfig } from '../storybook/graphql'
 import { HttpResponse, graphql } from 'msw'
 import { Destination } from '../../schema'
 
 const meta = {
-  title: 'users/UserContactMethodListDest',
-  component: UserContactMethodListDest,
+  title: 'users/UserContactMethodList',
+  component: UserContactMethodList,
   tags: ['autodocs'],
   parameters: {
     msw: {
@@ -109,9 +109,9 @@ const meta = {
     },
   },
   render: function Component(args) {
-    return <UserContactMethodListDest {...args} />
+    return <UserContactMethodList {...args} />
   },
-} satisfies Meta<typeof UserContactMethodListDest>
+} satisfies Meta<typeof UserContactMethodList>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -16,8 +16,8 @@ import SendTestDialog from './SendTestDialog'
 import { styles as globalStyles } from '../styles/materialStyles'
 import { UserContactMethod } from '../../schema'
 import { useSessionInfo, useContactMethodTypes } from '../util/RequireConfig'
-import UserContactMethodEditDialogDest from './UserContactMethodEditDialogDest'
-import UserContactMethodCreateDialogDest from './UserContactMethodCreateDialogDest'
+import UserContactMethodEditDialog from './UserContactMethodEditDialog'
+import UserContactMethodCreateDialog from './UserContactMethodCreateDialog'
 
 const query = gql`
   query cmList($id: ID!) {
@@ -67,7 +67,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   cardHeader: globalStyles(theme).cardHeader,
 }))
 
-export default function UserContactMethodListDest(
+export default function UserContactMethodList(
   props: UserContactMethodListProps,
 ): ReactNode {
   const classes = useStyles()
@@ -232,7 +232,7 @@ export default function UserContactMethodListDest(
         />
         <Suspense>
           {showAddDialog && (
-            <UserContactMethodCreateDialogDest
+            <UserContactMethodCreateDialog
               userID={props.userID}
               onClose={(contactMethodID = '') => {
                 setShowAddDialog(false)
@@ -247,7 +247,7 @@ export default function UserContactMethodListDest(
             />
           )}
           {showEditDialogByID && (
-            <UserContactMethodEditDialogDest
+            <UserContactMethodEditDialog
               contactMethodID={showEditDialogByID}
               onClose={() => setShowEditDialogByID('')}
             />

--- a/web/src/app/users/UserDetails.tsx
+++ b/web/src/app/users/UserDetails.tsx
@@ -4,10 +4,10 @@ import Delete from '@mui/icons-material/Delete'
 import LockOpenIcon from '@mui/icons-material/LockOpen'
 import DetailsPage from '../details/DetailsPage'
 import { UserAvatar } from '../util/avatars'
-import UserContactMethodListDest from './UserContactMethodListDest'
+import UserContactMethodList from './UserContactMethodList'
 import { AddAlarm, SettingsPhone } from '@mui/icons-material'
 import SpeedDial from '../util/SpeedDial'
-import UserNotificationRuleListDest from './UserNotificationRuleListDest'
+import UserNotificationRuleList from './UserNotificationRuleList'
 import { Grid } from '@mui/material'
 import UserNotificationRuleCreateDialog from './UserNotificationRuleCreateDialog'
 import UserContactMethodVerificationDialog from './UserContactMethodVerificationDialog'
@@ -19,7 +19,7 @@ import { QuerySetFavoriteButton } from '../util/QuerySetFavoriteButton'
 import { User } from '../../schema'
 import { useIsWidthDown } from '../util/useWidth'
 import UserShiftsCalendar from './UserShiftsCalendar'
-import UserContactMethodCreateDialogDest from './UserContactMethodCreateDialogDest'
+import UserContactMethodCreateDialog from './UserContactMethodCreateDialog'
 
 const userQuery = gql`
   query userInfo($id: ID!) {
@@ -182,7 +182,7 @@ export default function UserDetails(props: {
           />
         )}
         {createCM && (
-          <UserContactMethodCreateDialogDest
+          <UserContactMethodCreateDialog
             userID={userID}
             onClose={(contactMethodID) => {
               setCreateCM(false)
@@ -210,11 +210,8 @@ export default function UserDetails(props: {
         subheader={user.email}
         pageContent={
           <Grid container spacing={2}>
-            <UserContactMethodListDest
-              userID={userID}
-              readOnly={props.readOnly}
-            />
-            <UserNotificationRuleListDest
+            <UserContactMethodList userID={userID} readOnly={props.readOnly} />
+            <UserNotificationRuleList
               userID={userID}
               readOnly={props.readOnly}
             />

--- a/web/src/app/users/UserNotificationRuleList.tsx
+++ b/web/src/app/users/UserNotificationRuleList.tsx
@@ -57,7 +57,7 @@ const useStyles = makeStyles((theme: Theme) => {
   }
 })
 
-export default function UserNotificationRuleListDest(props: {
+export default function UserNotificationRuleList(props: {
   userID: string
   readOnly: boolean
 }): ReactNode {

--- a/web/src/app/users/UserNotificationRuleListDest.stories.tsx
+++ b/web/src/app/users/UserNotificationRuleListDest.stories.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
-import UserNotificationRuleListDest from './UserNotificationRuleListDest'
+import UserNotificationRuleList from './UserNotificationRuleList'
 import { expect, within, userEvent, screen } from '@storybook/test'
 import { handleDefaultConfig } from '../storybook/graphql'
 import { HttpResponse, graphql } from 'msw'
 
 const meta = {
-  title: 'users/UserNotificationRuleListDest',
-  component: UserNotificationRuleListDest,
+  title: 'users/UserNotificationRuleList',
+  component: UserNotificationRuleList,
   tags: ['autodocs'],
   parameters: {
     msw: {
@@ -95,9 +95,9 @@ const meta = {
     },
   },
   render: function Component(args) {
-    return <UserNotificationRuleListDest {...args} />
+    return <UserNotificationRuleList {...args} />
   },
-} satisfies Meta<typeof UserNotificationRuleListDest>
+} satisfies Meta<typeof UserNotificationRuleList>
 
 export default meta
 type Story = StoryObj<typeof meta>


### PR DESCRIPTION
Now that the `dest-types` experimental flag has been merged and the legwork behind removing the conditional rendering behind the feature flag is complete, this PR focuses on renaming all of the files with "Dest" at the end back to their original names.