### PR TITLE
ui: fix step number display for EP step delay text

### DIFF
--- a/test/integration/escalation-policies.spec.ts
+++ b/test/integration/escalation-policies.spec.ts
@@ -64,7 +64,7 @@ test.afterEach(async ({ page }) => {
 test('check caption delay text while creating steps', async ({ page }) => {
   await page.goto(`/escalation-policies/${epID}`)
 
-  async function createStep(delayMinutes: string) {
+  async function createStep(delayMinutes: string): Promise<void> {
     await page.getByRole('button', { name: 'Create Step' }).click()
     await page.getByLabel('Destination Type').click()
     await page.locator('li', { hasText: 'User' }).click()

--- a/test/integration/escalation-policies.spec.ts
+++ b/test/integration/escalation-policies.spec.ts
@@ -61,6 +61,45 @@ test.afterEach(async ({ page }) => {
   await page.click('button:has-text("Confirm")')
 })
 
+test('check caption delay text while creating steps', async ({ page }) => {
+  await page.goto(`/escalation-policies/${epID}`)
+
+  async function createStep(delayMinutes: string) {
+    await page.getByRole('button', { name: 'Create Step' }).click()
+    await page.getByLabel('Destination Type').click()
+    await page.locator('li', { hasText: 'User' }).click()
+    await page.getByRole('combobox', { name: 'User', exact: true }).click()
+    await page
+      .getByRole('combobox', { name: 'User', exact: true })
+      .fill('Admin McIntegrationFace')
+    await page
+      .locator('div[role=presentation]')
+      .locator('li', { hasText: 'Admin McIntegrationFace' })
+      .click()
+    await page.getByRole('button', { name: 'Add Destination' }).click()
+    await expect(
+      page
+        .getByRole('dialog')
+        .getByTestId('destination-chip')
+        .filter({ hasText: 'Admin McIntegrationFace' }),
+    ).toBeVisible()
+    await page.locator('input[name=delayMinutes]').fill(delayMinutes)
+    await page.locator('button[type=submit]', { hasText: 'Submit' }).click()
+  }
+
+  await createStep('5')
+  await expect(
+    page.getByText('Go back to step #1 after 5 minutes'),
+  ).toBeVisible()
+  await createStep('20')
+  await expect(
+    page.getByText('Move on to step #2 after 5 minutes'),
+  ).toBeVisible()
+  await expect(
+    page.getByText('Go back to step #1 after 20 minutes'),
+  ).toBeVisible()
+})
+
 test('create escalation policy step using destination actions', async ({
   page,
 }) => {

--- a/web/src/app/escalation-policies/stepUtil.tsx
+++ b/web/src/app/escalation-policies/stepUtil.tsx
@@ -45,7 +45,7 @@ export function renderDelayMessage(
   const pluralizer = (x: number): string => (x === 1 ? '' : 's')
 
   let repeatText = `Move on to step #${
-    idx + 1
+    idx + 2
   } after ${step.delayMinutes} minute${pluralizer(step.delayMinutes)}`
 
   if (isLastStep && idx === 0) {


### PR DESCRIPTION
Fixes the the display for the EP step delay text to properly be the next index + 1 (so +2 overall).

Before:

![before](https://github.com/target/goalert/assets/11381794/032a892a-fa7c-4c6d-b3dd-d8529018c6b7)

After:

![after](https://github.com/target/goalert/assets/11381794/d4df41a6-cea2-4860-aad9-6e617c28e1fe)
