### PR TITLE
uik: switch from global to per-rule continue option

### DIFF
--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -404,18 +404,18 @@ type ComplexityRoot struct {
 	}
 
 	KeyConfig struct {
-		DefaultActions  func(childComplexity int) int
-		OneRule         func(childComplexity int, id string) int
-		Rules           func(childComplexity int) int
-		StopAtFirstRule func(childComplexity int) int
+		DefaultActions func(childComplexity int) int
+		OneRule        func(childComplexity int, id string) int
+		Rules          func(childComplexity int) int
 	}
 
 	KeyRule struct {
-		Actions       func(childComplexity int) int
-		ConditionExpr func(childComplexity int) int
-		Description   func(childComplexity int) int
-		ID            func(childComplexity int) int
-		Name          func(childComplexity int) int
+		Actions            func(childComplexity int) int
+		ConditionExpr      func(childComplexity int) int
+		ContinueAfterMatch func(childComplexity int) int
+		Description        func(childComplexity int) int
+		ID                 func(childComplexity int) int
+		Name               func(childComplexity int) int
 	}
 
 	Label struct {
@@ -2448,13 +2448,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.KeyConfig.Rules(childComplexity), true
 
-	case "KeyConfig.stopAtFirstRule":
-		if e.complexity.KeyConfig.StopAtFirstRule == nil {
-			break
-		}
-
-		return e.complexity.KeyConfig.StopAtFirstRule(childComplexity), true
-
 	case "KeyRule.actions":
 		if e.complexity.KeyRule.Actions == nil {
 			break
@@ -2468,6 +2461,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.KeyRule.ConditionExpr(childComplexity), true
+
+	case "KeyRule.continueAfterMatch":
+		if e.complexity.KeyRule.ContinueAfterMatch == nil {
+			break
+		}
+
+		return e.complexity.KeyRule.ContinueAfterMatch(childComplexity), true
 
 	case "KeyRule.description":
 		if e.complexity.KeyRule.Description == nil {
@@ -14949,8 +14949,6 @@ func (ec *executionContext) fieldContext_IntegrationKey_config(_ context.Context
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "stopAtFirstRule":
-				return ec.fieldContext_KeyConfig_stopAtFirstRule(ctx, field)
 			case "rules":
 				return ec.fieldContext_KeyConfig_rules(ctx, field)
 			case "oneRule":
@@ -15326,50 +15324,6 @@ func (ec *executionContext) fieldContext_IntegrationKeyTypeInfo_enabled(_ contex
 	return fc, nil
 }
 
-func (ec *executionContext) _KeyConfig_stopAtFirstRule(ctx context.Context, field graphql.CollectedField, obj *KeyConfig) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_KeyConfig_stopAtFirstRule(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.StopAtFirstRule, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(bool)
-	fc.Result = res
-	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_KeyConfig_stopAtFirstRule(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "KeyConfig",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _KeyConfig_rules(ctx context.Context, field graphql.CollectedField, obj *KeyConfig) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_KeyConfig_rules(ctx, field)
 	if err != nil {
@@ -15419,6 +15373,8 @@ func (ec *executionContext) fieldContext_KeyConfig_rules(_ context.Context, fiel
 				return ec.fieldContext_KeyRule_conditionExpr(ctx, field)
 			case "actions":
 				return ec.fieldContext_KeyRule_actions(ctx, field)
+			case "continueAfterMatch":
+				return ec.fieldContext_KeyRule_continueAfterMatch(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type KeyRule", field.Name)
 		},
@@ -15472,6 +15428,8 @@ func (ec *executionContext) fieldContext_KeyConfig_oneRule(ctx context.Context, 
 				return ec.fieldContext_KeyRule_conditionExpr(ctx, field)
 			case "actions":
 				return ec.fieldContext_KeyRule_actions(ctx, field)
+			case "continueAfterMatch":
+				return ec.fieldContext_KeyRule_continueAfterMatch(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type KeyRule", field.Name)
 		},
@@ -15761,6 +15719,50 @@ func (ec *executionContext) fieldContext_KeyRule_actions(_ context.Context, fiel
 				return ec.fieldContext_Action_params(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Action", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _KeyRule_continueAfterMatch(ctx context.Context, field graphql.CollectedField, obj *KeyRule) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_KeyRule_continueAfterMatch(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ContinueAfterMatch, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_KeyRule_continueAfterMatch(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "KeyRule",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -35706,7 +35708,7 @@ func (ec *executionContext) unmarshalInputKeyRuleInput(ctx context.Context, obj 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "name", "description", "conditionExpr", "actions"}
+	fieldsInOrder := [...]string{"id", "name", "description", "conditionExpr", "actions", "continueAfterMatch"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -35748,6 +35750,13 @@ func (ec *executionContext) unmarshalInputKeyRuleInput(ctx context.Context, obj 
 				return it, err
 			}
 			it.Actions = data
+		case "continueAfterMatch":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("continueAfterMatch"))
+			data, err := ec.unmarshalNBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ContinueAfterMatch = data
 		}
 	}
 
@@ -37270,7 +37279,7 @@ func (ec *executionContext) unmarshalInputUpdateKeyConfigInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"keyID", "stopAtFirstRule", "rules", "setRule", "deleteRule", "defaultActions"}
+	fieldsInOrder := [...]string{"keyID", "rules", "setRule", "deleteRule", "defaultActions"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -37284,13 +37293,6 @@ func (ec *executionContext) unmarshalInputUpdateKeyConfigInput(ctx context.Conte
 				return it, err
 			}
 			it.KeyID = data
-		case "stopAtFirstRule":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("stopAtFirstRule"))
-			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.StopAtFirstRule = data
 		case "rules":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rules"))
 			data, err := ec.unmarshalOKeyRuleInput2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐKeyRuleInputᚄ(ctx, v)
@@ -41244,11 +41246,6 @@ func (ec *executionContext) _KeyConfig(ctx context.Context, sel ast.SelectionSet
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("KeyConfig")
-		case "stopAtFirstRule":
-			out.Values[i] = ec._KeyConfig_stopAtFirstRule(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "rules":
 			out.Values[i] = ec._KeyConfig_rules(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -41348,6 +41345,11 @@ func (ec *executionContext) _KeyRule(ctx context.Context, sel ast.SelectionSet, 
 			}
 		case "actions":
 			out.Values[i] = ec._KeyRule_actions(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "continueAfterMatch":
+			out.Values[i] = ec._KeyRule_continueAfterMatch(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/graphql2/graph/univkeys.graphqls
+++ b/graphql2/graph/univkeys.graphqls
@@ -49,11 +49,6 @@ extend type Mutation {
 }
 
 type KeyConfig {
-  """
-  Stop evaluating rules after the first rule that matches.
-  """
-  stopAtFirstRule: Boolean!
-
   rules: [KeyRule!]!
 
   """
@@ -79,15 +74,15 @@ type KeyRule {
   conditionExpr: ExprBooleanExpression!
 
   actions: [Action!]!
+
+  """
+  Continue evaluating rules after this rule matches.
+  """
+  continueAfterMatch: Boolean!
 }
 
 input UpdateKeyConfigInput {
   keyID: ID!
-
-  """
-  Stop evaluating rules after the first rule that matches.
-  """
-  stopAtFirstRule: Boolean
 
   rules: [KeyRuleInput!]
 
@@ -122,6 +117,13 @@ input KeyRuleInput {
   conditionExpr: ExprBooleanExpression!
 
   actions: [ActionInput!]!
+
+  """
+  Continue evaluating rules after this rule matches.
+
+  If this is set to false (default), no further rules will be evaluated after this rule matches.
+  """
+  continueAfterMatch: Boolean!
 }
 
 input ActionInput {

--- a/graphql2/graphqlapp/integrationkey.go
+++ b/graphql2/graphqlapp/integrationkey.go
@@ -100,10 +100,6 @@ func (m *Mutation) UpdateKeyConfig(ctx context.Context, input graphql2.UpdateKey
 			return err
 		}
 
-		if input.StopAtFirstRule != nil {
-			cfg.StopAfterFirstMatchingRule = *input.StopAtFirstRule
-		}
-
 		if input.Rules != nil {
 			cfg.Rules = make([]integrationkey.Rule, 0, len(input.Rules))
 			for _, r := range input.Rules {
@@ -121,6 +117,8 @@ func (m *Mutation) UpdateKeyConfig(ctx context.Context, input graphql2.UpdateKey
 					Description:   r.Description,
 					ConditionExpr: r.ConditionExpr,
 					Actions:       actionsGQLToGo(r.Actions),
+
+					ContinueAfterMatch: r.ContinueAfterMatch,
 				})
 			}
 		}
@@ -213,18 +211,18 @@ func (key *IntegrationKey) Config(ctx context.Context, raw *integrationkey.Integ
 	var rules []graphql2.KeyRule
 	for _, r := range cfg.Rules {
 		rules = append(rules, graphql2.KeyRule{
-			ID:            r.ID.String(),
-			Name:          r.Name,
-			Description:   r.Description,
-			ConditionExpr: r.ConditionExpr,
-			Actions:       actionsGoToGQL(r.Actions),
+			ID:                 r.ID.String(),
+			Name:               r.Name,
+			Description:        r.Description,
+			ConditionExpr:      r.ConditionExpr,
+			Actions:            actionsGoToGQL(r.Actions),
+			ContinueAfterMatch: r.ContinueAfterMatch,
 		})
 	}
 
 	return &graphql2.KeyConfig{
-		StopAtFirstRule: cfg.StopAfterFirstMatchingRule,
-		Rules:           rules,
-		DefaultActions:  actionsGoToGQL(cfg.DefaultActions),
+		Rules:          rules,
+		DefaultActions: actionsGoToGQL(cfg.DefaultActions),
 	}, nil
 }
 

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -576,9 +576,7 @@ type IntegrationKeyTypeInfo struct {
 }
 
 type KeyConfig struct {
-	// Stop evaluating rules after the first rule that matches.
-	StopAtFirstRule bool      `json:"stopAtFirstRule"`
-	Rules           []KeyRule `json:"rules"`
+	Rules []KeyRule `json:"rules"`
 	// Get a single rule by ID.
 	OneRule *KeyRule `json:"oneRule,omitempty"`
 	// defaultAction is the action to take if no rules match the request.
@@ -592,6 +590,8 @@ type KeyRule struct {
 	// An expression that must evaluate to true for the rule to match.
 	ConditionExpr string   `json:"conditionExpr"`
 	Actions       []Action `json:"actions"`
+	// Continue evaluating rules after this rule matches.
+	ContinueAfterMatch bool `json:"continueAfterMatch"`
 }
 
 type KeyRuleInput struct {
@@ -602,6 +602,10 @@ type KeyRuleInput struct {
 	// An expression that must evaluate to true for the rule to match.
 	ConditionExpr string        `json:"conditionExpr"`
 	Actions       []ActionInput `json:"actions"`
+	// Continue evaluating rules after this rule matches.
+	//
+	// If this is set to false (default), no further rules will be evaluated after this rule matches.
+	ContinueAfterMatch bool `json:"continueAfterMatch"`
 }
 
 type LabelConnection struct {
@@ -936,10 +940,8 @@ type UpdateHeartbeatMonitorInput struct {
 }
 
 type UpdateKeyConfigInput struct {
-	KeyID string `json:"keyID"`
-	// Stop evaluating rules after the first rule that matches.
-	StopAtFirstRule *bool          `json:"stopAtFirstRule,omitempty"`
-	Rules           []KeyRuleInput `json:"rules,omitempty"`
+	KeyID string         `json:"keyID"`
+	Rules []KeyRuleInput `json:"rules,omitempty"`
 	// setRule allows you to set a single rule. If ID is provided, the rule with that ID will be updated. If ID is not provided, a new rule will be created and appended to the list of rules.
 	SetRule *KeyRuleInput `json:"setRule,omitempty"`
 	// deleteRule allows you to delete a single rule by ID.

--- a/integrationkey/config.go
+++ b/integrationkey/config.go
@@ -42,6 +42,8 @@ type Rule struct {
 	Description   string
 	ConditionExpr string
 	Actions       []Action
+
+	ContinueAfterMatch bool
 }
 
 // An Action is a single action to take if a rule matches.

--- a/integrationkey/uik/handler.go
+++ b/integrationkey/uik/handler.go
@@ -110,6 +110,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			}
 			results = append(results, res)
 		}
+
+		if !rule.ContinueAfterMatch {
+			break
+		}
 	}
 
 	if !anyMatched {

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -651,12 +651,12 @@ export interface KeyConfig {
   defaultActions: Action[]
   oneRule?: null | KeyRule
   rules: KeyRule[]
-  stopAtFirstRule: boolean
 }
 
 export interface KeyRule {
   actions: Action[]
   conditionExpr: ExprBooleanExpression
+  continueAfterMatch: boolean
   description: string
   id: string
   name: string
@@ -665,6 +665,7 @@ export interface KeyRule {
 export interface KeyRuleInput {
   actions: ActionInput[]
   conditionExpr: ExprBooleanExpression
+  continueAfterMatch: boolean
   description: string
   id?: null | string
   name: string
@@ -1300,7 +1301,6 @@ export interface UpdateKeyConfigInput {
   keyID: string
   rules?: null | KeyRuleInput[]
   setRule?: null | KeyRuleInput
-  stopAtFirstRule?: null | boolean
 }
 
 export interface UpdateRotationInput {


### PR DESCRIPTION
**Description:**
Switches behavior from a per-integration-key setting of "stop at first rule" to a per-rule setting of "continue after this rule matches"

**Describe any introduced API changes:**
- `KeyConfig.stopAtFirstRule` was **removed** (breaking, but behind experimental flag)
- `KeyRule.continueAfterMatch` was **added**
