### PR TITLE
dest/action: simplify error flow in forms

### DIFF
--- a/web/src/app/forms/HelperText.tsx
+++ b/web/src/app/forms/HelperText.tsx
@@ -12,7 +12,11 @@ export type HelperTextProps = {
   value?: string
 }
 
-export function HelperText(props: HelperTextProps) {
+/** HelperText is a component that displays a hint or error message.
+ *
+ * It is intended to be used as the `helperText` prop of a TextField (or other MUI form components).
+ */
+export function HelperText(props: HelperTextProps): React.ReactNode {
   let content
   if (props.error) {
     const msg = props.error.replace(/^./, (str) => str.toUpperCase())

--- a/web/src/app/forms/HelperText.tsx
+++ b/web/src/app/forms/HelperText.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import FormHelperText from '@mui/material/FormHelperText'
+import AppLink from '../util/AppLink'
+import { Grid } from '@mui/material'
+
+export type HelperTextProps = {
+  hint?: string
+  hintURL?: string
+  error?: string
+  errorURL?: string
+  maxLength?: number
+  value?: string
+}
+
+export function HelperText(props: HelperTextProps) {
+  let content
+  if (props.error) {
+    const msg = props.error.replace(/^./, (str) => str.toUpperCase())
+    content = props.errorURL ? (
+      <AppLink to={props.errorURL} newTab data-cy='error-help-link'>
+        {msg}
+      </AppLink>
+    ) : (
+      msg
+    )
+  } else {
+    content = props.hintURL ? (
+      <AppLink to={props.hintURL} newTab data-cy='hint-help-link'>
+        {props.hint}
+      </AppLink>
+    ) : (
+      props.hint
+    )
+  }
+
+  if (props.maxLength) {
+    return (
+      <Grid container spacing={2}>
+        <Grid item xs={10}>
+          <FormHelperText component='span'>{content}</FormHelperText>
+        </Grid>
+        <Grid item xs={2}>
+          <FormHelperText style={{ textAlign: 'right' }}>
+            {props.value?.length || 0}/{props.maxLength}
+          </FormHelperText>
+        </Grid>
+      </Grid>
+    )
+  }
+
+  return <FormHelperText component='span'>{content}</FormHelperText>
+}

--- a/web/src/app/forms/index.js
+++ b/web/src/app/forms/index.js
@@ -1,3 +1,4 @@
 export * from './Form'
 export * from './FormContainer'
 export * from './FormField'
+export * from './HelperText'

--- a/web/src/app/selection/DestinationField.tsx
+++ b/web/src/app/selection/DestinationField.tsx
@@ -13,10 +13,10 @@ export type DestinationFieldProps = {
 
   disabled?: boolean
 
-  /* deprecated */
+  /** Deprecated, use fieldErrors instead. */
   destFieldErrors?: DestFieldValueError[]
 
-  fieldErrors?: DestFieldError[]
+  fieldErrors?: Readonly<Record<string, string>>
 }
 
 export interface DestFieldError {
@@ -34,15 +34,14 @@ export default function DestinationField(
 ): React.ReactNode {
   const dest = useDestinationType(props.destType)
 
-  const fieldErrors = new Map()
-  if (props.fieldErrors) {
-    for (const err of props.fieldErrors) {
-      fieldErrors.set(err.fieldID, err.message)
-    }
-  } else if (props.destFieldErrors) {
+  let fieldErrors = props.fieldErrors
+  // TODO: remove this block after removing destFieldErrors
+  if (!props.fieldErrors && props.destFieldErrors) {
+    const newErrs: Record<string, string> = {}
     for (const err of props.destFieldErrors) {
-      fieldErrors.set(err.extensions.fieldID, err.message)
+      newErrs[err.extensions.fieldID] = err.message
     }
+    fieldErrors = newErrs
   }
 
   return (
@@ -65,7 +64,7 @@ export default function DestinationField(
           props.onChange(newValues)
         }
 
-        const fieldErrMsg = capFirstLetter(fieldErrors.get(field.fieldID) || '')
+        const fieldErrMsg = capFirstLetter(fieldErrors?.[field.fieldID] || '')
 
         if (field.supportsSearch)
           return (
@@ -76,9 +75,7 @@ export default function DestinationField(
                 destType={props.destType}
                 disabled={props.disabled || !dest.enabled}
                 onChange={(val) => handleChange(val)}
-                error={!!fieldErrMsg}
-                hint={fieldErrMsg || field.hint}
-                hintURL={fieldErrMsg ? '' : field.hintURL}
+                error={fieldErrMsg}
               />
             </Grid>
           )
@@ -91,9 +88,7 @@ export default function DestinationField(
               destType={props.destType}
               disabled={props.disabled || !dest.enabled}
               onChange={(e) => handleChange(e.target.value)}
-              error={!!fieldErrMsg}
-              hint={fieldErrMsg || field.hint}
-              hintURL={fieldErrMsg ? '' : field.hintURL}
+              error={fieldErrMsg}
             />
           </Grid>
         )

--- a/web/src/app/selection/DestinationInputDirect.tsx
+++ b/web/src/app/selection/DestinationInputDirect.tsx
@@ -6,8 +6,8 @@ import { Check, Close } from '@mui/icons-material'
 import InputAdornment from '@mui/material/InputAdornment'
 import { DEBOUNCE_DELAY } from '../config'
 import { DestinationFieldConfig, DestinationType } from '../../schema'
-import AppLink from '../util/AppLink'
 import { green, red } from '@mui/material/colors'
+import { HelperText } from '../forms'
 
 const isValidValue = gql`
   query ValidateDestination($input: DestinationFieldValidateInput!) {
@@ -32,7 +32,7 @@ export type DestinationInputDirectProps = DestinationFieldConfig & {
   destType: DestinationType
 
   disabled?: boolean
-  error?: boolean
+  error?: string
 }
 
 /**
@@ -126,17 +126,15 @@ export default function DestinationInputDirect(
       placeholder={props.placeholderText}
       label={props.label}
       helperText={
-        props.hintURL ? (
-          <AppLink newTab to={props.hintURL}>
-            {props.hint}
-          </AppLink>
-        ) : (
-          props.hint
-        )
+        <HelperText
+          error={props.error}
+          hint={props.hint}
+          hintURL={props.hintURL}
+        />
       }
       onChange={handleChange}
       value={trimPrefix(props.value, props.prefix)}
-      error={props.error}
+      error={!!props.error}
     />
   )
 }

--- a/web/src/app/selection/DestinationSearchSelect.tsx
+++ b/web/src/app/selection/DestinationSearchSelect.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../schema'
 import MaterialSelect from './MaterialSelect'
 import { FavoriteIcon } from '../util/SetFavoriteButton'
-import AppLink from '../util/AppLink'
+import { HelperText } from '../forms'
 
 const searchOptionsQuery = gql`
   query DestinationFieldSearch($input: DestinationFieldSearchInput!) {
@@ -35,7 +35,7 @@ export type DestinationSearchSelectProps = DestinationFieldConfig & {
   destType: DestinationType
 
   disabled?: boolean
-  error?: boolean
+  error?: string
 }
 
 const cacheByJSON: Record<string, unknown> = {}
@@ -131,18 +131,16 @@ export default function DestinationSearchSelect(
       noOptionsText='No options'
       disabled={props.disabled}
       noOptionsError={error}
-      error={props.error}
+      error={!!props.error}
       onInputChange={(val) => setInputValue(val)}
       value={value as unknown as SelectOption}
       label={props.label}
       helperText={
-        props.hintURL ? (
-          <AppLink newTab to={props.hintURL}>
-            {props.hint}
-          </AppLink>
-        ) : (
-          props.hint
-        )
+        <HelperText
+          hint={props.hint}
+          hintURL={props.hintURL}
+          error={props.error}
+        />
       }
       options={options
         .map((opt) => ({

--- a/web/src/app/selection/DynamicActionForm.stories.tsx
+++ b/web/src/app/selection/DynamicActionForm.stories.tsx
@@ -135,22 +135,8 @@ export const Errors: Story = {
       staticParams: {},
       dynamicParams: {},
     },
-    errors: [
-      {
-        section: 'input',
-        inputID: 'dest-type',
-        message: 'Dest type validation error',
-      },
-      {
-        section: 'static-params',
-        fieldID: 'required-field',
-        message: 'Required field validation error',
-      },
-      {
-        section: 'dynamic-params',
-        paramID: 'dynamic-param',
-        message: 'Dynamic param validation error',
-      },
-    ],
+    destTypeError: 'Dest type validation error',
+    staticParamErrors: { 'required-field': 'Required field validation error' },
+    dynamicParamErrors: { 'dynamic-param': 'Dynamic param validation error' },
   },
 }


### PR DESCRIPTION
**Description:**
Move to explicit error props as strings in form components, rather than various structures.

This is part of an effort to simplify form rendering and disconnect it from the API. More work to follow.

- `HelperText` component was added to normalize how form helper text is rendered (part of effort to move away from the old Form code magic.
