### PR TITLE
dest: use gadb.DestV1 for Destination and DestinationInput

### DIFF
--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -884,7 +884,7 @@ type AlertMetricResolver interface {
 }
 type DestinationResolver interface {
 	Values(ctx context.Context, obj *Destination) ([]FieldValuePair, error)
-	Args(ctx context.Context, obj *Destination) (map[string]string, error)
+
 	DisplayInfo(ctx context.Context, obj *Destination) (InlineDisplayInfo, error)
 }
 type EscalationPolicyResolver interface {
@@ -10794,7 +10794,7 @@ func (ec *executionContext) _Destination_args(ctx context.Context, field graphql
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Destination().Args(rctx, obj)
+		return obj.Args, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -10815,8 +10815,8 @@ func (ec *executionContext) fieldContext_Destination_args(_ context.Context, fie
 	fc = &graphql.FieldContext{
 		Object:     "Destination",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type StringMap does not have child fields")
 		},
@@ -39609,41 +39609,10 @@ func (ec *executionContext) _Destination(ctx context.Context, sel ast.SelectionS
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "args":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Destination_args(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
+			out.Values[i] = ec._Destination_args(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
 			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "displayInfo":
 			field := field
 

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -883,9 +883,9 @@ type AlertMetricResolver interface {
 	TimeToClose(ctx context.Context, obj *alertmetrics.Metric) (*timeutil.ISODuration, error)
 }
 type DestinationResolver interface {
-	Values(ctx context.Context, obj *Destination) ([]FieldValuePair, error)
+	Values(ctx context.Context, obj *gadb.DestV1) ([]FieldValuePair, error)
 
-	DisplayInfo(ctx context.Context, obj *Destination) (InlineDisplayInfo, error)
+	DisplayInfo(ctx context.Context, obj *gadb.DestV1) (InlineDisplayInfo, error)
 }
 type EscalationPolicyResolver interface {
 	IsFavorite(ctx context.Context, obj *escalation.Policy) (bool, error)
@@ -896,7 +896,7 @@ type EscalationPolicyResolver interface {
 type EscalationPolicyStepResolver interface {
 	Targets(ctx context.Context, obj *escalation.Step) ([]assignment.RawTarget, error)
 	EscalationPolicy(ctx context.Context, obj *escalation.Step) (*escalation.Policy, error)
-	Actions(ctx context.Context, obj *escalation.Step) ([]Destination, error)
+	Actions(ctx context.Context, obj *escalation.Step) ([]gadb.DestV1, error)
 }
 type ExprResolver interface {
 	ExprToCondition(ctx context.Context, obj *Expr, input ExprToConditionInput) (*Condition, error)
@@ -986,7 +986,7 @@ type MutationResolver interface {
 }
 type OnCallNotificationRuleResolver interface {
 	Target(ctx context.Context, obj *schedule.OnCallNotificationRule) (*assignment.RawTarget, error)
-	Dest(ctx context.Context, obj *schedule.OnCallNotificationRule) (*Destination, error)
+	Dest(ctx context.Context, obj *schedule.OnCallNotificationRule) (*gadb.DestV1, error)
 }
 type OnCallShiftResolver interface {
 	User(ctx context.Context, obj *oncall.Shift) (*user.User, error)
@@ -1104,7 +1104,7 @@ type UserCalendarSubscriptionResolver interface {
 	URL(ctx context.Context, obj *calsub.Subscription) (*string, error)
 }
 type UserContactMethodResolver interface {
-	Dest(ctx context.Context, obj *contactmethod.ContactMethod) (*Destination, error)
+	Dest(ctx context.Context, obj *contactmethod.ContactMethod) (*gadb.DestV1, error)
 
 	Value(ctx context.Context, obj *contactmethod.ContactMethod) (string, error)
 	FormattedValue(ctx context.Context, obj *contactmethod.ContactMethod) (string, error)
@@ -7048,9 +7048,9 @@ func (ec *executionContext) _Action_dest(ctx context.Context, field graphql.Coll
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*Destination)
+	res := resTmp.(*gadb.DestV1)
 	fc.Result = res
-	return ec.marshalNDestination2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestination(ctx, field.Selections, res)
+	return ec.marshalNDestination2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Action_dest(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -10686,7 +10686,7 @@ func (ec *executionContext) fieldContext_DebugSendSMSInfo_fromNumber(_ context.C
 	return fc, nil
 }
 
-func (ec *executionContext) _Destination_type(ctx context.Context, field graphql.CollectedField, obj *Destination) (ret graphql.Marshaler) {
+func (ec *executionContext) _Destination_type(ctx context.Context, field graphql.CollectedField, obj *gadb.DestV1) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Destination_type(ctx, field)
 	if err != nil {
 		return graphql.Null
@@ -10730,7 +10730,7 @@ func (ec *executionContext) fieldContext_Destination_type(_ context.Context, fie
 	return fc, nil
 }
 
-func (ec *executionContext) _Destination_values(ctx context.Context, field graphql.CollectedField, obj *Destination) (ret graphql.Marshaler) {
+func (ec *executionContext) _Destination_values(ctx context.Context, field graphql.CollectedField, obj *gadb.DestV1) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Destination_values(ctx, field)
 	if err != nil {
 		return graphql.Null
@@ -10780,7 +10780,7 @@ func (ec *executionContext) fieldContext_Destination_values(_ context.Context, f
 	return fc, nil
 }
 
-func (ec *executionContext) _Destination_args(ctx context.Context, field graphql.CollectedField, obj *Destination) (ret graphql.Marshaler) {
+func (ec *executionContext) _Destination_args(ctx context.Context, field graphql.CollectedField, obj *gadb.DestV1) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Destination_args(ctx, field)
 	if err != nil {
 		return graphql.Null
@@ -10824,7 +10824,7 @@ func (ec *executionContext) fieldContext_Destination_args(_ context.Context, fie
 	return fc, nil
 }
 
-func (ec *executionContext) _Destination_displayInfo(ctx context.Context, field graphql.CollectedField, obj *Destination) (ret graphql.Marshaler) {
+func (ec *executionContext) _Destination_displayInfo(ctx context.Context, field graphql.CollectedField, obj *gadb.DestV1) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Destination_displayInfo(ctx, field)
 	if err != nil {
 		return graphql.Null
@@ -13069,9 +13069,9 @@ func (ec *executionContext) _EscalationPolicyStep_actions(ctx context.Context, f
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]Destination)
+	res := resTmp.([]gadb.DestV1)
 	fc.Result = res
-	return ec.marshalNDestination2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationᚄ(ctx, field.Selections, res)
+	return ec.marshalNDestination2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1ᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_EscalationPolicyStep_actions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -20168,9 +20168,9 @@ func (ec *executionContext) _OnCallNotificationRule_dest(ctx context.Context, fi
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*Destination)
+	res := resTmp.(*gadb.DestV1)
 	fc.Result = res
-	return ec.marshalNDestination2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestination(ctx, field.Selections, res)
+	return ec.marshalNDestination2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_OnCallNotificationRule_dest(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -30619,9 +30619,9 @@ func (ec *executionContext) _UserContactMethod_dest(ctx context.Context, field g
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*Destination)
+	res := resTmp.(*gadb.DestV1)
 	fc.Result = res
-	return ec.marshalNDestination2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestination(ctx, field.Selections, res)
+	return ec.marshalNDestination2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserContactMethod_dest(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -39558,7 +39558,7 @@ func (ec *executionContext) _DebugSendSMSInfo(ctx context.Context, sel ast.Selec
 
 var destinationImplementors = []string{"Destination"}
 
-func (ec *executionContext) _Destination(ctx context.Context, sel ast.SelectionSet, obj *Destination) graphql.Marshaler {
+func (ec *executionContext) _Destination(ctx context.Context, sel ast.SelectionSet, obj *gadb.DestV1) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, destinationImplementors)
 
 	out := graphql.NewFieldSet(fields)
@@ -48017,11 +48017,11 @@ func (ec *executionContext) unmarshalNDebugSendSMSInput2githubᚗcomᚋtargetᚋ
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNDestination2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestination(ctx context.Context, sel ast.SelectionSet, v Destination) graphql.Marshaler {
+func (ec *executionContext) marshalNDestination2githubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx context.Context, sel ast.SelectionSet, v gadb.DestV1) graphql.Marshaler {
 	return ec._Destination(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNDestination2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationᚄ(ctx context.Context, sel ast.SelectionSet, v []Destination) graphql.Marshaler {
+func (ec *executionContext) marshalNDestination2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1ᚄ(ctx context.Context, sel ast.SelectionSet, v []gadb.DestV1) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -48045,7 +48045,7 @@ func (ec *executionContext) marshalNDestination2ᚕgithubᚗcomᚋtargetᚋgoale
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNDestination2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestination(ctx, sel, v[i])
+			ret[i] = ec.marshalNDestination2githubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -48065,7 +48065,7 @@ func (ec *executionContext) marshalNDestination2ᚕgithubᚗcomᚋtargetᚋgoale
 	return ret
 }
 
-func (ec *executionContext) marshalNDestination2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestination(ctx context.Context, sel ast.SelectionSet, v *Destination) graphql.Marshaler {
+func (ec *executionContext) marshalNDestination2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx context.Context, sel ast.SelectionSet, v *gadb.DestV1) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -22,6 +22,7 @@ import (
 	"github.com/target/goalert/assignment"
 	"github.com/target/goalert/calsub"
 	"github.com/target/goalert/escalation"
+	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/heartbeat"
 	"github.com/target/goalert/integrationkey"
 	"github.com/target/goalert/label"
@@ -565,7 +566,7 @@ type ComplexityRoot struct {
 		ConfigHints               func(childComplexity int) int
 		DebugMessageStatus        func(childComplexity int, input DebugMessageStatusInput) int
 		DebugMessages             func(childComplexity int, input *DebugMessagesInput) int
-		DestinationDisplayInfo    func(childComplexity int, input DestinationInput) int
+		DestinationDisplayInfo    func(childComplexity int, input gadb.DestV1) int
 		DestinationFieldSearch    func(childComplexity int, input DestinationFieldSearchInput) int
 		DestinationFieldValidate  func(childComplexity int, input DestinationFieldValidateInput) int
 		DestinationFieldValueName func(childComplexity int, input DestinationFieldValidateInput) int
@@ -1036,7 +1037,7 @@ type QueryResolver interface {
 	DestinationFieldValidate(ctx context.Context, input DestinationFieldValidateInput) (bool, error)
 	DestinationFieldSearch(ctx context.Context, input DestinationFieldSearchInput) (*FieldSearchConnection, error)
 	DestinationFieldValueName(ctx context.Context, input DestinationFieldValidateInput) (string, error)
-	DestinationDisplayInfo(ctx context.Context, input DestinationInput) (*DestinationDisplayInfo, error)
+	DestinationDisplayInfo(ctx context.Context, input gadb.DestV1) (*DestinationDisplayInfo, error)
 	Expr(ctx context.Context) (*Expr, error)
 	GqlAPIKeys(ctx context.Context) ([]GQLAPIKey, error)
 	ActionInputValidate(ctx context.Context, input ActionInput) (bool, error)
@@ -1122,17 +1123,16 @@ type UserOverrideResolver interface {
 }
 
 type CreateEscalationPolicyStepInputResolver interface {
-	Actions(ctx context.Context, obj *CreateEscalationPolicyStepInput, data []DestinationInput) error
+	Actions(ctx context.Context, obj *CreateEscalationPolicyStepInput, data []gadb.DestV1) error
 }
 type DestinationInputResolver interface {
-	Values(ctx context.Context, obj *DestinationInput, data []FieldValueInput) error
-	Args(ctx context.Context, obj *DestinationInput, data map[string]string) error
+	Values(ctx context.Context, obj *gadb.DestV1, data []FieldValueInput) error
 }
 type OnCallNotificationRuleInputResolver interface {
-	Dest(ctx context.Context, obj *OnCallNotificationRuleInput, data *DestinationInput) error
+	Dest(ctx context.Context, obj *OnCallNotificationRuleInput, data *gadb.DestV1) error
 }
 type UpdateEscalationPolicyStepInputResolver interface {
-	Actions(ctx context.Context, obj *UpdateEscalationPolicyStepInput, data []DestinationInput) error
+	Actions(ctx context.Context, obj *UpdateEscalationPolicyStepInput, data []gadb.DestV1) error
 }
 
 type executableSchema struct {
@@ -3567,7 +3567,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.DestinationDisplayInfo(childComplexity, args["input"].(DestinationInput)), true
+		return e.complexity.Query.DestinationDisplayInfo(childComplexity, args["input"].(gadb.DestV1)), true
 
 	case "Query.destinationFieldSearch":
 		if e.complexity.Query.DestinationFieldSearch == nil {
@@ -6402,10 +6402,10 @@ func (ec *executionContext) field_Query_debugMessages_args(ctx context.Context, 
 func (ec *executionContext) field_Query_destinationDisplayInfo_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	var arg0 DestinationInput
+	var arg0 gadb.DestV1
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
-		arg0, err = ec.unmarshalNDestinationInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationInput(ctx, tmp)
+		arg0, err = ec.unmarshalNDestinationInput2githubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -24088,7 +24088,7 @@ func (ec *executionContext) _Query_destinationDisplayInfo(ctx context.Context, f
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().DestinationDisplayInfo(rctx, fc.Args["input"].(DestinationInput))
+		return ec.resolvers.Query().DestinationDisplayInfo(rctx, fc.Args["input"].(gadb.DestV1))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -33784,7 +33784,7 @@ func (ec *executionContext) unmarshalInputActionInput(ctx context.Context, obj i
 		switch k {
 		case "dest":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dest"))
-			data, err := ec.unmarshalNDestinationInput2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationInput(ctx, v)
+			data, err := ec.unmarshalNDestinationInput2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -34582,7 +34582,7 @@ func (ec *executionContext) unmarshalInputCreateEscalationPolicyStepInput(ctx co
 			it.NewSchedule = data
 		case "actions":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("actions"))
-			data, err := ec.unmarshalODestinationInput2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationInputᚄ(ctx, v)
+			data, err := ec.unmarshalODestinationInput2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1ᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -35053,7 +35053,7 @@ func (ec *executionContext) unmarshalInputCreateUserContactMethodInput(ctx conte
 			it.Type = data
 		case "dest":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dest"))
-			data, err := ec.unmarshalODestinationInput2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationInput(ctx, v)
+			data, err := ec.unmarshalODestinationInput2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -35497,8 +35497,8 @@ func (ec *executionContext) unmarshalInputDestinationFieldValidateInput(ctx cont
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputDestinationInput(ctx context.Context, obj interface{}) (DestinationInput, error) {
-	var it DestinationInput
+func (ec *executionContext) unmarshalInputDestinationInput(ctx context.Context, obj interface{}) (gadb.DestV1, error) {
+	var it gadb.DestV1
 	asMap := map[string]interface{}{}
 	for k, v := range obj.(map[string]interface{}) {
 		asMap[k] = v
@@ -35533,9 +35533,7 @@ func (ec *executionContext) unmarshalInputDestinationInput(ctx context.Context, 
 			if err != nil {
 				return it, err
 			}
-			if err = ec.resolvers.DestinationInput().Args(ctx, &it, data); err != nil {
-				return it, err
-			}
+			it.Args = data
 		}
 	}
 
@@ -36094,7 +36092,7 @@ func (ec *executionContext) unmarshalInputOnCallNotificationRuleInput(ctx contex
 			it.Target = data
 		case "dest":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dest"))
-			data, err := ec.unmarshalODestinationInput2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationInput(ctx, v)
+			data, err := ec.unmarshalODestinationInput2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -37208,7 +37206,7 @@ func (ec *executionContext) unmarshalInputUpdateEscalationPolicyStepInput(ctx co
 			it.Targets = data
 		case "actions":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("actions"))
-			data, err := ec.unmarshalODestinationInput2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationInputᚄ(ctx, v)
+			data, err := ec.unmarshalODestinationInput2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1ᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -37931,7 +37929,7 @@ func (ec *executionContext) unmarshalInputUserSearchOptions(ctx context.Context,
 			it.CMType = data
 		case "dest":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dest"))
-			data, err := ec.unmarshalODestinationInput2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationInput(ctx, v)
+			data, err := ec.unmarshalODestinationInput2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -48180,12 +48178,12 @@ func (ec *executionContext) unmarshalNDestinationFieldValidateInput2githubᚗcom
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalNDestinationInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationInput(ctx context.Context, v interface{}) (DestinationInput, error) {
+func (ec *executionContext) unmarshalNDestinationInput2githubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx context.Context, v interface{}) (gadb.DestV1, error) {
 	res, err := ec.unmarshalInputDestinationInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalNDestinationInput2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationInput(ctx context.Context, v interface{}) (*DestinationInput, error) {
+func (ec *executionContext) unmarshalNDestinationInput2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx context.Context, v interface{}) (*gadb.DestV1, error) {
 	res, err := ec.unmarshalInputDestinationInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
@@ -51712,7 +51710,7 @@ func (ec *executionContext) marshalODebugSendSMSInfo2ᚖgithubᚗcomᚋtargetᚋ
 	return ec._DebugSendSMSInfo(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalODestinationInput2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationInputᚄ(ctx context.Context, v interface{}) ([]DestinationInput, error) {
+func (ec *executionContext) unmarshalODestinationInput2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1ᚄ(ctx context.Context, v interface{}) ([]gadb.DestV1, error) {
 	if v == nil {
 		return nil, nil
 	}
@@ -51721,10 +51719,10 @@ func (ec *executionContext) unmarshalODestinationInput2ᚕgithubᚗcomᚋtarget�
 		vSlice = graphql.CoerceList(v)
 	}
 	var err error
-	res := make([]DestinationInput, len(vSlice))
+	res := make([]gadb.DestV1, len(vSlice))
 	for i := range vSlice {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNDestinationInput2githubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationInput(ctx, vSlice[i])
+		res[i], err = ec.unmarshalNDestinationInput2githubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx, vSlice[i])
 		if err != nil {
 			return nil, err
 		}
@@ -51732,7 +51730,7 @@ func (ec *executionContext) unmarshalODestinationInput2ᚕgithubᚗcomᚋtarget�
 	return res, nil
 }
 
-func (ec *executionContext) unmarshalODestinationInput2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐDestinationInput(ctx context.Context, v interface{}) (*DestinationInput, error) {
+func (ec *executionContext) unmarshalODestinationInput2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx context.Context, v interface{}) (*gadb.DestV1, error) {
 	if v == nil {
 		return nil, nil
 	}

--- a/graphql2/gqlgen.yml
+++ b/graphql2/gqlgen.yml
@@ -124,3 +124,5 @@ models:
     model: github.com/target/goalert/graphql2.ExprStringMap
   StringMap:
     model: github.com/target/goalert/graphql2.StringMap
+  DestinationInput:
+    model: github.com/target/goalert/gadb.DestV1

--- a/graphql2/gqlgen.yml
+++ b/graphql2/gqlgen.yml
@@ -126,3 +126,5 @@ models:
     model: github.com/target/goalert/graphql2.StringMap
   DestinationInput:
     model: github.com/target/goalert/gadb.DestV1
+  Destination:
+    model: github.com/target/goalert/gadb.DestV1

--- a/graphql2/graph/destinations.graphqls
+++ b/graphql2/graph/destinations.graphqls
@@ -123,7 +123,7 @@ type Destination {
   values: [FieldValuePair!]!
     @goField(forceResolver: true)
     @deprecated(reason: "Use the args field instead")
-  args: StringMap! @goField(forceResolver: true)
+  args: StringMap!
   displayInfo: InlineDisplayInfo! @goField(forceResolver: true)
 }
 

--- a/graphql2/graph/destinations.graphqls
+++ b/graphql2/graph/destinations.graphqls
@@ -176,7 +176,7 @@ input DestinationInput {
   values: [FieldValueInput!]
     @goField(forceResolver: true)
     @deprecated(reason: "Use the args field instead")
-  args: StringMap @goField(forceResolver: true)
+  args: StringMap
 }
 
 input FieldValueInput {

--- a/graphql2/graphqlapp/compat.go
+++ b/graphql2/graphqlapp/compat.go
@@ -8,46 +8,45 @@ import (
 	"github.com/google/uuid"
 	"github.com/target/goalert/assignment"
 	"github.com/target/goalert/gadb"
-	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/notificationchannel"
 	"github.com/target/goalert/user/contactmethod"
 )
 
-// CompatTargetToDest converts an assignment.Target to a graphql2.Destination.
-func CompatTargetToDest(tgt assignment.Target) (graphql2.Destination, error) {
+// CompatTargetToDest converts an assignment.Target to a gadb.DestV1.
+func CompatTargetToDest(tgt assignment.Target) (gadb.DestV1, error) {
 	switch tgt.TargetType() {
 	case assignment.TargetTypeUser:
-		return graphql2.Destination{
+		return gadb.DestV1{
 			Type: destUser,
 			Args: map[string]string{fieldUserID: tgt.TargetID()},
 		}, nil
 	case assignment.TargetTypeRotation:
-		return graphql2.Destination{
+		return gadb.DestV1{
 			Type: destRotation,
 			Args: map[string]string{fieldRotationID: tgt.TargetID()},
 		}, nil
 	case assignment.TargetTypeSchedule:
-		return graphql2.Destination{
+		return gadb.DestV1{
 			Type: destSchedule,
 			Args: map[string]string{fieldScheduleID: tgt.TargetID()},
 		}, nil
 	case assignment.TargetTypeChanWebhook:
-		return graphql2.Destination{
+		return gadb.DestV1{
 			Type: destWebhook,
 			Args: map[string]string{fieldWebhookURL: tgt.TargetID()},
 		}, nil
 	case assignment.TargetTypeSlackChannel:
-		return graphql2.Destination{
+		return gadb.DestV1{
 			Type: destSlackChan,
 			Args: map[string]string{fieldSlackChanID: tgt.TargetID()},
 		}, nil
 	}
 
-	return graphql2.Destination{}, fmt.Errorf("unknown target type: %s", tgt.TargetType())
+	return gadb.DestV1{}, fmt.Errorf("unknown target type: %s", tgt.TargetType())
 }
 
 // CompatNCToDest converts a notification channel to a destination.
-func (a *App) CompatNCToDest(ctx context.Context, ncID uuid.UUID) (*graphql2.Destination, error) {
+func (a *App) CompatNCToDest(ctx context.Context, ncID uuid.UUID) (*gadb.DestV1, error) {
 	nc, err := a.FindOneNC(ctx, ncID)
 	if err != nil {
 		return nil, err
@@ -55,7 +54,7 @@ func (a *App) CompatNCToDest(ctx context.Context, ncID uuid.UUID) (*graphql2.Des
 
 	switch nc.Type {
 	case notificationchannel.TypeSlackChan:
-		return &graphql2.Destination{
+		return &gadb.DestV1{
 			Type: destSlackChan,
 			Args: map[string]string{fieldSlackChanID: nc.Value},
 		}, nil
@@ -65,7 +64,7 @@ func (a *App) CompatNCToDest(ctx context.Context, ncID uuid.UUID) (*graphql2.Des
 			return nil, fmt.Errorf("invalid slack usergroup pair: %s", nc.Value)
 		}
 
-		return &graphql2.Destination{
+		return &gadb.DestV1{
 			Type: destSlackUG,
 			Args: map[string]string{
 				fieldSlackUGID:   ugID,
@@ -73,7 +72,7 @@ func (a *App) CompatNCToDest(ctx context.Context, ncID uuid.UUID) (*graphql2.Des
 			},
 		}, nil
 	case notificationchannel.TypeWebhook:
-		return &graphql2.Destination{
+		return &gadb.DestV1{
 			Type: destWebhook,
 			Args: map[string]string{fieldWebhookURL: nc.Value},
 		}, nil

--- a/graphql2/graphqlapp/compat.go
+++ b/graphql2/graphqlapp/compat.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/target/goalert/assignment"
+	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/notificationchannel"
 	"github.com/target/goalert/user/contactmethod"
@@ -81,9 +82,9 @@ func (a *App) CompatNCToDest(ctx context.Context, ncID uuid.UUID) (*graphql2.Des
 	}
 }
 
-// CompatDestToCMTypeVal converts a graphql2.DestinationInput to a contactmethod.Type and string value
+// CompatDestToCMTypeVal converts a gadb.DestV1 to a contactmethod.Type and string value
 // for the built-in destination types.
-func CompatDestToCMTypeVal(d graphql2.DestinationInput) (contactmethod.Type, string) {
+func CompatDestToCMTypeVal(d gadb.DestV1) (contactmethod.Type, string) {
 	switch d.Type {
 	case destTwilioSMS:
 		return contactmethod.TypeSMS, d.Args[fieldPhoneNumber]
@@ -100,8 +101,8 @@ func CompatDestToCMTypeVal(d graphql2.DestinationInput) (contactmethod.Type, str
 	return "", ""
 }
 
-// CompatDestToTarget converts a graphql2.DestinationInput to a graphql2.RawTarget
-func CompatDestToTarget(d graphql2.DestinationInput) (assignment.RawTarget, error) {
+// CompatDestToTarget converts a gadb.DestV1 to a graphql2.RawTarget
+func CompatDestToTarget(d gadb.DestV1) (assignment.RawTarget, error) {
 	switch d.Type {
 	case destUser:
 		return assignment.RawTarget{

--- a/graphql2/graphqlapp/contactmethod.go
+++ b/graphql2/graphqlapp/contactmethod.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/target/goalert/config"
+	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/notification"
 	"github.com/target/goalert/notification/webhook"
@@ -22,30 +23,30 @@ func (a *App) UserContactMethod() graphql2.UserContactMethodResolver {
 	return (*ContactMethod)(a)
 }
 
-func (a *ContactMethod) Dest(ctx context.Context, obj *contactmethod.ContactMethod) (*graphql2.Destination, error) {
+func (a *ContactMethod) Dest(ctx context.Context, obj *contactmethod.ContactMethod) (*gadb.DestV1, error) {
 	switch obj.Type {
 	case contactmethod.TypeSMS:
-		return &graphql2.Destination{
+		return &gadb.DestV1{
 			Type: destTwilioSMS,
 			Args: map[string]string{fieldPhoneNumber: obj.Value},
 		}, nil
 	case contactmethod.TypeVoice:
-		return &graphql2.Destination{
+		return &gadb.DestV1{
 			Type: destTwilioVoice,
 			Args: map[string]string{fieldPhoneNumber: obj.Value},
 		}, nil
 	case contactmethod.TypeEmail:
-		return &graphql2.Destination{
+		return &gadb.DestV1{
 			Type: destSMTP,
 			Args: map[string]string{fieldEmailAddress: obj.Value},
 		}, nil
 	case contactmethod.TypeWebhook:
-		return &graphql2.Destination{
+		return &gadb.DestV1{
 			Type: destWebhook,
 			Args: map[string]string{fieldWebhookURL: obj.Value},
 		}, nil
 	case contactmethod.TypeSlackDM:
-		return &graphql2.Destination{
+		return &gadb.DestV1{
 			Type: destSlackDM,
 			Args: map[string]string{fieldSlackUserID: obj.Value},
 		}, nil

--- a/graphql2/graphqlapp/destinationdisplayinfo.go
+++ b/graphql2/graphqlapp/destinationdisplayinfo.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nyaruka/phonenumbers"
 	"github.com/target/goalert/config"
+	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/util/errutil"
 	"github.com/target/goalert/util/log"
@@ -21,19 +22,7 @@ type (
 func (a *App) Destination() graphql2.DestinationResolver           { return (*Destination)(a) }
 func (a *App) DestinationInput() graphql2.DestinationInputResolver { return (*DestinationInput)(a) }
 
-func (a *DestinationInput) Args(ctx context.Context, obj *graphql2.DestinationInput, args map[string]string) error {
-	obj.Args = args
-
-	obj.Values = make([]graphql2.FieldValueInput, 0, len(args))
-	for k, v := range args {
-		obj.Values = append(obj.Values, graphql2.FieldValueInput{FieldID: k, Value: v})
-	}
-
-	return nil
-}
-
-func (a *DestinationInput) Values(ctx context.Context, obj *graphql2.DestinationInput, values []graphql2.FieldValueInput) error {
-	obj.Values = values
+func (a *DestinationInput) Values(ctx context.Context, obj *gadb.DestV1, values []graphql2.FieldValueInput) error {
 	obj.Args = make(map[string]string, len(values))
 	for _, val := range values {
 		obj.Args[val.FieldID] = val.Value
@@ -72,7 +61,7 @@ func (a *Destination) DisplayInfo(ctx context.Context, obj *graphql2.Destination
 		return obj.DisplayInfo, nil
 	}
 
-	info, err := (*Query)(a)._DestinationDisplayInfo(ctx, graphql2.DestinationInput{Type: obj.Type, Args: obj.Args}, true)
+	info, err := (*Query)(a)._DestinationDisplayInfo(ctx, gadb.DestV1{Type: obj.Type, Args: obj.Args}, true)
 	if err != nil {
 		isUnsafe, safeErr := errutil.ScrubError(err)
 		if isUnsafe {
@@ -84,11 +73,11 @@ func (a *Destination) DisplayInfo(ctx context.Context, obj *graphql2.Destination
 	return info, nil
 }
 
-func (a *Query) DestinationDisplayInfo(ctx context.Context, dest graphql2.DestinationInput) (*graphql2.DestinationDisplayInfo, error) {
+func (a *Query) DestinationDisplayInfo(ctx context.Context, dest gadb.DestV1) (*graphql2.DestinationDisplayInfo, error) {
 	return a._DestinationDisplayInfo(ctx, dest, false)
 }
 
-func (a *Query) _DestinationDisplayInfo(ctx context.Context, dest graphql2.DestinationInput, skipValidation bool) (*graphql2.DestinationDisplayInfo, error) {
+func (a *Query) _DestinationDisplayInfo(ctx context.Context, dest gadb.DestV1, skipValidation bool) (*graphql2.DestinationDisplayInfo, error) {
 	app := (*App)(a)
 	cfg := config.FromContext(ctx)
 	if !skipValidation {

--- a/graphql2/graphqlapp/destinationdisplayinfo.go
+++ b/graphql2/graphqlapp/destinationdisplayinfo.go
@@ -30,19 +30,6 @@ func (a *DestinationInput) Values(ctx context.Context, obj *gadb.DestV1, values 
 	return nil
 }
 
-func (a *Destination) Args(ctx context.Context, obj *graphql2.Destination) (map[string]string, error) {
-	if obj.Args != nil {
-		return obj.Args, nil
-	}
-
-	m := make(map[string]string, len(obj.Values))
-	for _, val := range obj.Values {
-		m[val.FieldID] = val.Value
-	}
-
-	return m, nil
-}
-
 func (a *Destination) Values(ctx context.Context, obj *graphql2.Destination) ([]graphql2.FieldValuePair, error) {
 	if obj.Args != nil {
 		pairs := make([]graphql2.FieldValuePair, 0, len(obj.Args))
@@ -52,7 +39,7 @@ func (a *Destination) Values(ctx context.Context, obj *graphql2.Destination) ([]
 		return pairs, nil
 	}
 
-	return obj.Values, nil
+	return nil, nil
 }
 
 // DisplayInfo will return the display information for a destination by mapping to Query.DestinationDisplayInfo.

--- a/graphql2/graphqlapp/destinationdisplayinfo.go
+++ b/graphql2/graphqlapp/destinationdisplayinfo.go
@@ -30,7 +30,7 @@ func (a *DestinationInput) Values(ctx context.Context, obj *gadb.DestV1, values 
 	return nil
 }
 
-func (a *Destination) Values(ctx context.Context, obj *graphql2.Destination) ([]graphql2.FieldValuePair, error) {
+func (a *Destination) Values(ctx context.Context, obj *gadb.DestV1) ([]graphql2.FieldValuePair, error) {
 	if obj.Args != nil {
 		pairs := make([]graphql2.FieldValuePair, 0, len(obj.Args))
 		for k, v := range obj.Args {
@@ -43,11 +43,7 @@ func (a *Destination) Values(ctx context.Context, obj *graphql2.Destination) ([]
 }
 
 // DisplayInfo will return the display information for a destination by mapping to Query.DestinationDisplayInfo.
-func (a *Destination) DisplayInfo(ctx context.Context, obj *graphql2.Destination) (graphql2.InlineDisplayInfo, error) {
-	if obj.DisplayInfo != nil {
-		return obj.DisplayInfo, nil
-	}
-
+func (a *Destination) DisplayInfo(ctx context.Context, obj *gadb.DestV1) (graphql2.InlineDisplayInfo, error) {
 	info, err := (*Query)(a)._DestinationDisplayInfo(ctx, gadb.DestV1{Type: obj.Type, Args: obj.Args}, true)
 	if err != nil {
 		isUnsafe, safeErr := errutil.ScrubError(err)

--- a/graphql2/graphqlapp/destinationvalidation.go
+++ b/graphql2/graphqlapp/destinationvalidation.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/target/goalert/config"
+	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/validation"
@@ -132,7 +133,7 @@ func addInputError(ctx context.Context, err error) {
 // ValidateDestination will validate a destination input.
 //
 // In the future this will be a call to the plugin system.
-func (a *App) ValidateDestination(ctx context.Context, fieldName string, dest *graphql2.DestinationInput) (err error) {
+func (a *App) ValidateDestination(ctx context.Context, fieldName string, dest *gadb.DestV1) (err error) {
 	cfg := config.FromContext(ctx)
 	switch dest.Type {
 	case destAlert:

--- a/graphql2/graphqlapp/escalationpolicy.go
+++ b/graphql2/graphqlapp/escalationpolicy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/target/goalert/assignment"
 	"github.com/target/goalert/config"
 	"github.com/target/goalert/escalation"
+	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/notice"
 	"github.com/target/goalert/permission"
@@ -17,10 +18,12 @@ import (
 	"github.com/target/goalert/validation/validate"
 )
 
-type EscalationPolicy App
-type EscalationPolicyStep App
-type CreateEscalationPolicyStepInput App
-type UpdateEscalationPolicyStepInput App
+type (
+	EscalationPolicy                App
+	EscalationPolicyStep            App
+	CreateEscalationPolicyStepInput App
+	UpdateEscalationPolicyStepInput App
+)
 
 func (a *App) EscalationPolicy() graphql2.EscalationPolicyResolver { return (*EscalationPolicy)(a) }
 func (a *App) EscalationPolicyStep() graphql2.EscalationPolicyStepResolver {
@@ -31,7 +34,7 @@ func (a *App) CreateEscalationPolicyStepInput() graphql2.CreateEscalationPolicyS
 	return (*CreateEscalationPolicyStepInput)(a)
 }
 
-func (a *CreateEscalationPolicyStepInput) Actions(ctx context.Context, input *graphql2.CreateEscalationPolicyStepInput, actions []graphql2.DestinationInput) error {
+func (a *CreateEscalationPolicyStepInput) Actions(ctx context.Context, input *graphql2.CreateEscalationPolicyStepInput, actions []gadb.DestV1) error {
 	tgts := make([]assignment.RawTarget, len(actions))
 	var err error
 	for i, action := range actions {
@@ -52,7 +55,7 @@ func (a *App) UpdateEscalationPolicyStepInput() graphql2.UpdateEscalationPolicyS
 	return (*UpdateEscalationPolicyStepInput)(a)
 }
 
-func (a *UpdateEscalationPolicyStepInput) Actions(ctx context.Context, input *graphql2.UpdateEscalationPolicyStepInput, actions []graphql2.DestinationInput) error {
+func (a *UpdateEscalationPolicyStepInput) Actions(ctx context.Context, input *graphql2.UpdateEscalationPolicyStepInput, actions []gadb.DestV1) error {
 	tgts := make([]assignment.RawTarget, len(actions))
 	var err error
 	for i, action := range actions {
@@ -404,6 +407,7 @@ func (step *EscalationPolicyStep) Targets(ctx context.Context, raw *escalation.S
 
 	return result, nil
 }
+
 func (step *EscalationPolicyStep) EscalationPolicy(ctx context.Context, raw *escalation.Step) (*escalation.Policy, error) {
 	return (*App)(step).FindOnePolicy(ctx, raw.PolicyID)
 }

--- a/graphql2/graphqlapp/escalationpolicy.go
+++ b/graphql2/graphqlapp/escalationpolicy.go
@@ -363,13 +363,13 @@ func (m *Mutation) UpdateEscalationPolicyStep(ctx context.Context, input graphql
 	return true, err
 }
 
-func (a *EscalationPolicyStep) Actions(ctx context.Context, raw *escalation.Step) ([]graphql2.Destination, error) {
+func (a *EscalationPolicyStep) Actions(ctx context.Context, raw *escalation.Step) ([]gadb.DestV1, error) {
 	tgts, err := a.Targets(ctx, raw)
 	if err != nil {
 		return nil, err
 	}
 
-	actions := make([]graphql2.Destination, len(tgts))
+	actions := make([]gadb.DestV1, len(tgts))
 	for i, tgt := range tgts {
 		actions[i], err = CompatTargetToDest(tgt)
 		if err != nil {

--- a/graphql2/graphqlapp/integrationkey.go
+++ b/graphql2/graphqlapp/integrationkey.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/target/goalert/config"
+	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/integrationkey"
 	"github.com/target/goalert/search"
@@ -253,7 +254,7 @@ func actionsGoToGQL(a []integrationkey.Action) []graphql2.Action {
 	res := make([]graphql2.Action, 0, len(a))
 	for _, v := range a {
 		res = append(res, graphql2.Action{
-			Dest:   &graphql2.Destination{Type: v.Type, Args: v.StaticParams},
+			Dest:   &gadb.DestV1{Type: v.Type, Args: v.StaticParams},
 			Params: v.DynamicParams,
 		})
 	}

--- a/graphql2/graphqlapp/schedule.go
+++ b/graphql2/graphqlapp/schedule.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/target/goalert/assignment"
+	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/notificationchannel"
 	"github.com/target/goalert/oncall"
@@ -36,11 +37,12 @@ func (a *App) TemporarySchedule() graphql2.TemporaryScheduleResolver { return (*
 func (a *App) OnCallNotificationRule() graphql2.OnCallNotificationRuleResolver {
 	return (*OnCallNotificationRule)(a)
 }
+
 func (a *App) OnCallNotificationRuleInput() graphql2.OnCallNotificationRuleInputResolver {
 	return (*OnCallNotificationRuleInput)(a)
 }
 
-func (a *OnCallNotificationRuleInput) Dest(ctx context.Context, input *graphql2.OnCallNotificationRuleInput, dest *graphql2.DestinationInput) error {
+func (a *OnCallNotificationRuleInput) Dest(ctx context.Context, input *graphql2.OnCallNotificationRuleInput, dest *gadb.DestV1) error {
 	err := (*App)(a).ValidateDestination(ctx, "", dest)
 	if err != nil {
 		return err

--- a/graphql2/graphqlapp/schedule.go
+++ b/graphql2/graphqlapp/schedule.go
@@ -56,7 +56,7 @@ func (a *OnCallNotificationRuleInput) Dest(ctx context.Context, input *graphql2.
 	return nil
 }
 
-func (a *OnCallNotificationRule) Dest(ctx context.Context, raw *schedule.OnCallNotificationRule) (*graphql2.Destination, error) {
+func (a *OnCallNotificationRule) Dest(ctx context.Context, raw *schedule.OnCallNotificationRule) (*gadb.DestV1, error) {
 	return (*App)(a).CompatNCToDest(ctx, raw.ChannelID)
 }
 

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -13,6 +13,7 @@ import (
 	"github.com/target/goalert/alert/alertlog"
 	"github.com/target/goalert/assignment"
 	"github.com/target/goalert/escalation"
+	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/integrationkey"
 	"github.com/target/goalert/label"
 	"github.com/target/goalert/limit"
@@ -38,7 +39,7 @@ type Action struct {
 }
 
 type ActionInput struct {
-	Dest   *DestinationInput `json:"dest"`
+	Dest   *gadb.DestV1      `json:"dest"`
 	Params map[string]string `json:"params"`
 }
 
@@ -202,7 +203,7 @@ type CreateEscalationPolicyStepInput struct {
 	Targets            []assignment.RawTarget `json:"targets,omitempty"`
 	NewRotation        *CreateRotationInput   `json:"newRotation,omitempty"`
 	NewSchedule        *CreateScheduleInput   `json:"newSchedule,omitempty"`
-	Actions            []DestinationInput     `json:"actions,omitempty"`
+	Actions            []gadb.DestV1          `json:"actions,omitempty"`
 }
 
 type CreateGQLAPIKeyInput struct {
@@ -270,7 +271,7 @@ type CreateUserCalendarSubscriptionInput struct {
 type CreateUserContactMethodInput struct {
 	UserID                  string                           `json:"userID"`
 	Type                    *contactmethod.Type              `json:"type,omitempty"`
-	Dest                    *DestinationInput                `json:"dest,omitempty"`
+	Dest                    *gadb.DestV1                     `json:"dest,omitempty"`
 	Name                    string                           `json:"name"`
 	Value                   *string                          `json:"value,omitempty"`
 	NewUserNotificationRule *CreateUserNotificationRuleInput `json:"newUserNotificationRule,omitempty"`
@@ -425,12 +426,6 @@ type DestinationFieldValidateInput struct {
 	FieldID string `json:"fieldID"`
 	// the value to validate
 	Value string `json:"value"`
-}
-
-type DestinationInput struct {
-	Type   string            `json:"type"`
-	Values []FieldValueInput `json:"values,omitempty"`
-	Args   map[string]string `json:"args,omitempty"`
 }
 
 type DestinationTypeInfo struct {
@@ -915,7 +910,7 @@ type UpdateEscalationPolicyStepInput struct {
 	ID           string                 `json:"id"`
 	DelayMinutes *int                   `json:"delayMinutes,omitempty"`
 	Targets      []assignment.RawTarget `json:"targets,omitempty"`
-	Actions      []DestinationInput     `json:"actions,omitempty"`
+	Actions      []gadb.DestV1          `json:"actions,omitempty"`
 }
 
 type UpdateGQLAPIKeyInput struct {
@@ -1029,7 +1024,7 @@ type UserSearchOptions struct {
 	Omit           []string            `json:"omit,omitempty"`
 	CMValue        *string             `json:"CMValue,omitempty"`
 	CMType         *contactmethod.Type `json:"CMType,omitempty"`
-	Dest           *DestinationInput   `json:"dest,omitempty"`
+	Dest           *gadb.DestV1        `json:"dest,omitempty"`
 	FavoritesOnly  *bool               `json:"favoritesOnly,omitempty"`
 	FavoritesFirst *bool               `json:"favoritesFirst,omitempty"`
 }

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -34,7 +34,7 @@ type InlineDisplayInfo interface {
 }
 
 type Action struct {
-	Dest   *Destination      `json:"dest"`
+	Dest   *gadb.DestV1      `json:"dest"`
 	Params map[string]string `json:"params"`
 }
 
@@ -352,14 +352,6 @@ type DebugSendSMSInput struct {
 	From string `json:"from"`
 	To   string `json:"to"`
 	Body string `json:"body"`
-}
-
-// Destination represents a destination that can be used for notifications.
-type Destination struct {
-	Type        string            `json:"type"`
-	Values      []FieldValuePair  `json:"values"`
-	Args        map[string]string `json:"args"`
-	DisplayInfo InlineDisplayInfo `json:"displayInfo"`
 }
 
 // DestinationDisplayInfo provides information for displaying a destination.

--- a/test/smoke/actionvalidate_test.go
+++ b/test/smoke/actionvalidate_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/target/goalert/expflag"
+	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/test/smoke/harness"
 )
@@ -29,7 +30,7 @@ func TestActionValid(t *testing.T) {
 			Input graphql2.ActionInput `json:"input"`
 		}
 		vars.Input.Params = dyn
-		vars.Input.Dest = &graphql2.DestinationInput{Type: destType, Args: dest}
+		vars.Input.Dest = &gadb.DestV1{Type: destType, Args: dest}
 
 		return *h.GraphQLQueryUserVarsT(t, harness.DefaultGraphQLAdminUserID, actionValidQuery, "TestActionValid", vars)
 	}

--- a/test/smoke/actionvalidate_test.go
+++ b/test/smoke/actionvalidate_test.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/target/goalert/expflag"
-	"github.com/target/goalert/gadb"
-	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/test/smoke/harness"
 )
 
@@ -27,10 +25,17 @@ func TestActionValid(t *testing.T) {
 	check := func(destType string, dest, dyn params) harness.QLResponse {
 		t.Helper()
 		var vars struct {
-			Input graphql2.ActionInput `json:"input"`
+			Input struct {
+				Dest struct {
+					Type string `json:"type"`
+					Args params `json:"args"`
+				} `json:"dest"`
+				Params params `json:"params"`
+			} `json:"input"`
 		}
 		vars.Input.Params = dyn
-		vars.Input.Dest = &gadb.DestV1{Type: destType, Args: dest}
+		vars.Input.Dest.Type = destType
+		vars.Input.Dest.Args = dest
 
 		return *h.GraphQLQueryUserVarsT(t, harness.DefaultGraphQLAdminUserID, actionValidQuery, "TestActionValid", vars)
 	}


### PR DESCRIPTION
**Description:**
Switches from generated models to use `gadb.DestV1` for GraphQL to simplify code and future validation.
