### PR TITLE
notification/dest: refactor to allow future map values

### DIFF
--- a/devtools/resetdb/datagen.go
+++ b/devtools/resetdb/datagen.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
+	"github.com/google/uuid"
 	"github.com/target/goalert/alert"
 	"github.com/target/goalert/assignment"
 	"github.com/target/goalert/escalation"
@@ -147,7 +148,7 @@ func (d *datagen) NewUser() {
 // NewCM will generate a contact method for the given UserID.
 func (d *datagen) NewCM(userID string) {
 	cm := contactmethod.ContactMethod{
-		ID:       d.UUID(),
+		ID:       uuid.MustParse(d.UUID()),
 		Type:     contactmethod.TypeSMS,
 		Name:     d.ids.Gen(d.FirstName, userID),
 		Disabled: true,
@@ -167,7 +168,7 @@ func (d *datagen) NewNR(userID, cmID string) {
 	nr := notificationrule.NotificationRule{
 		ID:              d.UUID(),
 		UserID:          userID,
-		ContactMethodID: cmID,
+		ContactMethodID: uuid.MustParse(cmID),
 		DelayMinutes:    d.ints.Gen(600, cmID),
 	}
 	d.NotificationRules = append(d.NotificationRules, nr)
@@ -404,7 +405,7 @@ func (d *datagen) NewAlertMessages(a alert.Alert, max int) {
 			Status:    "delivered",
 			UserID:    cm.UserID,
 			EPID:      getEPID(a.ServiceID),
-			CMID:      cm.ID,
+			CMID:      cm.ID.String(),
 			SentAt:    ts,
 			CreatedAt: d.DateRange(ts.Add(-time.Minute), ts),
 		})
@@ -595,7 +596,7 @@ func (cfg datagenConfig) Generate() datagen {
 		if len(cmMethods) == 0 {
 			continue
 		}
-		run(d.Intn(cfg.NRMax), func() { d.NewNR(u.ID, cmMethods[d.Intn(len(cmMethods))].ID) })
+		run(d.Intn(cfg.NRMax), func() { d.NewNR(u.ID, cmMethods[d.Intn(len(cmMethods))].ID.String()) })
 	}
 
 	run(cfg.RotationCount, d.NewRotation)

--- a/devtools/resetdb/main.go
+++ b/devtools/resetdb/main.go
@@ -142,11 +142,11 @@ func fillDB(ctx context.Context, dataCfg *datagenConfig, url string) error {
 	})
 	copyFrom("user_contact_methods", []string{"id", "user_id", "name", "type", "value", "disabled", "pending"}, len(data.ContactMethods), func(n int) []interface{} {
 		cm := data.ContactMethods[n]
-		return []interface{}{asUUID(cm.ID), asUUID(cm.UserID), cm.Name, cm.Type, cm.Value, cm.Disabled, cm.Pending}
+		return []interface{}{cm.ID, asUUID(cm.UserID), cm.Name, cm.Type, cm.Value, cm.Disabled, cm.Pending}
 	}, "users")
 	copyFrom("user_notification_rules", []string{"id", "user_id", "contact_method_id", "delay_minutes"}, len(data.NotificationRules), func(n int) []interface{} {
 		nr := data.NotificationRules[n]
-		return []interface{}{asUUID(nr.ID), asUUID(nr.UserID), asUUID(nr.ContactMethodID), nr.DelayMinutes}
+		return []interface{}{asUUID(nr.ID), asUUID(nr.UserID), nr.ContactMethodID, nr.DelayMinutes}
 	}, "user_contact_methods")
 	copyFrom("rotations", []string{"id", "name", "description", "type", "shift_length", "start_time", "time_zone"}, len(data.Rotations), func(n int) []interface{} {
 		r := data.Rotations[n]

--- a/engine/backend.go
+++ b/engine/backend.go
@@ -60,13 +60,13 @@ func (b *backend) FindOne(ctx context.Context, id string) (*callback, error) {
 	var c callback
 	var alertID sql.NullInt64
 	var serviceID sql.NullString
-	var cmID sql.NullString
+	var cmID uuid.NullUUID
 	err = b.findOne.QueryRowContext(ctx, id).Scan(&c.ID, &alertID, &serviceID, &cmID, &c.CreatedAt)
 	if err != nil {
 		return nil, err
 	}
 	c.AlertID = int(alertID.Int64)
 	c.ServiceID = serviceID.String
-	c.ContactMethodID = cmID.String
+	c.ContactMethodID = cmID.UUID
 	return &c, nil
 }

--- a/engine/callback.go
+++ b/engine/callback.go
@@ -12,7 +12,7 @@ type callback struct {
 	ID              string
 	AlertID         int
 	ServiceID       string
-	ContactMethodID string
+	ContactMethodID uuid.UUID
 	CreatedAt       time.Time
 }
 
@@ -22,7 +22,6 @@ func (c callback) Normalize() (*callback, error) {
 	}
 	err := validate.Many(
 		validate.UUID("ID", c.ID),
-		validate.UUID("ContactMethodID", c.ContactMethodID),
 	)
 	if err != nil {
 		return nil, err

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -415,14 +415,15 @@ func (p *Engine) Receive(ctx context.Context, callbackID string, result notifica
 // Start will enable all associated contact methods of `value` with type `t`. This should
 // be invoked if a user, for example, responds with `START` via sms.
 func (p *Engine) Start(ctx context.Context, d notification.Dest) error {
-	if !d.Type.IsUserCM() {
-		return errors.New("START only supported on user contact methods")
-	}
-
 	var err error
 	permission.SudoContext(ctx, func(ctx context.Context) {
 		err = p.cfg.ContactMethodStore.EnableByValue(ctx, p.b.db, d.Type.CMType(), d.Value)
 	})
+
+	if errors.Is(err, sql.ErrNoRows) {
+		// no contact methods found, nothing to do
+		return nil
+	}
 
 	return err
 }
@@ -430,14 +431,15 @@ func (p *Engine) Start(ctx context.Context, d notification.Dest) error {
 // Stop will disable all associated contact methods of `value` with type `t`. This should
 // be invoked if a user, for example, responds with `STOP` via SMS.
 func (p *Engine) Stop(ctx context.Context, d notification.Dest) error {
-	if !d.Type.IsUserCM() {
-		return errors.New("STOP only supported on user contact methods")
-	}
-
 	var err error
 	permission.SudoContext(ctx, func(ctx context.Context) {
 		err = p.cfg.ContactMethodStore.DisableByValue(ctx, p.b.db, d.Type.CMType(), d.Value)
 	})
+
+	if errors.Is(err, sql.ErrNoRows) {
+		// no contact methods found, nothing to do
+		return nil
+	}
 
 	return err
 }

--- a/engine/isknowndest.go
+++ b/engine/isknowndest.go
@@ -2,23 +2,18 @@ package engine
 
 import (
 	"context"
-	"database/sql"
-	"errors"
 
+	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/notification"
 )
 
 func (n *Engine) IsKnownDest(ctx context.Context, destType notification.DestType, destValue string) (bool, error) {
-	var isKnown bool
-	var err error
-	if destType.IsUserCM() {
-		err = n.b.validCM.QueryRowContext(ctx, destType.CMType(), destValue).Scan(&isKnown)
-	} else {
-		err = n.b.validNC.QueryRowContext(ctx, destType.NCType(), destValue).Scan(&isKnown)
-	}
-	if errors.Is(err, sql.ErrNoRows) {
-		err = nil
+	d := notification.Dest{Type: destType, Value: destValue}
+
+	b, err := gadb.New(n.b.db).EngineIsKnownDest(ctx, gadb.NullDestV1{Valid: true, DestV1: d.ToDestV1()})
+	if err != nil {
+		return false, err
 	}
 
-	return isKnown, err
+	return b.Bool, nil
 }

--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -405,17 +405,18 @@ func (db *DB) currentQueue(ctx context.Context, tx *sql.Tx, now time.Time) (*que
 	}
 
 	result, err = bundleAlertMessages(result, func(msg Message) (string, error) {
-		var cmID, chanID, userID sql.NullString
+		var cmID, chanID uuid.NullUUID
+		var userID sql.NullString
 		if msg.UserID != "" {
 			userID.Valid = true
 			userID.String = msg.UserID
 		}
-		if msg.Dest.Type.IsUserCM() {
+		if msg.Dest.ID.IsUserCM() {
 			cmID.Valid = true
-			cmID.String = msg.Dest.ID
+			cmID.UUID = msg.Dest.ID.UUID()
 		} else {
 			chanID.Valid = true
-			chanID.String = msg.Dest.ID
+			chanID.UUID = msg.Dest.ID.UUID()
 		}
 
 		newID := uuid.NewString()

--- a/engine/message/dedupalerts_test.go
+++ b/engine/message/dedupalerts_test.go
@@ -5,22 +5,25 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/target/goalert/notification"
 )
 
 func TestDedupAlerts(t *testing.T) {
+	foo := notification.UserContactMethodID(uuid.Must(uuid.FromBytes([]byte("foofoofoofoofoof"))))
+	bar := notification.UserContactMethodID(uuid.Must(uuid.FromBytes([]byte("barbarbarbarbarb"))))
 	messages := []Message{
 		{ID: "1", Type: notification.MessageTypeTest},
 		{ID: "2", Type: notification.MessageTypeAlertBundle},
-		{ID: "3", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 11, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "foo"}}, // duplicates 4 (same dest and alert, but newer)
-		{ID: "4", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 10, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "foo"}},
-		{ID: "5", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 12, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "foo"}}, // duplicates 4 (same dest and alert, but newer)
+		{ID: "3", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 11, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: foo}}, // duplicates 4 (same dest and alert, but newer)
+		{ID: "4", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 10, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: foo}},
+		{ID: "5", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 12, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: foo}}, // duplicates 4 (same dest and alert, but newer)
 
-		{ID: "6", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 8, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "bar"}, SentAt: time.Unix(1, 0)}, // duplicates 7 but sent already
+		{ID: "6", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 8, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: bar}, SentAt: time.Unix(1, 0)}, // duplicates 7 but sent already
 
-		{ID: "7", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 9, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "bar"}},
-		{ID: "8", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 13, 0, 0, 0, time.UTC), AlertID: 2, Dest: notification.Dest{ID: "foo"}},
+		{ID: "7", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 9, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: bar}},
+		{ID: "8", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 13, 0, 0, 0, time.UTC), AlertID: 2, Dest: notification.Dest{ID: foo}},
 	}
 
 	res, err := dedupAlerts(messages, func(parentID string, duplicates []string) error {
@@ -36,10 +39,10 @@ func TestDedupAlerts(t *testing.T) {
 		[]Message{
 			{ID: "1", Type: notification.MessageTypeTest},
 			{ID: "2", Type: notification.MessageTypeAlertBundle},
-			{ID: "4", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 10, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "foo"}},
-			{ID: "7", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 9, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "bar"}},
-			{ID: "8", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 13, 0, 0, 0, time.UTC), AlertID: 2, Dest: notification.Dest{ID: "foo"}},
-			{ID: "6", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 8, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: "bar"}, SentAt: time.Unix(1, 0)},
+			{ID: "4", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 10, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: foo}},
+			{ID: "7", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 9, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: bar}},
+			{ID: "8", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 13, 0, 0, 0, time.UTC), AlertID: 2, Dest: notification.Dest{ID: foo}},
+			{ID: "6", Type: notification.MessageTypeAlert, CreatedAt: time.Date(2021, 7, 15, 8, 0, 0, 0, time.UTC), AlertID: 1, Dest: notification.Dest{ID: bar}, SentAt: time.Unix(1, 0)},
 		},
 		res)
 }

--- a/engine/message/dedupalerts_test.go
+++ b/engine/message/dedupalerts_test.go
@@ -10,9 +10,13 @@ import (
 	"github.com/target/goalert/notification"
 )
 
+func destIDFrom(s string) notification.DestID {
+	return notification.DestID{CMID: uuid.NullUUID{Valid: true, UUID: uuid.Must(uuid.FromBytes([]byte(s)))}}
+}
+
 func TestDedupAlerts(t *testing.T) {
-	foo := notification.UserContactMethodID(uuid.Must(uuid.FromBytes([]byte("foofoofoofoofoof"))))
-	bar := notification.UserContactMethodID(uuid.Must(uuid.FromBytes([]byte("barbarbarbarbarb"))))
+	foo := destIDFrom("foofoofoofoofoof")
+	bar := destIDFrom("barbarbarbarbarb")
 	messages := []Message{
 		{ID: "1", Type: notification.MessageTypeTest},
 		{ID: "2", Type: notification.MessageTypeAlertBundle},

--- a/engine/message/queue_test.go
+++ b/engine/message/queue_test.go
@@ -44,19 +44,19 @@ func TestQueue_Sort(t *testing.T) {
 			// as the user has been notified *somehow*. That way if we need
 			// to make a choice, a user who has gotten no message of any kind
 			// would take priority (all other criteria being equal).
-			Dest:   notification.Dest{Type: notification.DestTypeVoice, ID: "Voice C"},
+			Dest:   notification.Dest{Type: notification.DestTypeVoice, Value: "Voice C"},
 			SentAt: n.Add(-2 * time.Minute),
 		},
 		{
 			Type:   notification.MessageTypeTest,
 			UserID: "User H",
-			Dest:   notification.Dest{Type: notification.DestTypeSMS, ID: "SMS H"},
+			Dest:   notification.Dest{Type: notification.DestTypeSMS, Value: "SMS H"},
 			SentAt: n.Add(-30 * time.Second),
 		},
 		{
 			Type:      notification.MessageTypeAlert,
 			ServiceID: "Service B",
-			Dest:      notification.Dest{Type: notification.DestTypeSlackChannel, ID: "Slack B"},
+			Dest:      notification.Dest{Type: notification.DestTypeSlackChannel, Value: "Slack B"},
 			SentAt:    n.Add(-30 * time.Second),
 		},
 
@@ -66,43 +66,49 @@ func TestQueue_Sort(t *testing.T) {
 			Type:      notification.MessageTypeAlert,
 			UserID:    "User A",
 			ServiceID: "Service A",
-			Dest:      notification.Dest{Type: notification.DestTypeSMS, ID: "SMS A"},
+			Dest:      notification.Dest{Type: notification.DestTypeSMS, Value: "SMS A"},
 			CreatedAt: n,
-		}, {
+		},
+		{
 			ID:        "1",
 			Type:      notification.MessageTypeAlert,
 			UserID:    "User E",
 			ServiceID: "Service B",
-			Dest:      notification.Dest{Type: notification.DestTypeSMS, ID: "SMS E"},
+			Dest:      notification.Dest{Type: notification.DestTypeSMS, Value: "SMS E"},
 			CreatedAt: n.Add(1),
-		}, {
+		},
+		{
 			// no ID, this message should not be sent this cycle
 			Type:      notification.MessageTypeAlert,
 			UserID:    "User H",
 			ServiceID: "Service C",
-			Dest:      notification.Dest{Type: notification.DestTypeSMS, ID: "SMS H"},
+			Dest:      notification.Dest{Type: notification.DestTypeSMS, Value: "SMS H"},
 			CreatedAt: n.Add(2),
-		}, {
+		},
+		{
 			ID:     "2",
 			Type:   notification.MessageTypeVerification,
 			UserID: "User F",
-			Dest:   notification.Dest{Type: notification.DestTypeSMS, ID: "SMS F"},
-		}, {
+			Dest:   notification.Dest{Type: notification.DestTypeSMS, Value: "SMS F"},
+		},
+		{
 			// no ID, this message should not be sent this cycle
 			Type:   notification.MessageTypeVerification,
 			UserID: "User A",
-			Dest:   notification.Dest{Type: notification.DestTypeSMS, ID: "SMS A"},
-		}, {
+			Dest:   notification.Dest{Type: notification.DestTypeSMS, Value: "SMS A"},
+		},
+		{
 			ID:     "3",
 			Type:   notification.MessageTypeTest,
 			UserID: "User B",
-			Dest:   notification.Dest{Type: notification.DestTypeSMS, ID: "SMS B"},
-		}, {
+			Dest:   notification.Dest{Type: notification.DestTypeSMS, Value: "SMS B"},
+		},
+		{
 			ID:        "4",
 			Type:      notification.MessageTypeAlert,
 			UserID:    "User C",
 			ServiceID: "Service A",
-			Dest:      notification.Dest{Type: notification.DestTypeSMS, ID: "SMS C"},
+			Dest:      notification.Dest{Type: notification.DestTypeSMS, Value: "SMS C"},
 		},
 
 		// ThrottleConfig limits 5 messages to be sent in 15 min for DestTypeSMS
@@ -110,15 +116,17 @@ func TestQueue_Sort(t *testing.T) {
 			ID:        "5",
 			Type:      notification.MessageTypeAlertStatus,
 			UserID:    "User D",
-			Dest:      notification.Dest{Type: notification.DestTypeSMS, ID: "SMS D"},
+			Dest:      notification.Dest{Type: notification.DestTypeSMS, Value: "SMS D"},
 			CreatedAt: n,
-		}, {
+		},
+		{
 			ID:        "6",
 			Type:      notification.MessageTypeAlertStatus,
 			UserID:    "User G",
-			Dest:      notification.Dest{Type: notification.DestTypeSMS, ID: "SMS G"},
+			Dest:      notification.Dest{Type: notification.DestTypeSMS, Value: "SMS G"},
 			CreatedAt: n.Add(1),
-		}}
+		},
+	}
 
 	var expected []Message
 	for _, m := range messages {
@@ -149,5 +157,4 @@ func TestQueue_Sort(t *testing.T) {
 	// no more expected messages
 	msg := q.NextByType(notification.DestTypeSMS)
 	assert.Nil(t, msg)
-
 }

--- a/engine/message/throttle.go
+++ b/engine/message/throttle.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"crypto/sha256"
 	"time"
 
 	"github.com/target/goalert/notification"
@@ -9,17 +10,17 @@ import (
 // Throttle represents the throttled messages for a queue.
 type Throttle struct {
 	cfg      ThrottleConfig
-	ignoreID bool
+	typeOnly bool
 	now      time.Time
 
 	first    map[ThrottleItem]time.Time
 	count    map[ThrottleItem]int
-	cooldown map[notification.Dest]bool
+	cooldown map[notification.DestHash]bool
 }
 
 // ThrottleItem represents the messages being throttled.
 type ThrottleItem struct {
-	Dest      notification.Dest
+	DestHash  notification.DestHash
 	BucketDur time.Duration
 }
 
@@ -41,24 +42,29 @@ func maxThrottleDuration(cfgs ...ThrottleConfig) time.Duration {
 }
 
 // NewThrottle creates a new Throttle used to manage outgoing messages in a queue.
-func NewThrottle(cfg ThrottleConfig, now time.Time, ignoreID bool) *Throttle {
+func NewThrottle(cfg ThrottleConfig, now time.Time, byTypeOnly bool) *Throttle {
 	return &Throttle{
 		cfg:      cfg,
 		now:      now,
-		ignoreID: ignoreID,
+		typeOnly: byTypeOnly,
 
 		first:    make(map[ThrottleItem]time.Time),
 		count:    make(map[ThrottleItem]int),
-		cooldown: make(map[notification.Dest]bool),
+		cooldown: make(map[notification.DestHash]bool),
 	}
+}
+
+func (tr *Throttle) destKey(d notification.Dest) notification.DestHash {
+	if tr.typeOnly {
+		return sha256.Sum256([]byte(d.Type.String()))
+	}
+
+	return d.DestHash()
 }
 
 // Record keeps track of the outgoing messages being throttled in a queue.
 func (tr *Throttle) Record(msg Message) {
-	if tr.ignoreID {
-		msg.Dest.ID = ""
-	}
-	msg.Dest.Value = ""
+	keyHash := tr.destKey(msg.Dest)
 
 	since := tr.now.Sub(msg.SentAt)
 	rules := tr.cfg.Rules(msg)
@@ -66,7 +72,7 @@ func (tr *Throttle) Record(msg Message) {
 		if since >= rule.Per {
 			continue
 		}
-		key := ThrottleItem{Dest: msg.Dest, BucketDur: rule.Per}
+		key := ThrottleItem{DestHash: keyHash, BucketDur: rule.Per}
 		tr.count[key]++
 		count := tr.count[key]
 		if tr.first[key].IsZero() || msg.SentAt.Before(tr.first[key]) {
@@ -74,7 +80,7 @@ func (tr *Throttle) Record(msg Message) {
 		}
 
 		if count >= rule.Count {
-			tr.cooldown[msg.Dest] = true
+			tr.cooldown[keyHash] = true
 			continue
 		}
 
@@ -99,17 +105,12 @@ func (tr *Throttle) Record(msg Message) {
 		per := rule.Per - prevRule.Per
 
 		if count > int(elapsed*time.Duration(rule.Count-prevRule.Count)/per) {
-			tr.cooldown[msg.Dest] = true
+			tr.cooldown[keyHash] = true
 		}
 	}
 }
 
 // InCooldown returns true or false depending on the cooldown state of a throttled message.
 func (tr *Throttle) InCooldown(msg Message) bool {
-	if tr.ignoreID {
-		msg.Dest.ID = ""
-	}
-	msg.Dest.Value = ""
-
-	return tr.cooldown[msg.Dest]
+	return tr.cooldown[tr.destKey(msg.Dest)]
 }

--- a/engine/queries.sql
+++ b/engine/queries.sql
@@ -7,3 +7,19 @@ FROM
 WHERE
     message_id = $1;
 
+-- name: EngineIsKnownDest :one
+-- Check if a destination is known in user_contact_methods or notification_channels table.
+SELECT
+    EXISTS (
+        SELECT
+        FROM
+            user_contact_methods uc
+        WHERE
+            uc.dest = $1)
+    OR EXISTS (
+        SELECT
+        FROM
+            notification_channels nc
+        WHERE
+            nc.dest = $1);
+

--- a/engine/queries.sql
+++ b/engine/queries.sql
@@ -15,7 +15,8 @@ SELECT
         FROM
             user_contact_methods uc
         WHERE
-            uc.dest = $1)
+            uc.dest = $1
+            AND uc.disabled = FALSE)
     OR EXISTS (
         SELECT
         FROM

--- a/engine/sendmessage.go
+++ b/engine/sendmessage.go
@@ -19,16 +19,16 @@ import (
 func (p *Engine) sendMessage(ctx context.Context, msg *message.Message) (*notification.SendResult, error) {
 	ctx = log.WithField(ctx, "CallbackID", msg.ID)
 
-	if msg.Dest.Type.IsUserCM() {
+	if msg.Dest.ID.IsUserCM() {
 		ctx = permission.UserSourceContext(ctx, msg.UserID, permission.RoleUser, &permission.SourceInfo{
 			Type: permission.SourceTypeContactMethod,
-			ID:   msg.Dest.ID,
+			ID:   msg.Dest.ID.UUID().String(),
 		})
 	} else {
 		ctx = permission.SystemContext(ctx, "SendMessage")
 		ctx = permission.SourceContext(ctx, &permission.SourceInfo{
 			Type: permission.SourceTypeNotificationChannel,
-			ID:   msg.Dest.ID,
+			ID:   msg.Dest.ID.UUID().String(),
 		})
 	}
 
@@ -220,10 +220,10 @@ func (p *Engine) sendMessage(ctx context.Context, msg *message.Message) (*notifi
 		var chanID, cmID sql.NullString
 		if msg.Dest.Type.IsUserCM() {
 			cmID.Valid = true
-			cmID.String = msg.Dest.ID
+			cmID.String = msg.Dest.ID.String()
 		} else {
 			chanID.Valid = true
-			chanID.String = msg.Dest.ID
+			chanID.String = msg.Dest.ID.String()
 		}
 		_, err = p.b.trackStatus.ExecContext(ctx, chanID, cmID, msg.AlertID)
 		if err != nil {

--- a/engine/sendmessage.go
+++ b/engine/sendmessage.go
@@ -218,7 +218,7 @@ func (p *Engine) sendMessage(ctx context.Context, msg *message.Message) (*notifi
 
 	if isFirstAlertMessage && res.State.IsOK() {
 		var chanID, cmID sql.NullString
-		if msg.Dest.Type.IsUserCM() {
+		if msg.Dest.ID.IsUserCM() {
 			cmID.Valid = true
 			cmID.String = msg.Dest.ID.String()
 		} else {

--- a/gadb/queries.sql.go
+++ b/gadb/queries.sql.go
@@ -1276,6 +1276,30 @@ func (q *Queries) EngineGetSignalParams(ctx context.Context, messageID uuid.Null
 	return params, err
 }
 
+const engineIsKnownDest = `-- name: EngineIsKnownDest :one
+SELECT
+    EXISTS (
+        SELECT
+        FROM
+            user_contact_methods uc
+        WHERE
+            uc.dest = $1)
+    OR EXISTS (
+        SELECT
+        FROM
+            notification_channels nc
+        WHERE
+            nc.dest = $1)
+`
+
+// Check if a destination is known in user_contact_methods or notification_channels table.
+func (q *Queries) EngineIsKnownDest(ctx context.Context, dest NullDestV1) (sql.NullBool, error) {
+	row := q.db.QueryRowContext(ctx, engineIsKnownDest, dest)
+	var column_1 sql.NullBool
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const findManyCalSubByUser = `-- name: FindManyCalSubByUser :many
 SELECT
     id,

--- a/gadb/queries.sql.go
+++ b/gadb/queries.sql.go
@@ -1283,7 +1283,8 @@ SELECT
         FROM
             user_contact_methods uc
         WHERE
-            uc.dest = $1)
+            uc.dest = $1
+            AND uc.disabled = FALSE)
     OR EXISTS (
         SELECT
         FROM

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -30589,9 +30589,9 @@ func (ec *executionContext) _UserContactMethod_id(ctx context.Context, field gra
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(uuid.UUID)
 	fc.Result = res
-	return ec.marshalNID2string(ctx, field.Selections, res)
+	return ec.marshalNID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserContactMethod_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -31219,9 +31219,9 @@ func (ec *executionContext) _UserNotificationRule_contactMethodID(ctx context.Co
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(uuid.UUID)
 	fc.Result = res
-	return ec.marshalNID2string(ctx, field.Selections, res)
+	return ec.marshalNID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserNotificationRule_contactMethodID(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {

--- a/graphql2/graphqlapp/contactmethod.go
+++ b/graphql2/graphqlapp/contactmethod.go
@@ -93,7 +93,7 @@ func (a *ContactMethod) LastTestMessageState(ctx context.Context, obj *contactme
 		return nil, nil
 	}
 
-	status, _, err := a.NotificationStore.LastMessageStatus(ctx, notification.MessageTypeTest, obj.ID, t)
+	status, _, err := a.NotificationStore.LastMessageStatus(ctx, notification.MessageTypeTest, obj.ID.String(), t)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (a *ContactMethod) LastVerifyMessageState(ctx context.Context, obj *contact
 		return nil, nil
 	}
 
-	status, _, err := a.NotificationStore.LastMessageStatus(ctx, notification.MessageTypeVerification, obj.ID, t)
+	status, _, err := a.NotificationStore.LastMessageStatus(ctx, notification.MessageTypeVerification, obj.ID.String(), t)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,11 @@ func (a *ContactMethod) LastVerifyMessageState(ctx context.Context, obj *contact
 	return notificationStateFromSendResult(status.Status, a.FormatDestFunc(ctx, status.DestType, status.SrcValue)), nil
 }
 
-func (q *Query) UserContactMethod(ctx context.Context, id string) (*contactmethod.ContactMethod, error) {
+func (q *Query) UserContactMethod(ctx context.Context, idStr string) (*contactmethod.ContactMethod, error) {
+	id, err := validate.ParseUUID("ID", idStr)
+	if err != nil {
+		return nil, err
+	}
 	return (*App)(q).FindOneCM(ctx, id)
 }
 
@@ -178,7 +182,8 @@ func (m *Mutation) CreateUserContactMethod(ctx context.Context, input graphql2.C
 
 		if input.NewUserNotificationRule != nil {
 			input.NewUserNotificationRule.UserID = &input.UserID
-			input.NewUserNotificationRule.ContactMethodID = &cm.ID
+			str := cm.ID.String()
+			input.NewUserNotificationRule.ContactMethodID = &str
 
 			_, err = m.CreateUserNotificationRule(ctx, *input.NewUserNotificationRule)
 			if err != nil {
@@ -196,7 +201,11 @@ func (m *Mutation) CreateUserContactMethod(ctx context.Context, input graphql2.C
 
 func (m *Mutation) UpdateUserContactMethod(ctx context.Context, input graphql2.UpdateUserContactMethodInput) (bool, error) {
 	err := withContextTx(ctx, m.DB, func(ctx context.Context, tx *sql.Tx) error {
-		cm, err := m.CMStore.FindOne(ctx, tx, input.ID)
+		id, err := validate.ParseUUID("ID", input.ID)
+		if err != nil {
+			return err
+		}
+		cm, err := m.CMStore.FindOne(ctx, tx, id)
 		if errors.Is(err, sql.ErrNoRows) {
 			return validation.NewFieldError("id", "contact method not found")
 		}

--- a/graphql2/graphqlapp/dataloaders.go
+++ b/graphql2/graphqlapp/dataloaders.go
@@ -164,13 +164,13 @@ func (app *App) FindOneAlertMetric(ctx context.Context, id int) (*alertmetrics.M
 }
 
 // FindOneCM will return a single contact method for the given id, using the contexts dataloader if enabled.
-func (app *App) FindOneCM(ctx context.Context, id string) (*contactmethod.ContactMethod, error) {
+func (app *App) FindOneCM(ctx context.Context, id uuid.UUID) (*contactmethod.ContactMethod, error) {
 	loader, ok := ctx.Value(dataLoaderKeyCM).(*dataloader.Loader[string, contactmethod.ContactMethod])
 	if !ok {
 		return app.CMStore.FindOne(ctx, app.DB, id)
 	}
 
-	return loader.FetchOne(ctx, id)
+	return loader.FetchOne(ctx, id.String())
 }
 
 // FindOneNC will return a single notification channel for the given id, using the contexts dataloader if enabled.

--- a/graphql2/graphqlapp/dataloaders.go
+++ b/graphql2/graphqlapp/dataloaders.go
@@ -165,22 +165,22 @@ func (app *App) FindOneAlertMetric(ctx context.Context, id int) (*alertmetrics.M
 
 // FindOneCM will return a single contact method for the given id, using the contexts dataloader if enabled.
 func (app *App) FindOneCM(ctx context.Context, id uuid.UUID) (*contactmethod.ContactMethod, error) {
-	loader, ok := ctx.Value(dataLoaderKeyCM).(*dataloader.Loader[string, contactmethod.ContactMethod])
+	loader, ok := ctx.Value(dataLoaderKeyCM).(*dataloader.Loader[uuid.UUID, contactmethod.ContactMethod])
 	if !ok {
 		return app.CMStore.FindOne(ctx, app.DB, id)
 	}
 
-	return loader.FetchOne(ctx, id.String())
+	return loader.FetchOne(ctx, id)
 }
 
 // FindOneNC will return a single notification channel for the given id, using the contexts dataloader if enabled.
 func (app *App) FindOneNC(ctx context.Context, id uuid.UUID) (*notificationchannel.Channel, error) {
-	loader, ok := ctx.Value(dataLoaderKeyNC).(*dataloader.Loader[string, notificationchannel.Channel])
+	loader, ok := ctx.Value(dataLoaderKeyNC).(*dataloader.Loader[uuid.UUID, notificationchannel.Channel])
 	if !ok {
 		return app.NCStore.FindOne(ctx, id)
 	}
 
-	return loader.FetchOne(ctx, id.String())
+	return loader.FetchOne(ctx, id)
 }
 
 func (app *App) FindOnePolicy(ctx context.Context, id string) (*escalation.Policy, error) {

--- a/graphql2/graphqlapp/messagelog.go
+++ b/graphql2/graphqlapp/messagelog.go
@@ -16,16 +16,12 @@ import (
 
 type MessageLog App
 
-func (a *App) formatNC(ctx context.Context, id string) (string, error) {
-	if id == "" {
+func (a *App) formatNC(ctx context.Context, id uuid.UUID) (string, error) {
+	if id == uuid.Nil {
 		return "", nil
 	}
-	uid, err := uuid.Parse(id)
-	if err != nil {
-		return "", err
-	}
 
-	n, err := a.FindOneNC(ctx, uid)
+	n, err := a.FindOneNC(ctx, id)
 	if err != nil {
 		return "", err
 	}
@@ -41,8 +37,8 @@ func (a *App) formatNC(ctx context.Context, id string) (string, error) {
 }
 
 func (q *Query) formatDest(ctx context.Context, dst notification.Dest) (string, error) {
-	if !dst.Type.IsUserCM() {
-		return (*App)(q).formatNC(ctx, dst.ID)
+	if !dst.ID.IsUserCM() {
+		return (*App)(q).formatNC(ctx, dst.ID.UUID())
 	}
 
 	var str strings.Builder
@@ -196,7 +192,7 @@ func (q *Query) MessageLogs(ctx context.Context, opts *graphql2.MessageLogSearch
 		log := _log
 		var dest notification.Dest
 		switch {
-		case log.ContactMethodID != "":
+		case log.ContactMethodID != uuid.Nil:
 			cm, err := (*App)(q).FindOneCM(ctx, log.ContactMethodID)
 			if err != nil {
 				return nil, fmt.Errorf("lookup contact method %s: %w", log.ContactMethodID, err)
@@ -221,7 +217,7 @@ func (q *Query) MessageLogs(ctx context.Context, opts *graphql2.MessageLogSearch
 			RetryCount: log.RetryCount,
 			SentAt:     log.SentAt,
 		}
-		if dest.ID != "" {
+		if dest.ID.UUID() != uuid.Nil {
 			dm.Destination, err = q.formatDest(ctx, dest)
 			if err != nil {
 				return nil, fmt.Errorf("format dest: %w", err)

--- a/graphql2/graphqlapp/messagelog.go
+++ b/graphql2/graphqlapp/messagelog.go
@@ -217,7 +217,7 @@ func (q *Query) MessageLogs(ctx context.Context, opts *graphql2.MessageLogSearch
 			RetryCount: log.RetryCount,
 			SentAt:     log.SentAt,
 		}
-		if dest.ID.UUID() != uuid.Nil {
+		if dest.ID.String() != "" {
 			dm.Destination, err = q.formatDest(ctx, dest)
 			if err != nil {
 				return nil, fmt.Errorf("format dest: %w", err)

--- a/graphql2/graphqlapp/notificationrule.go
+++ b/graphql2/graphqlapp/notificationrule.go
@@ -3,6 +3,7 @@ package graphqlapp
 import (
 	context "context"
 	"database/sql"
+	"fmt"
 
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/user/contactmethod"
@@ -46,5 +47,6 @@ func (m *Mutation) CreateUserNotificationRule(ctx context.Context, input graphql
 }
 
 func (nr *UserNotificationRule) ContactMethod(ctx context.Context, raw *notificationrule.NotificationRule) (*contactmethod.ContactMethod, error) {
+	fmt.Println("raw.ContactMethodID", raw.ContactMethodID)
 	return (*App)(nr).FindOneCM(ctx, raw.ContactMethodID)
 }

--- a/graphql2/graphqlapp/notificationrule.go
+++ b/graphql2/graphqlapp/notificationrule.go
@@ -3,7 +3,6 @@ package graphqlapp
 import (
 	context "context"
 	"database/sql"
-	"fmt"
 
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/user/contactmethod"
@@ -47,6 +46,5 @@ func (m *Mutation) CreateUserNotificationRule(ctx context.Context, input graphql
 }
 
 func (nr *UserNotificationRule) ContactMethod(ctx context.Context, raw *notificationrule.NotificationRule) (*contactmethod.ContactMethod, error) {
-	fmt.Println("raw.ContactMethodID", raw.ContactMethodID)
 	return (*App)(nr).FindOneCM(ctx, raw.ContactMethodID)
 }

--- a/graphql2/graphqlapp/schedule.go
+++ b/graphql2/graphqlapp/schedule.go
@@ -87,7 +87,7 @@ func (a *OnCallNotificationRule) Target(ctx context.Context, raw *schedule.OnCal
 		}, nil
 	}
 
-	return &assignment.RawTarget{Type: assignment.TargetTypeNotificationChannel, ID: ch.ID, Name: ch.Name}, nil
+	return &assignment.RawTarget{Type: assignment.TargetTypeNotificationChannel, ID: ch.ID.String(), Name: ch.Name}, nil
 }
 
 func (a *TemporarySchedule) Shifts(ctx context.Context, temp *schedule.TemporarySchedule) ([]oncall.Shift, error) {

--- a/notification/destcompat.go
+++ b/notification/destcompat.go
@@ -1,0 +1,53 @@
+package notification
+
+import (
+	"strings"
+
+	"github.com/target/goalert/gadb"
+)
+
+func (d Dest) ToDestV1() gadb.DestV1 {
+	switch d.Type {
+	case DestTypeVoice:
+		return gadb.DestV1{
+			Type: "builtin-twilio-voice",
+			Args: map[string]string{"phone_number": d.Value},
+		}
+	case DestTypeSMS:
+		return gadb.DestV1{
+			Type: "builtin-twilio-sms",
+			Args: map[string]string{"phone_number": d.Value},
+		}
+	case DestTypeSlackChannel:
+		return gadb.DestV1{
+			Type: "builtin-slack-channel",
+			Args: map[string]string{"slack_channel_id": d.Value},
+		}
+	case DestTypeSlackDM:
+		return gadb.DestV1{
+			Type: "builtin-slack-dm",
+			Args: map[string]string{"slack_user_id": d.Value},
+		}
+	case DestTypeUserEmail:
+		return gadb.DestV1{
+			Type: "builtin-smtp-email",
+			Args: map[string]string{"email_address": d.Value},
+		}
+	case DestTypeUserWebhook, DestTypeChanWebhook:
+		return gadb.DestV1{
+			Type: "builtin-webhook",
+			Args: map[string]string{"webhook_url": d.Value},
+		}
+	case DestTypeSlackUG:
+		ugID, chanID, _ := strings.Cut(d.Value, ":")
+		return gadb.DestV1{
+			Type: "builtin-slack-usergroup",
+			Args: map[string]string{
+				"slack_usergroup_id": ugID,
+				"slack_channel_id":   chanID,
+			},
+		}
+	}
+
+	panic("unsupported destination type " + d.Type.String())
+}

--- a/notification/destcompat.go
+++ b/notification/destcompat.go
@@ -6,7 +6,12 @@ import (
 	"github.com/target/goalert/gadb"
 )
 
+// ToDestV1 converts a Dest to a DestV1.
 func (d Dest) ToDestV1() gadb.DestV1 {
+	// The values here are copied from the graphql package until we have a centralized location for these values.
+	//
+	// This method is also subject to deletion once Type/Value are no longer in use.
+
 	switch d.Type {
 	case DestTypeVoice:
 		return gadb.DestV1{

--- a/notification/desttype.go
+++ b/notification/desttype.go
@@ -1,6 +1,7 @@
 package notification
 
 import (
+	"crypto/sha256"
 	"database/sql"
 	"fmt"
 
@@ -35,6 +36,14 @@ type Dest struct {
 	Type  DestType
 	Value string
 }
+
+type DestHash [32]byte
+
+// DestHash returns a comparable hash of the destination.
+func (d Dest) DestHash() DestHash {
+	return DestHash(sha256.Sum256([]byte(fmt.Sprintf("%s\n%s\n", d.Type.String(), d.Value))))
+}
+
 type SQLDest struct {
 	CMID    uuid.NullUUID
 	CMType  gadb.NullEnumUserContactMethodType
@@ -98,9 +107,6 @@ const (
 )
 
 func (d Dest) String() string { return fmt.Sprintf("%s(%s)", d.Type.String(), d.ID) }
-
-// IsUserCM returns true if the DestType represents a user contact method.
-func (t DestType) IsUserCM() bool { return t.CMType() != contactmethod.TypeUnknown }
 
 // ScannableDestType allows scanning a DestType from separate columns for user contact methods and notification channels.
 type ScannableDestType struct {

--- a/notification/search.go
+++ b/notification/search.go
@@ -31,7 +31,7 @@ type MessageLog struct {
 	UserID   string
 	UserName string
 
-	ContactMethodID string
+	ContactMethodID uuid.UUID
 
 	ChannelID uuid.UUID
 
@@ -287,7 +287,7 @@ func (s *Store) Search(ctx context.Context, opts *SearchOptions) ([]MessageLog, 
 		var serviceID, svcName sql.NullString
 		var srcValue sql.NullString
 		var userID, userName sql.NullString
-		var cmID sql.NullString
+		var cmID uuid.NullUUID
 		var providerID sql.NullString
 		var lastStatusAt, sentAt sql.NullTime
 		err = rows.Scan(
@@ -328,7 +328,7 @@ func (s *Store) Search(ctx context.Context, opts *SearchOptions) ([]MessageLog, 
 		l.SrcValue = srcValue.String
 		l.UserID = userID.String
 		l.UserName = userName.String
-		l.ContactMethodID = cmID.String
+		l.ContactMethodID = cmID.UUID
 		l.LastStatusAt = lastStatusAt.Time
 		if sentAt.Valid {
 			l.SentAt = &sentAt.Time

--- a/notification/store.go
+++ b/notification/store.go
@@ -183,16 +183,11 @@ func (s *Store) OriginalMessageStatus(ctx context.Context, alertID int, dst Dest
 		return nil, err
 	}
 
-	err = validate.UUID("Dest.ID", dst.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	var cmID, chanID sql.NullString
-	if dst.Type.IsUserCM() {
-		cmID.String, cmID.Valid = dst.ID, true
+	var cmID, chanID uuid.NullUUID
+	if dst.ID.IsUserCM() {
+		cmID.UUID, cmID.Valid = dst.ID.UUID(), true
 	} else {
-		chanID.String, chanID.Valid = dst.ID, true
+		chanID.UUID, chanID.Valid = dst.ID.UUID(), true
 	}
 
 	row := s.origAlertMessage.QueryRowContext(ctx, alertID, cmID, chanID)

--- a/notification/twilio/client_test.go
+++ b/notification/twilio/client_test.go
@@ -14,7 +14,6 @@ func TestSetMsgParams(t *testing.T) {
 		err := result.setMsgParams(
 			notification.Test{
 				Dest: notification.Dest{
-					ID:    "1",
 					Type:  notification.DestTypeVoice,
 					Value: "+16125551234",
 				},
@@ -35,7 +34,6 @@ func TestSetMsgParams(t *testing.T) {
 		err := result.setMsgParams(
 			notification.AlertBundle{
 				Dest: notification.Dest{
-					ID:    "1",
 					Type:  notification.DestTypeVoice,
 					Value: "+16125551234",
 				},
@@ -62,7 +60,6 @@ func TestSetMsgParams(t *testing.T) {
 		err := result.setMsgParams(
 			notification.Alert{
 				Dest: notification.Dest{
-					ID:    "1",
 					Type:  notification.DestTypeVoice,
 					Value: "+16125551234",
 				},
@@ -86,7 +83,6 @@ func TestSetMsgParams(t *testing.T) {
 		err := result.setMsgParams(
 			notification.AlertStatus{
 				Dest: notification.Dest{
-					ID:    "1",
 					Type:  notification.DestTypeVoice,
 					Value: "+16125551234",
 				},
@@ -111,7 +107,6 @@ func TestSetMsgParams(t *testing.T) {
 		err := result.setMsgParams(
 			notification.Verification{
 				Dest: notification.Dest{
-					ID:    "1",
 					Type:  notification.DestTypeVoice,
 					Value: "+16125551234",
 				},
@@ -133,7 +128,6 @@ func TestSetMsgParams(t *testing.T) {
 		err := result.setMsgParams(
 			notification.ScheduleOnCallUsers{
 				Dest: notification.Dest{
-					ID:    "1",
 					Type:  notification.DestTypeVoice,
 					Value: "+16125551234",
 				},

--- a/notification/twilio/voice_test.go
+++ b/notification/twilio/voice_test.go
@@ -111,7 +111,6 @@ func BenchmarkBuildMessage(b *testing.B) {
 			fmt.Sprintf("%d", i),
 			notification.Test{
 				Dest: notification.Dest{
-					ID:    "1",
 					Type:  notification.DestTypeVoice,
 					Value: fmt.Sprintf("+1612555123%d", i),
 				},

--- a/notificationchannel/channel.go
+++ b/notificationchannel/channel.go
@@ -9,26 +9,25 @@ import (
 )
 
 type Channel struct {
-	ID    string
+	ID    uuid.UUID
 	Name  string
 	Type  Type
 	Value string
 }
 
 func (c *Channel) fromRow(row gadb.NotificationChannel) {
-	c.ID = row.ID.String()
+	c.ID = row.ID
 	c.Name = row.Name
 	c.Type = Type(row.Type)
 	c.Value = row.Value
 }
 
 func (c Channel) Normalize() (*Channel, error) {
-	if c.ID == "" {
-		c.ID = uuid.New().String()
+	if c.ID == uuid.Nil {
+		c.ID = uuid.New()
 	}
 
 	err := validate.Many(
-		validate.UUID("ID", c.ID),
 		validate.Text("Name", c.Name, 1, 255),
 		validate.OneOf("Type", c.Type, TypeSlackChan, TypeWebhook, TypeSlackUG),
 	)

--- a/test/smoke/harness/harness.go
+++ b/test/smoke/harness/harness.go
@@ -495,7 +495,7 @@ func (h *Harness) AddNotificationRule(userID, cmID string, delayMinutes int) {
 	nr := &notificationrule.NotificationRule{
 		DelayMinutes:    delayMinutes,
 		UserID:          userID,
-		ContactMethodID: cmID,
+		ContactMethodID: uuid.MustParse(cmID),
 	}
 	h.t.Logf("insert notification rule: %v", nr)
 	permission.SudoContext(context.Background(), func(ctx context.Context) {

--- a/user/contactmethod/contactmethod.go
+++ b/user/contactmethod/contactmethod.go
@@ -10,7 +10,7 @@ import (
 
 // ContactMethod stores the information for contacting a user.
 type ContactMethod struct {
-	ID       string
+	ID       uuid.UUID
 	Name     string
 	Type     Type
 	Value    string
@@ -29,11 +29,10 @@ func (c ContactMethod) LastTestVerifyAt() time.Time { return c.lastTestVerifyAt.
 // Normalize will validate and 'normalize' the ContactMethod -- such as making email lower-case
 // and setting carrier to "" (for non-phone types).
 func (c ContactMethod) Normalize() (*ContactMethod, error) {
-	if c.ID == "" {
-		c.ID = uuid.New().String()
+	if c.ID == uuid.Nil {
+		c.ID = uuid.New()
 	}
 	err := validate.Many(
-		validate.UUID("ID", c.ID),
 		validate.IDName("Name", c.Name),
 		validate.OneOf("Type", c.Type, TypeSMS, TypeVoice, TypeEmail, TypePush, TypeWebhook, TypeSlackDM),
 	)

--- a/user/notificationrule/notificationrule.go
+++ b/user/notificationrule/notificationrule.go
@@ -1,14 +1,15 @@
 package notificationrule
 
 import (
+	"github.com/google/uuid"
 	"github.com/target/goalert/validation/validate"
 )
 
 type NotificationRule struct {
-	ID              string `json:"id"`
-	UserID          string `json:"-"`
-	DelayMinutes    int    `json:"delay"`
-	ContactMethodID string `json:"contact_method_id"`
+	ID              string    `json:"id"`
+	UserID          string    `json:"-"`
+	DelayMinutes    int       `json:"delay"`
+	ContactMethodID uuid.UUID `json:"contact_method_id"`
 }
 
 func validateDelay(d int) error {
@@ -21,7 +22,6 @@ func (n NotificationRule) Normalize(update bool) (*NotificationRule, error) {
 	if !update {
 		err = validate.Many(
 			err,
-			validate.UUID("ContactMethodID", n.ContactMethodID),
 			validate.UUID("UserID", n.UserID),
 		)
 	}

--- a/user/notificationrule/notificationrule_test.go
+++ b/user/notificationrule/notificationrule_test.go
@@ -2,6 +2,8 @@ package notificationrule
 
 import (
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 func TestNotificationRule_Normalize(t *testing.T) {
@@ -22,7 +24,7 @@ func TestNotificationRule_Normalize(t *testing.T) {
 	}
 
 	valid := []NotificationRule{
-		{DelayMinutes: 5, ContactMethodID: "ececacc0-4764-012d-7bfb-002500d5dece", UserID: "bcefacc0-4764-012d-7bfb-002500d5decb"},
+		{DelayMinutes: 5, ContactMethodID: uuid.MustParse("ececacc0-4764-012d-7bfb-002500d5dece"), UserID: "bcefacc0-4764-012d-7bfb-002500d5decb"},
 	}
 	invalid := []NotificationRule{
 		{},


### PR DESCRIPTION
**Description:**
Prep work for moving to the new Destination structured format (away from Type/Value)

- Switches to using a hash for comparing destinations in the throttle
- Use the ID to determine if a Dest came from a contact method vs. notification channel (instead of relying on type which may overlap in the future)
- Updates notification channel and contact method structs to use uuid.UUID
