### PR TITLE
nfydest: move slack usergroup support to registry

### DIFF
--- a/app/startup.go
+++ b/app/startup.go
@@ -88,6 +88,7 @@ func (app *App) startup(ctx context.Context) error {
 
 	app.DestRegistry.RegisterProvider(ctx, app.slackChan)
 	app.DestRegistry.RegisterProvider(ctx, app.slackChan.DMSender())
+	app.DestRegistry.RegisterProvider(ctx, app.slackChan.UserGroupSender())
 
 	err := app.mgr.SetPauseResumer(lifecycle.MultiPauseResume(
 		app.Engine,

--- a/graphql2/graphqlapp/compat.go
+++ b/graphql2/graphqlapp/compat.go
@@ -66,10 +66,10 @@ func (a *App) CompatNCToDest(ctx context.Context, ncID uuid.UUID) (*gadb.DestV1,
 		}
 
 		return &gadb.DestV1{
-			Type: destSlackUG,
+			Type: slack.DestTypeSlackUsergroup,
 			Args: map[string]string{
-				fieldSlackUGID:            ugID,
-				slack.FieldSlackChannelID: chanID,
+				slack.FieldSlackUsergroupID: ugID,
+				slack.FieldSlackChannelID:   chanID,
 			},
 		}, nil
 	case notificationchannel.TypeWebhook:
@@ -124,10 +124,10 @@ func CompatDestToTarget(d gadb.DestV1) (assignment.RawTarget, error) {
 			Type: assignment.TargetTypeSlackChannel,
 			ID:   d.Arg(slack.FieldSlackChannelID),
 		}, nil
-	case destSlackUG:
+	case slack.DestTypeSlackUsergroup:
 		return assignment.RawTarget{
 			Type: assignment.TargetTypeSlackUserGroup,
-			ID:   d.Arg(fieldSlackUGID) + ":" + d.Arg(slack.FieldSlackChannelID),
+			ID:   d.Arg(slack.FieldSlackUsergroupID) + ":" + d.Arg(slack.FieldSlackChannelID),
 		}, nil
 	case destWebhook:
 		return assignment.RawTarget{

--- a/graphql2/graphqlapp/destinationdisplayinfo.go
+++ b/graphql2/graphqlapp/destinationdisplayinfo.go
@@ -151,26 +151,6 @@ func (a *Query) _DestinationDisplayInfo(ctx context.Context, dest gadb.DestV1, s
 			IconAltText: "Webhook",
 			Text:        u.Hostname(),
 		}, nil
-
-	case destSlackUG:
-		ug, err := app.SlackStore.UserGroup(ctx, dest.Arg(fieldSlackUGID))
-		if err != nil {
-			return nil, err
-		}
-
-		team, err := app.SlackStore.Team(ctx, ug.TeamID)
-		if err != nil {
-			return nil, err
-		}
-
-		if team.IconURL == "" {
-			team.IconURL = "builtin://slack"
-		}
-		return &nfydest.DisplayInfo{
-			IconURL:     team.IconURL,
-			IconAltText: team.Name,
-			Text:        ug.Handle,
-		}, nil
 	}
 
 	return app.DestReg.DisplayInfo(ctx, dest)

--- a/graphql2/graphqlapp/destinationvalidation.go
+++ b/graphql2/graphqlapp/destinationvalidation.go
@@ -13,7 +13,6 @@ import (
 	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/notification/nfydest"
-	"github.com/target/goalert/notification/slack"
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/validation"
 	"github.com/target/goalert/validation/validate"
@@ -153,20 +152,6 @@ func (a *App) ValidateDestination(ctx context.Context, fieldName string, dest *g
 		if err != nil {
 			return addDestFieldError(ctx, fieldName, fieldPhoneNumber, err)
 		}
-		return nil
-	case destSlackUG:
-		ugID := dest.Arg(fieldSlackUGID)
-		userErr := a.SlackStore.ValidateUserGroup(ctx, ugID)
-		if userErr != nil {
-			return addDestFieldError(ctx, fieldName, fieldSlackUGID, userErr)
-		}
-
-		chanID := dest.Arg(slack.FieldSlackChannelID)
-		chanErr := a.SlackStore.ValidateChannel(ctx, chanID)
-		if chanErr != nil {
-			return addDestFieldError(ctx, fieldName, slack.FieldSlackChannelID, chanErr)
-		}
-
 		return nil
 	case destSMTP:
 		email := dest.Arg(fieldEmailAddress)

--- a/notification/slack/nfydestug.go
+++ b/notification/slack/nfydestug.go
@@ -1,0 +1,111 @@
+package slack
+
+import (
+	"context"
+
+	"github.com/target/goalert/config"
+	"github.com/target/goalert/notification/nfydest"
+	"github.com/target/goalert/validation"
+)
+
+var (
+	_ nfydest.Provider      = (*UserGroupSender)(nil)
+	_ nfydest.FieldSearcher = (*UserGroupSender)(nil)
+)
+
+func (ug *UserGroupSender) ID() string { return DestTypeSlackUsergroup }
+func (ug *UserGroupSender) TypeInfo(ctx context.Context) (*nfydest.TypeInfo, error) {
+	cfg := config.FromContext(ctx)
+	return &nfydest.TypeInfo{
+		Type:                 DestTypeSlackUsergroup,
+		Name:                 "Update Slack User Group",
+		Enabled:              cfg.Slack.Enable,
+		SupportsOnCallNotify: true,
+		RequiredFields: []nfydest.FieldConfig{{
+			FieldID:        FieldSlackUsergroupID,
+			Label:          "User Group",
+			InputType:      "text",
+			SupportsSearch: true,
+			Hint:           "The selected group's membership will be replaced/set to the schedule's on-call user(s).",
+		}, {
+			FieldID:        FieldSlackChannelID,
+			Label:          "Slack Channel (for errors)",
+			InputType:      "text",
+			SupportsSearch: true,
+			Hint:           "If the user group update fails, an error will be posted to this channel.",
+		}},
+	}, nil
+}
+
+func (ug *UserGroupSender) ValidateField(ctx context.Context, fieldID, value string) error {
+	switch fieldID {
+	case FieldSlackUsergroupID:
+		return ug.ValidateUserGroup(ctx, value)
+	case FieldSlackChannelID:
+		return ug.ValidateChannel(ctx, value)
+	}
+
+	return validation.NewGenericError("unknown field ID")
+}
+
+func (ug *UserGroupSender) DisplayInfo(ctx context.Context, args map[string]string) (*nfydest.DisplayInfo, error) {
+	if args == nil {
+		args = make(map[string]string)
+	}
+
+	u, err := ug.UserGroup(ctx, args[FieldSlackUsergroupID])
+	if err != nil {
+		return nil, err
+	}
+
+	team, err := ug.Team(ctx, u.TeamID)
+	if err != nil {
+		return nil, err
+	}
+
+	if team.IconURL == "" {
+		team.IconURL = "builtin://slack"
+	}
+
+	return &nfydest.DisplayInfo{
+		IconURL:     team.IconURL,
+		IconAltText: team.Name,
+		Text:        u.Handle,
+	}, nil
+}
+
+func (ug *UserGroupSender) SearchField(ctx context.Context, fieldID string, options nfydest.SearchOptions) (*nfydest.SearchResult, error) {
+	switch fieldID {
+	case FieldSlackChannelID:
+		return ug.ChannelSender.SearchField(ctx, fieldID, options)
+	case FieldSlackUsergroupID:
+		groups, err := ug.ListUserGroups(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return nfydest.SearchByList(groups, options, func(ch UserGroup) nfydest.FieldValue {
+			return nfydest.FieldValue{
+				Label: ch.Handle,
+				Value: ch.ID,
+			}
+		})
+	}
+
+	return nil, validation.NewGenericError("unsupported field ID")
+}
+
+func (ug *UserGroupSender) FieldLabel(ctx context.Context, fieldID, value string) (string, error) {
+	switch fieldID {
+	case FieldSlackChannelID:
+		return ug.ChannelSender.FieldLabel(ctx, fieldID, value)
+	case FieldSlackUsergroupID:
+		grp, err := ug.UserGroup(ctx, value)
+		if err != nil {
+			return "", err
+		}
+
+		return grp.Handle, nil
+	}
+
+	return "", validation.NewGenericError("unsupported field ID")
+}


### PR DESCRIPTION
**Description:**
Moves "Update Slack Usergroup" destination to use the `nfydest.Registry` instead of hard-coded in the graphql2 package.
