### PR TITLE
nfydest: move webhook to `nfydest.Registry`

### DIFF
--- a/app/startup.go
+++ b/app/startup.go
@@ -89,6 +89,7 @@ func (app *App) startup(ctx context.Context) error {
 	app.DestRegistry.RegisterProvider(ctx, app.slackChan)
 	app.DestRegistry.RegisterProvider(ctx, app.slackChan.DMSender())
 	app.DestRegistry.RegisterProvider(ctx, app.slackChan.UserGroupSender())
+	app.DestRegistry.RegisterProvider(ctx, webhook.NewSender(ctx))
 
 	err := app.mgr.SetPauseResumer(lifecycle.MultiPauseResume(
 		app.Engine,

--- a/graphql2/graphqlapp/compat.go
+++ b/graphql2/graphqlapp/compat.go
@@ -9,6 +9,7 @@ import (
 	"github.com/target/goalert/assignment"
 	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/notification/slack"
+	"github.com/target/goalert/notification/webhook"
 	"github.com/target/goalert/notificationchannel"
 	"github.com/target/goalert/user/contactmethod"
 )
@@ -33,8 +34,8 @@ func CompatTargetToDest(tgt assignment.Target) (gadb.DestV1, error) {
 		}, nil
 	case assignment.TargetTypeChanWebhook:
 		return gadb.DestV1{
-			Type: destWebhook,
-			Args: map[string]string{fieldWebhookURL: tgt.TargetID()},
+			Type: webhook.DestTypeWebhook,
+			Args: map[string]string{webhook.FieldWebhookURL: tgt.TargetID()},
 		}, nil
 	case assignment.TargetTypeSlackChannel:
 		return gadb.DestV1{
@@ -74,8 +75,8 @@ func (a *App) CompatNCToDest(ctx context.Context, ncID uuid.UUID) (*gadb.DestV1,
 		}, nil
 	case notificationchannel.TypeWebhook:
 		return &gadb.DestV1{
-			Type: destWebhook,
-			Args: map[string]string{fieldWebhookURL: nc.Value},
+			Type: webhook.DestTypeWebhook,
+			Args: map[string]string{webhook.FieldWebhookURL: nc.Value},
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported notification channel type: %s", nc.Type)
@@ -92,8 +93,8 @@ func CompatDestToCMTypeVal(d gadb.DestV1) (contactmethod.Type, string) {
 		return contactmethod.TypeVoice, d.Arg(fieldPhoneNumber)
 	case destSMTP:
 		return contactmethod.TypeEmail, d.Arg(fieldEmailAddress)
-	case destWebhook:
-		return contactmethod.TypeWebhook, d.Arg(fieldWebhookURL)
+	case webhook.DestTypeWebhook:
+		return contactmethod.TypeWebhook, d.Arg(webhook.FieldWebhookURL)
 	case slack.DestTypeSlackDirectMessage:
 		return contactmethod.TypeSlackDM, d.Arg(slack.FieldSlackUserID)
 	}
@@ -129,10 +130,10 @@ func CompatDestToTarget(d gadb.DestV1) (assignment.RawTarget, error) {
 			Type: assignment.TargetTypeSlackUserGroup,
 			ID:   d.Arg(fieldSlackUGID) + ":" + d.Arg(slack.FieldSlackChannelID),
 		}, nil
-	case destWebhook:
+	case webhook.DestTypeWebhook:
 		return assignment.RawTarget{
 			Type: assignment.TargetTypeChanWebhook,
-			ID:   d.Arg(fieldWebhookURL),
+			ID:   d.Arg(webhook.FieldWebhookURL),
 		}, nil
 	}
 

--- a/graphql2/graphqlapp/contactmethod.go
+++ b/graphql2/graphqlapp/contactmethod.go
@@ -43,8 +43,8 @@ func (a *ContactMethod) Dest(ctx context.Context, obj *contactmethod.ContactMeth
 		}, nil
 	case contactmethod.TypeWebhook:
 		return &gadb.DestV1{
-			Type: destWebhook,
-			Args: map[string]string{fieldWebhookURL: obj.Value},
+			Type: webhook.DestTypeWebhook,
+			Args: map[string]string{webhook.FieldWebhookURL: obj.Value},
 		}, nil
 	case contactmethod.TypeSlackDM:
 		return &gadb.DestV1{

--- a/graphql2/graphqlapp/destinationdisplayinfo.go
+++ b/graphql2/graphqlapp/destinationdisplayinfo.go
@@ -3,7 +3,6 @@ package graphqlapp
 import (
 	"context"
 	"net/mail"
-	"net/url"
 
 	"github.com/nyaruka/phonenumbers"
 	"github.com/target/goalert/config"
@@ -140,18 +139,6 @@ func (a *Query) _DestinationDisplayInfo(ctx context.Context, dest gadb.DestV1, s
 			LinkURL:     cfg.CallbackURL("/users/" + u.ID),
 			Text:        u.Name,
 		}, nil
-
-	case destWebhook:
-		u, err := url.Parse(dest.Arg(fieldWebhookURL))
-		if err != nil {
-			return nil, validation.WrapError(err)
-		}
-		return &nfydest.DisplayInfo{
-			IconURL:     "builtin://webhook",
-			IconAltText: "Webhook",
-			Text:        u.Hostname(),
-		}, nil
-
 	case destSlackUG:
 		ug, err := app.SlackStore.UserGroup(ctx, dest.Arg(fieldSlackUGID))
 		if err != nil {

--- a/graphql2/graphqlapp/destinationtypes.go
+++ b/graphql2/graphqlapp/destinationtypes.go
@@ -18,7 +18,6 @@ const (
 	destTwilioSMS   = "builtin-twilio-sms"
 	destTwilioVoice = "builtin-twilio-voice"
 	destSMTP        = "builtin-smtp-email"
-	destWebhook     = "builtin-webhook"
 	destSlackUG     = "builtin-slack-usergroup"
 	destUser        = "builtin-user"
 	destRotation    = "builtin-rotation"
@@ -27,7 +26,6 @@ const (
 
 	fieldPhoneNumber  = "phone_number"
 	fieldEmailAddress = "email_address"
-	fieldWebhookURL   = "webhook_url"
 	fieldSlackUGID    = "slack_usergroup_id"
 	fieldUserID       = "user_id"
 	fieldRotationID   = "rotation_id"
@@ -249,13 +247,6 @@ func (q *Query) DestinationFieldValidate(ctx context.Context, input graphql2.Des
 		}
 
 		return validate.Email("Email", input.Value) == nil, nil
-	case destWebhook:
-		if input.FieldID != fieldWebhookURL {
-			return false, validation.NewGenericError("unsupported field")
-		}
-
-		err := validate.AbsoluteURL("URL", input.Value)
-		return err == nil, nil
 	}
 
 	err := q.DestReg.ValidateField(ctx, input.DestType, input.FieldID, input.Value)
@@ -353,39 +344,6 @@ func (q *Query) DestinationTypes(ctx context.Context, isDynamicAction *bool) ([]
 				Label:   "Body",
 				Hint:    "Body of the email message.",
 			}},
-		},
-		{
-			Type:                       destWebhook,
-			Name:                       "Webhook",
-			Enabled:                    cfg.Webhook.Enable,
-			SupportsUserVerification:   true,
-			SupportsOnCallNotify:       true,
-			SupportsSignals:            true,
-			SupportsStatusUpdates:      true,
-			SupportsAlertNotifications: true,
-			StatusUpdatesRequired:      true,
-			RequiredFields: []nfydest.FieldConfig{{
-				FieldID:            fieldWebhookURL,
-				Label:              "Webhook URL",
-				PlaceholderText:    "https://example.com",
-				InputType:          "url",
-				Hint:               "Webhook Documentation",
-				HintURL:            "/docs#webhooks",
-				SupportsValidation: true,
-			}},
-			DynamicParams: []nfydest.DynamicParamConfig{
-				{
-					ParamID: "body",
-					Label:   "Body",
-					Hint:    "The body of the request.",
-				},
-				{
-					ParamID:      "content-type",
-					Label:        "Content Type",
-					Hint:         "The content type (e.g., application/json).",
-					DefaultValue: `"application/json"`, // Because this is an expression, it needs the double quotes.
-				},
-			},
 		},
 		{
 			Type:                 destSlackUG,

--- a/graphql2/graphqlapp/destinationvalidation.go
+++ b/graphql2/graphqlapp/destinationvalidation.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/99designs/gqlgen/graphql"
-	"github.com/target/goalert/config"
 	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/notification/nfydest"
@@ -136,7 +135,6 @@ func addInputError(ctx context.Context, err error) {
 //
 // In the future this will be a call to the plugin system.
 func (a *App) ValidateDestination(ctx context.Context, fieldName string, dest *gadb.DestV1) (err error) {
-	cfg := config.FromContext(ctx)
 	switch dest.Type {
 	case destAlert:
 		return nil
@@ -173,16 +171,6 @@ func (a *App) ValidateDestination(ctx context.Context, fieldName string, dest *g
 		err := validate.Email(fieldEmailAddress, email)
 		if err != nil {
 			return addDestFieldError(ctx, fieldName, fieldEmailAddress, err)
-		}
-		return nil
-	case destWebhook:
-		url := dest.Arg(fieldWebhookURL)
-		err := validate.AbsoluteURL(fieldWebhookURL, url)
-		if err != nil {
-			return addDestFieldError(ctx, fieldName, fieldWebhookURL, err)
-		}
-		if !cfg.ValidWebhookURL(url) {
-			return addDestFieldError(ctx, fieldName, fieldWebhookURL, validation.NewGenericError("url is not allowed by administator"))
 		}
 		return nil
 	case destSchedule: // must be valid UUID and exist

--- a/notification/webhook/nfydest.go
+++ b/notification/webhook/nfydest.go
@@ -1,0 +1,94 @@
+package webhook
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/target/goalert/config"
+	"github.com/target/goalert/notification/nfydest"
+	"github.com/target/goalert/validation"
+	"github.com/target/goalert/validation/validate"
+)
+
+const (
+	DestTypeWebhook  = "builtin-webhook"
+	FieldWebhookURL  = "webhook_url"
+	ParamBody        = "body"
+	ParamContentType = "content_type"
+	FallbackIconURL  = "builtin://webhook"
+)
+
+var _ (nfydest.Provider) = (*Sender)(nil)
+
+func (Sender) ID() string { return DestTypeWebhook }
+
+func (Sender) TypeInfo(ctx context.Context) (*nfydest.TypeInfo, error) {
+	cfg := config.FromContext(ctx)
+	return &nfydest.TypeInfo{
+		Type:                       DestTypeWebhook,
+		Name:                       "Webhook",
+		Enabled:                    cfg.Webhook.Enable,
+		SupportsUserVerification:   true,
+		SupportsOnCallNotify:       true,
+		SupportsSignals:            true,
+		SupportsStatusUpdates:      true,
+		SupportsAlertNotifications: true,
+		StatusUpdatesRequired:      true,
+		RequiredFields: []nfydest.FieldConfig{{
+			FieldID:            FieldWebhookURL,
+			Label:              "Webhook URL",
+			PlaceholderText:    "https://example.com",
+			InputType:          "url",
+			Hint:               "Webhook Documentation",
+			HintURL:            "/docs#webhooks",
+			SupportsValidation: true,
+		}},
+		DynamicParams: []nfydest.DynamicParamConfig{
+			{
+				ParamID: ParamBody,
+				Label:   "Body",
+				Hint:    "The body of the request.",
+			},
+			{
+				ParamID:      ParamContentType,
+				Label:        "Content Type",
+				Hint:         "The content type (e.g., application/json).",
+				DefaultValue: `"application/json"`, // Because this is an expression, it needs the double quotes.
+			},
+		},
+	}, nil
+}
+
+func (s *Sender) ValidateField(ctx context.Context, fieldID, value string) error {
+	cfg := config.FromContext(ctx)
+	switch fieldID {
+	case FieldWebhookURL:
+		err := validate.AbsoluteURL(FieldWebhookURL, value)
+		if err != nil {
+			return err
+		}
+		if !cfg.ValidWebhookURL(value) {
+			return validation.NewGenericError("url is not allowed by administator")
+		}
+
+		return nil
+	}
+
+	return validation.NewGenericError("unknown field ID")
+}
+
+func (s *Sender) DisplayInfo(ctx context.Context, args map[string]string) (*nfydest.DisplayInfo, error) {
+	if args == nil {
+		args = make(map[string]string)
+	}
+
+	u, err := url.Parse(args[FieldWebhookURL])
+	if err != nil {
+		return nil, validation.WrapError(err)
+	}
+	return &nfydest.DisplayInfo{
+		IconURL:     FallbackIconURL,
+		IconAltText: "Webhook",
+		Text:        u.Hostname(),
+	}, nil
+}


### PR DESCRIPTION
**Description:**
Moves webhook destination to use the `nfydest.Registry` instead of hard-coded in the graphql2 package.