### PR TITLE
ui: add tooltip to formdialog action buttons, use for universal keys

### DIFF
--- a/web/src/app/alerts/CreateAlertDialog/CreateAlertDialog.tsx
+++ b/web/src/app/alerts/CreateAlertDialog/CreateAlertDialog.tsx
@@ -161,7 +161,8 @@ export default function CreateAlertDialog(props: {
       }
       PaperProps={{ className: classes.dialog }}
       onSubmit={() => (hasCompleted ? props.onClose() : mutate())}
-      onNext={currentStep < 2 ? onNext : null}
+      disableNext={currentStep === 2}
+      onNext={onNext}
       onBack={currentStep > 0 ? () => setStep(currentStep - 1) : null}
     />
   )

--- a/web/src/app/dialogs/FormDialog.jsx
+++ b/web/src/app/dialogs/FormDialog.jsx
@@ -63,7 +63,6 @@ export default function FormDialog(props) {
     onBack,
     fullHeight,
     nextTooltip,
-    submitTooltip,
     disableBackdropClose,
     disablePortal,
     disableSubmit,
@@ -195,7 +194,6 @@ export default function FormDialog(props) {
           }}
           attemptCount={attemptCount}
           buttonText={primaryActionLabel || (confirm ? 'Confirm' : 'Submit')}
-          tooltip={submitTooltip}
           disabled={loading || disableSubmit}
           loading={loading}
           type='submit'
@@ -278,7 +276,6 @@ FormDialog.propTypes = {
   onClose: p.func,
 
   onSubmit: p.func,
-  submitTooltip: p.string,
 
   // if onNext is specified the submit button will be replaced with a 'Next' button
   onNext: p.func,

--- a/web/src/app/dialogs/FormDialog.jsx
+++ b/web/src/app/dialogs/FormDialog.jsx
@@ -49,7 +49,6 @@ export default function FormDialog(props) {
   const {
     alert,
     confirm = false,
-    errors = [],
     fullScreen,
     loading = false,
     primaryActionLabel, // remove from dialogProps spread
@@ -129,7 +128,7 @@ export default function FormDialog(props) {
 
   function renderErrors() {
     const errors =
-      typeof props.errors === 'function' ? props.errors() : props.errors
+      typeof props.errors === 'function' ? props.errors() : props?.errors ?? []
     return errors.map((err, idx) => (
       <DialogContentError
         className={classes.errorContainer}

--- a/web/src/app/dialogs/FormDialog.jsx
+++ b/web/src/app/dialogs/FormDialog.jsx
@@ -4,6 +4,7 @@ import Button from '@mui/material/Button'
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import makeStyles from '@mui/styles/makeStyles'
 
@@ -44,23 +45,25 @@ const useStyles = makeStyles((theme) => {
   }
 })
 
-function FormDialog(props) {
+export default function FormDialog(props) {
   const {
     alert,
-    confirm,
-    errors,
+    confirm = false,
+    errors = [],
     fullScreen,
-    loading,
+    loading = false,
     primaryActionLabel, // remove from dialogProps spread
-    maxWidth,
+    maxWidth = 'sm',
     notices,
-    onClose,
-    onSubmit,
+    onClose = () => {},
+    onSubmit = () => {},
     subTitle, // can't be used in dialogProps spread
     title,
     onNext,
     onBack,
     fullHeight,
+    nextTooltip,
+    submitTooltip,
     disableBackdropClose,
     disablePortal,
     disableSubmit,
@@ -149,6 +152,18 @@ function FormDialog(props) {
       )
     }
 
+    const nextButton = (
+      <Button
+        variant='contained'
+        color='secondary'
+        disabled={loading || disableNext}
+        onClick={onNext}
+        sx={{ mr: 1 }}
+      >
+        Next
+      </Button>
+    )
+
     return (
       <DialogActions>
         <Button
@@ -159,17 +174,16 @@ function FormDialog(props) {
         >
           {onBack ? 'Back' : 'Cancel'}
         </Button>
-        {onNext && (
-          <Button
-            variant='contained'
-            color='secondary'
-            disabled={loading || disableNext}
-            onClick={onNext}
-            sx={{ mr: 1 }}
-          >
-            Next
-          </Button>
-        )}
+
+        {onNext && nextTooltip ? (
+          <Tooltip title={nextTooltip}>
+            {/* wrapping in span as button may be disabled */}
+            <span>{nextButton}</span>
+          </Tooltip>
+        ) : onNext ? (
+          nextButton
+        ) : null}
+
         <LoadingButton
           form='dialog-form'
           onClick={() => {
@@ -181,6 +195,7 @@ function FormDialog(props) {
           }}
           attemptCount={attemptCount}
           buttonText={primaryActionLabel || (confirm ? 'Confirm' : 'Submit')}
+          tooltip={submitTooltip}
           disabled={loading || disableSubmit}
           loading={loading}
           type='submit'
@@ -263,9 +278,12 @@ FormDialog.propTypes = {
   onClose: p.func,
 
   onSubmit: p.func,
+  submitTooltip: p.string,
 
   // if onNext is specified the submit button will be replaced with a 'Next' button
   onNext: p.func,
+  nextTooltip: p.string,
+
   // if onBack is specified the cancel button will be replaced with a 'Back' button
   onBack: p.func,
 
@@ -286,15 +304,3 @@ FormDialog.propTypes = {
   // gets spread to material-ui
   PaperProps: p.object,
 }
-
-FormDialog.defaultProps = {
-  errors: [],
-  onClose: () => {},
-  onSubmit: () => {},
-  loading: false,
-  confirm: false,
-  caption: '',
-  maxWidth: 'sm',
-}
-
-export default FormDialog

--- a/web/src/app/loading/components/LoadingButton.tsx
+++ b/web/src/app/loading/components/LoadingButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Button, { ButtonProps } from '@mui/material/Button'
+import Tooltip from '@mui/material/Tooltip'
 import CircularProgress from '@mui/material/CircularProgress'
 
 interface LoadingButtonProps extends ButtonProps {
@@ -7,6 +8,7 @@ interface LoadingButtonProps extends ButtonProps {
   buttonText?: string
   loading?: boolean
   noSubmit?: boolean
+  tooltip?: string
   style?: React.CSSProperties
 }
 
@@ -19,23 +21,28 @@ const LoadingButton = (props: LoadingButtonProps): JSX.Element => {
     loading,
     noSubmit,
     onClick,
+    tooltip,
     style,
     ...rest
   } = props
 
+  const button = (
+    <Button
+      data-cy='loading-button'
+      variant='contained'
+      {...rest}
+      color={color || 'primary'}
+      onClick={onClick}
+      disabled={loading || disabled}
+      type={noSubmit ? 'button' : 'submit'}
+    >
+      {!attemptCount ? props.children || buttonText || 'Confirm' : 'Retry'}
+    </Button>
+  )
+
   return (
     <div style={{ position: 'relative', ...style }}>
-      <Button
-        data-cy='loading-button'
-        variant='contained'
-        {...rest}
-        color={color || 'primary'}
-        onClick={onClick}
-        disabled={loading || disabled}
-        type={noSubmit ? 'button' : 'submit'}
-      >
-        {!attemptCount ? props.children || buttonText || 'Confirm' : 'Retry'}
-      </Button>
+      {tooltip ? <Tooltip title={tooltip}>{button}</Tooltip> : button}
       {loading && (
         <CircularProgress
           color={color || 'primary'}

--- a/web/src/app/loading/components/LoadingButton.tsx
+++ b/web/src/app/loading/components/LoadingButton.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import Button, { ButtonProps } from '@mui/material/Button'
-import Tooltip from '@mui/material/Tooltip'
 import CircularProgress from '@mui/material/CircularProgress'
 
 interface LoadingButtonProps extends ButtonProps {

--- a/web/src/app/loading/components/LoadingButton.tsx
+++ b/web/src/app/loading/components/LoadingButton.tsx
@@ -8,7 +8,6 @@ interface LoadingButtonProps extends ButtonProps {
   buttonText?: string
   loading?: boolean
   noSubmit?: boolean
-  tooltip?: string
   style?: React.CSSProperties
 }
 
@@ -21,28 +20,23 @@ const LoadingButton = (props: LoadingButtonProps): JSX.Element => {
     loading,
     noSubmit,
     onClick,
-    tooltip,
     style,
     ...rest
   } = props
 
-  const button = (
-    <Button
-      data-cy='loading-button'
-      variant='contained'
-      {...rest}
-      color={color || 'primary'}
-      onClick={onClick}
-      disabled={loading || disabled}
-      type={noSubmit ? 'button' : 'submit'}
-    >
-      {!attemptCount ? props.children || buttonText || 'Confirm' : 'Retry'}
-    </Button>
-  )
-
   return (
     <div style={{ position: 'relative', ...style }}>
-      {tooltip ? <Tooltip title={tooltip}>{button}</Tooltip> : button}
+      <Button
+        data-cy='loading-button'
+        variant='contained'
+        {...rest}
+        color={color || 'primary'}
+        onClick={onClick}
+        disabled={loading || disabled}
+        type={noSubmit ? 'button' : 'submit'}
+      >
+        {!attemptCount ? props.children || buttonText || 'Confirm' : 'Retry'}
+      </Button>
       {loading && (
         <CircularProgress
           color={color || 'primary'}

--- a/web/src/app/services/UniversalKey/UniversalKeyActionsForm.tsx
+++ b/web/src/app/services/UniversalKey/UniversalKeyActionsForm.tsx
@@ -21,7 +21,7 @@ export type UniversalKeyActionsFormProps = {
   onChipClick?: (action: ActionInput) => void
 
   disablePortal?: boolean
-  setShowNextTooltip: (bool: boolean) => void
+  setShowNextTooltip?: (bool: boolean) => void
 }
 
 const query = gql`
@@ -57,7 +57,7 @@ export default function UniversalKeyActionsForm(
   }, [props.actionType])
 
   useEffect(() => {
-    if (currentAction) {
+    if (currentAction && props.setShowNextTooltip) {
       props.setShowNextTooltip(true)
     }
   }, [currentAction])
@@ -107,7 +107,9 @@ export default function UniversalKeyActionsForm(
             color='secondary'
             onClick={() => {
               setCurrentAction(null)
-              props.setShowNextTooltip(false)
+              if (props.setShowNextTooltip) {
+                props.setShowNextTooltip(false)
+              }
             }}
             sx={{ width: '30%', mr: 2 }}
           >
@@ -157,7 +159,9 @@ export default function UniversalKeyActionsForm(
 
                   // clear the current action
                   setCurrentAction(null)
-                  props.setShowNextTooltip(false)
+                  if (props.setShowNextTooltip) {
+                    props.setShowNextTooltip(false)
+                  }
 
                   props.onChange(actions.concat(input))
 

--- a/web/src/app/services/UniversalKey/UniversalKeyActionsForm.tsx
+++ b/web/src/app/services/UniversalKey/UniversalKeyActionsForm.tsx
@@ -107,6 +107,12 @@ export default function UniversalKeyActionsForm(
             color='secondary'
             onClick={() => {
               setCurrentAction(null)
+              if (props.onChipClick) {
+                props.onChipClick({
+                  dest: { type: '', args: {} },
+                  params: {},
+                })
+              }
               if (props.setShowNextTooltip) {
                 props.setShowNextTooltip(false)
               }

--- a/web/src/app/services/UniversalKey/UniversalKeyActionsForm.tsx
+++ b/web/src/app/services/UniversalKey/UniversalKeyActionsForm.tsx
@@ -105,7 +105,10 @@ export default function UniversalKeyActionsForm(
             startIcon={<Restore />}
             variant='contained'
             color='secondary'
-            onClick={() => setCurrentAction(null)}
+            onClick={() => {
+              setCurrentAction(null)
+              props.setShowNextTooltip(false)
+            }}
             sx={{ width: '30%', mr: 2 }}
           >
             Reset

--- a/web/src/app/services/UniversalKey/UniversalKeyActionsForm.tsx
+++ b/web/src/app/services/UniversalKey/UniversalKeyActionsForm.tsx
@@ -58,7 +58,6 @@ export default function UniversalKeyActionsForm(
 
   useEffect(() => {
     if (currentAction) {
-      console.log('setting tooltip: true')
       props.setShowNextTooltip(true)
     }
   }, [currentAction])

--- a/web/src/app/services/UniversalKey/UniversalKeyActionsForm.tsx
+++ b/web/src/app/services/UniversalKey/UniversalKeyActionsForm.tsx
@@ -102,71 +102,74 @@ export default function UniversalKeyActionsForm(
             alignItems: 'flex-end',
           }}
         >
-          <ButtonGroup variant='contained' color='secondary' fullWidth>
-            <Button
-              startIcon={<Restore />}
-              onClick={() => setCurrentAction(null)}
-              sx={{ width: '30%' }}
-            >
-              Reset
-            </Button>
-            <Button
-              type='button'
-              startIcon={<Add />}
-              onClick={() => {
-                const input = valueToActionInput(currentAction)
+          <Button
+            startIcon={<Restore />}
+            variant='contained'
+            color='secondary'
+            onClick={() => setCurrentAction(null)}
+            sx={{ width: '30%', mr: 2 }}
+          >
+            Reset
+          </Button>
+          <Button
+            type='button'
+            variant='contained'
+            color='secondary'
+            fullWidth
+            startIcon={<Add />}
+            onClick={() => {
+              const input = valueToActionInput(currentAction)
 
-                if (props.actionType !== '') {
-                  actions = props.value.filter(
-                    (v) => v.dest.type !== props.actionType,
-                  )
+              if (props.actionType !== '') {
+                actions = props.value.filter(
+                  (v) => v.dest.type !== props.actionType,
+                )
+              }
+
+              let cancel = ''
+              actions.forEach((_a) => {
+                const a = JSON.stringify(_a.dest.args)
+                const cur = JSON.stringify(input.dest.args)
+                if (a === cur) {
+                  cancel = 'Cannot add same destination twice'
                 }
+              })
 
-                let cancel = ''
-                actions.forEach((_a) => {
-                  const a = JSON.stringify(_a.dest.args)
-                  const cur = JSON.stringify(input.dest.args)
-                  if (a === cur) {
-                    cancel = 'Cannot add same destination twice'
+              if (cancel !== '') {
+                setAddError({
+                  message: cancel,
+                } as CombinedError)
+                return
+              }
+
+              // validating input of action
+              setAddError(null)
+              valClient
+                .query(query, { input })
+                .toPromise()
+                .then((res) => {
+                  if (res.error) {
+                    setAddError(res.error)
+                    return
+                  }
+
+                  // clear the current action
+                  setCurrentAction(null)
+                  props.setShowNextTooltip(false)
+
+                  props.onChange(actions.concat(input))
+
+                  if (props.onChipClick) {
+                    props.onChipClick({
+                      dest: { type: '', args: {} },
+                      params: {},
+                    })
                   }
                 })
-
-                if (cancel !== '') {
-                  setAddError({
-                    message: cancel,
-                  } as CombinedError)
-                  return
-                }
-
-                // validating input of action
-                setAddError(null)
-                valClient
-                  .query(query, { input })
-                  .toPromise()
-                  .then((res) => {
-                    if (res.error) {
-                      setAddError(res.error)
-                      return
-                    }
-
-                    // clear the current action
-                    setCurrentAction(null)
-                    props.setShowNextTooltip(false)
-
-                    props.onChange(actions.concat(input))
-
-                    if (props.onChipClick) {
-                      props.onChipClick({
-                        dest: { type: '', args: {} },
-                        params: {},
-                      })
-                    }
-                  })
-              }}
-            >
-              {props.actionType ? 'Save Action' : 'Add Action'}
-            </Button>
-          </ButtonGroup>
+            }}
+          >
+            {props.actionType ? 'Save Action' : 'Add Action'}
+          </Button>
         </Grid>
       )}
 

--- a/web/src/app/services/UniversalKey/UniversalKeyActionsForm.tsx
+++ b/web/src/app/services/UniversalKey/UniversalKeyActionsForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { Add, Restore } from '@mui/icons-material'
-import { Button, ButtonGroup, Grid, Typography } from '@mui/material'
+import { Button, Grid, Typography } from '@mui/material'
 import { ActionInput } from '../../../schema'
 import DynamicActionForm, {
   actionInputToValue,

--- a/web/src/app/services/UniversalKey/UniversalKeyRuleDialog.tsx
+++ b/web/src/app/services/UniversalKey/UniversalKeyRuleDialog.tsx
@@ -78,6 +78,7 @@ export default function UniversalKeyRuleDialog(
   const [m, commit] = useMutation(mutation)
   const [hasSubmitted, setHasSubmitted] = useState(0)
   const [hasConfirmed, setHasConfirmed] = useState(false)
+  const [showNextTooltip, setShowNextTooltip] = useState(false)
 
   const errs = useErrorConsumer(m.error)
   const unknownErrors = errs.remainingLegacyCallback()
@@ -136,8 +137,13 @@ export default function UniversalKeyRuleDialog(
       errors={unknownErrors}
       onSubmit={() => setHasSubmitted(hasSubmitted + 1)}
       disableSubmit={step < 2 && !hasSubmitted}
-      disableNext={step === 2}
+      disableNext={showNextTooltip}
       onNext={() => setStep(step + 1)}
+      nextTooltip={
+        showNextTooltip
+          ? 'Reset or finish adding the current action to continue'
+          : null
+      }
       onBack={step > 0 && step <= 2 ? () => setStep(step - 1) : null}
       form={
         <UniversalKeyRuleForm
@@ -148,6 +154,7 @@ export default function UniversalKeyRuleDialog(
           conditionError={conditionError}
           step={step}
           setStep={setStep}
+          setShowNextTooltip={(bool: boolean) => setShowNextTooltip(bool)}
         />
       }
       notices={getNotice(showNotice, hasConfirmed, setHasConfirmed)}

--- a/web/src/app/services/UniversalKey/UniversalKeyRuleDialog.tsx
+++ b/web/src/app/services/UniversalKey/UniversalKeyRuleDialog.tsx
@@ -137,7 +137,7 @@ export default function UniversalKeyRuleDialog(
       errors={unknownErrors}
       onSubmit={() => setHasSubmitted(hasSubmitted + 1)}
       disableSubmit={step < 2 && !hasSubmitted}
-      disableNext={showNextTooltip}
+      disableNext={step === 2 || showNextTooltip}
       onNext={() => setStep(step + 1)}
       nextTooltip={
         showNextTooltip

--- a/web/src/app/services/UniversalKey/UniversalKeyRuleDialog.tsx
+++ b/web/src/app/services/UniversalKey/UniversalKeyRuleDialog.tsx
@@ -144,7 +144,14 @@ export default function UniversalKeyRuleDialog(
           ? 'Reset or finish adding the current action to continue'
           : null
       }
-      onBack={step > 0 && step <= 2 ? () => setStep(step - 1) : null}
+      onBack={
+        step > 0 && step <= 2
+          ? () => {
+              setShowNextTooltip(false)
+              setStep(step - 1)
+            }
+          : null
+      }
       form={
         <UniversalKeyRuleForm
           value={value}

--- a/web/src/app/services/UniversalKey/UniversalKeyRuleForm.tsx
+++ b/web/src/app/services/UniversalKey/UniversalKeyRuleForm.tsx
@@ -27,6 +27,7 @@ interface UniversalKeyRuleFormProps {
 
   step: number
   setStep: (step: number) => void
+  setShowNextTooltip: (bool: boolean) => void
 }
 
 const STEPS = ['Configure Rule', 'Configure Action(s)', 'Wrap Up']
@@ -34,11 +35,10 @@ const STEPS = ['Configure Rule', 'Configure Action(s)', 'Wrap Up']
 export default function UniversalKeyRuleForm(
   props: UniversalKeyRuleFormProps,
 ): JSX.Element {
-  const { step, setStep } = props
+  const { step, setStep, setShowNextTooltip } = props
   const [actionType, setActionType] = useState('')
 
   const handleChipClick = (action: ActionInput): void => {
-    console.log('setting edit action type to: ', action.dest.type)
     setActionType(action.dest.type)
   }
 
@@ -132,6 +132,7 @@ export default function UniversalKeyRuleForm(
               }
               actionType={actionType}
               onChipClick={handleChipClick}
+              setShowNextTooltip={setShowNextTooltip}
             />
           </Grid>
         </React.Fragment>


### PR DESCRIPTION
Adds the prop `nextTooltip` to FormDialog, for optional use with the `next` button when using a stepper with FormDialog.

<details>
<summary>UIK Screenshot w/ tooltip</summary>

![Screenshot 2024-07-17 at 9 16 17 AM](https://github.com/user-attachments/assets/bb080aae-f3f8-4a07-8866-0b91523adc4a)
</details>

Also shows the next button on the last step when creating a new alert, rather than replacing it with the submit button.

<details>
<summary>Create Alert Screenshot</summary>

![Screenshot 2024-07-17 at 9 31 47 AM](https://github.com/user-attachments/assets/14df8d15-22bf-430e-b4a9-9113073938b7)
</details>

**Additional Changes:**
Addresses deprecation warning from using `FormDialog.defaultProps`