### PR TITLE
dest: bugfix on error paths

### DIFF
--- a/graphql2/graphqlapp/destinationvalidation.go
+++ b/graphql2/graphqlapp/destinationvalidation.go
@@ -178,7 +178,7 @@ func (a *App) ValidateDestination(ctx context.Context, fieldName string, dest *g
 
 	var argErr *nfydest.DestArgError
 	if errors.As(err, &argErr) {
-		return addDestFieldError(ctx, fieldName, argErr.FieldID, argErr.Err)
+		return addDestFieldError(ctx, fieldName+".args", argErr.FieldID, argErr.Err)
 	}
 
 	if err != nil {

--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -152,6 +152,10 @@ func (s *ChannelSender) ValidateChannel(ctx context.Context, id string) error {
 		return err
 	}
 
+	if id == "" {
+		return validation.NewGenericError("Channel is required.")
+	}
+
 	s.chanMx.Lock()
 	defer s.chanMx.Unlock()
 	res, ok := s.chanCache.Get(id)


### PR DESCRIPTION
**Description:**
- Fixes `unexpected error` on missing slack channel
- Fixes error path so dest field errors are now passed to the correct field in the UI
