### PR TITLE
dest: move remaining EP code away from targets and to dest

### DIFF
--- a/devtools/resetdb/datagen.go
+++ b/devtools/resetdb/datagen.go
@@ -267,7 +267,7 @@ func (d *datagen) NewEP() {
 // NewEPStep will generate a random escalation policy step for the provided policy.
 func (d *datagen) NewEPStep(epID string, n int) {
 	d.EscalationSteps = append(d.EscalationSteps, escalation.Step{
-		ID:           d.UUID(),
+		ID:           uuid.MustParse(d.UUID()),
 		PolicyID:     epID,
 		DelayMinutes: d.Intn(25) + 5,
 		StepNumber:   n,
@@ -620,7 +620,7 @@ func (cfg datagenConfig) Generate() datagen {
 		})
 	}
 	for _, step := range d.EscalationSteps {
-		run(d.Intn(cfg.EPMaxAssigned), func() { d.NewEPStepAction(step.ID) })
+		run(d.Intn(cfg.EPMaxAssigned), func() { d.NewEPStepAction(step.ID.String()) })
 	}
 
 	d.labelKeys = make([]string, cfg.UniqueLabelKeys)

--- a/devtools/resetdb/main.go
+++ b/devtools/resetdb/main.go
@@ -204,7 +204,7 @@ func fillDB(ctx context.Context, dataCfg *datagenConfig, url string) error {
 	})
 	copyFrom("escalation_policy_steps", []string{"id", "escalation_policy_id", "step_number", "delay"}, len(data.EscalationSteps), func(n int) []interface{} {
 		step := data.EscalationSteps[n]
-		return []interface{}{asUUID(step.ID), asUUID(step.PolicyID), step.StepNumber, step.DelayMinutes}
+		return []interface{}{step.ID, asUUID(step.PolicyID), step.StepNumber, step.DelayMinutes}
 	}, "escalation_policies")
 
 	copyFrom("escalation_policy_actions", []string{"id", "escalation_policy_step_id", "user_id", "rotation_id", "schedule_id", "channel_id"}, len(data.EscalationActions), func(n int) []interface{} {

--- a/escalation/desttargets.go
+++ b/escalation/desttargets.go
@@ -109,10 +109,14 @@ func (s *Store) DeleteStepActionTx(ctx context.Context, tx *sql.Tx, stepID uuid.
 	})
 }
 
-func (s *Store) FindAllStepActionsTx(ctx context.Context, tx *sql.Tx, stepID uuid.UUID) ([]gadb.DestV1, error) {
+func (s *Store) FindAllStepActionsTx(ctx context.Context, tx gadb.DBTX, stepID uuid.UUID) ([]gadb.DestV1, error) {
 	err := permission.LimitCheckAny(ctx, permission.User)
 	if err != nil {
 		return nil, err
+	}
+
+	if tx == nil {
+		tx = s.db
 	}
 
 	actions, err := gadb.New(tx).EPStepActionsByStepId(ctx, stepID)

--- a/escalation/step.go
+++ b/escalation/step.go
@@ -1,9 +1,10 @@
 package escalation
 
 import (
-	"github.com/target/goalert/assignment"
-	"github.com/target/goalert/validation/validate"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/target/goalert/validation/validate"
 )
 
 type ActiveStep struct {
@@ -17,17 +18,16 @@ type ActiveStep struct {
 }
 
 type Step struct {
-	ID           string `json:"id"`
-	PolicyID     string `json:"escalation_policy_id"`
-	DelayMinutes int    `json:"delay_minutes"`
-	StepNumber   int    `json:"step_number"`
-
-	Targets []assignment.Target
+	ID           uuid.UUID `json:"id"`
+	PolicyID     string    `json:"escalation_policy_id"`
+	DelayMinutes int       `json:"delay_minutes"`
+	StepNumber   int       `json:"step_number"`
 }
 
 func (s Step) Delay() time.Duration {
 	return time.Duration(s.DelayMinutes) * time.Minute
 }
+
 func (s Step) Normalize() (*Step, error) {
 	err := validate.Many(
 		validate.UUID("PolicyID", s.PolicyID),

--- a/escalation/store.go
+++ b/escalation/store.go
@@ -708,7 +708,7 @@ func (s *Store) CreateStepTx(ctx context.Context, tx *sql.Tx, st *Step) (*Step, 
 		stmt = tx.StmtContext(ctx, stmt)
 	}
 
-	n.ID = uuid.New().String()
+	n.ID = uuid.New()
 
 	err = stmt.QueryRowContext(ctx, n.ID, n.PolicyID, n.DelayMinutes).Scan(&n.StepNumber)
 	if err != nil {
@@ -720,13 +720,8 @@ func (s *Store) CreateStepTx(ctx context.Context, tx *sql.Tx, st *Step) (*Step, 
 }
 
 // UpdateStepNumberTx updates the step number for a step.
-func (s *Store) UpdateStepNumberTx(ctx context.Context, tx *sql.Tx, stepID string, stepNumber int) error {
+func (s *Store) UpdateStepNumberTx(ctx context.Context, tx *sql.Tx, stepID uuid.UUID, stepNumber int) error {
 	err := permission.LimitCheckAny(ctx, permission.Admin, permission.User)
-	if err != nil {
-		return err
-	}
-
-	err = validate.UUID("EscalationPolicyStepID", stepID)
 	if err != nil {
 		return err
 	}
@@ -745,13 +740,8 @@ func (s *Store) UpdateStepNumberTx(ctx context.Context, tx *sql.Tx, stepID strin
 }
 
 // UpdateStepDelayTx updates the delay for a step.
-func (s *Store) UpdateStepDelayTx(ctx context.Context, tx *sql.Tx, stepID string, stepDelay int) error {
+func (s *Store) UpdateStepDelayTx(ctx context.Context, tx *sql.Tx, stepID uuid.UUID, stepDelay int) error {
 	err := permission.LimitCheckAny(ctx, permission.Admin, permission.User)
-	if err != nil {
-		return err
-	}
-
-	err = validate.UUID("EscalationPolicyStepID", stepID)
 	if err != nil {
 		return err
 	}
@@ -775,13 +765,8 @@ func (s *Store) UpdateStepDelayTx(ctx context.Context, tx *sql.Tx, stepID string
 }
 
 // DeleteStepTx deletes a step from an escalation policy.
-func (s *Store) DeleteStepTx(ctx context.Context, tx *sql.Tx, id string) (string, error) {
-	err := validate.UUID("EscalationPolicyStepID", id)
-	if err != nil {
-		return "", err
-	}
-
-	err = permission.LimitCheckAny(ctx, permission.Admin, permission.User)
+func (s *Store) DeleteStepTx(ctx context.Context, tx *sql.Tx, id uuid.UUID) (string, error) {
+	err := permission.LimitCheckAny(ctx, permission.Admin, permission.User)
 	if err != nil {
 		return "", err
 	}

--- a/gadb/dest.go
+++ b/gadb/dest.go
@@ -10,24 +10,6 @@ type DestV1 struct {
 	Type string
 }
 
-func (d DestV1) Equals(other DestV1) bool {
-	if d.Type != other.Type {
-		return false
-	}
-
-	if len(d.Args) != len(other.Args) {
-		return false
-	}
-
-	for k, v := range d.Args {
-		if otherVal, ok := other.Args[k]; !ok || otherVal != v {
-			return false
-		}
-	}
-
-	return true
-}
-
 func (ns DestV1) Arg(name string) string {
 	if ns.Args == nil {
 		return ""

--- a/gadb/dest.go
+++ b/gadb/dest.go
@@ -10,6 +10,24 @@ type DestV1 struct {
 	Type string
 }
 
+func (d DestV1) Equals(other DestV1) bool {
+	if d.Type != other.Type {
+		return false
+	}
+
+	if len(d.Args) != len(other.Args) {
+		return false
+	}
+
+	for k, v := range d.Args {
+		if otherVal, ok := other.Args[k]; !ok || otherVal != v {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (ns DestV1) Arg(name string) string {
 	if ns.Args == nil {
 		return ""

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -1135,7 +1135,7 @@ type OnCallNotificationRuleInputResolver interface {
 	Dest(ctx context.Context, obj *OnCallNotificationRuleInput, data *gadb.DestV1) error
 }
 type UpdateEscalationPolicyStepInputResolver interface {
-	Actions(ctx context.Context, obj *UpdateEscalationPolicyStepInput, data []gadb.DestV1) error
+	Targets(ctx context.Context, obj *UpdateEscalationPolicyStepInput, data []assignment.RawTarget) error
 }
 
 type executableSchema struct {
@@ -37259,16 +37259,16 @@ func (ec *executionContext) unmarshalInputUpdateEscalationPolicyStepInput(ctx co
 			if err != nil {
 				return it, err
 			}
-			it.Targets = data
+			if err = ec.resolvers.UpdateEscalationPolicyStepInput().Targets(ctx, &it, data); err != nil {
+				return it, err
+			}
 		case "actions":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("actions"))
 			data, err := ec.unmarshalODestinationInput2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1ᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			if err = ec.resolvers.UpdateEscalationPolicyStepInput().Actions(ctx, &it, data); err != nil {
-				return it, err
-			}
+			it.Actions = data
 		}
 	}
 

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -12882,9 +12882,9 @@ func (ec *executionContext) _EscalationPolicyStep_id(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(uuid.UUID)
 	fc.Result = res
-	return ec.marshalNID2string(ctx, field.Selections, res)
+	return ec.marshalNID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_EscalationPolicyStep_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {

--- a/graphql2/graph/escalationpolicy.graphqls
+++ b/graphql2/graph/escalationpolicy.graphqls
@@ -7,5 +7,5 @@ extend input CreateEscalationPolicyStepInput {
 }
 
 extend input UpdateEscalationPolicyStepInput {
-  actions: [DestinationInput!] @goField(forceResolver: true) # force resolver for initial compat
+  actions: [DestinationInput!]
 }

--- a/graphql2/graphqlapp/escalationpolicy.go
+++ b/graphql2/graphqlapp/escalationpolicy.go
@@ -234,6 +234,9 @@ func (m *Mutation) UpdateEscalationPolicy(ctx context.Context, input graphql2.Up
 			}
 
 			inputStepIDs, err := validate.ParseManyUUID("stepIDs", input.StepIDs, len(steps))
+			if err != nil {
+				return err
+			}
 
 			// get list of step ids
 			var stepIDs []uuid.UUID

--- a/graphql2/graphqlapp/target.go
+++ b/graphql2/graphqlapp/target.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/target/goalert/assignment"
 	"github.com/target/goalert/graphql2"
-
-	"github.com/pkg/errors"
 )
 
 type Target App
@@ -14,42 +12,15 @@ type Target App
 func (a *App) Target() graphql2.TargetResolver { return (*Target)(a) }
 
 func (t *Target) Name(ctx context.Context, raw *assignment.RawTarget) (string, error) {
-	if raw.Name != "" {
-		return raw.Name, nil
-	}
-	switch raw.Type {
-	case assignment.TargetTypeRotation:
-		r, err := (*App)(t).FindOneRotation(ctx, raw.ID)
-		if err != nil {
-			return "", err
-		}
-		return r.Name, nil
-	case assignment.TargetTypeUser:
-		u, err := (*App)(t).FindOneUser(ctx, raw.ID)
-		if err != nil {
-			return "", err
-		}
-		return u.Name, nil
-	case assignment.TargetTypeEscalationPolicy:
-		ep, err := (*App)(t).FindOnePolicy(ctx, raw.ID)
-		if err != nil {
-			return "", err
-		}
-		return ep.Name, nil
-	case assignment.TargetTypeSchedule:
-		sched, err := (*App)(t).FindOneSchedule(ctx, raw.ID)
-		if err != nil {
-			return "", err
-		}
-		return sched.Name, nil
-	case assignment.TargetTypeService:
-		svc, err := (*App)(t).FindOneService(ctx, raw.ID)
-		if err != nil {
-			return "", err
-		}
-		return svc.Name, nil
-
+	dest, err := CompatTargetToDest(raw)
+	if err != nil {
+		return "", err
 	}
 
-	return "", errors.New("unhandled target type " + raw.Type.String())
+	info, err := t.DestReg.DisplayInfo(ctx, dest)
+	if err != nil {
+		return "", err
+	}
+
+	return info.Text, nil
 }

--- a/graphql2/graphqlapp/target.go
+++ b/graphql2/graphqlapp/target.go
@@ -12,6 +12,24 @@ type Target App
 func (a *App) Target() graphql2.TargetResolver { return (*Target)(a) }
 
 func (t *Target) Name(ctx context.Context, raw *assignment.RawTarget) (string, error) {
+	if raw.Name != "" {
+		return raw.Name, nil
+	}
+	switch raw.Type {
+	case assignment.TargetTypeEscalationPolicy:
+		ep, err := (*App)(t).FindOnePolicy(ctx, raw.ID)
+		if err != nil {
+			return "", err
+		}
+		return ep.Name, nil
+	case assignment.TargetTypeService:
+		svc, err := (*App)(t).FindOneService(ctx, raw.ID)
+		if err != nil {
+			return "", err
+		}
+		return svc.Name, nil
+	}
+
 	dest, err := CompatTargetToDest(raw)
 	if err != nil {
 		return "", err

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -597,6 +597,8 @@ input UpdateEscalationPolicyStepInput {
   id: ID!
   delayMinutes: Int
   targets: [TargetInput!]
+    @goField(forceResolver: true)
+    @deprecated(reason: "use actions instead")
 }
 
 input SetFavoriteInput {

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -565,6 +565,8 @@ type EscalationPolicyStep {
   stepNumber: Int!
   delayMinutes: Int!
   targets: [Target!]!
+    @goField(forceResolver: true)
+    @deprecated(reason: "use actions instead")
   escalationPolicy: EscalationPolicy
 }
 

--- a/util/errutil/maperror.go
+++ b/util/errutil/maperror.go
@@ -67,6 +67,18 @@ func MapDBError(err error) error {
 		if dbErr.ConstraintName == "auth_basic_users_pkey" {
 			return validation.NewFieldError("UserID", "already has a basic auth username configured")
 		}
+		if dbErr.ConstraintName == "epa_no_duplicate_schedules" {
+			return validation.NewGenericError("same schedule cannot be assigned twice to the same step")
+		}
+		if dbErr.ConstraintName == "epa_no_duplicate_rotations" {
+			return validation.NewGenericError("same rotation cannot be assigned twice to the same step")
+		}
+		if dbErr.ConstraintName == "epa_no_duplicate_users" {
+			return validation.NewGenericError("same user cannot be assigned twice to the same step")
+		}
+		if dbErr.ConstraintName == "epa_no_duplicate_channels" {
+			return validation.NewGenericError("same destination cannot be assigned twice to the same step")
+		}
 	case "23514": // check constraint
 		newErr := mapLimitError(dbErr)
 		if newErr != nil {


### PR DESCRIPTION
**Description:**
- move escalation.Step to use uuid for ID
- updated GraphQL code to use EP step `actions` field instead of `targets`

**Out of Scope:**
- Deleting the old methods and SQL queries will be done in a separate PR