### PR TITLE
Transition OnCallNotificatonRule to use 'Dest' field

### DIFF
--- a/gadb/queries.sql.go
+++ b/gadb/queries.sql.go
@@ -2227,28 +2227,6 @@ func (q *Queries) NoticeUnackedAlertsByService(ctx context.Context, dollar_1 uui
 	return i, err
 }
 
-const notifChanCreate = `-- name: NotifChanCreate :exec
-INSERT INTO notification_channels(id, name, type, value)
-    VALUES ($1, $2, $3, $4)
-`
-
-type NotifChanCreateParams struct {
-	ID    uuid.UUID
-	Name  string
-	Type  EnumNotifChannelType
-	Value string
-}
-
-func (q *Queries) NotifChanCreate(ctx context.Context, arg NotifChanCreateParams) error {
-	_, err := q.db.ExecContext(ctx, notifChanCreate,
-		arg.ID,
-		arg.Name,
-		arg.Type,
-		arg.Value,
-	)
-	return err
-}
-
 const notifChanDeleteMany = `-- name: NotifChanDeleteMany :exec
 DELETE FROM notification_channels
 WHERE id = ANY ($1::uuid[])
@@ -2257,36 +2235,6 @@ WHERE id = ANY ($1::uuid[])
 func (q *Queries) NotifChanDeleteMany(ctx context.Context, dollar_1 []uuid.UUID) error {
 	_, err := q.db.ExecContext(ctx, notifChanDeleteMany, pq.Array(dollar_1))
 	return err
-}
-
-const notifChanFindByValue = `-- name: NotifChanFindByValue :one
-SELECT
-    created_at, dest, id, meta, name, type, value
-FROM
-    notification_channels
-WHERE
-    type = $1
-    AND value = $2
-`
-
-type NotifChanFindByValueParams struct {
-	Type  EnumNotifChannelType
-	Value string
-}
-
-func (q *Queries) NotifChanFindByValue(ctx context.Context, arg NotifChanFindByValueParams) (NotificationChannel, error) {
-	row := q.db.QueryRowContext(ctx, notifChanFindByValue, arg.Type, arg.Value)
-	var i NotificationChannel
-	err := row.Scan(
-		&i.CreatedAt,
-		&i.Dest,
-		&i.ID,
-		&i.Meta,
-		&i.Name,
-		&i.Type,
-		&i.Value,
-	)
-	return i, err
 }
 
 const notifChanFindDestID = `-- name: NotifChanFindDestID :one
@@ -2375,25 +2323,6 @@ LOCK notification_channels IN SHARE ROW EXCLUSIVE MODE
 
 func (q *Queries) NotifChanLock(ctx context.Context) error {
 	_, err := q.db.ExecContext(ctx, notifChanLock)
-	return err
-}
-
-const notifChanUpdateName = `-- name: NotifChanUpdateName :exec
-UPDATE
-    notification_channels
-SET
-    name = $2
-WHERE
-    id = $1
-`
-
-type NotifChanUpdateNameParams struct {
-	ID   uuid.UUID
-	Name string
-}
-
-func (q *Queries) NotifChanUpdateName(ctx context.Context, arg NotifChanUpdateNameParams) error {
-	_, err := q.db.ExecContext(ctx, notifChanUpdateName, arg.ID, arg.Name)
 	return err
 }
 

--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -1132,7 +1132,7 @@ type DestinationInputResolver interface {
 	Values(ctx context.Context, obj *gadb.DestV1, data []FieldValueInput) error
 }
 type OnCallNotificationRuleInputResolver interface {
-	Dest(ctx context.Context, obj *OnCallNotificationRuleInput, data *gadb.DestV1) error
+	Target(ctx context.Context, obj *OnCallNotificationRuleInput, data *assignment.RawTarget) error
 }
 type UpdateEscalationPolicyStepInputResolver interface {
 	Targets(ctx context.Context, obj *UpdateEscalationPolicyStepInput, data []assignment.RawTarget) error
@@ -36141,20 +36141,20 @@ func (ec *executionContext) unmarshalInputOnCallNotificationRuleInput(ctx contex
 			it.ID = data
 		case "target":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("target"))
-			data, err := ec.unmarshalOTargetInput2githubᚗcomᚋtargetᚋgoalertᚋassignmentᚐRawTarget(ctx, v)
+			data, err := ec.unmarshalOTargetInput2ᚖgithubᚗcomᚋtargetᚋgoalertᚋassignmentᚐRawTarget(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Target = data
+			if err = ec.resolvers.OnCallNotificationRuleInput().Target(ctx, &it, data); err != nil {
+				return it, err
+			}
 		case "dest":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dest"))
-			data, err := ec.unmarshalODestinationInput2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx, v)
+			data, err := ec.unmarshalODestinationInput2githubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			if err = ec.resolvers.OnCallNotificationRuleInput().Dest(ctx, &it, data); err != nil {
-				return it, err
-			}
+			it.Dest = data
 		case "time":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("time"))
 			data, err := ec.unmarshalOClockTime2ᚖgithubᚗcomᚋtargetᚋgoalertᚋutilᚋtimeutilᚐClock(ctx, v)
@@ -51765,6 +51765,11 @@ func (ec *executionContext) marshalODebugSendSMSInfo2ᚖgithubᚗcomᚋtargetᚋ
 	return ec._DebugSendSMSInfo(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalODestinationInput2githubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1(ctx context.Context, v interface{}) (gadb.DestV1, error) {
+	res, err := ec.unmarshalInputDestinationInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalODestinationInput2ᚕgithubᚗcomᚋtargetᚋgoalertᚋgadbᚐDestV1ᚄ(ctx context.Context, v interface{}) ([]gadb.DestV1, error) {
 	if v == nil {
 		return nil, nil
@@ -52401,11 +52406,6 @@ func (ec *executionContext) marshalOStringMap2map(ctx context.Context, sel ast.S
 	}
 	res := MarshalStringMap(v)
 	return res
-}
-
-func (ec *executionContext) unmarshalOTargetInput2githubᚗcomᚋtargetᚋgoalertᚋassignmentᚐRawTarget(ctx context.Context, v interface{}) (assignment.RawTarget, error) {
-	res, err := ec.unmarshalInputTargetInput(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalOTargetInput2ᚕgithubᚗcomᚋtargetᚋgoalertᚋassignmentᚐRawTargetᚄ(ctx context.Context, v interface{}) ([]assignment.RawTarget, error) {

--- a/graphql2/graphqlapp/escalationpolicy.go
+++ b/graphql2/graphqlapp/escalationpolicy.go
@@ -43,7 +43,7 @@ func (a *CreateEscalationPolicyStepInput) Targets(ctx context.Context, input *gr
 	input.Actions = make([]gadb.DestV1, len(targets))
 	for i, tgt := range targets {
 		var err error
-		input.Actions[i], err = CompatTargetToDest(tgt)
+		input.Actions[i], err = (*App)(a).CompatTargetToDest(ctx, tgt)
 		if err != nil {
 			return validation.NewFieldError(fmt.Sprintf("Targets[%d]", i), err.Error())
 		}
@@ -60,7 +60,7 @@ func (a *UpdateEscalationPolicyStepInput) Targets(ctx context.Context, input *gr
 	input.Actions = make([]gadb.DestV1, len(targets))
 	for i, tgt := range targets {
 		var err error
-		input.Actions[i], err = CompatTargetToDest(tgt)
+		input.Actions[i], err = (*App)(a).CompatTargetToDest(ctx, tgt)
 		if err != nil {
 			return validation.NewFieldError(fmt.Sprintf("Targets[%d]", i), err.Error())
 		}

--- a/graphql2/graphqlapp/mutation.go
+++ b/graphql2/graphqlapp/mutation.go
@@ -57,6 +57,7 @@ func (a *Mutation) SetScheduleOnCallNotificationRules(ctx context.Context, input
 				return validation.NewFieldError("Rules[%d].Dest.Type", "unsupported destination type")
 			}
 
+			// MapDestToID handles the appropriate validation checks, outside of the IsSchedOnCallNotify check done above.
 			chID, err := a.NCStore.MapDestToID(ctx, tx, r.Dest)
 			if err != nil {
 				return err

--- a/graphql2/graphqlapp/queries.sql
+++ b/graphql2/graphqlapp/queries.sql
@@ -31,11 +31,3 @@ FROM
 WHERE
     oc.user_id = $1;
 
--- name: GQLLookupNCDest :one
-SELECT
-    dest
-FROM
-    notification_channels
-WHERE
-    id = $1;
-

--- a/graphql2/graphqlapp/queries.sql
+++ b/graphql2/graphqlapp/queries.sql
@@ -31,3 +31,11 @@ FROM
 WHERE
     oc.user_id = $1;
 
+-- name: GQLLookupNCDest :one
+SELECT
+    dest
+FROM
+    notification_channels
+WHERE
+    id = $1;
+

--- a/graphql2/graphqlapp/schedule.go
+++ b/graphql2/graphqlapp/schedule.go
@@ -43,7 +43,7 @@ func (a *App) OnCallNotificationRuleInput() graphql2.OnCallNotificationRuleInput
 
 func (a *OnCallNotificationRuleInput) Target(ctx context.Context, input *graphql2.OnCallNotificationRuleInput, tgt *assignment.RawTarget) error {
 	var err error
-	input.Dest, err = CompatTargetToDest(tgt)
+	input.Dest, err = (*App)(a).CompatTargetToDest(ctx, tgt)
 	if err != nil {
 		return err
 	}

--- a/graphql2/graphqlapp/schedule.go
+++ b/graphql2/graphqlapp/schedule.go
@@ -14,7 +14,6 @@ import (
 	"github.com/target/goalert/assignment"
 	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/graphql2"
-	"github.com/target/goalert/notificationchannel"
 	"github.com/target/goalert/oncall"
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/schedule"
@@ -53,34 +52,18 @@ func (a *OnCallNotificationRuleInput) Target(ctx context.Context, input *graphql
 }
 
 func (a *OnCallNotificationRule) Dest(ctx context.Context, raw *schedule.OnCallNotificationRule) (*gadb.DestV1, error) {
-	return (*App)(a).CompatNCToDest(ctx, raw.ChannelID)
+	dest, err := a.NCStore.FindDestByID(ctx, nil, raw.ChannelID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dest, nil
 }
 
 func (a *OnCallNotificationRule) Target(ctx context.Context, raw *schedule.OnCallNotificationRule) (*assignment.RawTarget, error) {
 	ch, err := (*App)(a).FindOneNC(ctx, raw.ChannelID)
 	if err != nil {
 		return nil, err
-	}
-
-	switch ch.Type {
-	case notificationchannel.TypeSlackChan:
-		return &assignment.RawTarget{
-			Type: assignment.TargetTypeSlackChannel,
-			ID:   ch.Value,
-			Name: ch.Name,
-		}, nil
-	case notificationchannel.TypeSlackUG:
-		return &assignment.RawTarget{
-			Type: assignment.TargetTypeSlackUserGroup,
-			ID:   ch.Value,
-			Name: ch.Name,
-		}, nil
-	case notificationchannel.TypeWebhook:
-		return &assignment.RawTarget{
-			Type: assignment.TargetTypeChanWebhook,
-			ID:   ch.Value,
-			Name: ch.Name,
-		}, nil
 	}
 
 	return &assignment.RawTarget{Type: assignment.TargetTypeNotificationChannel, ID: ch.ID.String(), Name: ch.Name}, nil

--- a/graphql2/graphqlapp/schedule.go
+++ b/graphql2/graphqlapp/schedule.go
@@ -42,13 +42,9 @@ func (a *App) OnCallNotificationRuleInput() graphql2.OnCallNotificationRuleInput
 	return (*OnCallNotificationRuleInput)(a)
 }
 
-func (a *OnCallNotificationRuleInput) Dest(ctx context.Context, input *graphql2.OnCallNotificationRuleInput, dest *gadb.DestV1) error {
-	err := (*App)(a).ValidateDestination(ctx, "", dest)
-	if err != nil {
-		return err
-	}
-
-	input.Target, err = CompatDestToTarget(*dest)
+func (a *OnCallNotificationRuleInput) Target(ctx context.Context, input *graphql2.OnCallNotificationRuleInput, tgt *assignment.RawTarget) error {
+	var err error
+	input.Dest, err = CompatTargetToDest(tgt)
 	if err != nil {
 		return err
 	}

--- a/graphql2/graphqlapp/target.go
+++ b/graphql2/graphqlapp/target.go
@@ -30,7 +30,7 @@ func (t *Target) Name(ctx context.Context, raw *assignment.RawTarget) (string, e
 		return svc.Name, nil
 	}
 
-	dest, err := CompatTargetToDest(raw)
+	dest, err := (*App)(t).CompatTargetToDest(ctx, raw)
 	if err != nil {
 		return "", err
 	}

--- a/graphql2/inputs.go
+++ b/graphql2/inputs.go
@@ -1,11 +1,11 @@
 package graphql2
 
 import (
-	"github.com/target/goalert/assignment"
+	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/schedule"
 )
 
 type OnCallNotificationRuleInput struct {
 	schedule.OnCallNotificationRule
-	Target assignment.RawTarget
+	Dest gadb.DestV1
 }

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -654,6 +654,9 @@ input OnCallNotificationRuleInput {
   target is required if dest is unset
   """
   target: TargetInput
+    @goField(forceResolver: true)
+    @deprecated(reason: "use dest instead")
+
   dest: DestinationInput
 
   # time indicates a time-of-day (in the schedule's time zone)
@@ -672,6 +675,8 @@ input OnCallNotificationRuleInput {
 type OnCallNotificationRule {
   id: ID!
   target: Target!
+    @goField(forceResolver: true)
+    @deprecated(reason: "use dest instead")
   dest: Destination!
   time: ClockTime
   weekdayFilter: WeekdayFilter

--- a/notificationchannel/queries.sql
+++ b/notificationchannel/queries.sql
@@ -14,30 +14,9 @@ FROM
 WHERE
     id = ANY ($1::uuid[]);
 
--- name: NotifChanCreate :exec
-INSERT INTO notification_channels(id, name, type, value)
-    VALUES ($1, $2, $3, $4);
-
--- name: NotifChanUpdateName :exec
-UPDATE
-    notification_channels
-SET
-    name = $2
-WHERE
-    id = $1;
-
 -- name: NotifChanDeleteMany :exec
 DELETE FROM notification_channels
 WHERE id = ANY ($1::uuid[]);
-
--- name: NotifChanFindByValue :one
-SELECT
-    *
-FROM
-    notification_channels
-WHERE
-    type = $1
-    AND value = $2;
 
 -- name: NotifChanLock :exec
 LOCK notification_channels IN SHARE ROW EXCLUSIVE MODE;

--- a/notificationchannel/store.go
+++ b/notificationchannel/store.go
@@ -57,6 +57,24 @@ func (s *Store) FindMany(ctx context.Context, ids []string) ([]Channel, error) {
 	return channels, nil
 }
 
+func (s *Store) FindDestByID(ctx context.Context, tx gadb.DBTX, id uuid.UUID) (gadb.DestV1, error) {
+	err := permission.LimitCheckAny(ctx, permission.User)
+	if err != nil {
+		return gadb.DestV1{}, err
+	}
+
+	if tx == nil {
+		tx = s.db
+	}
+
+	row, err := gadb.New(tx).NotifChanFindOne(ctx, id)
+	if err != nil {
+		return gadb.DestV1{}, err
+	}
+
+	return row.Dest.DestV1, nil
+}
+
 func (s *Store) LookupDestID(ctx context.Context, tx *sql.Tx, d gadb.DestV1) (uuid.UUID, error) {
 	err := permission.LimitCheckAny(ctx, permission.User)
 	if err != nil {

--- a/notificationchannel/store.go
+++ b/notificationchannel/store.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/target/goalert/gadb"
@@ -12,7 +11,6 @@ import (
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/search"
 	"github.com/target/goalert/util"
-	"github.com/target/goalert/util/sqlutil"
 	"github.com/target/goalert/validation/validate"
 )
 
@@ -103,103 +101,6 @@ func (s *Store) MapDestToID(ctx context.Context, tx *sql.Tx, d gadb.DestV1) (uui
 		Dest: gadb.NullDestV1{Valid: true, DestV1: d},
 		Name: info.Text,
 	})
-}
-
-func (s *Store) MapToID(ctx context.Context, tx *sql.Tx, c *Channel) (uuid.UUID, error) {
-	err := permission.LimitCheckAny(ctx, permission.System, permission.User)
-	if err != nil {
-		return uuid.UUID{}, err
-	}
-
-	n, err := c.Normalize()
-	if err != nil {
-		return uuid.UUID{}, err
-	}
-
-	db := gadb.New(s.db)
-	if tx != nil {
-		db = db.WithTx(tx)
-	}
-
-	row, err := db.NotifChanFindByValue(ctx, gadb.NotifChanFindByValueParams{
-		Type:  gadb.EnumNotifChannelType(n.Type),
-		Value: n.Value,
-	})
-	if errors.Is(err, sql.ErrNoRows) {
-		err = nil
-	}
-	if err != nil {
-		return uuid.UUID{}, fmt.Errorf("lookup existing entry: %w", err)
-	}
-
-	if row.Name == c.Name {
-		// short-circuit if it already exists and is up-to-date.
-		return row.ID, nil
-	}
-
-	var ownTx bool
-	if tx == nil {
-		ownTx = true
-		tx, err = s.db.BeginTx(ctx, nil)
-		if err != nil {
-			return uuid.UUID{}, fmt.Errorf("start tx: %w", err)
-		}
-		defer sqlutil.Rollback(ctx, "notificationchannel: map channel ID to UUID", tx)
-		db = db.WithTx(tx)
-	}
-
-	err = db.NotifChanLock(ctx)
-	if err != nil {
-		return uuid.UUID{}, fmt.Errorf("acquire lock: %w", err)
-	}
-
-	// try again after exclusive lock
-	row, err = db.NotifChanFindByValue(ctx, gadb.NotifChanFindByValueParams{
-		Type:  gadb.EnumNotifChannelType(n.Type),
-		Value: n.Value,
-	})
-	if errors.Is(err, sql.ErrNoRows) {
-		err = nil
-	}
-	if err != nil {
-		return uuid.UUID{}, fmt.Errorf("lookup existing entry exclusively: %w", err)
-	}
-	if row.Name == c.Name {
-		// short-circuit if it already exists and is up-to-date.
-		return row.ID, nil
-	}
-
-	if row.ID == uuid.Nil {
-		// create new one
-		row.ID = uuid.New()
-		err = db.NotifChanCreate(ctx, gadb.NotifChanCreateParams{
-			ID:    row.ID,
-			Name:  n.Name,
-			Type:  gadb.EnumNotifChannelType(n.Type),
-			Value: n.Value,
-		})
-		if err != nil {
-			return uuid.UUID{}, fmt.Errorf("create new NC: %w", err)
-		}
-	} else {
-		// update existing name
-		err = db.NotifChanUpdateName(ctx, gadb.NotifChanUpdateNameParams{
-			ID:   row.ID,
-			Name: n.Name,
-		})
-		if err != nil {
-			return uuid.UUID{}, fmt.Errorf("update NC name: %w", err)
-		}
-	}
-
-	if ownTx {
-		err = tx.Commit()
-		if err != nil {
-			return uuid.UUID{}, fmt.Errorf("commit tx: %w", err)
-		}
-	}
-
-	return row.ID, nil
 }
 
 func (s *Store) DeleteManyTx(ctx context.Context, tx *sql.Tx, ids []string) error {

--- a/schedule/oncallnotificationrule.go
+++ b/schedule/oncallnotificationrule.go
@@ -36,14 +36,17 @@ type RuleID struct {
 	valid      bool
 }
 
-var _ encoding.TextMarshaler = RuleID{}
-var _ encoding.TextUnmarshaler = &RuleID{}
-var _ graphql.Marshaler = RuleID{}
-var _ graphql.Unmarshaler = &RuleID{}
+var (
+	_ encoding.TextMarshaler   = RuleID{}
+	_ encoding.TextUnmarshaler = &RuleID{}
+	_ graphql.Marshaler        = RuleID{}
+	_ graphql.Unmarshaler      = &RuleID{}
+)
 
 func (r RuleID) MarshalGQL(w io.Writer) {
 	graphql.MarshalString(r.String()).MarshalGQL(w)
 }
+
 func (r *RuleID) UnmarshalGQL(v interface{}) error {
 	s, err := graphql.UnmarshalString(v)
 	if err != nil {
@@ -56,6 +59,7 @@ func (r *RuleID) UnmarshalGQL(v interface{}) error {
 
 	return nil
 }
+
 func (r RuleID) String() string {
 	if !r.valid {
 		return ""
@@ -63,6 +67,7 @@ func (r RuleID) String() string {
 
 	return fmt.Sprintf("%s:%d", r.scheduleID.String(), r.id)
 }
+
 func (r RuleID) MarshalText() ([]byte, error) {
 	if !r.valid {
 		return nil, nil


### PR DESCRIPTION
- Changed OnCallNotificationRuleInput to use 'Dest' instead of 'Target'
- Refactored resolver and mutation logic for new field
- Deprecated 'Target' in the schema and added relevant annotations
- Removed unused imports and redundant validation code
