### PR TITLE
dest: move to DestV1 away from DestType

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -417,7 +417,7 @@ func (p *Engine) Receive(ctx context.Context, callbackID string, result notifica
 func (p *Engine) Start(ctx context.Context, d notification.Dest) error {
 	var err error
 	permission.SudoContext(ctx, func(ctx context.Context) {
-		err = p.cfg.ContactMethodStore.EnableByValue(ctx, p.b.db, d.Type.CMType(), d.Value)
+		err = p.cfg.ContactMethodStore.EnableByDest(ctx, p.b.db, d.ToDestV1())
 	})
 
 	if errors.Is(err, sql.ErrNoRows) {
@@ -433,7 +433,7 @@ func (p *Engine) Start(ctx context.Context, d notification.Dest) error {
 func (p *Engine) Stop(ctx context.Context, d notification.Dest) error {
 	var err error
 	permission.SudoContext(ctx, func(ctx context.Context) {
-		err = p.cfg.ContactMethodStore.DisableByValue(ctx, p.b.db, d.Type.CMType(), d.Value)
+		err = p.cfg.ContactMethodStore.DisableByDest(ctx, p.b.db, d.ToDestV1())
 	})
 
 	if errors.Is(err, sql.ErrNoRows) {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -25,6 +25,7 @@ import (
 	"github.com/target/goalert/engine/statusmgr"
 	"github.com/target/goalert/engine/verifymanager"
 	"github.com/target/goalert/expflag"
+	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/notification"
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/user"
@@ -414,10 +415,10 @@ func (p *Engine) Receive(ctx context.Context, callbackID string, result notifica
 
 // Start will enable all associated contact methods of `value` with type `t`. This should
 // be invoked if a user, for example, responds with `START` via sms.
-func (p *Engine) Start(ctx context.Context, d notification.Dest) error {
+func (p *Engine) Start(ctx context.Context, d gadb.DestV1) error {
 	var err error
 	permission.SudoContext(ctx, func(ctx context.Context) {
-		err = p.cfg.ContactMethodStore.EnableByDest(ctx, p.b.db, d.ToDestV1())
+		err = p.cfg.ContactMethodStore.EnableByDest(ctx, p.b.db, d)
 	})
 
 	if errors.Is(err, sql.ErrNoRows) {
@@ -430,10 +431,10 @@ func (p *Engine) Start(ctx context.Context, d notification.Dest) error {
 
 // Stop will disable all associated contact methods of `value` with type `t`. This should
 // be invoked if a user, for example, responds with `STOP` via SMS.
-func (p *Engine) Stop(ctx context.Context, d notification.Dest) error {
+func (p *Engine) Stop(ctx context.Context, d gadb.DestV1) error {
 	var err error
 	permission.SudoContext(ctx, func(ctx context.Context) {
-		err = p.cfg.ContactMethodStore.DisableByDest(ctx, p.b.db, d.ToDestV1())
+		err = p.cfg.ContactMethodStore.DisableByDest(ctx, p.b.db, d)
 	})
 
 	if errors.Is(err, sql.ErrNoRows) {

--- a/engine/isknowndest.go
+++ b/engine/isknowndest.go
@@ -4,13 +4,10 @@ import (
 	"context"
 
 	"github.com/target/goalert/gadb"
-	"github.com/target/goalert/notification"
 )
 
-func (n *Engine) IsKnownDest(ctx context.Context, destType notification.DestType, destValue string) (bool, error) {
-	d := notification.Dest{Type: destType, Value: destValue}
-
-	b, err := gadb.New(n.b.db).EngineIsKnownDest(ctx, gadb.NullDestV1{Valid: true, DestV1: d.ToDestV1()})
+func (n *Engine) IsKnownDest(ctx context.Context, dest gadb.DestV1) (bool, error) {
+	b, err := gadb.New(n.b.db).EngineIsKnownDest(ctx, gadb.NullDestV1{Valid: true, DestV1: dest})
 	if err != nil {
 		return false, err
 	}

--- a/engine/message/bundlealerts.go
+++ b/engine/message/bundlealerts.go
@@ -30,14 +30,14 @@ func bundleAlertMessages(messages []Message, newBundleFunc func(Message) (string
 	})
 
 	type key struct {
-		notification.Dest
+		notification.DestHash
 		ServiceID string
 	}
 
 	groups := make(map[key][]Message)
 	for _, msg := range toProcess {
 		key := key{
-			Dest:      msg.Dest,
+			DestHash:  msg.Dest.DestHash(),
 			ServiceID: msg.ServiceID,
 		}
 		groups[key] = append(groups[key], msg)

--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -784,7 +784,7 @@ func (db *DB) sendMessagesByType(ctx context.Context, cLock *processinglock.Conn
 func (db *DB) sendMessage(ctx context.Context, cLock *processinglock.Conn, send SendFunc, m *Message) (bool, error) {
 	ctx = log.WithFields(ctx, log.Fields{
 		"DestTypeID": m.Dest.ID,
-		"DestType":   m.Dest.Type.String(),
+		"DestType":   m.Dest.DestType(),
 		"CallbackID": m.ID,
 	})
 

--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -660,7 +660,7 @@ func (db *DB) _SendMessages(ctx context.Context, send SendFunc, status StatusFun
 	var wg sync.WaitGroup
 	for _, t := range q.Types() {
 		wg.Add(1)
-		go func(typ notification.DestType) {
+		go func(typ string) {
 			defer wg.Done()
 			err := db.sendMessagesByType(ctx, cLock, send, q, typ)
 			if err != nil && !errors.Is(err, processinglock.ErrNoLock) {
@@ -745,7 +745,7 @@ func (db *DB) updateStuckMessages(ctx context.Context, statusFn StatusFunc) erro
 	return nil
 }
 
-func (db *DB) sendMessagesByType(ctx context.Context, cLock *processinglock.Conn, send SendFunc, q *queue, typ notification.DestType) error {
+func (db *DB) sendMessagesByType(ctx context.Context, cLock *processinglock.Conn, send SendFunc, q *queue, typ string) error {
 	ch := make(chan error)
 	var count int
 	for {

--- a/engine/message/dedupalerts.go
+++ b/engine/message/dedupalerts.go
@@ -18,7 +18,7 @@ func dedupAlerts(msgs []Message, bundleFunc func(parentID string, duplicateIDs [
 	sort.Slice(toProcess, func(i, j int) bool { return toProcess[i].CreatedAt.Before(toProcess[j].CreatedAt) })
 
 	type msgKey struct {
-		notification.Dest
+		notification.DestHash
 		AlertID int
 	}
 	alerts := make(map[msgKey]string, len(msgs))
@@ -26,7 +26,7 @@ func dedupAlerts(msgs []Message, bundleFunc func(parentID string, duplicateIDs [
 
 	for _, msg := range toProcess {
 		// check if we have seen this alert before
-		key := msgKey{msg.Dest, msg.AlertID}
+		key := msgKey{msg.Dest.DestHash(), msg.AlertID}
 
 		if parentID, ok := alerts[key]; ok {
 			duplicates[parentID] = append(duplicates[parentID], msg.ID)

--- a/engine/message/deduponcallnotifications.go
+++ b/engine/message/deduponcallnotifications.go
@@ -13,13 +13,13 @@ func dedupOnCallNotifications(messages []Message) ([]Message, []string) {
 
 	type msgKey struct {
 		scheduleID string
-		dest       notification.Dest
+		dest       notification.DestHash
 	}
 
 	m := make(map[msgKey]struct{})
 	var toDelete []string
 	for _, msg := range toProcess {
-		key := msgKey{scheduleID: msg.ScheduleID, dest: msg.Dest}
+		key := msgKey{scheduleID: msg.ScheduleID, dest: msg.Dest.DestHash()}
 		if _, ok := m[key]; ok {
 			toDelete = append(toDelete, msg.ID)
 			continue

--- a/engine/message/dedupstatusmessages.go
+++ b/engine/message/dedupstatusmessages.go
@@ -13,13 +13,13 @@ func dedupStatusMessages(messages []Message) ([]Message, []string) {
 
 	type msgKey struct {
 		alertID int
-		dest    notification.Dest
+		dest    notification.DestHash
 	}
 
 	m := make(map[msgKey]struct{})
 	var toDelete []string
 	for _, msg := range toProcess {
-		key := msgKey{alertID: msg.AlertID, dest: msg.Dest}
+		key := msgKey{alertID: msg.AlertID, dest: msg.Dest.DestHash()}
 		if _, ok := m[key]; ok {
 			toDelete = append(toDelete, msg.ID)
 			continue

--- a/engine/message/queue_test.go
+++ b/engine/message/queue_test.go
@@ -149,12 +149,12 @@ func TestQueue_Sort(t *testing.T) {
 	expected = expected[:rules[1].Count]
 
 	for i, exp := range expected {
-		msg := q.NextByType(notification.DestTypeSMS)
+		msg := q.NextByType(notification.DestTypeSMS.String())
 		require.NotNilf(t, msg, "message #%d", i)
 		assert.Equalf(t, exp, *msg, "message #%d", i)
 	}
 
 	// no more expected messages
-	msg := q.NextByType(notification.DestTypeSMS)
+	msg := q.NextByType(notification.DestTypeSMS.String())
 	assert.Nil(t, msg)
 }

--- a/engine/sendmessage.go
+++ b/engine/sendmessage.go
@@ -66,7 +66,7 @@ func (p *Engine) sendMessage(ctx context.Context, msg *message.Message) (*notifi
 		if err != nil {
 			return nil, errors.Wrap(err, "lookup alert")
 		}
-		stat, err := p.cfg.NotificationStore.OriginalMessageStatus(ctx, msg.AlertID, msg.Dest)
+		stat, err := p.cfg.NotificationStore.OriginalMessageStatus(ctx, msg.AlertID, msg.Dest.ID)
 		if err != nil {
 			return nil, fmt.Errorf("lookup original message: %w", err)
 		}
@@ -100,7 +100,7 @@ func (p *Engine) sendMessage(ctx context.Context, msg *message.Message) (*notifi
 		if err != nil {
 			return nil, fmt.Errorf("lookup original alert: %w", err)
 		}
-		stat, err := p.cfg.NotificationStore.OriginalMessageStatus(ctx, msg.AlertID, msg.Dest)
+		stat, err := p.cfg.NotificationStore.OriginalMessageStatus(ctx, msg.AlertID, msg.Dest.ID)
 		if err != nil {
 			return nil, fmt.Errorf("lookup original message: %w", err)
 		}

--- a/gadb/dest.go
+++ b/gadb/dest.go
@@ -5,6 +5,22 @@ import (
 	"fmt"
 )
 
+func NewDestV1(typeID string, args ...string) DestV1 {
+	d := DestV1{
+		Type: typeID,
+	}
+
+	if len(args)%2 != 0 {
+		panic("args must be key-value pairs")
+	}
+
+	for i := 0; i < len(args); i += 2 {
+		d.SetArg(args[i], args[i+1])
+	}
+
+	return d
+}
+
 type DestV1 struct {
 	Args map[string]string
 	Type string

--- a/gadb/queries.sql.go
+++ b/gadb/queries.sql.go
@@ -888,52 +888,34 @@ func (q *Queries) ContactMethodEnableDisable(ctx context.Context, arg ContactMet
 
 const contactMethodFindAll = `-- name: ContactMethodFindAll :many
 SELECT
-    id,
-    name,
-    type,
-    value,
-    disabled,
-    user_id,
-    last_test_verify_at,
-    enable_status_updates,
-    pending
+    dest, disabled, enable_status_updates, id, last_test_verify_at, metadata, name, pending, type, user_id, value
 FROM
     user_contact_methods
 WHERE
     user_id = $1
 `
 
-type ContactMethodFindAllRow struct {
-	ID                  uuid.UUID
-	Name                string
-	Type                EnumUserContactMethodType
-	Value               string
-	Disabled            bool
-	UserID              uuid.UUID
-	LastTestVerifyAt    sql.NullTime
-	EnableStatusUpdates bool
-	Pending             bool
-}
-
-func (q *Queries) ContactMethodFindAll(ctx context.Context, userID uuid.UUID) ([]ContactMethodFindAllRow, error) {
+func (q *Queries) ContactMethodFindAll(ctx context.Context, userID uuid.UUID) ([]UserContactMethod, error) {
 	rows, err := q.db.QueryContext(ctx, contactMethodFindAll, userID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ContactMethodFindAllRow
+	var items []UserContactMethod
 	for rows.Next() {
-		var i ContactMethodFindAllRow
+		var i UserContactMethod
 		if err := rows.Scan(
-			&i.ID,
-			&i.Name,
-			&i.Type,
-			&i.Value,
+			&i.Dest,
 			&i.Disabled,
-			&i.UserID,
-			&i.LastTestVerifyAt,
 			&i.EnableStatusUpdates,
+			&i.ID,
+			&i.LastTestVerifyAt,
+			&i.Metadata,
+			&i.Name,
 			&i.Pending,
+			&i.Type,
+			&i.UserID,
+			&i.Value,
 		); err != nil {
 			return nil, err
 		}
@@ -950,52 +932,34 @@ func (q *Queries) ContactMethodFindAll(ctx context.Context, userID uuid.UUID) ([
 
 const contactMethodFindMany = `-- name: ContactMethodFindMany :many
 SELECT
-    id,
-    name,
-    type,
-    value,
-    disabled,
-    user_id,
-    last_test_verify_at,
-    enable_status_updates,
-    pending
+    dest, disabled, enable_status_updates, id, last_test_verify_at, metadata, name, pending, type, user_id, value
 FROM
     user_contact_methods
 WHERE
     id = ANY ($1::uuid[])
 `
 
-type ContactMethodFindManyRow struct {
-	ID                  uuid.UUID
-	Name                string
-	Type                EnumUserContactMethodType
-	Value               string
-	Disabled            bool
-	UserID              uuid.UUID
-	LastTestVerifyAt    sql.NullTime
-	EnableStatusUpdates bool
-	Pending             bool
-}
-
-func (q *Queries) ContactMethodFindMany(ctx context.Context, dollar_1 []uuid.UUID) ([]ContactMethodFindManyRow, error) {
+func (q *Queries) ContactMethodFindMany(ctx context.Context, dollar_1 []uuid.UUID) ([]UserContactMethod, error) {
 	rows, err := q.db.QueryContext(ctx, contactMethodFindMany, pq.Array(dollar_1))
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ContactMethodFindManyRow
+	var items []UserContactMethod
 	for rows.Next() {
-		var i ContactMethodFindManyRow
+		var i UserContactMethod
 		if err := rows.Scan(
-			&i.ID,
-			&i.Name,
-			&i.Type,
-			&i.Value,
+			&i.Dest,
 			&i.Disabled,
-			&i.UserID,
-			&i.LastTestVerifyAt,
 			&i.EnableStatusUpdates,
+			&i.ID,
+			&i.LastTestVerifyAt,
+			&i.Metadata,
+			&i.Name,
 			&i.Pending,
+			&i.Type,
+			&i.UserID,
+			&i.Value,
 		); err != nil {
 			return nil, err
 		}
@@ -1012,15 +976,7 @@ func (q *Queries) ContactMethodFindMany(ctx context.Context, dollar_1 []uuid.UUI
 
 const contactMethodFindOneUpdate = `-- name: ContactMethodFindOneUpdate :one
 SELECT
-    id,
-    name,
-    type,
-    value,
-    disabled,
-    user_id,
-    last_test_verify_at,
-    enable_status_updates,
-    pending
+    dest, disabled, enable_status_updates, id, last_test_verify_at, metadata, name, pending, type, user_id, value
 FROM
     user_contact_methods
 WHERE
@@ -1028,77 +984,49 @@ WHERE
 FOR UPDATE
 `
 
-type ContactMethodFindOneUpdateRow struct {
-	ID                  uuid.UUID
-	Name                string
-	Type                EnumUserContactMethodType
-	Value               string
-	Disabled            bool
-	UserID              uuid.UUID
-	LastTestVerifyAt    sql.NullTime
-	EnableStatusUpdates bool
-	Pending             bool
-}
-
-func (q *Queries) ContactMethodFindOneUpdate(ctx context.Context, id uuid.UUID) (ContactMethodFindOneUpdateRow, error) {
+func (q *Queries) ContactMethodFindOneUpdate(ctx context.Context, id uuid.UUID) (UserContactMethod, error) {
 	row := q.db.QueryRowContext(ctx, contactMethodFindOneUpdate, id)
-	var i ContactMethodFindOneUpdateRow
+	var i UserContactMethod
 	err := row.Scan(
-		&i.ID,
-		&i.Name,
-		&i.Type,
-		&i.Value,
+		&i.Dest,
 		&i.Disabled,
-		&i.UserID,
-		&i.LastTestVerifyAt,
 		&i.EnableStatusUpdates,
+		&i.ID,
+		&i.LastTestVerifyAt,
+		&i.Metadata,
+		&i.Name,
 		&i.Pending,
+		&i.Type,
+		&i.UserID,
+		&i.Value,
 	)
 	return i, err
 }
 
 const contactMethodFineOne = `-- name: ContactMethodFineOne :one
 SELECT
-    id,
-    name,
-    type,
-    value,
-    disabled,
-    user_id,
-    last_test_verify_at,
-    enable_status_updates,
-    pending
+    dest, disabled, enable_status_updates, id, last_test_verify_at, metadata, name, pending, type, user_id, value
 FROM
     user_contact_methods
 WHERE
     id = $1
 `
 
-type ContactMethodFineOneRow struct {
-	ID                  uuid.UUID
-	Name                string
-	Type                EnumUserContactMethodType
-	Value               string
-	Disabled            bool
-	UserID              uuid.UUID
-	LastTestVerifyAt    sql.NullTime
-	EnableStatusUpdates bool
-	Pending             bool
-}
-
-func (q *Queries) ContactMethodFineOne(ctx context.Context, id uuid.UUID) (ContactMethodFineOneRow, error) {
+func (q *Queries) ContactMethodFineOne(ctx context.Context, id uuid.UUID) (UserContactMethod, error) {
 	row := q.db.QueryRowContext(ctx, contactMethodFineOne, id)
-	var i ContactMethodFineOneRow
+	var i UserContactMethod
 	err := row.Scan(
-		&i.ID,
-		&i.Name,
-		&i.Type,
-		&i.Value,
+		&i.Dest,
 		&i.Disabled,
-		&i.UserID,
-		&i.LastTestVerifyAt,
 		&i.EnableStatusUpdates,
+		&i.ID,
+		&i.LastTestVerifyAt,
+		&i.Metadata,
+		&i.Name,
 		&i.Pending,
+		&i.Type,
+		&i.UserID,
+		&i.Value,
 	)
 	return i, err
 }

--- a/notification/desttype.go
+++ b/notification/desttype.go
@@ -51,6 +51,15 @@ type DestHash [32]byte
 
 // DestHash returns a comparable hash of the destination.
 func (d Dest) DestHash() DestHash {
+	if d.ID.CMID.Valid || d.ID.NCID.Valid {
+		// If we have a CMID or NCID, we can use that as the unique identifier.
+		var h [32]byte
+		copy(h[:], d.ID.CMID.UUID[:])
+		copy(h[16:], d.ID.NCID.UUID[:])
+		return DestHash(h)
+	}
+
+	// Otherwise, we hash the type and value as a fallback until we move to DestV1 everywhere.
 	return DestHash(sha256.Sum256([]byte(fmt.Sprintf("%s\n%s\n", d.Type.String(), d.Value))))
 }
 

--- a/notification/desttype.go
+++ b/notification/desttype.go
@@ -54,6 +54,10 @@ func (d Dest) DestHash() DestHash {
 	return DestHash(sha256.Sum256([]byte(fmt.Sprintf("%s\n%s\n", d.Type.String(), d.Value))))
 }
 
+func (d Dest) DestType() string {
+	return d.Type.String()
+}
+
 type SQLDest struct {
 	CMID    uuid.NullUUID
 	CMType  gadb.NullEnumUserContactMethodType

--- a/notification/namedreceiver.go
+++ b/notification/namedreceiver.go
@@ -34,14 +34,14 @@ func (nr *namedReceiver) AuthLinkURL(ctx context.Context, providerID, subjectID 
 }
 
 // Start implements the Receiver interface by calling the underlying Receiver.Start method.
-func (nr *namedReceiver) Start(ctx context.Context, d Dest) error {
-	metricRecvTotal.WithLabelValues(d.Type.String(), "START")
+func (nr *namedReceiver) Start(ctx context.Context, d gadb.DestV1) error {
+	metricRecvTotal.WithLabelValues(d.Type, "START")
 	return nr.r.Start(ctx, d)
 }
 
 // Stop implements the Receiver interface by calling the underlying Receiver.Stop method.
-func (nr *namedReceiver) Stop(ctx context.Context, d Dest) error {
-	metricRecvTotal.WithLabelValues(d.Type.String(), "STOP")
+func (nr *namedReceiver) Stop(ctx context.Context, d gadb.DestV1) error {
+	metricRecvTotal.WithLabelValues(d.Type, "STOP")
 	return nr.r.Stop(ctx, d)
 }
 

--- a/notification/namedreceiver.go
+++ b/notification/namedreceiver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/target/goalert/auth/authlink"
+	"github.com/target/goalert/gadb"
 )
 
 type namedReceiver struct {
@@ -14,8 +15,8 @@ type namedReceiver struct {
 var _ Receiver = &namedReceiver{}
 
 // IsKnownDest calls the underlying ResultReceiver.IsKnownDest method for the current type.
-func (nr *namedReceiver) IsKnownDest(ctx context.Context, value string) (bool, error) {
-	return nr.r.IsKnownDest(ctx, nr.ns.destType, value)
+func (nr *namedReceiver) IsKnownDest(ctx context.Context, dest gadb.DestV1) (bool, error) {
+	return nr.r.IsKnownDest(ctx, dest)
 }
 
 // SetMessageStatus calls the underlying ResultReceiver's SetSendResult method after wrapping the status for the

--- a/notification/receiver.go
+++ b/notification/receiver.go
@@ -22,10 +22,10 @@ type Receiver interface {
 	AuthLinkURL(ctx context.Context, providerID, subjectID string, meta authlink.Metadata) (string, error)
 
 	// Start indicates a user has opted-in for notifications to this contact method.
-	Start(context.Context, Dest) error
+	Start(context.Context, gadb.DestV1) error
 
 	// Stop indicates a user has opted-out of notifications from a contact method.
-	Stop(context.Context, Dest) error
+	Stop(context.Context, gadb.DestV1) error
 
 	// IsKnownDest checks if the given destination is known/not disabled.
 	IsKnownDest(ctx context.Context, dest gadb.DestV1) (bool, error)

--- a/notification/receiver.go
+++ b/notification/receiver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/target/goalert/auth/authlink"
+	"github.com/target/goalert/gadb"
 )
 
 // A Receiver processes incoming messages and responses.
@@ -27,7 +28,7 @@ type Receiver interface {
 	Stop(context.Context, Dest) error
 
 	// IsKnownDest checks if the given destination is known/not disabled.
-	IsKnownDest(ctx context.Context, value string) (bool, error)
+	IsKnownDest(ctx context.Context, dest gadb.DestV1) (bool, error)
 }
 
 // UnknownSubjectError is returned from ReceiveSubject when the subject is unknown.

--- a/notification/resultreceiver.go
+++ b/notification/resultreceiver.go
@@ -14,8 +14,8 @@ type ResultReceiver interface {
 	Receive(ctx context.Context, callbackID string, result Result) error
 	ReceiveSubject(ctx context.Context, providerID, subjectID, callbackID string, result Result) error
 	AuthLinkURL(ctx context.Context, providerID, subjectID string, meta authlink.Metadata) (string, error)
-	Start(context.Context, Dest) error
-	Stop(context.Context, Dest) error
+	Start(context.Context, gadb.DestV1) error
+	Stop(context.Context, gadb.DestV1) error
 
 	IsKnownDest(ctx context.Context, dest gadb.DestV1) (bool, error)
 }

--- a/notification/resultreceiver.go
+++ b/notification/resultreceiver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/target/goalert/auth/authlink"
+	"github.com/target/goalert/gadb"
 )
 
 // A ResultReceiver processes notification responses.
@@ -16,5 +17,5 @@ type ResultReceiver interface {
 	Start(context.Context, Dest) error
 	Stop(context.Context, Dest) error
 
-	IsKnownDest(ctx context.Context, destType DestType, destValue string) (bool, error)
+	IsKnownDest(ctx context.Context, dest gadb.DestV1) (bool, error)
 }

--- a/notification/store.go
+++ b/notification/store.go
@@ -118,23 +118,16 @@ func NewStore(ctx context.Context, db *sql.DB) (*Store, error) {
 }
 
 // OriginalMessageStatus will return the status of the first alert notification sent to `dest` for the given `alertID`.
-func (s *Store) OriginalMessageStatus(ctx context.Context, alertID int, dst Dest) (*SendResult, error) {
+func (s *Store) OriginalMessageStatus(ctx context.Context, alertID int, dstID DestID) (*SendResult, error) {
 	err := permission.LimitCheckAny(ctx, permission.System)
 	if err != nil {
 		return nil, err
 	}
 
-	var cmID, chanID uuid.NullUUID
-	if dst.ID.IsUserCM() {
-		cmID.UUID, cmID.Valid = dst.ID.UUID(), true
-	} else {
-		chanID.UUID, chanID.Valid = dst.ID.UUID(), true
-	}
-
 	row, err := gadb.New(s.db).NfyOriginalMessageStatus(ctx, gadb.NfyOriginalMessageStatusParams{
 		AlertID:         sql.NullInt64{Valid: true, Int64: int64(alertID)},
-		ContactMethodID: cmID,
-		ChannelID:       chanID,
+		ContactMethodID: dstID.CMID,
+		ChannelID:       dstID.NCID,
 	})
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil

--- a/notification/twilio/sms.go
+++ b/notification/twilio/sms.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nyaruka/phonenumbers"
 	"github.com/target/goalert/alert"
 	"github.com/target/goalert/config"
+	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/notification"
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/retry"
@@ -249,7 +250,7 @@ func (s *SMS) ServeMessage(w http.ResponseWriter, req *http.Request) {
 		}
 
 		if isPassive {
-			valid, err := s.r.IsKnownDest(ctx, from)
+			valid, err := s.r.IsKnownDest(ctx, gadb.NewDestV1(DestTypeTwilioSMS, FieldPhoneNumber, from))
 			if err != nil {
 				log.Log(ctx, fmt.Errorf("check if known SMS number: %w", err))
 			} else if !valid {

--- a/notification/twilio/sms.go
+++ b/notification/twilio/sms.go
@@ -33,6 +33,10 @@ var (
 	svcReplyRx = regexp.MustCompile(`^'?\s*([0-9]+)\s*(cc|aa)\s*'?$`)
 )
 
+func newSMSDest(number string) gadb.DestV1 {
+	return gadb.NewDestV1(DestTypeTwilioSMS, FieldPhoneNumber, number)
+}
+
 // SMS implements a notification.Sender for Twilio SMS.
 type SMS struct {
 	b *dbSMS
@@ -277,16 +281,15 @@ func (s *SMS) ServeMessage(w http.ResponseWriter, req *http.Request) {
 
 	// handle start and stop codes from user
 	body := req.FormValue("Body")
-	dest := notification.Dest{Type: notification.DestTypeSMS, Value: from}
 	if isStartMessage(body) {
-		err := retry.DoTemporaryError(func(int) error { return s.r.Start(ctx, dest) }, retryOpts...)
+		err := retry.DoTemporaryError(func(int) error { return s.r.Start(ctx, newSMSDest(from)) }, retryOpts...)
 		if err != nil {
 			log.Log(ctx, fmt.Errorf("process START message: %w", err))
 		}
 		return
 	}
 	if isStopMessage(body) {
-		err := retry.DoTemporaryError(func(int) error { return s.r.Stop(ctx, dest) }, retryOpts...)
+		err := retry.DoTemporaryError(func(int) error { return s.r.Stop(ctx, newSMSDest(from)) }, retryOpts...)
 		if err != nil {
 			log.Log(ctx, fmt.Errorf("process STOP message: %w", err))
 		}

--- a/notification/twilio/voice.go
+++ b/notification/twilio/voice.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/target/goalert/alert"
 	"github.com/target/goalert/config"
+	"github.com/target/goalert/gadb"
 	"github.com/target/goalert/notification"
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/retry"
@@ -71,6 +72,10 @@ var (
 	_               notification.FriendlyValuer = &Voice{}
 	rmParen                                     = regexp.MustCompile(`\s*\(.*?\)`)
 )
+
+func newVoiceDest(number string) gadb.DestV1 {
+	return gadb.NewDestV1(DestTypeTwilioVoice, FieldPhoneNumber, number)
+}
 
 func voiceErrorMessage(ctx context.Context, err error) (string, error) {
 	var e alert.LogEntryFetcher
@@ -325,7 +330,7 @@ func (v *Voice) ServeStop(w http.ResponseWriter, req *http.Request) {
 		return
 	case digitConfirm:
 		err := doDeadline(ctx, func() error {
-			return v.r.Stop(ctx, notification.Dest{Type: notification.DestTypeVoice, Value: call.Number})
+			return v.r.Stop(ctx, newVoiceDest(call.Number))
 		})
 
 		if errResp(false, errors.Wrap(err, "process STOP response"), "") {

--- a/user/contactmethod/queries.sql
+++ b/user/contactmethod/queries.sql
@@ -18,15 +18,7 @@ WHERE id = ANY ($1::uuid[]);
 
 -- name: ContactMethodFineOne :one
 SELECT
-    id,
-    name,
-    type,
-    value,
-    disabled,
-    user_id,
-    last_test_verify_at,
-    enable_status_updates,
-    pending
+    *
 FROM
     user_contact_methods
 WHERE
@@ -34,15 +26,7 @@ WHERE
 
 -- name: ContactMethodFindOneUpdate :one
 SELECT
-    id,
-    name,
-    type,
-    value,
-    disabled,
-    user_id,
-    last_test_verify_at,
-    enable_status_updates,
-    pending
+    *
 FROM
     user_contact_methods
 WHERE
@@ -51,15 +35,7 @@ FOR UPDATE;
 
 -- name: ContactMethodFindMany :many
 SELECT
-    id,
-    name,
-    type,
-    value,
-    disabled,
-    user_id,
-    last_test_verify_at,
-    enable_status_updates,
-    pending
+    *
 FROM
     user_contact_methods
 WHERE
@@ -67,15 +43,7 @@ WHERE
 
 -- name: ContactMethodFindAll :many
 SELECT
-    id,
-    name,
-    type,
-    value,
-    disabled,
-    user_id,
-    last_test_verify_at,
-    enable_status_updates,
-    pending
+    *
 FROM
     user_contact_methods
 WHERE

--- a/user/contactmethod/queries.sql
+++ b/user/contactmethod/queries.sql
@@ -89,14 +89,13 @@ FROM
 WHERE
     id = ANY ($1::uuid[]);
 
--- name: ContactMethodEnable :one
+-- name: ContactMethodEnableDisable :one
 UPDATE
     user_contact_methods
 SET
-    disabled = FALSE
+    disabled = $2
 WHERE
-    type = $1
-    AND value = $2
+    dest = $1
 RETURNING
     id;
 
@@ -114,19 +113,8 @@ WHERE
 UPDATE
     user_contact_methods
 SET
-    metadata = jsonb_set(jsonb_set(metadata, '{CarrierV1}', @carrier_v1::jsonb), '{CarrierV1,UpdatedAt}',('"' || NOW()::timestamptz AT TIME ZONE 'UTC' || '"')::jsonb) 
+    metadata = jsonb_set(jsonb_set(metadata, '{CarrierV1}', @carrier_v1::jsonb), '{CarrierV1,UpdatedAt}',('"' || NOW()::timestamptz AT TIME ZONE 'UTC' || '"')::jsonb)
 WHERE
     type = $1
     AND value = $2;
-
--- name: ContactMethodDisable :one
-UPDATE
-    user_contact_methods
-SET
-    disabled = TRUE
-WHERE
-    type = $1
-    AND value = $2
-RETURNING
-    id;
 

--- a/user/contactmethod/store.go
+++ b/user/contactmethod/store.go
@@ -55,6 +55,20 @@ func (s *Store) SetCarrierV1MetadataByTypeValue(ctx context.Context, dbtx gadb.D
 	return nil
 }
 
+func (s *Store) FindDestByID(ctx context.Context, tx gadb.DBTX, id uuid.UUID) (gadb.DestV1, error) {
+	err := permission.LimitCheckAny(ctx, permission.User)
+	if err != nil {
+		return gadb.DestV1{}, err
+	}
+
+	row, err := gadb.New(tx).ContactMethodFineOne(ctx, id)
+	if err != nil {
+		return gadb.DestV1{}, err
+	}
+
+	return row.Dest.DestV1, nil
+}
+
 func (s *Store) EnableByDest(ctx context.Context, dbtx gadb.DBTX, dest gadb.DestV1) error {
 	err := permission.LimitCheckAny(ctx, permission.System)
 	if err != nil {

--- a/user/contactmethod/store.go
+++ b/user/contactmethod/store.go
@@ -55,19 +55,16 @@ func (s *Store) SetCarrierV1MetadataByTypeValue(ctx context.Context, dbtx gadb.D
 	return nil
 }
 
-func (s *Store) EnableByValue(ctx context.Context, dbtx gadb.DBTX, t Type, v string) error {
+func (s *Store) EnableByDest(ctx context.Context, dbtx gadb.DBTX, dest gadb.DestV1) error {
 	err := permission.LimitCheckAny(ctx, permission.System)
 	if err != nil {
 		return err
 	}
 
-	c := ContactMethod{Name: "Enable", Type: t, Value: v}
-	n, err := c.Normalize()
-	if err != nil {
-		return err
-	}
-
-	id, err := gadb.New(dbtx).ContactMethodEnable(ctx, gadb.ContactMethodEnableParams{Type: gadb.EnumUserContactMethodType(n.Type), Value: n.Value})
+	id, err := gadb.New(dbtx).ContactMethodEnableDisable(ctx, gadb.ContactMethodEnableDisableParams{
+		Dest:     gadb.NullDestV1{Valid: true, DestV1: dest},
+		Disabled: false,
+	})
 
 	if err == nil {
 		// NOTE: maintain a record of consent/dissent
@@ -81,19 +78,16 @@ func (s *Store) EnableByValue(ctx context.Context, dbtx gadb.DBTX, t Type, v str
 	return err
 }
 
-func (s *Store) DisableByValue(ctx context.Context, dbtx gadb.DBTX, t Type, v string) error {
+func (s *Store) DisableByDest(ctx context.Context, dbtx gadb.DBTX, dest gadb.DestV1) error {
 	err := permission.LimitCheckAny(ctx, permission.System)
 	if err != nil {
 		return err
 	}
 
-	c := ContactMethod{Name: "Disable", Type: t, Value: v}
-	n, err := c.Normalize()
-	if err != nil {
-		return err
-	}
-
-	id, err := gadb.New(dbtx).ContactMethodDisable(ctx, gadb.ContactMethodDisableParams{Type: gadb.EnumUserContactMethodType(n.Type), Value: v})
+	id, err := gadb.New(dbtx).ContactMethodEnableDisable(ctx, gadb.ContactMethodEnableDisableParams{
+		Dest:     gadb.NullDestV1{Valid: true, DestV1: dest},
+		Disabled: true,
+	})
 
 	if err == nil {
 		// NOTE: maintain a record of consent/dissent


### PR DESCRIPTION
**Description:**
Updates code using `notification.Dest` as a comparable value to use `DestHash` instead along with updating some signatures to use `gadb.DestV1` directly instead of type/value.
