### PR TITLE
graphql: Improve error handling for validation for arg and param types

### DIFF
--- a/graphql2/graphqlapp/app.go
+++ b/graphql2/graphqlapp/app.go
@@ -228,6 +228,31 @@ func (a *App) Handler() http.Handler {
 				},
 			}
 		}
+
+		var argErr *nfydest.DestArgError
+		if errors.As(err, &argErr) {
+			return &gqlerror.Error{
+				Message: argErr.Err.Error(),
+				Path:    graphql.GetPath(ctx),
+				Extensions: map[string]interface{}{
+					"code":    graphql2.ErrorCodeInvalidDestFieldValue,
+					"fieldID": argErr.FieldID,
+				},
+			}
+		}
+
+		var paramErr *nfydest.ActionParamError
+		if errors.As(err, &paramErr) {
+			return &gqlerror.Error{
+				Message: paramErr.Err.Error(),
+				Path:    graphql.GetPath(ctx),
+				Extensions: map[string]interface{}{
+					"code": graphql2.ErrorCodeInvalidMapFieldValue,
+					"key":  paramErr.ParamID,
+				},
+			}
+		}
+
 		err = errutil.MapDBError(err)
 		var gqlErr *gqlerror.Error
 

--- a/notification/nfydest/validate.go
+++ b/notification/nfydest/validate.go
@@ -22,6 +22,8 @@ type DestArgError struct {
 
 func (e *DestArgError) Error() string { return fmt.Sprintf("field %s: %s", e.FieldID, e.Err) }
 
+func (e *DestArgError) ClientError() bool { return true }
+
 func (r *Registry) ValidateDest(ctx context.Context, dest gadb.DestV1) error {
 	p := r.Provider(dest.Type)
 	if p == nil {

--- a/notification/nfydest/validateaction.go
+++ b/notification/nfydest/validateaction.go
@@ -27,6 +27,8 @@ type ActionParamError struct {
 
 func (e *ActionParamError) Error() string { return fmt.Sprintf("parameter %s: %s", e.ParamID, e.Err) }
 
+func (e *ActionParamError) ClientError() bool { return true }
+
 func (r *Registry) ValidateAction(ctx context.Context, act gadb.UIKActionV1) error {
 	p := r.Provider(act.Dest.Type)
 	if p == nil {


### PR DESCRIPTION
**Description:**
Fixes an issue where invalid fields would result in 500 unexpected errors for field validation issues.

- arg and param errors are now correctly marked client-safe
- updated error presenter to return proper codes for these types
