### PR TITLE
Fix no-rows bug with last message status

### DIFF
--- a/notification/store.go
+++ b/notification/store.go
@@ -407,6 +407,9 @@ func (s *Store) LastMessageStatus(ctx context.Context, typ gadb.EnumOutgoingMess
 		ContactMethodID: uuid.NullUUID{UUID: cmID, Valid: true},
 		CreatedAt:       from,
 	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, time.Time{}, nil
+	}
 	if err != nil {
 		return nil, time.Time{}, err
 	}


### PR DESCRIPTION
This pull request improves the error handling for validation in GraphQL. It includes a fix for a bug where the LastMessageStatus function was returning an error when there were no rows found in the database. Now, if the query returns no rows, the function will return nil instead of an error. This improves the overall error handling and ensures a smoother experience when working with GraphQL validation.