### PR TITLE
Add permissions to labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   labeler:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     name: Label the PR size


### PR DESCRIPTION
This pull request adds permissions to the labeler job in the workflow file. The permissions include read access to contents and write access to pull requests.

Fixes broken PRs due to recent API changes.