### PR TITLE
integrationkey/uik: Wrap error in validation for HTTP response

### DIFF
--- a/integrationkey/uik/handler.go
+++ b/integrationkey/uik/handler.go
@@ -145,7 +145,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 
 		res, err := vm.Run(p, env)
-		if errutil.HTTPError(ctx, w, err) {
+		if errutil.HTTPError(ctx, w, validation.WrapError(err)) {
 			return
 		}
 


### PR DESCRIPTION
Encapsulates errors in validation for more informative responses.