### PR TITLE
fix: fix slice init length

### DIFF
--- a/alert/store.go
+++ b/alert/store.go
@@ -809,7 +809,7 @@ func (s *Store) Feedback(ctx context.Context, alertIDs []int) ([]Feedback, error
 		return nil, err
 	}
 
-	ids := make([]int32, len(alertIDs))
+	ids := make([]int32, 0, len(alertIDs))
 	for _, id := range alertIDs {
 		ids = append(ids, int32(id))
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [ ] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [ ] All new and existing tests passed.
- [ ] Added comments in the code, where necessary.
- [ ] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**


The intention here should be to initialize a slice with a capacity of  `len(alertIDs)`  rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW

