### PR TITLE
Switch to `pull_request_target` in labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,6 @@
 name: labeler
-
 on:
-  pull_request:
+  pull_request_target:
     types: ['opened', 'ready_for_review', 'reopened', 'synchronize']
 
 jobs:


### PR DESCRIPTION
This pull request switches the labeler workflow to use `pull_request_target` instead of `pull_request` as the event trigger.

This is to allow outside/forked PRs to still run the labeler workflow.