### PR TITLE
add smtp retries

### DIFF
--- a/remotemonitor/config.go
+++ b/remotemonitor/config.go
@@ -35,6 +35,9 @@ type Config struct {
 		// ServerAddr is the address of the SMTP server, including port.
 		ServerAddr string
 		User, Pass string
+
+		// Retries is the number of times to retry sending with an email integration key.
+		Retries int
 	}
 
 	// Instances determine what remote GoAlert instances will be monitored and send potential errors.
@@ -93,6 +96,9 @@ func (cfg Config) Validate() error {
 	}
 	if cfg.SMTP.From == "" {
 		return errors.New("SMTP from address is required")
+	}
+	if cfg.SMTP.Retries > 5 || cfg.SMTP.Retries < 0 {
+		return errors.New("SMTP retries must be between 0 and 5")
 	}
 
 	return nil

--- a/remotemonitor/monitor.go
+++ b/remotemonitor/monitor.go
@@ -2,7 +2,6 @@ package remotemonitor
 
 import (
 	"context"
-	// "errors"
 	"fmt"
 	"io"
 	"log"

--- a/remotemonitor/monitor.go
+++ b/remotemonitor/monitor.go
@@ -191,7 +191,7 @@ func (m *Monitor) createEmailAlert(i Instance, dedup, summary, details string) e
 	err = retry.DoTemporaryError(func(_ int) error {
 		err = smtp.SendMail(m.cfg.SMTP.ServerAddr, auth, m.cfg.SMTP.From, []string{addr.Address}, []byte(msg))
 		err = errors.Wrap(err, "send email")
-		return err
+		return retry.TemporaryError(err)
 	},
 		retry.Log(m.context()),
 		retry.Limit(m.cfg.SMTP.Retries),


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
`remotemonitor` should retry sending emails to create alerts to avoid getting paged due to a temporary network outage or similar.

**Which issue(s) this PR fixes:**
N/A - this is a small change to implement retrying SMTP send in `remotemonitor` only

**Out of Scope:**

**Screenshots:**

**Describe any introduced user-facing changes:**

**Describe any introduced API changes:**
For users of `goalert monitor` command, an additional field is added to the TOML config to allow specifying a number of times to retry sending email when creating test alerts.  The field is validated to ensure inputs are reasonable (in range 0-5).

**Additional Info:**
