### PR TITLE
engine/schedulemanager: convert to sqlc

### DIFF
--- a/engine/schedulemanager/db.go
+++ b/engine/schedulemanager/db.go
@@ -6,25 +6,11 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/target/goalert/engine/processinglock"
-	"github.com/target/goalert/util"
 )
 
 // DB will manage schedules and schedule rules in Postgres.
 type DB struct {
 	lock *processinglock.Lock
-
-	overrides   *sql.Stmt
-	rules       *sql.Stmt
-	currentTime *sql.Stmt
-	getOnCall   *sql.Stmt
-	endOnCall   *sql.Stmt
-	startOnCall *sql.Stmt
-	data        *sql.Stmt
-	updateData  *sql.Stmt
-
-	schedTZ *sql.Stmt
-
-	scheduleOnCallNotification *sql.Stmt
 
 	migrateSchedIDs []uuid.UUID
 	migrateMap      map[uuid.UUID]uuid.UUID
@@ -42,64 +28,6 @@ func NewDB(ctx context.Context, db *sql.DB) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	p := &util.Prepare{DB: db, Ctx: ctx}
 
-	return &DB{
-		lock: lock,
-
-		overrides: p.P(`
-			select
-				add_user_id,
-				remove_user_id,
-				tgt_schedule_id
-			from user_overrides
-			where now() between start_time and end_time
-		`),
-		data:       p.P(`select schedule_id, data from schedule_data where data notnull for update`),
-		updateData: p.P(`update schedule_data set data = $2 where schedule_id = $1`),
-		schedTZ:    p.P(`select id, time_zone from schedules`),
-		rules: p.P(`
-			select
-				rule.schedule_id,
-				ARRAY[
-					sunday,
-					monday,
-					tuesday,
-					wednesday,
-					thursday,
-					friday,
-					saturday
-				],
-				start_time,
-				end_time,
-				coalesce(rule.tgt_user_id, part.user_id)
-			from schedule_rules rule
-			left join rotation_state rState on rState.rotation_id = rule.tgt_rotation_id
-			left join rotation_participants part on part.id = rState.rotation_participant_id
-			where
-				coalesce(rule.tgt_user_id, part.user_id) notnull
-		`),
-		getOnCall: p.P(`
-			select schedule_id, user_id
-			from schedule_on_call_users
-			where
-				end_time isnull
-		`),
-		startOnCall: p.P(`
-			insert into schedule_on_call_users (schedule_id, start_time, user_id)
-			select $1, now(), $2 from users where id = $2
-		`),
-		endOnCall: p.P(`
-			update schedule_on_call_users
-			set end_time = now()
-			where
-				schedule_id = $1 and
-				user_id = $2 and
-				end_time isnull
-		`),
-		scheduleOnCallNotification: p.P(`
-			insert into outgoing_messages (id, message_type, channel_id, schedule_id) values ($1, 'schedule_on_call_notification', $2, $3)
-		`),
-		currentTime: p.P(`select now()`),
-	}, p.Err
+	return &DB{lock: lock}, nil
 }

--- a/engine/schedulemanager/queries.sql
+++ b/engine/schedulemanager/queries.sql
@@ -40,7 +40,8 @@ FROM
     LEFT JOIN rotation_state rState ON rState.rotation_id = rule.tgt_rotation_id
     LEFT JOIN rotation_participants part ON part.id = rState.rotation_participant_id
 WHERE
-    resolved_user_id NOTNULL;
+    coalesce(rule.tgt_user_id, part.user_id)
+    NOTNULL;
 
 -- name: SchedMgrOverrides :many
 SELECT

--- a/engine/schedulemanager/queries.sql
+++ b/engine/schedulemanager/queries.sql
@@ -31,3 +31,83 @@ SET
 WHERE
     schedule_id = $1;
 
+-- name: SchedMgrRules :many
+SELECT
+    rule.*,
+    coalesce(rule.tgt_user_id, part.user_id) AS resolved_user_id
+FROM
+    schedule_rules rule
+    LEFT JOIN rotation_state rState ON rState.rotation_id = rule.tgt_rotation_id
+    LEFT JOIN rotation_participants part ON part.id = rState.rotation_participant_id
+WHERE
+    resolved_user_id NOTNULL;
+
+-- name: SchedMgrOverrides :many
+SELECT
+    add_user_id,
+    remove_user_id,
+    tgt_schedule_id
+FROM
+    user_overrides
+WHERE
+    now() BETWEEN start_time AND end_time;
+
+-- name: SchedMgrDataForUpdate :many
+SELECT
+    schedule_id,
+    data
+FROM
+    schedule_data
+WHERE
+    data NOTNULL
+FOR UPDATE;
+
+-- name: SchedMgrSetData :exec
+UPDATE
+    schedule_data
+SET
+    data = $2
+WHERE
+    schedule_id = $1;
+
+-- name: SchedMgrTimezones :many
+SELECT
+    id,
+    time_zone
+FROM
+    schedules;
+
+-- name: SchedMgrOnCall :many
+SELECT
+    schedule_id,
+    user_id
+FROM
+    schedule_on_call_users
+WHERE
+    end_time ISNULL;
+
+-- name: SchedMgrStartOnCall :exec
+INSERT INTO schedule_on_call_users(schedule_id, start_time, user_id)
+SELECT
+    $1,
+    now(),
+    $2
+FROM
+    users
+WHERE
+    id = $2;
+
+-- name: SchedMgrEndOnCall :exec
+UPDATE
+    schedule_on_call_users
+SET
+    end_time = now()
+WHERE
+    schedule_id = $1
+    AND user_id = $2
+    AND end_time ISNULL;
+
+-- name: SchedMgrInsertMessage :exec
+INSERT INTO outgoing_messages(id, message_type, channel_id, schedule_id)
+    VALUES ($1, 'schedule_on_call_notification', $2, $3);
+

--- a/engine/schedulemanager/update.go
+++ b/engine/schedulemanager/update.go
@@ -55,8 +55,8 @@ func ruleRowIsActive(row gadb.SchedMgrRulesRow, t time.Time) bool {
 		wf[6] = 1
 	}
 	return rule.Rule{
-		Start:         timeutil.NewClockFromTime(row.StartTime),
-		End:           timeutil.NewClockFromTime(row.EndTime),
+		Start:         row.StartTime,
+		End:           row.EndTime,
 		WeekdayFilter: wf,
 	}.IsActive(t)
 }

--- a/gadb/models.go
+++ b/gadb/models.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
+	"github.com/target/goalert/util/timeutil"
 )
 
 type EngineProcessingType string
@@ -1098,14 +1099,14 @@ type ScheduleOnCallUser struct {
 
 type ScheduleRule struct {
 	CreatedAt     time.Time
-	EndTime       time.Time
+	EndTime       timeutil.Clock
 	Friday        bool
 	ID            uuid.UUID
 	IsActive      bool
 	Monday        bool
 	Saturday      bool
 	ScheduleID    uuid.UUID
-	StartTime     time.Time
+	StartTime     timeutil.Clock
 	Sunday        bool
 	TgtRotationID uuid.NullUUID
 	TgtUserID     uuid.NullUUID

--- a/gadb/queries.sql.go
+++ b/gadb/queries.sql.go
@@ -2832,7 +2832,8 @@ FROM
     LEFT JOIN rotation_state rState ON rState.rotation_id = rule.tgt_rotation_id
     LEFT JOIN rotation_participants part ON part.id = rState.rotation_participant_id
 WHERE
-    resolved_user_id NOTNULL
+    coalesce(rule.tgt_user_id, part.user_id)
+    NOTNULL
 `
 
 type SchedMgrRulesRow struct {

--- a/gadb/queries.sql.go
+++ b/gadb/queries.sql.go
@@ -2584,6 +2584,45 @@ func (q *Queries) RequestAlertEscalationByTime(ctx context.Context, arg RequestA
 	return column_1, err
 }
 
+const schedMgrDataForUpdate = `-- name: SchedMgrDataForUpdate :many
+SELECT
+    schedule_id,
+    data
+FROM
+    schedule_data
+WHERE
+    data NOTNULL
+FOR UPDATE
+`
+
+type SchedMgrDataForUpdateRow struct {
+	ScheduleID uuid.UUID
+	Data       json.RawMessage
+}
+
+func (q *Queries) SchedMgrDataForUpdate(ctx context.Context) ([]SchedMgrDataForUpdateRow, error) {
+	rows, err := q.db.QueryContext(ctx, schedMgrDataForUpdate)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SchedMgrDataForUpdateRow
+	for rows.Next() {
+		var i SchedMgrDataForUpdateRow
+		if err := rows.Scan(&i.ScheduleID, &i.Data); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const schedMgrDataIDs = `-- name: SchedMgrDataIDs :many
 SELECT
     schedule_id
@@ -2615,6 +2654,27 @@ func (q *Queries) SchedMgrDataIDs(ctx context.Context) ([]uuid.UUID, error) {
 	return items, nil
 }
 
+const schedMgrEndOnCall = `-- name: SchedMgrEndOnCall :exec
+UPDATE
+    schedule_on_call_users
+SET
+    end_time = now()
+WHERE
+    schedule_id = $1
+    AND user_id = $2
+    AND end_time ISNULL
+`
+
+type SchedMgrEndOnCallParams struct {
+	ScheduleID uuid.UUID
+	UserID     uuid.UUID
+}
+
+func (q *Queries) SchedMgrEndOnCall(ctx context.Context, arg SchedMgrEndOnCallParams) error {
+	_, err := q.db.ExecContext(ctx, schedMgrEndOnCall, arg.ScheduleID, arg.UserID)
+	return err
+}
+
 const schedMgrGetData = `-- name: SchedMgrGetData :one
 SELECT
     data
@@ -2630,6 +2690,22 @@ func (q *Queries) SchedMgrGetData(ctx context.Context, scheduleID uuid.UUID) (js
 	var data json.RawMessage
 	err := row.Scan(&data)
 	return data, err
+}
+
+const schedMgrInsertMessage = `-- name: SchedMgrInsertMessage :exec
+INSERT INTO outgoing_messages(id, message_type, channel_id, schedule_id)
+    VALUES ($1, 'schedule_on_call_notification', $2, $3)
+`
+
+type SchedMgrInsertMessageParams struct {
+	ID         uuid.UUID
+	ChannelID  uuid.NullUUID
+	ScheduleID uuid.NullUUID
+}
+
+func (q *Queries) SchedMgrInsertMessage(ctx context.Context, arg SchedMgrInsertMessageParams) error {
+	_, err := q.db.ExecContext(ctx, schedMgrInsertMessage, arg.ID, arg.ChannelID, arg.ScheduleID)
+	return err
 }
 
 const schedMgrNCDedupMapping = `-- name: SchedMgrNCDedupMapping :many
@@ -2669,6 +2745,174 @@ func (q *Queries) SchedMgrNCDedupMapping(ctx context.Context) ([]SchedMgrNCDedup
 	return items, nil
 }
 
+const schedMgrOnCall = `-- name: SchedMgrOnCall :many
+SELECT
+    schedule_id,
+    user_id
+FROM
+    schedule_on_call_users
+WHERE
+    end_time ISNULL
+`
+
+type SchedMgrOnCallRow struct {
+	ScheduleID uuid.UUID
+	UserID     uuid.UUID
+}
+
+func (q *Queries) SchedMgrOnCall(ctx context.Context) ([]SchedMgrOnCallRow, error) {
+	rows, err := q.db.QueryContext(ctx, schedMgrOnCall)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SchedMgrOnCallRow
+	for rows.Next() {
+		var i SchedMgrOnCallRow
+		if err := rows.Scan(&i.ScheduleID, &i.UserID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const schedMgrOverrides = `-- name: SchedMgrOverrides :many
+SELECT
+    add_user_id,
+    remove_user_id,
+    tgt_schedule_id
+FROM
+    user_overrides
+WHERE
+    now() BETWEEN start_time AND end_time
+`
+
+type SchedMgrOverridesRow struct {
+	AddUserID     uuid.NullUUID
+	RemoveUserID  uuid.NullUUID
+	TgtScheduleID uuid.UUID
+}
+
+func (q *Queries) SchedMgrOverrides(ctx context.Context) ([]SchedMgrOverridesRow, error) {
+	rows, err := q.db.QueryContext(ctx, schedMgrOverrides)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SchedMgrOverridesRow
+	for rows.Next() {
+		var i SchedMgrOverridesRow
+		if err := rows.Scan(&i.AddUserID, &i.RemoveUserID, &i.TgtScheduleID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const schedMgrRules = `-- name: SchedMgrRules :many
+SELECT
+    rule.created_at, rule.end_time, rule.friday, rule.id, rule.is_active, rule.monday, rule.saturday, rule.schedule_id, rule.start_time, rule.sunday, rule.tgt_rotation_id, rule.tgt_user_id, rule.thursday, rule.tuesday, rule.wednesday,
+    coalesce(rule.tgt_user_id, part.user_id) AS resolved_user_id
+FROM
+    schedule_rules rule
+    LEFT JOIN rotation_state rState ON rState.rotation_id = rule.tgt_rotation_id
+    LEFT JOIN rotation_participants part ON part.id = rState.rotation_participant_id
+WHERE
+    resolved_user_id NOTNULL
+`
+
+type SchedMgrRulesRow struct {
+	CreatedAt      time.Time
+	EndTime        time.Time
+	Friday         bool
+	ID             uuid.UUID
+	IsActive       bool
+	Monday         bool
+	Saturday       bool
+	ScheduleID     uuid.UUID
+	StartTime      time.Time
+	Sunday         bool
+	TgtRotationID  uuid.NullUUID
+	TgtUserID      uuid.NullUUID
+	Thursday       bool
+	Tuesday        bool
+	Wednesday      bool
+	ResolvedUserID uuid.UUID
+}
+
+func (q *Queries) SchedMgrRules(ctx context.Context) ([]SchedMgrRulesRow, error) {
+	rows, err := q.db.QueryContext(ctx, schedMgrRules)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SchedMgrRulesRow
+	for rows.Next() {
+		var i SchedMgrRulesRow
+		if err := rows.Scan(
+			&i.CreatedAt,
+			&i.EndTime,
+			&i.Friday,
+			&i.ID,
+			&i.IsActive,
+			&i.Monday,
+			&i.Saturday,
+			&i.ScheduleID,
+			&i.StartTime,
+			&i.Sunday,
+			&i.TgtRotationID,
+			&i.TgtUserID,
+			&i.Thursday,
+			&i.Tuesday,
+			&i.Wednesday,
+			&i.ResolvedUserID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const schedMgrSetData = `-- name: SchedMgrSetData :exec
+UPDATE
+    schedule_data
+SET
+    data = $2
+WHERE
+    schedule_id = $1
+`
+
+type SchedMgrSetDataParams struct {
+	ScheduleID uuid.UUID
+	Data       json.RawMessage
+}
+
+func (q *Queries) SchedMgrSetData(ctx context.Context, arg SchedMgrSetDataParams) error {
+	_, err := q.db.ExecContext(ctx, schedMgrSetData, arg.ScheduleID, arg.Data)
+	return err
+}
+
 const schedMgrSetDataV1Rules = `-- name: SchedMgrSetDataV1Rules :exec
 UPDATE
     schedule_data
@@ -2687,6 +2931,64 @@ type SchedMgrSetDataV1RulesParams struct {
 func (q *Queries) SchedMgrSetDataV1Rules(ctx context.Context, arg SchedMgrSetDataV1RulesParams) error {
 	_, err := q.db.ExecContext(ctx, schedMgrSetDataV1Rules, arg.ScheduleID, arg.Replacement)
 	return err
+}
+
+const schedMgrStartOnCall = `-- name: SchedMgrStartOnCall :exec
+INSERT INTO schedule_on_call_users(schedule_id, start_time, user_id)
+SELECT
+    $1,
+    now(),
+    $2
+FROM
+    users
+WHERE
+    id = $2
+`
+
+type SchedMgrStartOnCallParams struct {
+	ScheduleID uuid.UUID
+	UserID     uuid.UUID
+}
+
+func (q *Queries) SchedMgrStartOnCall(ctx context.Context, arg SchedMgrStartOnCallParams) error {
+	_, err := q.db.ExecContext(ctx, schedMgrStartOnCall, arg.ScheduleID, arg.UserID)
+	return err
+}
+
+const schedMgrTimezones = `-- name: SchedMgrTimezones :many
+SELECT
+    id,
+    time_zone
+FROM
+    schedules
+`
+
+type SchedMgrTimezonesRow struct {
+	ID       uuid.UUID
+	TimeZone string
+}
+
+func (q *Queries) SchedMgrTimezones(ctx context.Context) ([]SchedMgrTimezonesRow, error) {
+	rows, err := q.db.QueryContext(ctx, schedMgrTimezones)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SchedMgrTimezonesRow
+	for rows.Next() {
+		var i SchedMgrTimezonesRow
+		if err := rows.Scan(&i.ID, &i.TimeZone); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const scheduleFindManyByUser = `-- name: ScheduleFindManyByUser :many

--- a/gadb/queries.sql.go
+++ b/gadb/queries.sql.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/lib/pq"
 	"github.com/sqlc-dev/pqtype"
+	"github.com/target/goalert/util/timeutil"
 )
 
 const aPIKeyAuthCheck = `-- name: APIKeyAuthCheck :one
@@ -2838,14 +2839,14 @@ WHERE
 
 type SchedMgrRulesRow struct {
 	CreatedAt      time.Time
-	EndTime        time.Time
+	EndTime        timeutil.Clock
 	Friday         bool
 	ID             uuid.UUID
 	IsActive       bool
 	Monday         bool
 	Saturday       bool
 	ScheduleID     uuid.UUID
-	StartTime      time.Time
+	StartTime      timeutil.Clock
 	Sunday         bool
 	TgtRotationID  uuid.NullUUID
 	TgtUserID      uuid.NullUUID

--- a/schedule/data.go
+++ b/schedule/data.go
@@ -1,6 +1,10 @@
 package schedule
 
-import "time"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
 
 // Data contains configuration for a single schedule.
 type Data struct {
@@ -12,7 +16,7 @@ type Data struct {
 
 // TempOnCall will calculate any on-call users for the given time. isActive will
 // be true if a temporary schedule is active.
-func (data *Data) TempOnCall(t time.Time) (isActive bool, users []string) {
+func (data *Data) TempOnCall(t time.Time) (isActive bool, users []uuid.UUID) {
 	if data == nil {
 		return false, nil
 	}
@@ -26,7 +30,11 @@ func (data *Data) TempOnCall(t time.Time) (isActive bool, users []string) {
 			if t.Before(shift.Start) || !t.Before(shift.End) {
 				continue
 			}
-			users = append(users, shift.UserID)
+			id, err := uuid.Parse(shift.UserID)
+			if err != nil {
+				continue
+			}
+			users = append(users, id)
 		}
 
 		// only one TemporarySchedule will ever be active (should be merged & sorted)

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -44,6 +44,14 @@ sql:
         out: gadb
         sql_package: database/sql
         overrides:
+          - column: public.schedule_rules.start_time
+            go_type:
+              import: github.com/target/goalert/util/timeutil
+              type: Clock
+          - column: public.schedule_rules.end_time
+            go_type:
+              import: github.com/target/goalert/util/timeutil
+              type: Clock
           - column: public.outgoing_messages.provider_msg_id
             go_type:
               type: ProviderMessageID


### PR DESCRIPTION
**Description:**
Transitions the schedule manager to sqlc
- most IDs are now handled natively as UUIDs
- Queries are unchanged
