### PR TITLE
logging: introduce slog.Logger

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -133,6 +133,10 @@ type App struct {
 
 // NewApp constructs a new App and binds the listening socket.
 func NewApp(c Config, db *sql.DB) (*App, error) {
+	if c.Logger == nil {
+		return nil, errors.New("Logger is required")
+	}
+
 	var err error
 	permission.SudoContext(context.Background(), func(ctx context.Context) {
 		// Should not be possible for the app to ever see `use_next_db` unless misconfigured.

--- a/app/app.go
+++ b/app/app.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 
@@ -57,6 +58,8 @@ import (
 // App represents an instance of the GoAlert application.
 type App struct {
 	cfg Config
+
+	Logger *slog.Logger
 
 	mgr *lifecycle.Manager
 
@@ -164,10 +167,10 @@ func NewApp(c Config, db *sql.DB) (*App, error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "listen %s", c.TLSListenAddr)
 		}
-		l = newMultiListener(c.Logger, l, l2)
+		l = newMultiListener(l, l2)
 	}
 
-	c.Logger.AddErrorMapper(func(ctx context.Context, err error) context.Context {
+	c.LegacyLogger.AddErrorMapper(func(ctx context.Context, err error) context.Context {
 		if e := sqlutil.MapError(err); e != nil && e.Detail != "" {
 			ctx = log.WithField(ctx, "SQLErrDetails", e.Detail)
 		}
@@ -180,6 +183,7 @@ func NewApp(c Config, db *sql.DB) (*App, error) {
 		db:     db,
 		cfg:    c,
 		doneCh: make(chan struct{}),
+		Logger: c.Logger,
 	}
 
 	if c.StatusAddr != "" {

--- a/app/config.go
+++ b/app/config.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"crypto/tls"
+	"log/slog"
 	"time"
 
 	"github.com/target/goalert/config"
@@ -12,7 +13,9 @@ import (
 )
 
 type Config struct {
-	Logger *log.Logger
+	LegacyLogger *log.Logger
+
+	Logger *slog.Logger
 
 	ExpFlags expflag.FlagSet
 

--- a/app/context.go
+++ b/app/context.go
@@ -14,7 +14,7 @@ import (
 // the correct configuration is used.
 func (app *App) Context(ctx context.Context) context.Context {
 	ctx = expflag.Context(ctx, app.cfg.ExpFlags)
-	ctx = log.WithLogger(ctx, app.cfg.Logger)
+	ctx = log.WithLogger(ctx, app.cfg.LegacyLogger)
 
 	if app.ConfigStore != nil {
 		ctx = app.ConfigStore.Config().Context(ctx)

--- a/app/initsmtpsrv.go
+++ b/app/initsmtpsrv.go
@@ -58,7 +58,7 @@ func (app *App) initSMTPServer(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		app.smtpsrvL = newMultiListener(app.cfg.Logger, app.smtpsrvL, l)
+		app.smtpsrvL = newMultiListener(app.smtpsrvL, l)
 	}
 
 	return nil

--- a/app/initstores.go
+++ b/app/initstores.go
@@ -73,14 +73,14 @@ func (app *App) initStores(ctx context.Context) error {
 	}
 
 	if app.NonceStore == nil {
-		app.NonceStore, err = nonce.NewStore(ctx, app.cfg.Logger, app.db)
+		app.NonceStore, err = nonce.NewStore(ctx, app.cfg.LegacyLogger, app.db)
 	}
 	if err != nil {
 		return errors.Wrap(err, "init nonce store")
 	}
 
 	if app.OAuthKeyring == nil {
-		app.OAuthKeyring, err = keyring.NewDB(ctx, app.cfg.Logger, app.db, &keyring.Config{
+		app.OAuthKeyring, err = keyring.NewDB(ctx, app.cfg.LegacyLogger, app.db, &keyring.Config{
 			Name:         "oauth-state",
 			RotationDays: 1,
 			MaxOldKeys:   1,
@@ -92,7 +92,7 @@ func (app *App) initStores(ctx context.Context) error {
 	}
 
 	if app.AuthLinkKeyring == nil {
-		app.AuthLinkKeyring, err = keyring.NewDB(ctx, app.cfg.Logger, app.db, &keyring.Config{
+		app.AuthLinkKeyring, err = keyring.NewDB(ctx, app.cfg.LegacyLogger, app.db, &keyring.Config{
 			Name:         "auth-link",
 			RotationDays: 1,
 			MaxOldKeys:   1,
@@ -104,7 +104,7 @@ func (app *App) initStores(ctx context.Context) error {
 	}
 
 	if app.SessionKeyring == nil {
-		app.SessionKeyring, err = keyring.NewDB(ctx, app.cfg.Logger, app.db, &keyring.Config{
+		app.SessionKeyring, err = keyring.NewDB(ctx, app.cfg.LegacyLogger, app.db, &keyring.Config{
 			Name:         "browser-sessions",
 			RotationDays: 1,
 			MaxOldKeys:   30,
@@ -116,7 +116,7 @@ func (app *App) initStores(ctx context.Context) error {
 	}
 
 	if app.APIKeyring == nil {
-		app.APIKeyring, err = keyring.NewDB(ctx, app.cfg.Logger, app.db, &keyring.Config{
+		app.APIKeyring, err = keyring.NewDB(ctx, app.cfg.LegacyLogger, app.db, &keyring.Config{
 			Name:       "api-keys",
 			MaxOldKeys: 100,
 			Keys:       app.cfg.EncryptionKeys,

--- a/app/listenevents.go
+++ b/app/listenevents.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (app *App) listenEvents(ctx context.Context) (<-chan struct{}, error) {
-	l, err := sqlutil.NewListener(ctx, app.cfg.Logger, app.db, "/goalert/config-refresh")
+	l, err := sqlutil.NewListener(ctx, app.cfg.LegacyLogger, app.db, "/goalert/config-refresh")
 	if err != nil {
 		return nil, err
 	}

--- a/app/multilistener_test.go
+++ b/app/multilistener_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/target/goalert/util/log"
 )
 
 func withTimeout(t *testing.T, name string, fn func() error) error {
@@ -29,12 +28,11 @@ func withTimeout(t *testing.T, name string, fn func() error) error {
 }
 
 func TestMultiListener_Close(t *testing.T) {
-
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	assert.NoError(t, err)
 	defer l.Close()
 
-	m := newMultiListener(log.NewLogger(), l)
+	m := newMultiListener(l)
 
 	c, err := net.Dial("tcp", l.Addr().String())
 	assert.NoError(t, err)
@@ -46,7 +44,6 @@ func TestMultiListener_Close(t *testing.T) {
 
 func TestMultiListener_Accept(t *testing.T) {
 	t.Run("multiple listeners", func(t *testing.T) {
-
 		l1, err := net.Listen("tcp", "127.0.0.1:0")
 		assert.NoError(t, err)
 		defer l1.Close()
@@ -55,7 +52,7 @@ func TestMultiListener_Accept(t *testing.T) {
 		assert.NoError(t, err)
 		defer l2.Close()
 
-		m := newMultiListener(log.NewLogger(), l1, l2)
+		m := newMultiListener(l1, l2)
 
 		c1, err := net.Dial("tcp", l1.Addr().String())
 		assert.NoError(t, err)
@@ -86,12 +83,11 @@ func TestMultiListener_Accept(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("return on accept pending", func(t *testing.T) {
-
 		l, err := net.Listen("tcp", "127.0.0.1:0")
 		assert.NoError(t, err)
 		defer l.Close()
 
-		m := newMultiListener(log.NewLogger(), l)
+		m := newMultiListener(l)
 
 		go func() {
 			time.Sleep(10 * time.Millisecond) // wait until Accept is called

--- a/app/pause.go
+++ b/app/pause.go
@@ -6,7 +6,9 @@ import (
 )
 
 // LogBackgroundContext returns a context.Background with the application logger configured.
-func (app *App) LogBackgroundContext() context.Context { return app.cfg.Logger.BackgroundContext() }
+func (app *App) LogBackgroundContext() context.Context {
+	return app.cfg.LegacyLogger.BackgroundContext()
+}
 
 func (app *App) Pause(ctx context.Context) error {
 	return app.mgr.Pause(app.Context(ctx))

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5
 	github.com/rubenv/sql-migrate v1.7.0
+	github.com/samber/slog-logrus v1.0.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/slack-go/slack v0.15.0
 	github.com/spf13/cobra v1.8.1
@@ -112,6 +113,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.6.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
+	github.com/samber/lo v1.38.1 // indirect
 	github.com/sosodev/duration v1.3.1 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,10 @@ github.com/sagikazarmark/locafero v0.6.0 h1:ON7AQg37yzcRPU69mt7gwhFEBwxI6P9T4Qu3
 github.com/sagikazarmark/locafero v0.6.0/go.mod h1:77OmuIc6VTraTXKXIs/uvUxKGUXjE1GbemJYHqdNjX0=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
+github.com/samber/lo v1.38.1 h1:j2XEAqXKb09Am4ebOg31SpvzUTTs6EN3VfgeLUhPdXM=
+github.com/samber/lo v1.38.1/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
+github.com/samber/slog-logrus v1.0.0 h1:SsrN0p9akjCEaYd42Q5GtisMdHm0q11UD4fp4XCZi04=
+github.com/samber/slog-logrus v1.0.0/go.mod h1:ZTdPCmVWljwlfjz6XflKNvW4TcmYlexz4HMUOO/42bI=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=

--- a/smtpsrv/config.go
+++ b/smtpsrv/config.go
@@ -3,9 +3,9 @@ package smtpsrv
 import (
 	"context"
 	"crypto/tls"
+	"log/slog"
 
 	"github.com/target/goalert/alert"
-	"github.com/target/goalert/util/log"
 )
 
 // Config is used to configure the SMTP server.
@@ -16,7 +16,7 @@ type Config struct {
 	MaxRecipients  int
 
 	BackgroundContext func() context.Context
-	Logger            *log.Logger
+	Logger            *slog.Logger
 
 	AuthorizeFunc   func(ctx context.Context, id string) (context.Context, error)
 	CreateAlertFunc func(ctx context.Context, a *alert.Alert) error

--- a/smtpsrv/server.go
+++ b/smtpsrv/server.go
@@ -2,19 +2,18 @@ package smtpsrv
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"strings"
 	"time"
 
 	"github.com/emersion/go-smtp"
-	"github.com/target/goalert/util/log"
 )
 
 // SMTPLogger implements the smtp.Logger interface using the main app Logger.
 type SMTPLogger struct {
-	logger *log.Logger
+	logger *slog.Logger
 }
 
 // Printf adheres to smtp.Server's Logger interface.
@@ -25,7 +24,7 @@ func (l *SMTPLogger) Printf(format string, v ...interface{}) {
 	if strings.Contains(s, "read: connection reset by peer") {
 		return
 	}
-	l.logger.Error(context.Background(), errors.New(s))
+	l.logger.Error("SMTP error.", slog.String("error", s))
 }
 
 // Print adheres to smtp.Server's Logger interface.
@@ -36,7 +35,7 @@ func (l *SMTPLogger) Println(v ...interface{}) {
 	if strings.Contains(s, "read: connection reset by peer") {
 		return
 	}
-	l.logger.Error(context.Background(), errors.New(s))
+	l.logger.Error("SMTP error.", slog.String("error", s))
 }
 
 // Server implements an SMTP server that creates alerts.

--- a/test/smoke/harness/harness.go
+++ b/test/smoke/harness/harness.go
@@ -291,7 +291,7 @@ func (h *Harness) Start() {
 
 	appCfg := app.Defaults()
 	appCfg.ExpFlags = h.expFlags
-	appCfg.Logger = log.NewLogger()
+	appCfg.LegacyLogger = log.NewLogger()
 	appCfg.ListenAddr = "localhost:0"
 	appCfg.Verbose = true
 	appCfg.JSON = true
@@ -306,8 +306,8 @@ func (h *Harness) Start() {
 	r, w := io.Pipe()
 	h.backendLogs = w
 
-	appCfg.Logger.EnableJSON()
-	appCfg.Logger.SetOutput(w)
+	appCfg.LegacyLogger.EnableJSON()
+	appCfg.LegacyLogger.SetOutput(w)
 
 	go h.watchBackendLogs(r)
 

--- a/test/smoke/harness/harness.go
+++ b/test/smoke/harness/harness.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	stdlog "log"
+	"log/slog"
 	"net/http/httptest"
 	"net/smtp"
 	"net/url"
@@ -25,6 +26,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/pkg/errors"
+	sloglogrus "github.com/samber/slog-logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/target/goalert/alert"
@@ -292,6 +294,9 @@ func (h *Harness) Start() {
 	appCfg := app.Defaults()
 	appCfg.ExpFlags = h.expFlags
 	appCfg.LegacyLogger = log.NewLogger()
+	appCfg.Logger = slog.New(sloglogrus.Option{
+		Logger: appCfg.LegacyLogger.Logrus(),
+	}.NewLogrusHandler())
 	appCfg.ListenAddr = "localhost:0"
 	appCfg.Verbose = true
 	appCfg.JSON = true

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -27,6 +27,8 @@ type Logger struct {
 	errHooks []func(context.Context, error) context.Context
 }
 
+func (l *Logger) Logrus() *logrus.Logger { return l.l }
+
 func NewLogger() *Logger {
 	l := logrus.New()
 


### PR DESCRIPTION
**Description:**
Introduced `*slog.Logger` to the `App` struct as an eventual replacement for the custom logging package.

This can also be used as a logger to pass into other tools that take an *slog.Logger argument.