### PR TITLE
pgxpool: Don't use idle connections with stdlib when doing pooling

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -202,9 +202,6 @@ func NewApp(c Config, pool *pgxpool.Pool) (*App, error) {
 		}
 	}
 
-	app.db.SetMaxIdleConns(c.DBMaxIdle)
-	app.db.SetMaxOpenConns(c.DBMaxOpen)
-
 	app.mgr = lifecycle.NewManager(app._Run, app._Shutdown)
 	err = app.mgr.SetStartupFunc(app.startup)
 	if err != nil {

--- a/app/cmd.go
+++ b/app/cmd.go
@@ -145,6 +145,11 @@ Available Flags:
 
 		var pool *pgxpool.Pool
 		if cfg.DBURLNext != "" {
+			err = migrate.VerifyIsLatest(ctx, cfg.DBURL)
+			if err != nil {
+				return errors.Wrap(err, "verify db")
+			}
+
 			err = doMigrations(cfg.DBURLNext)
 			if err != nil {
 				return errors.Wrap(err, "nextdb")

--- a/app/pause.go
+++ b/app/pause.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"time"
 )
 
 // LogBackgroundContext returns a context.Background with the application logger configured.
@@ -19,17 +18,11 @@ func (app *App) Resume(ctx context.Context) error {
 }
 
 func (app *App) _pause(ctx context.Context) error {
-	app.db.SetMaxIdleConns(0)
-	app.db.SetConnMaxLifetime(time.Second)
-	app.db.SetMaxOpenConns(3)
 	app.events.Stop()
 	return nil
 }
 
 func (app *App) _resume(ctx context.Context) error {
-	app.db.SetMaxOpenConns(app.cfg.DBMaxOpen)
-	app.db.SetMaxIdleConns(app.cfg.DBMaxIdle)
-	app.db.SetConnMaxLifetime(0)
 	app.events.Start()
 
 	return nil

--- a/swo/manager.go
+++ b/swo/manager.go
@@ -57,6 +57,9 @@ type Config struct {
 	OldDBURL, NewDBURL string
 	CanExec            bool
 	Logger             *log.Logger
+
+	MaxOpen int
+	MaxIdle int
 }
 
 // NewManager will create a new Manager with the given configuration.
@@ -97,7 +100,7 @@ func NewManager(cfg Config) (*Manager, error) {
 		return nil, fmt.Errorf("connect to new db: %w", err)
 	}
 
-	appPgx, err := NewAppPGXPool(appMainURL, appNextURL)
+	appPgx, err := NewAppPGXPool(appMainURL, appNextURL, cfg.MaxOpen, cfg.MaxIdle)
 	if err != nil {
 		return nil, fmt.Errorf("create pool: %w", err)
 	}


### PR DESCRIPTION
**Description:**
Removes connection management for `sql.DB` now that it's backed by a `pgxpool.Pool`.
- Also, added validation that migration version matches to prevent using a switchover from an older version of GoAlert when newer DB migrations are present.
