### PR TITLE
engine: update advisory lock handling and add locked transaction support

### DIFF
--- a/engine/message/db.go
+++ b/engine/message/db.go
@@ -530,7 +530,7 @@ func (db *DB) _SendMessages(ctx context.Context, send SendFunc, status StatusFun
 
 	var gotLock bool
 	err = cLock.WithTx(execCtx, func(tx *sql.Tx) error {
-		return tx.StmtContext(execCtx, db.advLock).QueryRowContext(execCtx).Scan(&gotLock)
+		return tx.StmtContext(execCtx, db.advLock).QueryRowContext(execCtx, lock.GlobalMessageSending).Scan(&gotLock)
 	})
 	if err != nil {
 		return errors.Wrap(err, "acquire global sending advisory lock")


### PR DESCRIPTION
**Description:**
Updates use of the global message sending lock to use the `_try` variant. If multiple instances of the engine are running, it can cause all instances to block until released, preventing other modules from processing.

