### PR TITLE
engine/processinglock: enable shared locking for concurrent work

### DIFF
--- a/engine/processinglock/conn.go
+++ b/engine/processinglock/conn.go
@@ -38,7 +38,7 @@ func (l *Lock) Conn(ctx context.Context) (*Conn, error) {
 
 // BeginTx will start a new transaction.
 func (c *Conn) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
-	return c.l._BeginTx(ctx, c.conn, opts)
+	return c.l._BeginTx(ctx, c.conn, opts, false)
 }
 
 // Exec will call ExecContext on the statement wrapped in a locked transaction.

--- a/engine/processinglock/conn.go
+++ b/engine/processinglock/conn.go
@@ -47,7 +47,7 @@ func (c *Conn) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error
 func (c *Conn) WithTx(ctx context.Context, txFn func(tx *sql.Tx) error) error {
 	c.mx.Lock()
 	defer c.mx.Unlock()
-	tx, err := c.l._BeginTx(ctx, c.conn, nil)
+	tx, err := c.l._BeginTx(ctx, c.conn, nil, false)
 	if err != nil {
 		return err
 	}

--- a/engine/processinglock/lock.go
+++ b/engine/processinglock/lock.go
@@ -60,7 +60,7 @@ func NewLock(ctx context.Context, db *sql.DB, cfg Config) (*Lock, error) {
 	}, nil
 }
 
-func (l *Lock) _BeginTx(ctx context.Context, b txBeginner, opts *sql.TxOptions) (*sql.Tx, error) {
+func (l *Lock) _BeginTx(ctx context.Context, b txBeginner, opts *sql.TxOptions, shared bool) (*sql.Tx, error) {
 	tx, err := b.BeginTx(ctx, opts)
 	if err != nil {
 		return nil, err
@@ -78,7 +78,12 @@ func (l *Lock) _BeginTx(ctx context.Context, b txBeginner, opts *sql.TxOptions) 
 		return nil, ErrNoLock
 	}
 
-	dbVersion, err := q.ProcAcquireModuleLock(ctx, gadb.EngineProcessingType(l.cfg.Type))
+	var dbVersion int32
+	if shared {
+		dbVersion, err = q.ProcAcquireModuleSharedLock(ctx, gadb.EngineProcessingType(l.cfg.Type))
+	} else {
+		dbVersion, err = q.ProcAcquireModuleLock(ctx, gadb.EngineProcessingType(l.cfg.Type))
+	}
 	if err != nil {
 		sqlutil.Rollback(ctx, "processing lock: begin", tx)
 		// 55P03 is lock_not_available (due to the `nowait` in the query)
@@ -99,7 +104,7 @@ func (l *Lock) _BeginTx(ctx context.Context, b txBeginner, opts *sql.TxOptions) 
 
 // WithTx will run the given function in a locked transaction.
 func (l *Lock) WithTx(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
-	tx, err := l._BeginTx(ctx, l.db, nil)
+	tx, err := l._BeginTx(ctx, l.db, nil, false)
 	if err != nil {
 		return err
 	}
@@ -118,8 +123,29 @@ func (l *Lock) WithTx(ctx context.Context, fn func(context.Context, *sql.Tx) err
 	return nil
 }
 
+// WithTxShared will run the given function in a locked transaction that is compatible with other shared locks.
+func (l *Lock) WithTxShared(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	tx, err := l._BeginTx(ctx, l.db, nil, true)
+	if err != nil {
+		return err
+	}
+	defer sqlutil.Rollback(ctx, "processing lock: with tx (shared)", tx)
+
+	err = fn(ctx, tx)
+	if err != nil {
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (l *Lock) _Exec(ctx context.Context, b txBeginner, stmt *sql.Stmt, args ...interface{}) (sql.Result, error) {
-	tx, err := l._BeginTx(ctx, b, nil)
+	tx, err := l._BeginTx(ctx, b, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +166,7 @@ func (l *Lock) _Exec(ctx context.Context, b txBeginner, stmt *sql.Stmt, args ...
 
 // BeginTx will start a transaction with the appropriate lock in place (based on Config).
 func (l *Lock) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
-	return l._BeginTx(ctx, l.db, opts)
+	return l._BeginTx(ctx, l.db, opts, false)
 }
 
 // Exec will run ExecContext on the statement, wrapped in a locked transaction.

--- a/engine/processinglock/queries.sql
+++ b/engine/processinglock/queries.sql
@@ -12,6 +12,14 @@ WHERE
 FOR UPDATE
     NOWAIT;
 
+-- name: ProcAcquireModuleSharedLock :one
+SELECT
+    version
+FROM
+    engine_processing_versions
+WHERE
+    type_id = $1 FOR SHARE NOWAIT;
+
 -- name: ProcReadModuleVersion :one
 SELECT
     version

--- a/engine/processinglock/queries.sql
+++ b/engine/processinglock/queries.sql
@@ -2,23 +2,25 @@
 SELECT
     pg_try_advisory_xact_lock_shared($1) AS lock_acquired;
 
--- name: ProcAcquireModuleLock :one
+-- name: ProcAcquireModuleLockNoWait :one
 SELECT
-    version
+    1
 FROM
     engine_processing_versions
 WHERE
     type_id = $1
+    AND version = $2
 FOR UPDATE
     NOWAIT;
 
 -- name: ProcAcquireModuleSharedLock :one
 SELECT
-    version
+    1
 FROM
     engine_processing_versions
 WHERE
-    type_id = $1 FOR SHARE NOWAIT;
+    type_id = $1
+    AND version = $2 FOR SHARE;
 
 -- name: ProcReadModuleVersion :one
 SELECT

--- a/engine/signalmgr/schedulemessages.go
+++ b/engine/signalmgr/schedulemessages.go
@@ -13,7 +13,7 @@ import (
 
 func (db *DB) scheduleMessages(ctx context.Context, serviceID uuid.NullUUID) error {
 	var didWork bool
-	err := db.lock.WithTx(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := db.lock.WithTxShared(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		q := gadb.New(tx)
 
 		messages, err := q.SignalMgrGetPending(ctx, serviceID)

--- a/engine/signalmgr/setup.go
+++ b/engine/signalmgr/setup.go
@@ -32,7 +32,7 @@ func (SchedMsgsArgs) Kind() string { return "signal-manager-schedule-outgoing-me
 
 func (db *DB) Setup(ctx context.Context, args processinglock.SetupArgs) error {
 	river.AddWorker(args.Workers, river.WorkFunc(func(ctx context.Context, j *river.Job[MaintArgs]) error {
-		return db.lock.WithTx(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return db.lock.WithTxShared(ctx, func(ctx context.Context, tx *sql.Tx) error {
 			return gadb.New(tx).SignalMgrDeleteStale(ctx)
 		})
 	}))
@@ -41,7 +41,7 @@ func (db *DB) Setup(ctx context.Context, args processinglock.SetupArgs) error {
 		return db.scheduleMessages(ctx, j.Args.ServiceID)
 	}))
 
-	err := args.River.Queues().Add(QueueName, river.QueueConfig{MaxWorkers: 1})
+	err := args.River.Queues().Add(QueueName, river.QueueConfig{MaxWorkers: 3})
 	if err != nil {
 		return err
 	}

--- a/gadb/queries.sql.go
+++ b/gadb/queries.sql.go
@@ -3256,38 +3256,50 @@ func (q *Queries) OverrideSearch(ctx context.Context, arg OverrideSearchParams) 
 	return items, nil
 }
 
-const procAcquireModuleLock = `-- name: ProcAcquireModuleLock :one
+const procAcquireModuleLockNoWait = `-- name: ProcAcquireModuleLockNoWait :one
 SELECT
-    version
+    1
 FROM
     engine_processing_versions
 WHERE
     type_id = $1
+    AND version = $2
 FOR UPDATE
     NOWAIT
 `
 
-func (q *Queries) ProcAcquireModuleLock(ctx context.Context, typeID EngineProcessingType) (int32, error) {
-	row := q.db.QueryRowContext(ctx, procAcquireModuleLock, typeID)
-	var version int32
-	err := row.Scan(&version)
-	return version, err
+type ProcAcquireModuleLockNoWaitParams struct {
+	TypeID  EngineProcessingType
+	Version int32
+}
+
+func (q *Queries) ProcAcquireModuleLockNoWait(ctx context.Context, arg ProcAcquireModuleLockNoWaitParams) (int32, error) {
+	row := q.db.QueryRowContext(ctx, procAcquireModuleLockNoWait, arg.TypeID, arg.Version)
+	var column_1 int32
+	err := row.Scan(&column_1)
+	return column_1, err
 }
 
 const procAcquireModuleSharedLock = `-- name: ProcAcquireModuleSharedLock :one
 SELECT
-    version
+    1
 FROM
     engine_processing_versions
 WHERE
-    type_id = $1 FOR SHARE NOWAIT
+    type_id = $1
+    AND version = $2 FOR SHARE
 `
 
-func (q *Queries) ProcAcquireModuleSharedLock(ctx context.Context, typeID EngineProcessingType) (int32, error) {
-	row := q.db.QueryRowContext(ctx, procAcquireModuleSharedLock, typeID)
-	var version int32
-	err := row.Scan(&version)
-	return version, err
+type ProcAcquireModuleSharedLockParams struct {
+	TypeID  EngineProcessingType
+	Version int32
+}
+
+func (q *Queries) ProcAcquireModuleSharedLock(ctx context.Context, arg ProcAcquireModuleSharedLockParams) (int32, error) {
+	row := q.db.QueryRowContext(ctx, procAcquireModuleSharedLock, arg.TypeID, arg.Version)
+	var column_1 int32
+	err := row.Scan(&column_1)
+	return column_1, err
 }
 
 const procLoadState = `-- name: ProcLoadState :one

--- a/gadb/queries.sql.go
+++ b/gadb/queries.sql.go
@@ -3274,6 +3274,22 @@ func (q *Queries) ProcAcquireModuleLock(ctx context.Context, typeID EngineProces
 	return version, err
 }
 
+const procAcquireModuleSharedLock = `-- name: ProcAcquireModuleSharedLock :one
+SELECT
+    version
+FROM
+    engine_processing_versions
+WHERE
+    type_id = $1 FOR SHARE NOWAIT
+`
+
+func (q *Queries) ProcAcquireModuleSharedLock(ctx context.Context, typeID EngineProcessingType) (int32, error) {
+	row := q.db.QueryRowContext(ctx, procAcquireModuleSharedLock, typeID)
+	var version int32
+	err := row.Scan(&version)
+	return version, err
+}
+
 const procLoadState = `-- name: ProcLoadState :one
 SELECT
     state


### PR DESCRIPTION
**Description:**
This PR adds a `WithTxShared` to the processing lock package. This gives the same module-version guarantees as before, but allows for concurrent workers. Additionally, the signals code has been updated to allow for up to 3 workers and leveraging this.

- Existing/older versions of the engine will continue to use `NO WAIT` and are granted exclusive access, ensuring no conflicts with new code
- the shared lock will BLOCK, since it is used by workers not in the engine cycle (thus no need for the same non-blocking guarantees, but DO want to guarantee work is performed)
- Previously, lock acquisition was performed as "get lock, check version" which could cause out-of-date instances to cause skips or unnecessary blocking. This has been changed to "get lock, if-correct-version" by including the version in the WHERE clause of both shared and unshared locks
