### PR TITLE
uik: add some clarity to using universal keys 

### DIFF
--- a/web/src/app/services/IntegrationKeyList.tsx
+++ b/web/src/app/services/IntegrationKeyList.tsx
@@ -134,7 +134,7 @@ export default function IntegrationKeyList(props: {
               <Grid item>
                 <AppLink to={key.id}>
                   <Button
-                    aria-label='Manage configuration and tokens for this key.'
+                    title='Manage configuration and tokens for this key.'
                     onClick={() => {}}
                     variant='contained'
                   >
@@ -145,6 +145,7 @@ export default function IntegrationKeyList(props: {
             )}
             <Grid item>
               <IconButton
+                title='Delete this key.'
                 onClick={(): void => setDeleteDialog(key.id)}
                 size='large'
               >

--- a/web/src/app/services/IntegrationKeyList.tsx
+++ b/web/src/app/services/IntegrationKeyList.tsx
@@ -120,7 +120,6 @@ export default function IntegrationKeyList(props: {
     .map(
       (key: IntegrationKey): FlatListListItem => ({
         title: key.name,
-        url: key.type === 'universal' ? key.id : undefined,
         subText: (
           <IntegrationKeyDetails
             key={key.id}
@@ -130,12 +129,29 @@ export default function IntegrationKeyList(props: {
           />
         ),
         secondaryAction: (
-          <IconButton
-            onClick={(): void => setDeleteDialog(key.id)}
-            size='large'
-          >
-            <Trash />
-          </IconButton>
+          <Grid container spacing={2} alignItems='center' wrap='nowrap'>
+            {key.type === 'universal' && (
+              <Grid item>
+                <AppLink to={key.id}>
+                  <Button
+                    aria-label='Manage configuration and tokens for this key.'
+                    onClick={() => {}}
+                    variant='contained'
+                  >
+                    Manage
+                  </Button>
+                </AppLink>
+              </Grid>
+            )}
+            <Grid item>
+              <IconButton
+                onClick={(): void => setDeleteDialog(key.id)}
+                size='large'
+              >
+                <Trash />
+              </IconButton>
+            </Grid>
+          </Grid>
         ),
       }),
     )

--- a/web/src/app/services/UniversalKey/UniversalKeyPage.tsx
+++ b/web/src/app/services/UniversalKey/UniversalKeyPage.tsx
@@ -23,6 +23,7 @@ const query = gql`
       id
       name
       serviceID
+      href
       tokenInfo {
         primaryHint
         secondaryHint
@@ -70,9 +71,25 @@ export default function UniversalKeyPage(
   const primaryHint = q.data.integrationKey.tokenInfo.primaryHint
   const secondaryHint = q.data.integrationKey.tokenInfo.secondaryHint
 
-  const desc = secondaryHint
+  const tokenInfo = secondaryHint
     ? `Primary Auth Token: ${primaryHint}\nSecondary Auth Token: ${secondaryHint}`
     : `Auth Token: ${primaryHint || 'N/A'}`
+
+  const desc = `
+Example Request:
+
+\`\`\`
+POST ${q.data.integrationKey.href}
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{"foo":"bar"}
+\`\`\`
+
+_**Note:** Replace <token> with a valid auth token (no brackets)._
+
+${tokenInfo}
+`
 
   function makeGenerateButtons(): Array<Action> {
     if (primaryHint && !secondaryHint) {


### PR DESCRIPTION
**Description:**
This PR makes two changes to reduce confusion:
- Rather than clickable items mixed in the integration key list, UIKs will now have a MANAGE button
- The universal key edit page now includes an example request for how to use a key.

**Which issue(s) this PR fixes:**
Part of #4187 

**Screenshots:**
![image](https://github.com/user-attachments/assets/8c4d9210-5ca5-4a1d-9168-cfde8700daeb)
![image](https://github.com/user-attachments/assets/a4ca13f0-fc8e-4122-b81f-ba6aa096b263)

**Describe any introduced user-facing changes:**
See above

**Describe any introduced API changes:**
N/A
