### PR TITLE
adding info link to expr syntax

### DIFF
--- a/web/src/app/services/UniversalKey/ExprField.tsx
+++ b/web/src/app/services/UniversalKey/ExprField.tsx
@@ -1,9 +1,9 @@
 import { FormControl, InputLabel, OutlinedInput } from '@mui/material'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
-import Link from '@mui/material/Link'
 import Tooltip from '@mui/material/Tooltip'
 import React from 'react'
 import ExprEditor from '../../editor/ExprEditor'
+import AppLink from '../../util/AppLink'
 
 export type ExprFieldProps = {
   error?: boolean
@@ -24,7 +24,7 @@ export function ExprField(props: ExprFieldProps): React.ReactNode {
       variant='outlined'
       data-testid={'code-' + props.name}
     >
-      <InputLabel htmlFor={props.name} sx={{ padding: '0 50px 0 0' }}>
+      <InputLabel htmlFor={props.name} sx={{ padding: '0 50px 0 0' }} shrink>
         <div style={{ display: 'flex', alignItems: 'center' }}>
           {props.label}
           <AppLink
@@ -35,7 +35,7 @@ export function ExprField(props: ExprFieldProps): React.ReactNode {
             <Tooltip title='Expr syntax'>
               <InfoOutlinedIcon />
             </Tooltip>
-          </Link>
+          </AppLink>
         </div>
       </InputLabel>
       <OutlinedInput

--- a/web/src/app/services/UniversalKey/ExprField.tsx
+++ b/web/src/app/services/UniversalKey/ExprField.tsx
@@ -1,4 +1,7 @@
 import { FormControl, InputLabel, OutlinedInput } from '@mui/material'
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
+import Link from '@mui/material/Link'
+import Tooltip from '@mui/material/Tooltip'
 import React from 'react'
 import ExprEditor from '../../editor/ExprEditor'
 
@@ -21,13 +24,25 @@ export function ExprField(props: ExprFieldProps): React.ReactNode {
       variant='outlined'
       data-testid={'code-' + props.name}
     >
-      <InputLabel htmlFor={props.name} shrink>
-        {props.label} (Expr syntax)
+      <InputLabel htmlFor={props.name} sx={{ padding: '0 50px 0 0' }}>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          {props.label}
+          <Link
+            href='https://expr-lang.org/docs/language-definition'
+            target='_blank'
+            rel='noreferrer'
+            style={{ marginTop: '5px', marginRight: '5px', marginLeft: '5px' }}
+          >
+            <Tooltip title='Expr syntax'>
+              <InfoOutlinedIcon />
+            </Tooltip>
+          </Link>
+        </div>
       </InputLabel>
       <OutlinedInput
         name={props.name}
         id={props.name}
-        label={props.label + ' (Expr syntax)'} // used for sizing, not display
+        label={props.label + ' ((i)) '} // used for sizing, not display
         notched
         sx={{ padding: '1em' }}
         disabled={props.disabled}

--- a/web/src/app/services/UniversalKey/ExprField.tsx
+++ b/web/src/app/services/UniversalKey/ExprField.tsx
@@ -27,10 +27,9 @@ export function ExprField(props: ExprFieldProps): React.ReactNode {
       <InputLabel htmlFor={props.name} sx={{ padding: '0 50px 0 0' }}>
         <div style={{ display: 'flex', alignItems: 'center' }}>
           {props.label}
-          <Link
-            href='https://expr-lang.org/docs/language-definition'
-            target='_blank'
-            rel='noreferrer'
+          <AppLink
+            to='https://expr-lang.org/docs/language-definition'
+            newTab
             style={{ marginTop: '5px', marginRight: '5px', marginLeft: '5px' }}
           >
             <Tooltip title='Expr syntax'>


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [X] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [X] Code builds clean without any errors or warnings.
- [X] Added appropriate tests for any new functionality.
- [X] All new and existing tests passed.
- [X] Added comments in the code, where necessary.
- [X] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This adds in a a info icon with a link to the expr syntax docs in the label of each expr field.

**Which issue(s) this PR fixes:**
Part of [4187](https://github.com/target/goalert/issues/4187)

**Out of Scope:**
N/A

**Screenshots:**
![Screenshot 2024-12-12 at 10 15 03 AM (1)](https://github.com/user-attachments/assets/e655489d-ed21-45ed-9944-a9a144fb314c)


**Describe any introduced user-facing changes:**
Users can now click to see the docks via the info icon

**Describe any introduced API changes:**
N/A

**Additional Info:**
N/A
