### PR TITLE
chore(deps): add group for Go dependencies in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -95,6 +95,9 @@ updates:
       timezone: 'Asia/Kolkata'
     allow:
       - dependency-type: 'direct'
+    groups:
+      go-deps:
+        patterns: ['*']
 
   - package-ecosystem: 'gradle'
     directory: '/'


### PR DESCRIPTION
This pull request includes a change to the `.github/dependabot.yml` file to better manage dependencies by introducing a grouping mechanism.

Dependency management improvements:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R98-R100): Added a `groups` section under the `go-deps` dependency type to allow pattern-based grouping of dependencies.