### PR TITLE
chore(deps): organize JavaScript dependencies in groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -128,6 +128,16 @@ updates:
       timezone: 'Asia/Kolkata'
     allow:
       - dependency-type: 'direct'
+    groups:
+      js-mui-deps:
+        patterns: ['@mui/*']
+      js-deps:
+        patterns: ['*']
+        exclude-patterns:
+          - '@mui/*'
+        update-types:
+          - 'patch'
+          - 'minor'
 
   - package-ecosystem: 'nuget'
     directory: '/'


### PR DESCRIPTION
This pull request includes changes to the `.github/dependabot.yml` file to better organize and manage dependency updates. The most important changes include the addition of groups for JavaScript dependencies, which allows for more granular control over update patterns and types.

Dependency management improvements:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R131-R140): Added a `js-mui-deps` group to handle updates for `@mui/*` dependencies separately.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R131-R140): Added a `js-deps` group for all other JavaScript dependencies, excluding `@mui/*`, and specified that only patch and minor updates should be applied.