### PR TITLE
notification/webhook: all webhooks are signed by a new set of signing keys

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -129,6 +129,7 @@ type App struct {
 	SessionKeyring  keyring.Keyring
 	APIKeyring      keyring.Keyring
 	AuthLinkKeyring keyring.Keyring
+	WebhookKeyring  keyring.Keyring
 
 	NonceStore    *nonce.Store
 	LabelStore    *label.Store

--- a/app/initstores.go
+++ b/app/initstores.go
@@ -126,6 +126,18 @@ func (app *App) initStores(ctx context.Context) error {
 		return errors.Wrap(err, "init API keyring")
 	}
 
+	if app.WebhookKeyring == nil {
+		app.WebhookKeyring, err = keyring.NewDB(ctx, app.cfg.LegacyLogger, app.db, &keyring.Config{
+			Name:       "webhook-keys",
+			MaxOldKeys: 100,
+			Keys:       app.cfg.EncryptionKeys,
+		})
+
+		if err != nil {
+			return errors.Wrap(err, "init webhook keyring")
+		}
+	}
+
 	if app.AuthLinkStore == nil {
 		app.AuthLinkStore, err = authlink.NewStore(ctx, app.db, app.AuthLinkKeyring)
 	}

--- a/app/startup.go
+++ b/app/startup.go
@@ -94,7 +94,7 @@ func (app *App) startup(ctx context.Context) error {
 	app.DestRegistry.RegisterProvider(ctx, app.slackChan)
 	app.DestRegistry.RegisterProvider(ctx, app.slackChan.DMSender())
 	app.DestRegistry.RegisterProvider(ctx, app.slackChan.UserGroupSender())
-	app.DestRegistry.RegisterProvider(ctx, webhook.NewSender(ctx))
+	app.DestRegistry.RegisterProvider(ctx, webhook.NewSender(ctx, app.WebhookKeyring))
 	if app.cfg.StubNotifiers {
 		app.DestRegistry.StubNotifiers()
 	}

--- a/notification/webhook/sender.go
+++ b/notification/webhook/sender.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/target/goalert/keyring"
 	"net/http"
 	"time"
 
@@ -13,7 +14,9 @@ import (
 	"github.com/target/goalert/notification/nfydest"
 )
 
-type Sender struct{}
+type Sender struct {
+	signingKeyring keyring.Keyring
+}
 
 // POSTDataAlert represents fields in outgoing alert notification.
 type POSTDataAlert struct {
@@ -83,8 +86,10 @@ type POSTDataTest struct {
 	Type    string
 }
 
-func NewSender(ctx context.Context) *Sender {
-	return &Sender{}
+func NewSender(ctx context.Context, keyring keyring.Keyring) *Sender {
+	return &Sender{
+		signingKeyring: keyring,
+	}
 }
 
 var _ nfydest.MessageSender = &Sender{}


### PR DESCRIPTION
- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [ ] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
This PR:
- initializes a new set of signing keys for the webhook delivery method
- ensures that every outgoing webhook is signed
- ensures that the signature is included in `X-Webhook-Signature`, converting the raw binary signature to base64

**Which issue(s) this PR fixes:**
Begins to fix https://github.com/target/goalert/issues/4224

**Out of Scope:**

- API changes to expose the public signing key
- API changes to allow for the rotation of the signing key
- UI changes to allow for getting the signing key of the instance

**Screenshots:**

<img width="1465" alt="very basic webhook signatures" src="https://github.com/user-attachments/assets/56dbb05f-8f8d-4a48-974d-cc1a9e74a68c" />

**Describe any introduced user-facing changes:**
Users will notice a new `X-Webhook-Signature` header on any outgoing webhook.

They will _not_ be able to validate the webhook signature with just this PR as the public key will not have been exposed.

**Describe any introduced API changes:**
N/a

**Additional Info:**
Additional PRs for API/UI changes to come with confirmation this is the approach we want to take for resolving #4224 
