### PR TITLE
change deprecated JSX namespace to React.JSX #3435

### DIFF
--- a/web/src/app/NewVersionCheck.tsx
+++ b/web/src/app/NewVersionCheck.tsx
@@ -33,7 +33,7 @@ const fetchCurrentVersion = (): Promise<string> =>
     .then((res) => res.text())
     .then((docStr) => extractMetaTagValue(docStr, 'x-goalert-version'))
 
-export default function NewVersionCheck(): JSX.Element {
+export default function NewVersionCheck(): React.JSX.Element {
   const [currentVersion, setCurrentVersion] = useState(GOALERT_VERSION)
   const [firstSeen, setFirstSeen] = useState(DateTime.utc())
   const [lastCheck, setLastCheck] = useState(DateTime.utc())

--- a/web/src/app/admin/AdminAPIKeys.tsx
+++ b/web/src/app/admin/AdminAPIKeys.tsx
@@ -51,7 +51,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }))
 
-export default function AdminAPIKeys(): JSX.Element {
+export default function AdminAPIKeys(): React.JSX.Element {
   const classes = useStyles()
   const [selectedAPIKey, setSelectedAPIKey] = useState<GQLAPIKey | null>(null)
   const [createDialog, setCreateDialog] = useState<boolean>(false)

--- a/web/src/app/admin/AdminConfig.tsx
+++ b/web/src/app/admin/AdminConfig.tsx
@@ -81,7 +81,7 @@ function formatHeading(s = ''): string {
     .replace(/R Ls\b/, 'RLs') // fix usages of `URLs`
 }
 
-export default function AdminConfig(): JSX.Element {
+export default function AdminConfig(): React.JSX.Element {
   const classes = useStyles()
   const [confirm, setConfirm] = useState(false)
   const [values, setValues] = useState({})

--- a/web/src/app/admin/AdminDialog.tsx
+++ b/web/src/app/admin/AdminDialog.tsx
@@ -34,7 +34,7 @@ interface AdminDialogProps {
   onComplete?: () => void
 }
 
-function AdminDialog(props: AdminDialogProps): JSX.Element {
+function AdminDialog(props: AdminDialogProps): React.JSX.Element {
   const [{ data, fetching, error: readError }] = useQuery({
     query: props.query || query,
   })

--- a/web/src/app/admin/AdminFieldComponents.tsx
+++ b/web/src/app/admin/AdminFieldComponents.tsx
@@ -17,11 +17,11 @@ interface InputProps {
   autoComplete?: string
 }
 
-export function StringInput(props: InputProps): JSX.Element {
+export function StringInput(props: InputProps): React.JSX.Element {
   const [showPassword, setShowPassword] = useState(false)
   const { onChange, password, type = 'text', ...rest } = props
 
-  const renderPasswordAdornment = (): JSX.Element | null => {
+  const renderPasswordAdornment = (): React.JSX.Element | null => {
     if (!props.password) return null
 
     return (
@@ -52,7 +52,7 @@ export function StringInput(props: InputProps): JSX.Element {
   )
 }
 
-export const StringListInput = (props: InputProps): JSX.Element => {
+export const StringListInput = (props: InputProps): React.JSX.Element => {
   const value = props.value ? props.value.split('\n').concat('') : ['']
   return (
     <Grid container spacing={1}>
@@ -80,7 +80,7 @@ export const StringListInput = (props: InputProps): JSX.Element => {
   )
 }
 
-export const IntegerInput = (props: InputProps): JSX.Element => (
+export const IntegerInput = (props: InputProps): React.JSX.Element => (
   <Input
     name={props.name}
     value={props.value}
@@ -95,7 +95,7 @@ export const IntegerInput = (props: InputProps): JSX.Element => (
   />
 )
 
-export const BoolInput = (props: InputProps): JSX.Element => (
+export const BoolInput = (props: InputProps): React.JSX.Element => (
   <Switch
     name={props.name}
     value={props.value}

--- a/web/src/app/admin/AdminLimits.tsx
+++ b/web/src/app/admin/AdminLimits.tsx
@@ -52,7 +52,7 @@ interface LimitsValues {
   [id: string]: string
 }
 
-export default function AdminLimits(): JSX.Element {
+export default function AdminLimits(): React.JSX.Element {
   const classes = useStyles()
   const [confirm, setConfirm] = useState(false)
   const [values, setValues] = useState({})

--- a/web/src/app/admin/AdminNumberLookup.tsx
+++ b/web/src/app/admin/AdminNumberLookup.tsx
@@ -49,7 +49,7 @@ const numInfoQuery = gql`
 
 const noSuspense = { suspense: false }
 
-export default function AdminNumberLookup(): JSX.Element {
+export default function AdminNumberLookup(): React.JSX.Element {
   const [number, setNumber] = useState('')
   const [staleCarrier, setStaleCarrier] = useState(true)
 
@@ -74,7 +74,7 @@ export default function AdminNumberLookup(): JSX.Element {
     if (mutationError) setLastError(mutationError)
   }, [mutationError])
 
-  function renderListItem(label: string, text = ''): JSX.Element {
+  function renderListItem(label: string, text = ''): React.JSX.Element {
     return (
       <React.Fragment>
         <Divider />

--- a/web/src/app/admin/AdminSMSSend.tsx
+++ b/web/src/app/admin/AdminSMSSend.tsx
@@ -51,7 +51,7 @@ const useStyles = makeStyles({
   },
 })
 
-export default function AdminSMSSend(): JSX.Element {
+export default function AdminSMSSend(): React.JSX.Element {
   const classes = useStyles()
   const [cfgFromNumber, cfgSID] = useConfigValue(
     'Twilio.FromNumber',

--- a/web/src/app/admin/AdminSection.tsx
+++ b/web/src/app/admin/AdminSection.tsx
@@ -57,7 +57,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }))
 
-export default function AdminSection(props: AdminSectionProps): JSX.Element {
+export default function AdminSection(props: AdminSectionProps): React.JSX.Element {
   // TODO: add 'reset to default' buttons
   const classes = useStyles()
   const { fields, value, headerNote } = props

--- a/web/src/app/admin/AdminToolbox.tsx
+++ b/web/src/app/admin/AdminToolbox.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }))
 
-export default function AdminToolbox(): JSX.Element {
+export default function AdminToolbox(): React.JSX.Element {
   const classes = useStyles()
 
   return (

--- a/web/src/app/admin/SlackActions.tsx
+++ b/web/src/app/admin/SlackActions.tsx
@@ -32,14 +32,14 @@ const useStyles = makeStyles({
   },
 })
 
-export default function SlackActions(): JSX.Element {
+export default function SlackActions(): React.JSX.Element {
   const classes = useStyles()
   const [showManifest, setShowManifest] = useState(false)
 
   const [{ fetching, error, data }] = useQuery({ query })
   const manifest = data?.generateSlackAppManifest ?? ''
 
-  function renderContent(): JSX.Element {
+  function renderContent(): React.JSX.Element {
     if (fetching) return <Spinner />
     if (error) return <GenericError error={error.message} />
 

--- a/web/src/app/admin/admin-alert-counts/AdminAlertCounts.tsx
+++ b/web/src/app/admin/admin-alert-counts/AdminAlertCounts.tsx
@@ -27,7 +27,7 @@ const units: Record<string, DateTimeUnit> = {
   P1M: 'month',
 }
 
-export default function AdminAlertCounts(): JSX.Element {
+export default function AdminAlertCounts(): React.JSX.Element {
   const styles = useStyles()
 
   const [graphData, setGraphData] = useState<AlertCountSeries[]>([])

--- a/web/src/app/admin/admin-alert-counts/AlertCountControls.tsx
+++ b/web/src/app/admin/admin-alert-counts/AlertCountControls.tsx
@@ -14,7 +14,7 @@ import { ISODateTimePicker } from '../../util/ISOPickers'
 import { useURLParams, useResetURLParams } from '../../actions'
 import { DateTime } from 'luxon'
 
-export default function AlertCountControls(): JSX.Element {
+export default function AlertCountControls(): React.JSX.Element {
   const now = useMemo(() => DateTime.now(), [])
   const [params, setParams] = useURLParams({
     createdAfter: now.minus({ days: 1 }).toISO(),

--- a/web/src/app/admin/admin-alert-counts/AlertCountLineGraph.tsx
+++ b/web/src/app/admin/admin-alert-counts/AlertCountLineGraph.tsx
@@ -56,7 +56,7 @@ interface CustomDotProps extends DotProps {
   }
 }
 
-function CustomDot(props: CustomDotProps): JSX.Element {
+function CustomDot(props: CustomDotProps): React.JSX.Element {
   const { cy, cx, fill, r, stroke, strokeWidth, name = '', payload } = props
 
   return (
@@ -75,7 +75,7 @@ function CustomDot(props: CustomDotProps): JSX.Element {
 
 export default function AlertCountLineGraph(
   props: AlertCountLineGraphProps,
-): JSX.Element {
+): React.JSX.Element {
   const [active, setActive] = useState('')
   const classes = useStyles()
   const theme = useTheme()

--- a/web/src/app/admin/admin-alert-counts/AlertCountTable.tsx
+++ b/web/src/app/admin/admin-alert-counts/AlertCountTable.tsx
@@ -86,7 +86,7 @@ const columns = [
 
 export default function AlertCountTable(
   props: AlertCountTableProps,
-): JSX.Element {
+): React.JSX.Element {
   const classes = useStyles()
 
   const csvOpts = useMemo(
@@ -102,7 +102,7 @@ export default function AlertCountTable(
     [csvData],
   )
 
-  function CustomToolbar(): JSX.Element {
+  function CustomToolbar(): React.JSX.Element {
     const apiRef = useGridApiContext()
     const currentPage = gridPaginatedVisibleSortedGridRowEntriesSelector(
       apiRef,

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyDeleteDialog.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyDeleteDialog.tsx
@@ -26,7 +26,7 @@ const query = gql`
 export default function AdminAPIKeyDeleteDialog(props: {
   apiKeyID: string
   onClose: (yes: boolean) => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [{ fetching, data, error }] = useQuery({
     query,
   })

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyDrawer.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyDrawer.tsx
@@ -89,7 +89,7 @@ function ActionBy(props: {
   )
 }
 
-export default function AdminAPIKeyDrawer(props: Props): JSX.Element {
+export default function AdminAPIKeyDrawer(props: Props): React.JSX.Element {
   const { onClose, apiKeyID } = props
   const classes = useStyles()
   const isOpen = Boolean(apiKeyID)

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyEditDialog.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyEditDialog.tsx
@@ -29,7 +29,7 @@ const query = gql`
 export default function AdminAPIKeyEditDialog(props: {
   onClose: (param: boolean) => void
   apiKeyID: string
-}): JSX.Element {
+}): React.JSX.Element {
   const { apiKeyID, onClose } = props
   const [{ fetching, data, error }] = useQuery({
     query,

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyExpirationField.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyExpirationField.tsx
@@ -27,7 +27,7 @@ const presets = [7, 15, 30, 60, 90]
 
 export default function AdminAPIKeyExpirationField(
   props: FieldProps,
-): JSX.Element {
+): React.JSX.Element {
   const classes = useStyles()
 
   const [selected, setSelected] = useState<number>(

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyForm.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyForm.tsx
@@ -19,7 +19,7 @@ type AdminAPIKeyFormProps = {
 
 export default function AdminAPIKeyForm(
   props: AdminAPIKeyFormProps,
-): JSX.Element {
+): React.JSX.Element {
   const queryError = props.errors.find((e) => e.field === 'query')?.message
   return (
     <FormContainer optionalLabels {...props}>

--- a/web/src/app/admin/admin-api-keys/AdminAPIKeyShowQueryDialog.tsx
+++ b/web/src/app/admin/admin-api-keys/AdminAPIKeyShowQueryDialog.tsx
@@ -21,7 +21,7 @@ const query = gql`
 export default function AdminAPIKeyShowQueryDialog(props: {
   apiKeyID: string
   onClose: (yes: boolean) => void
-}): JSX.Element {
+}): React.JSX.Element {
   const theme = useTheme()
   const [{ fetching, data, error }] = useQuery({
     query,

--- a/web/src/app/admin/admin-message-logs/AdminMessageLogDrawer.tsx
+++ b/web/src/app/admin/admin-message-logs/AdminMessageLogDrawer.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }))
 
-export default function AdminMessageLogDrawer(props: Props): JSX.Element {
+export default function AdminMessageLogDrawer(props: Props): React.JSX.Element {
   const { onClose, log } = props
   const classes = useStyles()
 

--- a/web/src/app/admin/admin-message-logs/AdminMessageLogsControls.tsx
+++ b/web/src/app/admin/admin-message-logs/AdminMessageLogsControls.tsx
@@ -5,7 +5,7 @@ import { ISODateTimePicker } from '../../util/ISOPickers'
 import Search from '../../util/Search'
 import { useMessageLogsParams } from './util'
 
-export default function AdminMessageLogsControls(): JSX.Element {
+export default function AdminMessageLogsControls(): React.JSX.Element {
   const [params, setParams] = useMessageLogsParams()
 
   return (

--- a/web/src/app/admin/admin-message-logs/AdminMessageLogsGraph.tsx
+++ b/web/src/app/admin/admin-message-logs/AdminMessageLogsGraph.tsx
@@ -39,7 +39,7 @@ type Stats = Array<{
 
 interface MessageLogGraphData {
   date: string
-  label: JSX.Element
+  label: React.JSX.Element
   count: number
 }
 
@@ -60,7 +60,7 @@ const statsQuery = gql`
   }
 `
 
-export default function AdminMessageLogsGraph(): JSX.Element {
+export default function AdminMessageLogsGraph(): React.JSX.Element {
   const theme = useTheme()
 
   const [{ search, start, end, graphInterval }, setParams] =

--- a/web/src/app/admin/admin-message-logs/AdminMessageLogsLayout.tsx
+++ b/web/src/app/admin/admin-message-logs/AdminMessageLogsLayout.tsx
@@ -56,7 +56,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 const context = { suspense: false }
 
-export default function AdminMessageLogsLayout(): JSX.Element {
+export default function AdminMessageLogsLayout(): React.JSX.Element {
   const classes = useStyles()
   const [selectedLog, setSelectedLog] = useState<DebugMessage | null>(null)
 

--- a/web/src/app/admin/admin-service-metrics/AdminServiceFilter.tsx
+++ b/web/src/app/admin/admin-service-metrics/AdminServiceFilter.tsx
@@ -22,7 +22,7 @@ import { LabelKeySelect } from '../../selection'
 import { LabelValueSelect } from '../../selection/LabelValueSelect'
 import { useFeatures } from '../../util/RequireConfig'
 
-function AdminServiceFilter(): JSX.Element {
+function AdminServiceFilter(): React.JSX.Element {
   const [open, setOpen] = useState<boolean>(false)
 
   const [params, setParams] = useURLParams({
@@ -52,7 +52,7 @@ function AdminServiceFilter(): JSX.Element {
     setParams({ ...params, [filterName]: [] })
   }
 
-  function renderFilterChips(): JSX.Element {
+  function renderFilterChips(): React.JSX.Element {
     return (
       <Stack direction='row' spacing={1} sx={{ marginTop: '10px' }}>
         {!!params.epStepTgts.length && (
@@ -89,7 +89,7 @@ function AdminServiceFilter(): JSX.Element {
     )
   }
 
-  function renderFilterDrawer(): JSX.Element {
+  function renderFilterDrawer(): React.JSX.Element {
     return (
       <ClickAwayListener
         onClickAway={() => setOpen(false)}

--- a/web/src/app/admin/admin-service-metrics/AdminServiceMetrics.tsx
+++ b/web/src/app/admin/admin-service-metrics/AdminServiceMetrics.tsx
@@ -20,7 +20,7 @@ import AdminServiceTargetGraph from './AdminServiceTargetGraph'
 
 const STALE_ALERT_LIMIT = 2
 
-export default function AdminServiceMetrics(): JSX.Element {
+export default function AdminServiceMetrics(): React.JSX.Element {
   const now = useMemo(() => DateTime.now(), [])
   const [params] = useURLParams({
     epStepTgts: [] as string[],
@@ -95,7 +95,7 @@ export default function AdminServiceMetrics(): JSX.Element {
     ? 'Loading services... This may take a minute'
     : `Metrics pulled from ${metrics.filteredServices.length} services`
 
-  function renderOverviewMetrics(): JSX.Element {
+  function renderOverviewMetrics(): React.JSX.Element {
     return (
       <React.Fragment>
         <Grid item xs={4} sm={2.4}>
@@ -176,7 +176,7 @@ export default function AdminServiceMetrics(): JSX.Element {
     )
   }
 
-  function renderUsageGraphs(): JSX.Element {
+  function renderUsageGraphs(): React.JSX.Element {
     return (
       <React.Fragment>
         <Grid item xs>
@@ -221,7 +221,7 @@ export default function AdminServiceMetrics(): JSX.Element {
     )
   }
 
-  function renderServiceTable(): JSX.Element {
+  function renderServiceTable(): React.JSX.Element {
     return (
       <Card sx={{ marginTop: (theme) => theme.spacing(1) }}>
         <CardHeader title='Services' subheader={cardSubHeader} />

--- a/web/src/app/admin/admin-service-metrics/AdminServiceTable.tsx
+++ b/web/src/app/admin/admin-service-metrics/AdminServiceTable.tsx
@@ -35,7 +35,7 @@ interface AdminServiceTableProps {
 
 export default function AdminServiceTable(
   props: AdminServiceTableProps,
-): JSX.Element {
+): React.JSX.Element {
   const { services = [], loading, staleAlertServices } = props
   // Community version of MUI DataGrid only supports sortModels with a single SortItem
   const [sortModel, setSortModel] = useState<GridSortItem[]>([

--- a/web/src/app/admin/admin-service-metrics/AdminServiceTargetGraph.tsx
+++ b/web/src/app/admin/admin-service-metrics/AdminServiceTargetGraph.tsx
@@ -20,7 +20,7 @@ interface AdminServiceTargetGraphProps {
 
 export default function AdminServiceTargetGraph(
   props: AdminServiceTargetGraphProps,
-): JSX.Element {
+): React.JSX.Element {
   const theme = useTheme()
   const { metrics, loading } = props
   let targetMetrics = [] as { type: string; count: number }[]

--- a/web/src/app/admin/switchover/AdminSWOConfirmDialog.tsx
+++ b/web/src/app/admin/switchover/AdminSWOConfirmDialog.tsx
@@ -5,7 +5,7 @@ export default function AdminSWOConfirmDialog(props: {
   messages: string[]
   onConfirm: () => void
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   return (
     <FormDialog
       title='Continue with switchover?'

--- a/web/src/app/admin/switchover/AdminSWODBVersionCard.tsx
+++ b/web/src/app/admin/switchover/AdminSWODBVersionCard.tsx
@@ -15,7 +15,7 @@ interface DBVersionProps {
 
 export function AdminSWODBVersionCard(props: {
   data: DBVersionProps
-}): JSX.Element {
+}): React.JSX.Element {
   const curVer = props.data.mainDBVersion.split(' on ')
   const nextVer = props.data.nextDBVersion.split(' on ')
 

--- a/web/src/app/admin/switchover/AdminSWODone.tsx
+++ b/web/src/app/admin/switchover/AdminSWODone.tsx
@@ -5,7 +5,7 @@ import Typography from '@mui/material/Typography'
 import DatabaseCheck from 'mdi-material-ui/DatabaseCheck'
 import { TransitionGroup } from 'react-transition-group'
 
-export function AdminSWODone(): JSX.Element {
+export function AdminSWODone(): React.JSX.Element {
   return (
     <TransitionGroup appear={false}>
       <Zoom in timeout={500}>

--- a/web/src/app/admin/switchover/AdminSWOStatusCard.tsx
+++ b/web/src/app/admin/switchover/AdminSWOStatusCard.tsx
@@ -16,7 +16,7 @@ import LoadingButton from '@mui/lab/LoadingButton'
 import { toTitle } from './util'
 import { AdminSwitchoverGuideButton } from './AdminSwitchoverGuide'
 
-function getIcon(data: SWOStatus): JSX.Element {
+function getIcon(data: SWOStatus): React.JSX.Element {
   const i: SvgIconProps = { color: 'primary', sx: { fontSize: '3.5rem' } }
 
   if (data.lastError) {
@@ -61,7 +61,7 @@ type AdminSWOStatusCardProps = {
 
 export function AdminSWOStatusCard(
   props: AdminSWOStatusCardProps,
-): JSX.Element {
+): React.JSX.Element {
   const theme = useTheme()
 
   // We track this separately so we can wait for a NEW status without

--- a/web/src/app/admin/switchover/AdminSWOWrongMode.tsx
+++ b/web/src/app/admin/switchover/AdminSWOWrongMode.tsx
@@ -3,7 +3,7 @@ import Grid from '@mui/material/Grid'
 import Typography from '@mui/material/Typography'
 import DatabaseOff from 'mdi-material-ui/DatabaseOff'
 
-export function AdminSWOWrongMode(): JSX.Element {
+export function AdminSWOWrongMode(): React.JSX.Element {
   return (
     <Grid item container alignItems='center' justifyContent='center'>
       <DatabaseOff color='secondary' style={{ width: '100%', height: 256 }} />

--- a/web/src/app/admin/switchover/AdminSwitchover.tsx
+++ b/web/src/app/admin/switchover/AdminSwitchover.tsx
@@ -46,7 +46,7 @@ const mutation = gql`
   }
 `
 
-export default function AdminSwitchover(): JSX.Element {
+export default function AdminSwitchover(): React.JSX.Element {
   const [{ fetching, error, data: _data }, refetch] = useQuery({
     query,
   })

--- a/web/src/app/admin/switchover/AdminSwitchoverGuide.tsx
+++ b/web/src/app/admin/switchover/AdminSwitchoverGuide.tsx
@@ -6,7 +6,7 @@ import { Button, Card, CardContent, Typography } from '@mui/material'
 import AppLink from '../../util/AppLink'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 
-export function AdminSwitchoverGuideButton(): JSX.Element {
+export function AdminSwitchoverGuideButton(): React.JSX.Element {
   return (
     <Button
       variant='contained'
@@ -20,7 +20,7 @@ export function AdminSwitchoverGuideButton(): JSX.Element {
   )
 }
 
-export default function AdminSwitchoverGuide(): JSX.Element {
+export default function AdminSwitchoverGuide(): React.JSX.Element {
   return (
     <Card>
       <CardContent>

--- a/web/src/app/admin/switchover/SWONode.tsx
+++ b/web/src/app/admin/switchover/SWONode.tsx
@@ -17,7 +17,7 @@ interface SWONodeProps {
   name: string
 }
 
-export default function SWONode({ node, name }: SWONodeProps): JSX.Element {
+export default function SWONode({ node, name }: SWONodeProps): React.JSX.Element {
   const theme = useTheme()
 
   if (node.id.startsWith('unknown-')) {

--- a/web/src/app/alerts/AlertDetailLogs.tsx
+++ b/web/src/app/alerts/AlertDetailLogs.tsx
@@ -50,7 +50,7 @@ interface AlertDetailLogsProps {
 
 export default function AlertDetailLogs(
   props: AlertDetailLogsProps,
-): JSX.Element {
+): React.JSX.Element {
   const classes = useStyles()
   const [poll, setPoll] = useState(POLL_INTERVAL)
   const { data, error, loading, fetchMore } = useQuery(query, {
@@ -93,9 +93,9 @@ export default function AlertDetailLogs(
   }
 
   const renderList = (
-    items: JSX.Element | JSX.Element[],
+    items: React.JSX.Element | React.JSX.Element[],
     loadMore?: boolean,
-  ): JSX.Element => {
+  ): React.JSX.Element => {
     return (
       <List data-cy='alert-logs'>
         {items}
@@ -132,7 +132,7 @@ export default function AlertDetailLogs(
     }
   }
 
-  const renderItem = (event: AlertLogEntry, idx: number): JSX.Element => {
+  const renderItem = (event: AlertLogEntry, idx: number): React.JSX.Element => {
     const details = _.upperFirst(event?.state?.details ?? '')
     const status = (event?.state?.status ?? '') as NotificationStatus
 

--- a/web/src/app/alerts/AlertsList.tsx
+++ b/web/src/app/alerts/AlertsList.tsx
@@ -106,7 +106,7 @@ function getStatusFilter(s: string): string[] {
   }
 }
 
-export default function AlertsList(props: AlertsListProps): JSX.Element {
+export default function AlertsList(props: AlertsListProps): React.JSX.Element {
   const classes = useStyles()
 
   // event sent to Google Analytics

--- a/web/src/app/alerts/CreateAlertDialog/CreateAlertDialog.tsx
+++ b/web/src/app/alerts/CreateAlertDialog/CreateAlertDialog.tsx
@@ -40,7 +40,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 export default function CreateAlertDialog(props: {
   onClose: () => void
   serviceID?: string
-}): JSX.Element {
+}): React.JSX.Element {
   const classes = useStyles()
   const [step, setStep] = useState(0)
   const serviceID = props.serviceID

--- a/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertConfirm.tsx
+++ b/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertConfirm.tsx
@@ -19,7 +19,7 @@ type FieldProps = {
   label: string
 }
 
-function Field(props: FieldProps): JSX.Element {
+function Field(props: FieldProps): React.JSX.Element {
   const classes = useStyles()
   return (
     <Grid item xs={12}>
@@ -38,7 +38,7 @@ function Field(props: FieldProps): JSX.Element {
   )
 }
 
-export function CreateAlertConfirm(): JSX.Element {
+export function CreateAlertConfirm(): React.JSX.Element {
   return (
     <Grid container spacing={2}>
       <FormField

--- a/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertForm.tsx
+++ b/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertForm.tsx
@@ -36,7 +36,7 @@ interface Error {
 export function CreateAlertForm({
   activeStep,
   ...otherProps
-}: CreateAlertFormProps): JSX.Element {
+}: CreateAlertFormProps): React.JSX.Element {
   return (
     <FormContainer optionalLabels {...otherProps}>
       {activeStep === 0 && <CreateAlertInfo />}

--- a/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertInfo.tsx
+++ b/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertInfo.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Grid, TextField } from '@mui/material'
 import { FormField } from '../../../forms'
 
-export function CreateAlertInfo(): JSX.Element {
+export function CreateAlertInfo(): React.JSX.Element {
   return (
     <Grid container spacing={2}>
       <Grid item xs={12}>

--- a/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertListItem.tsx
+++ b/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertListItem.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles({
 
 export default function CreateAlertListItem(props: {
   id: string
-}): JSX.Element {
+}): React.JSX.Element {
   const { id } = props
 
   const classes = useStyles()

--- a/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertReview.tsx
+++ b/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertReview.tsx
@@ -13,7 +13,7 @@ interface CreateAlertReviewProps {
   failedServices?: FailedService[]
 }
 
-export function CreateAlertReview(props: CreateAlertReviewProps): JSX.Element {
+export function CreateAlertReview(props: CreateAlertReviewProps): React.JSX.Element {
   const { createdAlertIDs = [], failedServices = [] } = props
 
   return (

--- a/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertServiceListItem.tsx
+++ b/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertServiceListItem.tsx
@@ -32,7 +32,7 @@ interface CreateAlertServiceListItemProps {
 
 export default function CreateAlertServiceListItem(
   props: CreateAlertServiceListItemProps,
-): JSX.Element {
+): React.JSX.Element {
   const { id, err } = props
 
   const classes = useStyles()

--- a/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertServiceSelect.tsx
+++ b/web/src/app/alerts/CreateAlertDialog/StepContent/CreateAlertServiceSelect.tsx
@@ -77,7 +77,7 @@ export interface CreateAlertServiceSelectProps {
 
 export function CreateAlertServiceSelect(
   props: CreateAlertServiceSelectProps,
-): JSX.Element {
+): React.JSX.Element {
   const { value, onChange } = props
 
   const [searchQueryInput, setSearchQueryInput] = useState('')

--- a/web/src/app/alerts/components/AlertDetails.tsx
+++ b/web/src/app/alerts/components/AlertDetails.tsx
@@ -75,7 +75,7 @@ const updateStatusMutation = gql`
   }
 `
 
-export default function AlertDetails(props: AlertDetailsProps): JSX.Element {
+export default function AlertDetails(props: AlertDetailsProps): React.JSX.Element {
   const [analyticsID] = useConfigValue('General.GoogleAnalyticsID') as [string]
   const classes = useStyles()
   const isMobile = useIsWidthDown('sm')
@@ -182,7 +182,7 @@ export default function AlertDetails(props: AlertDetailsProps): JSX.Element {
     return true
   }
 
-  function getNextEscalation(): JSX.Element | string {
+  function getNextEscalation(): React.JSX.Element | string {
     const { currentLevel, lastEscalation, steps } = epsHelper()
     if (!canAutoEscalate()) return 'None'
 
@@ -201,7 +201,7 @@ export default function AlertDetails(props: AlertDetailsProps): JSX.Element {
     )
   }
 
-  function renderEscalationPolicySteps(): JSX.Element[] | JSX.Element {
+  function renderEscalationPolicySteps(): React.JSX.Element[] | React.JSX.Element {
     const { steps, status, currentLevel } = epsHelper()
 
     if (!steps?.length) {
@@ -288,7 +288,7 @@ export default function AlertDetails(props: AlertDetailsProps): JSX.Element {
   /*
    * Options to show for alert details menu
    */
-  function getMenuOptions(): Array<JSX.Element> {
+  function getMenuOptions(): Array<React.JSX.Element> {
     const { status } = props.data
     if (status === 'StatusClosed') return []
     const isMaintMode = Boolean(props.data?.service?.maintenanceExpiresAt)

--- a/web/src/app/alerts/components/AlertFeedback.tsx
+++ b/web/src/app/alerts/components/AlertFeedback.tsx
@@ -30,7 +30,7 @@ interface AlertFeedbackProps {
 
 export const options = ['False positive', 'Not actionable', 'Poor details']
 
-export default function AlertFeedback(props: AlertFeedbackProps): JSX.Element {
+export default function AlertFeedback(props: AlertFeedbackProps): React.JSX.Element {
   const { alertID } = props
 
   const [{ data }] = useQuery({

--- a/web/src/app/alerts/components/AlertFeedbackDialog.tsx
+++ b/web/src/app/alerts/components/AlertFeedbackDialog.tsx
@@ -29,7 +29,7 @@ interface AlertFeedbackDialogProps {
 
 export default function AlertFeedbackDialog(
   props: AlertFeedbackDialogProps,
-): JSX.Element {
+): React.JSX.Element {
   const { alertIDs, open, onClose } = props
 
   const [noiseReasons, setNoiseReasons] = useState<Array<string>>([])

--- a/web/src/app/alerts/components/AlertsListControls.tsx
+++ b/web/src/app/alerts/components/AlertsListControls.tsx
@@ -5,7 +5,7 @@ import { useURLParam } from '../../actions'
 
 const tabs = ['active', 'unacknowledged', 'acknowledged', 'closed', 'all']
 
-function AlertsListControls(): JSX.Element {
+function AlertsListControls(): React.JSX.Element {
   const [filter, setFilter] = useURLParam<string>('filter', 'active')
 
   let currTab = tabs.indexOf(filter)

--- a/web/src/app/alerts/components/AlertsListFilter.tsx
+++ b/web/src/app/alerts/components/AlertsListFilter.tsx
@@ -42,7 +42,7 @@ interface AlertsListFilterProps {
   serviceID: string
 }
 
-function AlertsListFilter(props: AlertsListFilterProps): JSX.Element {
+function AlertsListFilter(props: AlertsListFilterProps): React.JSX.Element {
   const classes = useStyles()
   const [show, setShow] = useState(false)
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
@@ -72,7 +72,7 @@ function AlertsListFilter(props: AlertsListFilterProps): JSX.Element {
     setShow(false)
   }
 
-  function renderFilters(): JSX.Element {
+  function renderFilters(): React.JSX.Element {
     let favoritesFilter = null
     if (!props.serviceID) {
       favoritesFilter = (

--- a/web/src/app/alerts/pages/AlertDetailPage.tsx
+++ b/web/src/app/alerts/pages/AlertDetailPage.tsx
@@ -52,7 +52,7 @@ const query = gql`
   }
 `
 
-function AlertDetailPage({ alertID }: { alertID: string }): JSX.Element {
+function AlertDetailPage({ alertID }: { alertID: string }): React.JSX.Element {
   const { loading, error, data } = useQuery(query, {
     variables: { id: alertID },
   })

--- a/web/src/app/details/CardActions.tsx
+++ b/web/src/app/details/CardActions.tsx
@@ -7,8 +7,8 @@ import Tooltip from '@mui/material/Tooltip'
 import { Theme } from '@mui/material'
 
 interface CardActionProps {
-  primaryActions?: Array<Action | JSX.Element>
-  secondaryActions?: Array<Action | JSX.Element>
+  primaryActions?: Array<Action | React.JSX.Element>
+  secondaryActions?: Array<Action | React.JSX.Element>
 }
 
 interface ActionProps {
@@ -19,7 +19,7 @@ interface ActionProps {
 export type Action = {
   label: string // primary button text, use for a tooltip if secondary action
   handleOnClick: MouseEventHandler<HTMLButtonElement>
-  icon?: JSX.Element // if true, adds a start icon to a button with text
+  icon?: React.JSX.Element // if true, adds a start icon to a button with text
   ButtonProps?: ButtonProps
 }
 
@@ -39,21 +39,21 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }))
 
-export default function CardActions(p: CardActionProps): JSX.Element {
+export default function CardActions(p: CardActionProps): React.JSX.Element {
   const classes = useStyles()
 
   const action = (
-    action: Action | JSX.Element,
+    action: Action | React.JSX.Element,
     key: string,
     secondary?: boolean,
-  ): JSX.Element => {
+  ): React.JSX.Element => {
     if ('label' in action && 'handleOnClick' in action) {
       return <Action key={key} action={action} secondary={secondary} />
     }
     return action
   }
 
-  let actions: Array<JSX.Element> = []
+  let actions: Array<React.JSX.Element> = []
   if (p.primaryActions) {
     actions = [
       <div
@@ -79,7 +79,7 @@ export default function CardActions(p: CardActionProps): JSX.Element {
   )
 }
 
-function Action(p: ActionProps): JSX.Element {
+function Action(p: ActionProps): React.JSX.Element {
   const { action, secondary } = p
   if (secondary && action.icon) {
     // wrapping button in span so tooltip can still

--- a/web/src/app/details/DetailsPage.tsx
+++ b/web/src/app/details/DetailsPage.tsx
@@ -22,15 +22,15 @@ interface DetailsPageProps {
   title: string
 
   // optional content
-  avatar?: JSX.Element // placement for an icon or image
-  subheader?: string | JSX.Element
+  avatar?: React.JSX.Element // placement for an icon or image
+  subheader?: string | React.JSX.Element
   details?: string
-  notices?: Array<Notice> | JSX.Element
+  notices?: Array<Notice> | React.JSX.Element
   labels?: Array<Label>
   links?: Array<Link>
-  pageContent?: JSX.Element
-  primaryActions?: Array<Action | JSX.Element>
-  secondaryActions?: Array<Action | JSX.Element>
+  pageContent?: React.JSX.Element
+  primaryActions?: Array<Action | React.JSX.Element>
+  secondaryActions?: Array<Action | React.JSX.Element>
 }
 
 export type LinkStatus = 'ok' | 'warn' | 'err'
@@ -60,7 +60,7 @@ const useStyles = makeStyles({
 })
 
 const LIApplink = forwardRef<HTMLAnchorElement, AppLinkProps>(
-  function LIApplink(props, ref): JSX.Element {
+  function LIApplink(props, ref): React.JSX.Element {
     return (
       <li>
         <AppLink ref={ref} {...props} />
@@ -69,7 +69,7 @@ const LIApplink = forwardRef<HTMLAnchorElement, AppLinkProps>(
   },
 )
 
-export default function DetailsPage(p: DetailsPageProps): JSX.Element {
+export default function DetailsPage(p: DetailsPageProps): React.JSX.Element {
   const classes = useStyles()
   const isMobile = useIsWidthDown('sm')
   const statusColors = useStatusColors()

--- a/web/src/app/details/Notices.tsx
+++ b/web/src/app/details/Notices.tsx
@@ -61,10 +61,10 @@ export function toSeverity(notice: NoticeType): AlertColor {
 
 export interface Notice {
   type: NoticeType
-  message: string | JSX.Element
-  details?: string | JSX.Element
-  endNote?: string | JSX.Element
-  action?: JSX.Element
+  message: string | React.JSX.Element
+  details?: string | React.JSX.Element
+  endNote?: string | React.JSX.Element
+  action?: React.JSX.Element
 }
 interface NoticesProps {
   notices?: Notice[]
@@ -72,7 +72,7 @@ interface NoticesProps {
 
 export default function Notices({
   notices = [],
-}: NoticesProps): JSX.Element | null {
+}: NoticesProps): React.JSX.Element | null {
   const classes = useStyles()
   const [noticesExpanded, setNoticesExpanded] = useState(false)
 
@@ -80,7 +80,7 @@ export default function Notices({
     return null
   }
 
-  function renderShowAllToggle(action?: JSX.Element): ReactNode {
+  function renderShowAllToggle(action?: React.JSX.Element): ReactNode {
     if (notices.length <= 1) return null
     return (
       <React.Fragment>
@@ -119,7 +119,7 @@ export default function Notices({
     }
   }
 
-  function renderNotice(notice: Notice, index: number): JSX.Element {
+  function renderNotice(notice: Notice, index: number): React.JSX.Element {
     return (
       <Grid key={index} className={getGridClassName(index)} item xs={12}>
         <Alert

--- a/web/src/app/dialogs/components/DialogTitleWrapper.jsx
+++ b/web/src/app/dialogs/components/DialogTitleWrapper.jsx
@@ -118,7 +118,7 @@ function DialogTitleWrapper(props) {
 DialogTitleWrapper.propTypes = {
   fullScreen: p.bool.isRequired,
   closeIcon: p.object,
-  toolbarItems: p.array, // list of JSX items to display on the toolbar
+  toolbarItems: p.array, // list of React.JSX items to display on the toolbar
   title: p.node.isRequired,
   subTitle: p.node,
   onClose: p.func,

--- a/web/src/app/documentation/Documentation.tsx
+++ b/web/src/app/documentation/Documentation.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles({
   },
 })
 
-export default function Documentation(): JSX.Element {
+export default function Documentation(): React.JSX.Element {
   const [publicURL, webhookEnabled] = useConfigValue(
     'General.PublicURL',
     'Webhook.Enable',

--- a/web/src/app/error-pages/Errors.tsx
+++ b/web/src/app/error-pages/Errors.tsx
@@ -11,7 +11,7 @@ interface ErrorsProps {
   type?: string
 }
 
-export function PageNotFound(): JSX.Element {
+export function PageNotFound(): React.JSX.Element {
   const theme = useTheme()
   return (
     <div style={{ textAlign: 'center', color: theme.palette.text.primary }}>
@@ -23,7 +23,7 @@ export function PageNotFound(): JSX.Element {
   )
 }
 
-export function ObjectNotFound(props: ErrorsProps): JSX.Element {
+export function ObjectNotFound(props: ErrorsProps): React.JSX.Element {
   const theme = useTheme()
   return (
     <div style={{ textAlign: 'center', color: theme.palette.text.primary }}>
@@ -39,7 +39,7 @@ export function ObjectNotFound(props: ErrorsProps): JSX.Element {
   )
 }
 
-export function GenericError(props: ErrorsProps): JSX.Element {
+export function GenericError(props: ErrorsProps): React.JSX.Element {
   const theme = useTheme()
   let errorText
   if (props.error) {

--- a/web/src/app/escalation-policies/PolicyCreateDialog.tsx
+++ b/web/src/app/escalation-policies/PolicyCreateDialog.tsx
@@ -13,7 +13,7 @@ const mutation = gql`
   }
 `
 
-function PolicyCreateDialog(props: { onClose: () => void }): JSX.Element {
+function PolicyCreateDialog(props: { onClose: () => void }): React.JSX.Element {
   const defaultValue = {
     name: '',
     description: '',

--- a/web/src/app/escalation-policies/PolicyDeleteDialog.tsx
+++ b/web/src/app/escalation-policies/PolicyDeleteDialog.tsx
@@ -12,7 +12,7 @@ const mutation = gql`
 export default function PolicyDeleteDialog(props: {
   escalationPolicyID: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [, navigate] = useLocation()
   const [deletePolicyStatus, deletePolicy] = useMutation(mutation)
 

--- a/web/src/app/escalation-policies/PolicyDetails.tsx
+++ b/web/src/app/escalation-policies/PolicyDetails.tsx
@@ -30,7 +30,7 @@ const query = gql`
 
 export default function PolicyDetails(props: {
   policyID: string
-}): JSX.Element {
+}): React.JSX.Element {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [showEditDialog, setShowEditDialog] = useState(false)
 

--- a/web/src/app/escalation-policies/PolicyEditDialog.tsx
+++ b/web/src/app/escalation-policies/PolicyEditDialog.tsx
@@ -25,7 +25,7 @@ const mutation = gql`
 function PolicyEditDialog(props: {
   escalationPolicyID: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [value, setValue] = useState<PolicyFormValue | null>(null)
   const [{ data, fetching }] = useQuery({
     query,

--- a/web/src/app/escalation-policies/PolicyForm.tsx
+++ b/web/src/app/escalation-policies/PolicyForm.tsx
@@ -21,7 +21,7 @@ interface PolicyFormProps {
   onChange?: (value: PolicyFormValue) => void
 }
 
-function PolicyForm(props: PolicyFormProps): JSX.Element {
+function PolicyForm(props: PolicyFormProps): React.JSX.Element {
   return (
     <FormContainer optionalLabels {...props}>
       <Grid container spacing={2}>

--- a/web/src/app/escalation-policies/PolicyList.tsx
+++ b/web/src/app/escalation-policies/PolicyList.tsx
@@ -26,7 +26,7 @@ const query = gql`
 `
 
 const context = { suspense: false }
-export default function PolicyList(): JSX.Element {
+export default function PolicyList(): React.JSX.Element {
   const [search] = useURLParam<string>('search', '')
   const [create, setCreate] = useState(false)
   const [cursor, setCursor] = useState('')

--- a/web/src/app/escalation-policies/PolicyServicesCard.tsx
+++ b/web/src/app/escalation-policies/PolicyServicesCard.tsx
@@ -14,7 +14,7 @@ interface PolicyServicesCardProps {
   services: { id: string; name: string }[]
 }
 
-function PolicyServicesCard(props: PolicyServicesCardProps): JSX.Element {
+function PolicyServicesCard(props: PolicyServicesCardProps): React.JSX.Element {
   const classes = useStyles()
 
   function getServicesItems(): FlatListListItem[] {

--- a/web/src/app/escalation-policies/PolicyServicesQuery.tsx
+++ b/web/src/app/escalation-policies/PolicyServicesQuery.tsx
@@ -16,7 +16,7 @@ const query = gql`
   }
 `
 
-function PolicyServicesQuery(props: { policyID: string }): JSX.Element {
+function PolicyServicesQuery(props: { policyID: string }): React.JSX.Element {
   const [{ data, fetching, error }] = useQuery({
     query,
     variables: { id: props.policyID },

--- a/web/src/app/escalation-policies/PolicyStepCreateDialog.tsx
+++ b/web/src/app/escalation-policies/PolicyStepCreateDialog.tsx
@@ -19,7 +19,7 @@ export default function PolicyStepCreateDialog(props: {
   escalationPolicyID: string
   disablePortal?: boolean
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [value, setValue] = useState<FormValue>({
     actions: [],
     delayMinutes: 15,

--- a/web/src/app/escalation-policies/PolicyStepDeleteDialog.tsx
+++ b/web/src/app/escalation-policies/PolicyStepDeleteDialog.tsx
@@ -27,7 +27,7 @@ export default function PolicyStepDeleteDialog(props: {
   escalationPolicyID: string
   stepID: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [{ fetching, data, error }] = useQuery({
     query,
     variables: { id: props.escalationPolicyID },

--- a/web/src/app/escalation-policies/PolicyStepForm.tsx
+++ b/web/src/app/escalation-policies/PolicyStepForm.tsx
@@ -69,7 +69,7 @@ export default function PolicyStepForm(props: PolicyStepFormProps): ReactNode {
     })
   }
 
-  function renderErrors(otherErrs: readonly string[]): React.JSX.Element[] {
+  function renderErrors(otherErrs: readonly string[]): React.React.JSX.Element[] {
     return otherErrs.map((err, idx) => (
       <DialogContentError
         error={err}

--- a/web/src/app/escalation-policies/PolicyStepsQuery.tsx
+++ b/web/src/app/escalation-policies/PolicyStepsQuery.tsx
@@ -31,7 +31,7 @@ export const policyStepsQueryDest = gql`
   }
 `
 
-function PolicyStepsQuery(props: { escalationPolicyID: string }): JSX.Element {
+function PolicyStepsQuery(props: { escalationPolicyID: string }): React.JSX.Element {
   const [{ data, error }] = useQuery({
     query: policyStepsQueryDest,
     variables: { id: props.escalationPolicyID },

--- a/web/src/app/links/RotationLink.tsx
+++ b/web/src/app/links/RotationLink.tsx
@@ -2,6 +2,6 @@ import React from 'react'
 import AppLink from '../util/AppLink'
 import { Target } from '../../schema'
 
-export const RotationLink = (rotation: Target): JSX.Element => {
+export const RotationLink = (rotation: Target): React.JSX.Element => {
   return <AppLink to={`/rotations/${rotation.id}`}>{rotation.name}</AppLink>
 }

--- a/web/src/app/links/ScheduleLink.tsx
+++ b/web/src/app/links/ScheduleLink.tsx
@@ -2,6 +2,6 @@ import React from 'react'
 import { Target } from '../../schema'
 import AppLink from '../util/AppLink'
 
-export const ScheduleLink = (schedule: Target): JSX.Element => {
+export const ScheduleLink = (schedule: Target): React.JSX.Element => {
   return <AppLink to={`/schedules/${schedule.id}`}>{schedule.name}</AppLink>
 }

--- a/web/src/app/links/ServiceLink.tsx
+++ b/web/src/app/links/ServiceLink.tsx
@@ -2,6 +2,6 @@ import React from 'react'
 import { Service } from '../../schema'
 import AppLink from '../util/AppLink'
 
-export const ServiceLink = (service: Service): JSX.Element => {
+export const ServiceLink = (service: Service): React.JSX.Element => {
   return <AppLink to={`/services/${service.id}`}>{service.name}</AppLink>
 }

--- a/web/src/app/links/SlackChannelLink.tsx
+++ b/web/src/app/links/SlackChannelLink.tsx
@@ -12,7 +12,7 @@ const query = gql`
   }
 `
 
-export const SlackChannelLink = (slackChannel: Target): JSX.Element => {
+export const SlackChannelLink = (slackChannel: Target): React.JSX.Element => {
   const { data, loading, error } = useQuery(query, {
     variables: { id: slackChannel.id },
     fetchPolicy: 'cache-first',

--- a/web/src/app/links/UserLink.tsx
+++ b/web/src/app/links/UserLink.tsx
@@ -2,6 +2,6 @@ import React from 'react'
 import AppLink from '../util/AppLink'
 import { Target } from '../../schema'
 
-export const UserLink = (user: Target): JSX.Element => {
+export const UserLink = (user: Target): React.JSX.Element => {
   return <AppLink to={`/users/${user.id}`}>{user.name}</AppLink>
 }

--- a/web/src/app/lists/ControlledPaginatedList.tsx
+++ b/web/src/app/lists/ControlledPaginatedList.tsx
@@ -56,7 +56,7 @@ export interface ControlledPaginatedListProps
 
   items: CheckboxItemsProps[] | PaginatedListItemProps[]
 
-  renderCreateDialog?: (onClose: () => void) => JSX.Element | undefined
+  renderCreateDialog?: (onClose: () => void) => React.JSX.Element | undefined
 
   createLabel?: string
   hideCreate?: boolean
@@ -90,7 +90,7 @@ export interface CheckboxItemsProps extends PaginatedListItemProps {
 
 export default function ControlledPaginatedList(
   props: ControlledPaginatedListProps,
-): JSX.Element {
+): React.JSX.Element {
   const classes = useStyles()
   const {
     checkboxActions,
@@ -235,7 +235,7 @@ export default function ControlledPaginatedList(
     )
   }
 
-  function getItemIcon(item: CheckboxItemsProps): JSX.Element | undefined {
+  function getItemIcon(item: CheckboxItemsProps): React.JSX.Element | undefined {
     if (!checkboxActions) return item.icon
 
     const checked = checkedItems.includes(item.id)

--- a/web/src/app/lists/CreateFAB.tsx
+++ b/web/src/app/lists/CreateFAB.tsx
@@ -33,7 +33,7 @@ interface CreateFabProps extends Omit<FabProps, 'children'> {
   transition?: boolean
 }
 
-export default function CreateFAB(props: CreateFabProps): JSX.Element {
+export default function CreateFAB(props: CreateFabProps): React.JSX.Element {
   const { title, transition, ...fabProps } = props
   const classes = useStyles()
 

--- a/web/src/app/lists/DraggableListItem.tsx
+++ b/web/src/app/lists/DraggableListItem.tsx
@@ -69,7 +69,7 @@ export function DraggableListItem({
   id,
   index,
   item,
-}: DraggableListItemProps): JSX.Element {
+}: DraggableListItemProps): React.JSX.Element {
   const theme = useTheme()
   const {
     attributes,

--- a/web/src/app/lists/FlatList.tsx
+++ b/web/src/app/lists/FlatList.tsx
@@ -90,13 +90,13 @@ const measuringConfig = {
 
 export interface FlatListSub {
   id?: string
-  subHeader: JSX.Element | string
+  subHeader: React.JSX.Element | string
   disableGutter?: boolean
 }
 
 export interface FlatListNotice extends Notice {
   id?: string
-  icon?: JSX.Element
+  icon?: React.JSX.Element
   transition?: boolean
   handleOnClick?: (event: MouseEvent) => void
   'data-cy'?: string
@@ -105,10 +105,10 @@ export interface FlatListItemOptions extends Omit<ListItemProps, 'title'> {
   title?: React.ReactNode
   primaryText?: React.ReactNode
   highlight?: boolean
-  subText?: JSX.Element | string
-  icon?: JSX.Element | null
+  subText?: React.JSX.Element | string
+  icon?: React.JSX.Element | null
   section?: string | number
-  secondaryAction?: JSX.Element | null
+  secondaryAction?: React.JSX.Element | null
   url?: string
   id?: string // required for drag and drop functionality
   scrollIntoView?: boolean
@@ -121,7 +121,7 @@ export interface FlatListItemOptions extends Omit<ListItemProps, 'title'> {
 export interface SectionTitle {
   title: React.ReactNode
   icon?: React.ReactNode | null
-  subText?: JSX.Element | string
+  subText?: React.JSX.Element | string
 }
 
 export type FlatListListItem =
@@ -136,8 +136,8 @@ export interface FlatListProps extends ListProps {
   sections?: SectionTitle[]
 
   // header elements will be displayed at the top of the list.
-  headerNote?: JSX.Element | string | ReactNode // left-aligned
-  headerAction?: JSX.Element // right-aligned
+  headerNote?: React.JSX.Element | string | ReactNode // left-aligned
+  headerAction?: React.JSX.Element // right-aligned
 
   // emptyMessage will be displayed if there are no items in the list.
   emptyMessage?: string
@@ -168,7 +168,7 @@ export default function FlatList({
   transition,
   collapsable,
   ...listProps
-}: FlatListProps): JSX.Element {
+}: FlatListProps): React.JSX.Element {
   const classes = useStyles()
 
   // collapsable sections state
@@ -223,7 +223,7 @@ export default function FlatList({
     }
   }
 
-  function renderEmptyMessage(): JSX.Element {
+  function renderEmptyMessage(): React.JSX.Element {
     return (
       <MUIListItem>
         <ListItemText
@@ -238,7 +238,7 @@ export default function FlatList({
     )
   }
 
-  function renderNoticeItem(item: FlatListNotice, idx: number): JSX.Element {
+  function renderNoticeItem(item: FlatListNotice, idx: number): React.JSX.Element {
     if (item.handleOnClick) {
       return (
         <ButtonBase
@@ -273,7 +273,7 @@ export default function FlatList({
     )
   }
 
-  function renderSubheaderItem(item: FlatListSub, idx: number): JSX.Element {
+  function renderSubheaderItem(item: FlatListSub, idx: number): React.JSX.Element {
     return (
       <ListSubheader
         key={idx}
@@ -292,7 +292,7 @@ export default function FlatList({
     )
   }
 
-  function renderTransitionItems(): JSX.Element[] {
+  function renderTransitionItems(): React.JSX.Element[] {
     return items.map((item, idx) => {
       if ('subHeader' in item) {
         return (
@@ -341,11 +341,11 @@ export default function FlatList({
     })
   }
 
-  function renderTransitions(): JSX.Element {
+  function renderTransitions(): React.JSX.Element {
     return <TransitionGroup>{renderTransitionItems()}</TransitionGroup>
   }
 
-  function renderItems(): (JSX.Element | undefined)[] | JSX.Element {
+  function renderItems(): (React.JSX.Element | undefined)[] | React.JSX.Element {
     return items.map((item: FlatListListItem, idx: number) => {
       if ('subHeader' in item) {
         return renderSubheaderItem(item, idx)
@@ -368,7 +368,7 @@ export default function FlatList({
     })
   }
 
-  function renderCollapsableItems(): JSX.Element[] | undefined {
+  function renderCollapsableItems(): React.JSX.Element[] | undefined {
     const toggleSection = (section: React.ReactNode): void => {
       if (openSections?.includes(section)) {
         setOpenSections(
@@ -403,11 +403,11 @@ export default function FlatList({
     })
   }
 
-  function renderList(): JSX.Element {
+  function renderList(): React.JSX.Element {
     const renderListItems = ():
-      | (JSX.Element | undefined)[]
-      | JSX.Element
-      | JSX.Element[]
+      | (React.JSX.Element | undefined)[]
+      | React.JSX.Element
+      | React.JSX.Element[]
       | undefined => {
       if (transition) return renderTransitions()
       if (collapsable) return renderCollapsableItems()

--- a/web/src/app/lists/FlatListItem.tsx
+++ b/web/src/app/lists/FlatListItem.tsx
@@ -34,7 +34,7 @@ export interface FlatListItemProps extends MUIListItemProps {
   index: number
 }
 
-export default function FlatListItem(props: FlatListItemProps): JSX.Element {
+export default function FlatListItem(props: FlatListItemProps): React.JSX.Element {
   const classes = useStyles()
 
   const {

--- a/web/src/app/lists/ListHeader.tsx
+++ b/web/src/app/lists/ListHeader.tsx
@@ -13,10 +13,10 @@ export interface ListHeaderProps {
   cardHeader?: ReactNode
   // header elements will be displayed at the top of the list.
   headerNote?: string // left-aligned
-  headerAction?: JSX.Element // right-aligned
+  headerAction?: React.JSX.Element // right-aligned
 }
 
-export function ListHeader(props: ListHeaderProps): JSX.Element {
+export function ListHeader(props: ListHeaderProps): React.JSX.Element {
   const classes = useStyles()
   const { headerNote, headerAction, cardHeader } = props
   return (

--- a/web/src/app/lists/PageControls.tsx
+++ b/web/src/app/lists/PageControls.tsx
@@ -25,7 +25,7 @@ export function PageControls(props: {
   page: number
   setPage: (page: number) => void
   isLoading: boolean
-}): JSX.Element {
+}): React.JSX.Element {
   const classes = useStyles()
   const { loadMore, pageCount, page, setPage, isLoading } = props
 

--- a/web/src/app/lists/PaginatedList.tsx
+++ b/web/src/app/lists/PaginatedList.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles(() => ({
   },
 }))
 
-function LoadingItem(props: { dense?: boolean }): JSX.Element {
+function LoadingItem(props: { dense?: boolean }): React.JSX.Element {
   return (
     <ListItem dense={props.dense}>
       <Skeleton variant='rectangular' animation='wave' width='100%'>
@@ -77,7 +77,7 @@ export interface PaginatedListItemProps {
   selected?: boolean
 }
 
-export function PaginatedList(props: PaginatedListProps): JSX.Element {
+export function PaginatedList(props: PaginatedListProps): React.JSX.Element {
   const {
     items = [],
     itemsPerPage = ITEMS_PER_PAGE,

--- a/web/src/app/lists/QueryList.tsx
+++ b/web/src/app/lists/QueryList.tsx
@@ -87,7 +87,7 @@ export interface _QueryListProps extends ControlledPaginatedListProps {
   // mapVariables transforms query variables just before submission
   mapVariables?: (vars: OperationVariables) => OperationVariables
 
-  renderCreateDialog?: (onClose: () => void) => JSX.Element | undefined
+  renderCreateDialog?: (onClose: () => void) => React.JSX.Element | undefined
 
   createLabel?: string
   hideCreate?: boolean
@@ -95,7 +95,7 @@ export interface _QueryListProps extends ControlledPaginatedListProps {
 
 export type QueryListProps = Omit<_QueryListProps, 'items'>
 
-export default function QueryList(props: QueryListProps): JSX.Element {
+export default function QueryList(props: QueryListProps): React.JSX.Element {
   const {
     mapDataNode = (n: ObjectMap) => ({
       id: n.id,
@@ -174,7 +174,7 @@ export default function QueryList(props: QueryListProps): JSX.Element {
     )
   }
 
-  function renderList(): JSX.Element {
+  function renderList(): React.JSX.Element {
     if (
       props.checkboxActions?.length ||
       props.secondaryActions ||

--- a/web/src/app/loading/components/LoadingButton.tsx
+++ b/web/src/app/loading/components/LoadingButton.tsx
@@ -10,7 +10,7 @@ interface LoadingButtonProps extends ButtonProps {
   style?: React.CSSProperties
 }
 
-const LoadingButton = (props: LoadingButtonProps): JSX.Element => {
+const LoadingButton = (props: LoadingButtonProps): React.JSX.Element => {
   const {
     attemptCount,
     buttonText,

--- a/web/src/app/loading/components/Spinner.tsx
+++ b/web/src/app/loading/components/Spinner.tsx
@@ -24,7 +24,7 @@ interface SpinnerProps {
 /*
  * Show a loading spinner in the center of the container.
  */
-export default function Spinner(props: SpinnerProps): JSX.Element | null {
+export default function Spinner(props: SpinnerProps): React.JSX.Element | null {
   const [spin, setSpin] = useState(false)
   const { delayMs = DEFAULT_SPIN_DELAY_MS, waitMs = DEFAULT_SPIN_WAIT_MS } =
     props

--- a/web/src/app/localdev/LocalDev.tsx
+++ b/web/src/app/localdev/LocalDev.tsx
@@ -22,12 +22,12 @@ type DevToolProps = {
   url?: string
 }
 
-export default function LocalDev(): JSX.Element {
+export default function LocalDev(): React.JSX.Element {
   const [updateConfig, setUpdateConfig] = useState<Partial<
     Record<ConfigID, string>
   > | null>(null)
 
-  function DevTool(props: DevToolProps): JSX.Element {
+  function DevTool(props: DevToolProps): React.JSX.Element {
     return (
       <Grid item xs={6}>
         <Card>

--- a/web/src/app/main/App.tsx
+++ b/web/src/app/main/App.tsx
@@ -53,7 +53,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }))
 
-export default function App(): JSX.Element {
+export default function App(): React.JSX.Element {
   const [analyticsID] = useConfigValue('General.GoogleAnalyticsID') as [string]
 
   useEffect(() => {

--- a/web/src/app/main/AppRoutes.tsx
+++ b/web/src/app/main/AppRoutes.tsx
@@ -46,7 +46,7 @@ import UniversalKeyPage from '../services/UniversalKey/UniversalKeyPage'
 import { useExpFlag } from '../util/useExpFlag'
 
 // ParamRoute will pass route parameters as props to the route's child.
-function ParamRoute(props: RouteProps): JSX.Element {
+function ParamRoute(props: RouteProps): React.JSX.Element {
   if (!props.path) {
     throw new Error('ParamRoute requires a path prop')
   }
@@ -134,7 +134,7 @@ if (process.env.NODE_ENV !== 'production') {
   routes['/dev'] = LocalDev
 }
 
-export default function AppRoutes(): JSX.Element {
+export default function AppRoutes(): React.JSX.Element {
   const [path, setPath] = useLocation()
   const { userID } = useSessionInfo()
 

--- a/web/src/app/main/NavBar.tsx
+++ b/web/src/app/main/NavBar.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }))
 
-export default function NavBar(): JSX.Element {
+export default function NavBar(): React.JSX.Element {
   const classes = useStyles()
   const theme = useTheme()
 

--- a/web/src/app/main/NavBarLink.tsx
+++ b/web/src/app/main/NavBarLink.tsx
@@ -49,7 +49,7 @@ export function NavBarSubLink({
   to,
   title,
   newTab,
-}: NavBarSubLinkProps): JSX.Element {
+}: NavBarSubLinkProps): React.JSX.Element {
   const { navSelected, nav, subMenuLinkText } = useStyles()
   const [path] = useLocation()
   return (
@@ -71,7 +71,7 @@ export function NavBarSubLink({
 }
 
 export type NavBarLinkProps = {
-  icon: JSX.Element
+  icon: React.JSX.Element
   title: string
   to: string
   children?: React.ReactNode[] | React.ReactNode
@@ -82,7 +82,7 @@ export default function NavBarLink({
   title,
   to,
   children,
-}: NavBarLinkProps): JSX.Element {
+}: NavBarLinkProps): React.JSX.Element {
   const classes = useStyles()
   const [path] = useLocation()
   const isRoute = path.startsWith(to)

--- a/web/src/app/main/SnackbarNotification.tsx
+++ b/web/src/app/main/SnackbarNotification.tsx
@@ -25,7 +25,7 @@ interface NotificationProviderProps {
 
 export const NotificationProvider = (
   props: NotificationProviderProps,
-): JSX.Element => {
+): React.JSX.Element => {
   const [notification, setNotification] = useState<Notification>()
   const [open, setOpen] = useState(false)
 

--- a/web/src/app/main/WideSideBar.tsx
+++ b/web/src/app/main/WideSideBar.tsx
@@ -20,7 +20,7 @@ interface WideSideBarProps {
   children: ReactNode
 }
 
-function WideSideBar(props: WideSideBarProps): JSX.Element {
+function WideSideBar(props: WideSideBarProps): React.JSX.Element {
   const classes = useStyles()
 
   return (

--- a/web/src/app/main/components/AuthLink.tsx
+++ b/web/src/app/main/components/AuthLink.tsx
@@ -31,7 +31,7 @@ const updateStatusMutation = gql`
   }
 `
 
-export default function AuthLink(): JSX.Element | null {
+export default function AuthLink(): React.JSX.Element | null {
   const [token, setToken] = useURLParam('authLinkToken', '')
   const [, navigate] = useLocation()
 

--- a/web/src/app/main/components/BreadCrumb.tsx
+++ b/web/src/app/main/components/BreadCrumb.tsx
@@ -80,7 +80,7 @@ export function useName(crumb: string, index: number, parts: string[]): string {
   return toTitleCase(crumb)
 }
 
-export default function BreadCrumb(props: BreadCrumbProps): JSX.Element {
+export default function BreadCrumb(props: BreadCrumbProps): React.JSX.Element {
   const { index, crumb, link, urlParts } = props
 
   const name = useName(crumb, index, urlParts)

--- a/web/src/app/main/components/Login.tsx
+++ b/web/src/app/main/components/Login.tsx
@@ -81,7 +81,7 @@ type Provider = {
   URL: string
 }
 
-export default function Login(): JSX.Element {
+export default function Login(): React.JSX.Element {
   const classes = useStyles()
   const theme = useTheme()
   const [error, setError] = useState(getParameterByName('login_error') || '')
@@ -99,7 +99,7 @@ export default function Login(): JSX.Element {
    * Renders a field from a provider
    */
 
-  function renderField(field: Field): JSX.Element {
+  function renderField(field: Field): React.JSX.Element {
     const {
       ID: id, // unique name/identifier of the field
       Label: label, // placeholder text that is displayed to the use in the field
@@ -126,7 +126,7 @@ export default function Login(): JSX.Element {
   function renderHasNextDivider(
     idx: number,
     len: number,
-  ): JSX.Element | undefined {
+  ): React.JSX.Element | undefined {
     if (idx + 1 < len) {
       return (
         <Grid item xs={12} className={classes.hasNext}>
@@ -146,7 +146,7 @@ export default function Login(): JSX.Element {
     provider: Provider,
     idx: number,
     len: number,
-  ): JSX.Element | null {
+  ): React.JSX.Element | null {
     const {
       ID: id, // unique identifier of the provider
       Fields: fields, // holds a list of fields to include with the request

--- a/web/src/app/main/components/NewUserSetup.tsx
+++ b/web/src/app/main/components/NewUserSetup.tsx
@@ -4,7 +4,7 @@ import { useSessionInfo } from '../../util/RequireConfig'
 import { useResetURLParams, useURLParam } from '../../actions'
 import UserContactMethodCreateDialog from '../../users/UserContactMethodCreateDialog'
 
-export default function NewUserSetup(): JSX.Element {
+export default function NewUserSetup(): React.JSX.Element {
   const [isFirstLogin] = useURLParam('isFirstLogin', '')
   const clearIsFirstLogin = useResetURLParams('isFirstLogin')
   const [contactMethodID, setContactMethodID] = useState('')

--- a/web/src/app/main/components/ToolbarAction.tsx
+++ b/web/src/app/main/components/ToolbarAction.tsx
@@ -18,12 +18,12 @@ function removeLastPartOfPath(path: string): string {
   return parts.join('/')
 }
 
-function ToolbarAction(props: ToolbarActionProps): JSX.Element {
+function ToolbarAction(props: ToolbarActionProps): React.JSX.Element {
   const fullScreen = useIsWidthDown('md')
 
   const [, navigate] = useLocation()
 
-  function renderToolbarAction(): JSX.Element {
+  function renderToolbarAction(): React.JSX.Element {
     const route = removeLastPartOfPath(window.location.pathname)
 
     // only show back button on mobile
@@ -44,7 +44,7 @@ function ToolbarAction(props: ToolbarActionProps): JSX.Element {
     )
   }
 
-  function renderToolbarMenu(): JSX.Element {
+  function renderToolbarMenu(): React.JSX.Element {
     return (
       <Hidden mdUp>
         <IconButton
@@ -63,7 +63,7 @@ function ToolbarAction(props: ToolbarActionProps): JSX.Element {
     )
   }
 
-  const getRoute = (route: string, idx: number): JSX.Element => (
+  const getRoute = (route: string, idx: number): React.JSX.Element => (
     <Route key={idx} path={route}>
       {renderToolbarAction()}
     </Route>

--- a/web/src/app/main/components/ToolbarPageTitle.tsx
+++ b/web/src/app/main/components/ToolbarPageTitle.tsx
@@ -18,7 +18,7 @@ export const getContrastColor = (theme: Theme): string => {
   )
 }
 
-export default function ToolbarPageTitle(): JSX.Element {
+export default function ToolbarPageTitle(): React.JSX.Element {
   const isMobile = useIsWidthDown('md')
 
   const [path] = useLocation()

--- a/web/src/app/main/components/UserSettingsPopover.tsx
+++ b/web/src/app/main/components/UserSettingsPopover.tsx
@@ -13,7 +13,7 @@ import { CurrentUserAvatar } from '../../util/avatars'
 import AppLink from '../../util/AppLink'
 import { useConfigValue, useSessionInfo } from '../../util/RequireConfig'
 
-export default function UserSettingsPopover(): JSX.Element {
+export default function UserSettingsPopover(): React.JSX.Element {
   const [feedbackEnabled, feedbackOverrideURL] = useConfigValue(
     'Feedback.Enable',
     'Feedback.OverrideURL',

--- a/web/src/app/rotations/HandoffSummary.tsx
+++ b/web/src/app/rotations/HandoffSummary.tsx
@@ -9,7 +9,7 @@ export interface HandoffSummaryProps {
   timeZone: string
 }
 
-function dur(p: HandoffSummaryProps): JSX.Element | string {
+function dur(p: HandoffSummaryProps): React.JSX.Element | string {
   if (p.type === 'hourly') return <Time duration={{ hours: p.shiftLength }} />
   if (p.type === 'daily') return <Time duration={{ days: p.shiftLength }} />
   if (p.type === 'weekly') return <Time duration={{ weeks: p.shiftLength }} />
@@ -17,7 +17,7 @@ function dur(p: HandoffSummaryProps): JSX.Element | string {
   throw new Error('unknown rotation type: ' + p.type)
 }
 
-function ts(p: HandoffSummaryProps): JSX.Element | string {
+function ts(p: HandoffSummaryProps): React.JSX.Element | string {
   if (p.type === 'hourly')
     return <Time prefix='from ' time={p.start} zone={p.timeZone} />
   if (p.type === 'daily')
@@ -38,7 +38,7 @@ function ts(p: HandoffSummaryProps): JSX.Element | string {
 
 // handoffSummary returns the summary description for the rotation
 export const HandoffSummary: React.FC<HandoffSummaryProps> =
-  function HandoffSummary(props: HandoffSummaryProps): JSX.Element {
+  function HandoffSummary(props: HandoffSummaryProps): React.JSX.Element {
     if (!props.timeZone) return <span>Loading handoff information...</span>
     return (
       <span>

--- a/web/src/app/rotations/RotationAddUserDialog.tsx
+++ b/web/src/app/rotations/RotationAddUserDialog.tsx
@@ -22,7 +22,7 @@ const mutation = gql`
 
 const RotationAddUserDialog = (
   props: RotationAddUserDialogProps,
-): JSX.Element => {
+): React.JSX.Element => {
   const { rotationID, userIDs, onClose } = props
   const [value, setValue] = useState<Value>({
     users: [],

--- a/web/src/app/rotations/RotationCreateDialog.tsx
+++ b/web/src/app/rotations/RotationCreateDialog.tsx
@@ -21,7 +21,7 @@ const mutation = gql`
   }
 `
 
-const RotationCreateDialog = (props: { onClose?: () => void }): JSX.Element => {
+const RotationCreateDialog = (props: { onClose?: () => void }): React.JSX.Element => {
   const [value, setValue] = useState<CreateRotationInput>({
     name: '',
     description: '',

--- a/web/src/app/rotations/RotationDeleteDialog.tsx
+++ b/web/src/app/rotations/RotationDeleteDialog.tsx
@@ -27,7 +27,7 @@ const mutation = gql`
 export default function RotationDeleteDialog(props: {
   rotationID: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [, navigate] = useLocation()
   const [{ data, fetching: dataLoading }] = useQuery({
     query,

--- a/web/src/app/rotations/RotationDetails.tsx
+++ b/web/src/app/rotations/RotationDetails.tsx
@@ -36,7 +36,7 @@ const query = gql`
 
 export default function RotationDetails(props: {
   rotationID: string
-}): JSX.Element {
+}): React.JSX.Element {
   const [showEdit, setShowEdit] = useState(false)
   const [showDelete, setShowDelete] = useState(false)
 

--- a/web/src/app/rotations/RotationEditDialog.tsx
+++ b/web/src/app/rotations/RotationEditDialog.tsx
@@ -32,7 +32,7 @@ const mutation = gql`
 export default function RotationEditDialog(props: {
   rotationID: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [value, setValue] = useState<CreateRotationInput | null>(null)
 
   const [{ fetching, error, data }] = useQuery({

--- a/web/src/app/rotations/RotationForm.tsx
+++ b/web/src/app/rotations/RotationForm.tsx
@@ -27,7 +27,7 @@ const sameAsLocal = (t: string, z: string): boolean => {
   return inZone.toFormat('Z') === inLocal.toFormat('Z')
 }
 
-export default function RotationForm(props: RotationFormProps): JSX.Element {
+export default function RotationForm(props: RotationFormProps): React.JSX.Element {
   const { value } = props
 
   const handoffWarning =

--- a/web/src/app/rotations/RotationFormHandoffTimes.tsx
+++ b/web/src/app/rotations/RotationFormHandoffTimes.tsx
@@ -34,7 +34,7 @@ interface RotationFormHandoffTimesProps {
 
 export default function RotationFormHandoffTimes({
   value,
-}: RotationFormHandoffTimesProps): JSX.Element {
+}: RotationFormHandoffTimesProps): React.JSX.Element {
   const [{ data, fetching, error }] = useQuery({
     query,
     variables: {

--- a/web/src/app/rotations/RotationList.tsx
+++ b/web/src/app/rotations/RotationList.tsx
@@ -26,7 +26,7 @@ const query = gql`
 `
 
 const context = { suspense: false }
-export default function RotationList(): JSX.Element {
+export default function RotationList(): React.JSX.Element {
   const [search] = useURLParam<string>('search', '')
   const [create, setCreate] = useState(false)
   const [cursor, setCursor] = useState('')

--- a/web/src/app/rotations/RotationSetActiveDialog.tsx
+++ b/web/src/app/rotations/RotationSetActiveDialog.tsx
@@ -26,7 +26,7 @@ const RotationSetActiveDialog = (props: {
   rotationID: string
   userIndex: number
   onClose: () => void
-}): JSX.Element => {
+}): React.JSX.Element => {
   const { rotationID, userIndex, onClose } = props
   const [{ fetching, data, error }] = useQuery({
     query,

--- a/web/src/app/rotations/RotationUserDeleteDialog.tsx
+++ b/web/src/app/rotations/RotationUserDeleteDialog.tsx
@@ -26,7 +26,7 @@ const RotationUserDeleteDialog = (props: {
   rotationID: string
   userIndex: number
   onClose: () => void
-}): JSX.Element => {
+}): React.JSX.Element => {
   const { rotationID, userIndex, onClose } = props
   const [deleteUserMutationStatus, deleteUserMutation] = useMutation(mutation)
   const [{ fetching, data, error }] = useQuery({

--- a/web/src/app/rotations/RotationUserList.tsx
+++ b/web/src/app/rotations/RotationUserList.tsx
@@ -60,7 +60,7 @@ type SwapType = {
   newIndex: number
 }
 
-function RotationUserList(props: RotationUserListProps): JSX.Element {
+function RotationUserList(props: RotationUserListProps): React.JSX.Element {
   const classes = useStyles()
   const { rotationID } = props
   const [deleteIndex, setDeleteIndex] = useState<number | null>(null)

--- a/web/src/app/rotations/UserForm.tsx
+++ b/web/src/app/rotations/UserForm.tsx
@@ -13,7 +13,7 @@ interface UserFormProps {
   value: UserFormValue
 }
 
-export default function UserForm(props: UserFormProps): JSX.Element {
+export default function UserForm(props: UserFormProps): React.JSX.Element {
   return (
     <FormContainer {...props}>
       <FormField

--- a/web/src/app/schedules/ScheduleAssignedToList.tsx
+++ b/web/src/app/schedules/ScheduleAssignedToList.tsx
@@ -20,7 +20,7 @@ const query = gql`
 
 export default function ScheduleAssignedToList(props: {
   scheduleID: string
-}): JSX.Element {
+}): React.JSX.Element {
   const [{ data, fetching, error }] = useQuery({
     query,
     variables: { id: props.scheduleID },

--- a/web/src/app/schedules/ScheduleCalendarQuery.tsx
+++ b/web/src/app/schedules/ScheduleCalendarQuery.tsx
@@ -74,7 +74,7 @@ interface ScheduleCalendarQueryProps {
 
 function ScheduleCalendarQuery({
   scheduleID,
-}: ScheduleCalendarQueryProps): JSX.Element | null {
+}: ScheduleCalendarQueryProps): React.JSX.Element | null {
   const isMobile = useIsWidthDown('md')
   const { weekly, start } = useCalendarNavigation()
 

--- a/web/src/app/schedules/ScheduleCreateDialog.tsx
+++ b/web/src/app/schedules/ScheduleCreateDialog.tsx
@@ -18,7 +18,7 @@ const mutation = gql`
 
 export default function ScheduleCreateDialog(props: {
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [value, setValue] = useState<Value>({
     name: '',
     description: '',

--- a/web/src/app/schedules/ScheduleDeleteDialog.tsx
+++ b/web/src/app/schedules/ScheduleDeleteDialog.tsx
@@ -22,7 +22,7 @@ const mutation = gql`
 export default function ScheduleDeleteDialog(props: {
   onClose: () => void
   scheduleID: string
-}): JSX.Element {
+}): React.JSX.Element {
   const [{ data, fetching }] = useQuery({
     query,
     variables: { id: props.scheduleID },

--- a/web/src/app/schedules/ScheduleDetails.tsx
+++ b/web/src/app/schedules/ScheduleDetails.tsx
@@ -67,7 +67,7 @@ export type ScheduleDetailsProps = {
 
 export default function ScheduleDetails({
   scheduleID,
-}: ScheduleDetailsProps): JSX.Element {
+}: ScheduleDetailsProps): React.JSX.Element {
   const [showEdit, setShowEdit] = useState(false)
   const [showDelete, setShowDelete] = useState(false)
 

--- a/web/src/app/schedules/ScheduleEditDialog.tsx
+++ b/web/src/app/schedules/ScheduleEditDialog.tsx
@@ -26,7 +26,7 @@ const mutation = gql`
 export default function ScheduleEditDialog(props: {
   scheduleID: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [value, setValue] = useState<Value | null>(null)
 
   const [{ data, error, fetching }] = useQuery({

--- a/web/src/app/schedules/ScheduleForm.tsx
+++ b/web/src/app/schedules/ScheduleForm.tsx
@@ -25,7 +25,7 @@ interface Error {
   helpLink?: string
 }
 
-export default function ScheduleForm(props: ScheduleFormProps): JSX.Element {
+export default function ScheduleForm(props: ScheduleFormProps): React.JSX.Element {
   return (
     <FormContainer optionalLabels {...props}>
       <Grid container spacing={2}>

--- a/web/src/app/schedules/ScheduleList.tsx
+++ b/web/src/app/schedules/ScheduleList.tsx
@@ -26,7 +26,7 @@ const query = gql`
 `
 
 const context = { suspense: false }
-export default function ScheduleList(): JSX.Element {
+export default function ScheduleList(): React.JSX.Element {
   const [search] = useURLParam<string>('search', '')
   const [create, setCreate] = useState(false)
   const [cursor, setCursor] = useState('')

--- a/web/src/app/schedules/ScheduleNewOverrideFAB.tsx
+++ b/web/src/app/schedules/ScheduleNewOverrideFAB.tsx
@@ -4,7 +4,7 @@ import { AccountSwitch, AccountMinus, AccountPlus } from 'mdi-material-ui'
 
 export default function ScheduleNewOverrideFAB(props: {
   onClick: (action: string) => void
-}): JSX.Element {
+}): React.JSX.Element {
   const actions = [
     {
       label: 'Temporarily Replace a User',

--- a/web/src/app/schedules/ScheduleOverrideCreateDialog.tsx
+++ b/web/src/app/schedules/ScheduleOverrideCreateDialog.tsx
@@ -61,7 +61,7 @@ export default function ScheduleOverrideCreateDialog({
   variant,
   onClose,
   removeUserReadOnly,
-}: ScheduleOverrideCreateDialogProps): JSX.Element {
+}: ScheduleOverrideCreateDialogProps): React.JSX.Element {
   const [value, setValue] = useState({
     addUserID: '',
     removeUserID: '',

--- a/web/src/app/schedules/ScheduleOverrideDeleteDialog.tsx
+++ b/web/src/app/schedules/ScheduleOverrideDeleteDialog.tsx
@@ -36,7 +36,7 @@ const mutation = gql`
 export default function ScheduleOverrideDeleteDialog(props: {
   overrideID: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [zone] = useURLParam('tz', 'local')
 
   const [{ data, fetching, error }] = useQuery({

--- a/web/src/app/schedules/ScheduleOverrideEditDialog.tsx
+++ b/web/src/app/schedules/ScheduleOverrideEditDialog.tsx
@@ -40,7 +40,7 @@ const mutation = gql`
 export default function ScheduleOverrideEditDialog(props: {
   overrideID: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [value, setValue] = useState<Value | null>(null)
 
   const [{ data, fetching, error }] = useQuery({

--- a/web/src/app/schedules/ScheduleOverrideForm.tsx
+++ b/web/src/app/schedules/ScheduleOverrideForm.tsx
@@ -51,7 +51,7 @@ interface ScheduleOverrideFormProps {
 
 export default function ScheduleOverrideForm(
   props: ScheduleOverrideFormProps,
-): JSX.Element {
+): React.JSX.Element {
   const {
     add,
     remove,

--- a/web/src/app/schedules/ScheduleRuleCreateDialog.tsx
+++ b/web/src/app/schedules/ScheduleRuleCreateDialog.tsx
@@ -30,7 +30,7 @@ interface ScheduleRuleCreateDialogProps {
 
 export default function ScheduleRuleCreateDialog(
   props: ScheduleRuleCreateDialogProps,
-): JSX.Element {
+): React.JSX.Element {
   const { scheduleID, targetType, onClose } = props
 
   const [{ data, fetching }] = useQuery({

--- a/web/src/app/schedules/ScheduleRuleDeleteDialog.tsx
+++ b/web/src/app/schedules/ScheduleRuleDeleteDialog.tsx
@@ -39,7 +39,7 @@ const mutation = gql`
 
 export default function ScheduleRuleDeleteDialog(
   props: ScheduleRuleDeleteDialogProps,
-): JSX.Element {
+): React.JSX.Element {
   const [{ data, error, fetching }] = useQuery({
     query,
     variables: { id: props.scheduleID, tgt: props.target },

--- a/web/src/app/schedules/ScheduleRuleEditDialog.tsx
+++ b/web/src/app/schedules/ScheduleRuleEditDialog.tsx
@@ -41,7 +41,7 @@ interface ScheduleRuleEditDialog {
 
 export default function ScheduleRuleEditDialog(
   props: ScheduleRuleEditDialog,
-): JSX.Element {
+): React.JSX.Element {
   const [state, setState] = useState<ScheduleRuleFormValue | null>(null)
 
   const [{ data, fetching, error: readError }] = useQuery({

--- a/web/src/app/schedules/ScheduleRuleList.tsx
+++ b/web/src/app/schedules/ScheduleRuleList.tsx
@@ -52,7 +52,7 @@ interface TargetValue {
 
 export default function ScheduleRuleList(
   props: ScheduleRuleListProps,
-): JSX.Element {
+): React.JSX.Element {
   const { scheduleID } = props
   const [editTarget, setEditTarget] = useState<TargetValue | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<TargetValue | null>(null)
@@ -70,7 +70,7 @@ export default function ScheduleRuleList(
     return <GenericError error={error.message} />
   }
 
-  function renderSubText(rules: ScheduleRule[], timeZone: string): JSX.Element {
+  function renderSubText(rules: ScheduleRule[], timeZone: string): React.JSX.Element {
     const tzSummary = ruleSummary(rules, timeZone, timeZone)
     const tzAbbr = DateTime.local({ zone: timeZone }).toFormat('ZZZZ')
     const localTzSummary = ruleSummary(rules, timeZone, 'local')
@@ -98,7 +98,7 @@ export default function ScheduleRuleList(
   function renderList(
     targets: ScheduleTarget[],
     timeZone: string,
-  ): JSX.Element {
+  ): React.JSX.Element {
     const items: FlatListListItem[] = []
 
     let lastType: TargetType

--- a/web/src/app/schedules/ScheduleShiftList.tsx
+++ b/web/src/app/schedules/ScheduleShiftList.tsx
@@ -75,7 +75,7 @@ const context = { suspense: false }
 
 function ScheduleShiftList({
   scheduleID,
-}: ScheduleShiftListProps): JSX.Element {
+}: ScheduleShiftListProps): React.JSX.Element {
   const classes = useStyles()
   const isMobile = useIsWidthDown('md')
 
@@ -146,7 +146,7 @@ function ScheduleShiftList({
       truncated: boolean
     },
     day: Interval,
-  ): JSX.Element | string {
+  ): React.JSX.Element | string {
     const locale: DateTimeFormatOptions = {
       hour: 'numeric',
       minute: 'numeric',
@@ -270,7 +270,7 @@ function ScheduleShiftList({
     return result
   }
 
-  function renderDurationSelector(): JSX.Element {
+  function renderDurationSelector(): React.JSX.Element {
     // Dropdown options (in ISO_8601 format)
     // https://en.wikipedia.org/wiki/ISO_8601#Durations
     const quickOptions = ['P1D', 'P3D', 'P7D', 'P14D', 'P1M']

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsCreateDialog.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsCreateDialog.tsx
@@ -46,7 +46,7 @@ interface ScheduleOnCallNotificationsCreateDialogProps {
 
 export default function ScheduleOnCallNotificationsCreateDialog(
   props: ScheduleOnCallNotificationsCreateDialogProps,
-): JSX.Element {
+): React.JSX.Element {
   const { onClose, scheduleID } = props
   const types = useSchedOnCallNotifyTypes()
   const [err, setErr] = useState<CombinedError | null>(null)

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsDeleteDialog.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsDeleteDialog.tsx
@@ -11,7 +11,7 @@ interface ScheduleOnCallNotificationsDeleteDialogProps {
 
 export default function ScheduleOnCallNotificationsDeleteDialog(
   p: ScheduleOnCallNotificationsDeleteDialogProps,
-): JSX.Element {
+): React.JSX.Element {
   const update = useDeleteOnCallRule(p.scheduleID, p.ruleID)
 
   if (!update.busy && !update.rule) {

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsEditDialog.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsEditDialog.tsx
@@ -45,7 +45,7 @@ interface ScheduleOnCallNotificationsEditDialogProps {
 
 export default function ScheduleOnCallNotificationsEditDialog(
   props: ScheduleOnCallNotificationsEditDialogProps,
-): JSX.Element {
+): React.JSX.Element {
   const { onClose, scheduleID } = props
   const [err, setErr] = useState<CombinedError | null>(null)
   const [q] = useQuery<{ schedule: Schedule }>({

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsForm.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsForm.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles({
 
 export default function ScheduleOnCallNotificationsForm(
   props: ScheduleOnCallNotificationsFormProps,
-): JSX.Element {
+): React.JSX.Element {
   const { scheduleID, ...formProps } = props
   const classes = useStyles()
   const { zone } = useScheduleTZ(scheduleID)

--- a/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsList.tsx
+++ b/web/src/app/schedules/on-call-notifications/ScheduleOnCallNotificationsList.tsx
@@ -52,7 +52,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export default function ScheduleOnCallNotificationsList({
   scheduleID,
-}: ScheduleOnCallNotificationsListProps): JSX.Element {
+}: ScheduleOnCallNotificationsListProps): React.JSX.Element {
   const [createRule, setCreateRule] = useState(false)
   const [editRuleID, setEditRuleID] = useState('')
   const [deleteRuleID, setDeleteRuleID] = useState('')

--- a/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
@@ -76,7 +76,7 @@ export default function TempSchedAddNewShift({
   value,
   shift,
   setShift,
-}: AddShiftsStepProps): JSX.Element {
+}: AddShiftsStepProps): React.JSX.Element {
   const [submitted, setSubmitted] = useState(false)
 
   const [custom, setCustom] = useState(false)

--- a/web/src/app/schedules/temp-sched/TempSchedDeleteConfirmation.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDeleteConfirmation.tsx
@@ -20,7 +20,7 @@ export default function TempSchedDeleteConfirmation({
   scheduleID,
   onClose,
   value,
-}: TempSchedDeleteConfirmationProps): JSX.Element {
+}: TempSchedDeleteConfirmationProps): React.JSX.Element {
   const [{ fetching, error }, commit] = useMutation(mutation)
 
   const start = DateTime.max(

--- a/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedDialog.tsx
@@ -100,7 +100,7 @@ export default function TempSchedDialog({
   scheduleID,
   value: _value,
   edit = false,
-}: TempScheduleDialogProps): JSX.Element {
+}: TempScheduleDialogProps): React.JSX.Element {
   const classes = useStyles()
   const { q, zone, isLocalZone } = useScheduleTZ(scheduleID)
   const [now] = useState(DateTime.utc().startOf('minute').toISO())

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -71,7 +71,7 @@ export default function TempSchedShiftsList({
   scheduleID,
   handleCoverageGapClick,
   confirmationStep,
-}: TempSchedShiftsListProps): JSX.Element {
+}: TempSchedShiftsListProps): React.JSX.Element {
   const classes = useStyles()
   const { zone, isLocalZone } = useScheduleTZ(scheduleID)
   const [now, setNow] = useState(DateTime.now().setZone(zone))

--- a/web/src/app/schedules/temp-sched/sharedUtils.tsx
+++ b/web/src/app/schedules/temp-sched/sharedUtils.tsx
@@ -78,7 +78,7 @@ export function StepContainer({
   children,
   width = '75%',
   ...rest
-}: StepContainerProps): JSX.Element {
+}: StepContainerProps): React.JSX.Element {
   const bodyStyle = {
     display: 'flex',
     justifyContent: 'center', // horizontal align

--- a/web/src/app/selection/DestinationInputDirect.tsx
+++ b/web/src/app/selection/DestinationInputDirect.tsx
@@ -45,7 +45,7 @@ export type DestinationInputDirectProps = Partial<DestinationFieldConfig> & {
  */
 export default function DestinationInputDirect(
   props: DestinationInputDirectProps,
-): JSX.Element {
+): React.JSX.Element {
   const [debouncedValue, setDebouncedValue] = useState(props.value)
 
   // debounce the input

--- a/web/src/app/selection/DestinationSearchSelect.tsx
+++ b/web/src/app/selection/DestinationSearchSelect.tsx
@@ -63,7 +63,7 @@ function cachify<T>(val: T): T {
  */
 export default function DestinationSearchSelect(
   props: DestinationSearchSelectProps,
-): JSX.Element {
+): React.JSX.Element {
   const [inputValue, setInputValue] = useState('')
 
   // check validation of the input phoneNumber through graphql

--- a/web/src/app/selection/DisableableMenuItem.tsx
+++ b/web/src/app/selection/DisableableMenuItem.tsx
@@ -20,13 +20,13 @@ export function sortDisableableMenuItems(
 
 // the parent Form element is looking for the value prop, which doesn't exist on
 // the base Tooltip.
-const MenuTooltip = (props: TooltipProps & { value: string }): JSX.Element => {
+const MenuTooltip = (props: TooltipProps & { value: string }): React.JSX.Element => {
   return <Tooltip {...props}>{props.children}</Tooltip>
 }
 
 export const renderMenuItem = (
   fields: DisableableMenuItemFields,
-): JSX.Element => {
+): React.JSX.Element => {
   const { value, label, disabled, disabledMessage } = fields
   return disabled ? (
     // tooltips don't work on disabled elements so the MenuItem must be wrapped in a <span/>

--- a/web/src/app/selection/MaterialSelect.tsx
+++ b/web/src/app/selection/MaterialSelect.tsx
@@ -95,7 +95,7 @@ interface MultiSelectProps {
 
 export default function MaterialSelect(
   props: CommonSelectProps & (MultiSelectProps | SingleSelectProps),
-): JSX.Element {
+): React.JSX.Element {
   const classes = useStyles()
   const {
     fullWidth,

--- a/web/src/app/services/AlertMetrics/AlertAveragesGraph.tsx
+++ b/web/src/app/services/AlertMetrics/AlertAveragesGraph.tsx
@@ -22,7 +22,7 @@ interface CustomDotProps extends DotProps {
   }
 }
 
-const CustomDot = (props: CustomDotProps): JSX.Element => {
+const CustomDot = (props: CustomDotProps): React.JSX.Element => {
   const { cy, cx, fill, r, stroke, strokeWidth, dataKey, payload } = props
   return (
     <circle
@@ -45,7 +45,7 @@ interface AlertAveragesGraphProps {
 
 export default function AlertAveragesGraph(
   props: AlertAveragesGraphProps,
-): JSX.Element {
+): React.JSX.Element {
   const theme = useTheme()
 
   return (

--- a/web/src/app/services/AlertMetrics/AlertCountGraph.tsx
+++ b/web/src/app/services/AlertMetrics/AlertCountGraph.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export default function AlertCountGraph(
   props: AlertCountGraphProps,
-): JSX.Element {
+): React.JSX.Element {
   const classes = useStyles()
   const theme = useTheme()
   return (

--- a/web/src/app/services/AlertMetrics/AlertMetrics.tsx
+++ b/web/src/app/services/AlertMetrics/AlertMetrics.tsx
@@ -26,7 +26,7 @@ const units: Record<string, DateTimeUnit> = {
 
 export default function AlertMetrics({
   serviceID,
-}: AlertMetricsProps): JSX.Element {
+}: AlertMetricsProps): React.JSX.Element {
   const now = useMemo(() => DateTime.now(), [])
 
   const [svc] = useQuery({

--- a/web/src/app/services/AlertMetrics/AlertMetricsFilter.tsx
+++ b/web/src/app/services/AlertMetrics/AlertMetricsFilter.tsx
@@ -9,7 +9,7 @@ import {
 import React from 'react'
 import { useURLParam } from '../../actions/hooks'
 
-export default function AlertMetricsFilter(): JSX.Element {
+export default function AlertMetricsFilter(): React.JSX.Element {
   const [range, setRange] = useURLParam<string>('range', 'P1M')
   const [ivl, setIvl] = useURLParam<string>('interval', 'P1D')
 

--- a/web/src/app/services/AlertMetrics/AlertMetricsTable.tsx
+++ b/web/src/app/services/AlertMetrics/AlertMetricsTable.tsx
@@ -127,7 +127,7 @@ const columns: GridColDef[] = [
 
 export default function AlertMetricsTable(
   props: AlertMetricsTableProps,
-): JSX.Element {
+): React.JSX.Element {
   const classes = useStyles()
   const alerts = useMemo(
     () => props.alerts.map((a) => ({ ...a, ...a.metrics })),
@@ -147,7 +147,7 @@ export default function AlertMetricsTable(
     [csvData],
   )
 
-  function CustomToolbar(): JSX.Element {
+  function CustomToolbar(): React.JSX.Element {
     return (
       <GridToolbarContainer className={gridClasses.toolbarContainer}>
         <Grid container justifyContent='space-between'>

--- a/web/src/app/services/HeartbeatMonitorCreateDialog.tsx
+++ b/web/src/app/services/HeartbeatMonitorCreateDialog.tsx
@@ -16,7 +16,7 @@ const createMutation = gql`
 export default function HeartbeatMonitorCreateDialog(props: {
   serviceID: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [value, setValue] = useState<Value>({
     name: '',
     timeoutMinutes: 15,

--- a/web/src/app/services/HeartbeatMonitorDeleteDialog.tsx
+++ b/web/src/app/services/HeartbeatMonitorDeleteDialog.tsx
@@ -23,7 +23,7 @@ const mutation = gql`
 export default function HeartbeatMonitorDeleteDialog(props: {
   monitorID: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [{ data, fetching, error }] = useQuery({
     query,
     variables: { id: props.monitorID },

--- a/web/src/app/services/HeartbeatMonitorEditDialog.tsx
+++ b/web/src/app/services/HeartbeatMonitorEditDialog.tsx
@@ -25,7 +25,7 @@ const query = gql`
 export default function HeartbeatMonitorEditDialog(props: {
   monitorID: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [value, setValue] = useState<Value | null>(null)
 
   const [{ data, error, fetching }] = useQuery({

--- a/web/src/app/services/HeartbeatMonitorForm.tsx
+++ b/web/src/app/services/HeartbeatMonitorForm.tsx
@@ -31,7 +31,7 @@ interface HeartbeatMonitorFormProps {
 
 export default function HeartbeatMonitorForm(
   props: HeartbeatMonitorFormProps,
-): JSX.Element {
+): React.JSX.Element {
   const { ...formProps } = props
   return (
     <FormContainer {...formProps} optionalLabels>

--- a/web/src/app/services/HeartbeatMonitorList.tsx
+++ b/web/src/app/services/HeartbeatMonitorList.tsx
@@ -61,7 +61,7 @@ const sortItems = (a: HeartbeatMonitor, b: HeartbeatMonitor): number => {
 
 export default function HeartbeatMonitorList(props: {
   serviceID: string
-}): JSX.Element {
+}): React.JSX.Element {
   const classes = useStyles()
   const isMobile = useIsWidthDown('md')
   const [showCreateDialog, setShowCreateDialog] = useState(false)

--- a/web/src/app/services/HeartbeatMonitorStatus.tsx
+++ b/web/src/app/services/HeartbeatMonitorStatus.tsx
@@ -40,7 +40,7 @@ const statusMap = {
 export default function HeartbeatMonitorStatus(props: {
   lastState: 'inactive' | 'healthy' | 'unhealthy'
   lastHeartbeat?: null | ISOTimestamp
-}): JSX.Element {
+}): React.JSX.Element {
   const classes = useStyles()
   const statusColors = useStatusColors()
 

--- a/web/src/app/services/IntegrationKeyCreateDialog.tsx
+++ b/web/src/app/services/IntegrationKeyCreateDialog.tsx
@@ -20,7 +20,7 @@ const mutation = gql`
 export default function IntegrationKeyCreateDialog(props: {
   serviceID: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [value, setValue] = useState<Value | null>(null)
   const { serviceID, onClose } = props
   const [createKeyStatus, createKey] = useMutation(mutation)

--- a/web/src/app/services/IntegrationKeyDeleteDialog.tsx
+++ b/web/src/app/services/IntegrationKeyDeleteDialog.tsx
@@ -31,7 +31,7 @@ const mutation = gql`
 export default function IntegrationKeyDeleteDialog(props: {
   integrationKeyID: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [{ error, data }] = useQuery({
     query,
     variables: { id: props.integrationKeyID },

--- a/web/src/app/services/IntegrationKeyForm.tsx
+++ b/web/src/app/services/IntegrationKeyForm.tsx
@@ -25,7 +25,7 @@ interface IntegrationKeyFormProps {
 
 export default function IntegrationKeyForm(
   props: IntegrationKeyFormProps,
-): JSX.Element {
+): React.JSX.Element {
   const types = useFeatures().integrationKeyTypes
 
   const { ...formProps } = props

--- a/web/src/app/services/IntegrationKeyList.tsx
+++ b/web/src/app/services/IntegrationKeyList.tsx
@@ -76,7 +76,7 @@ export function IntegrationKeyDetails(props: {
   href: string
   label: string
   type: string
-}): JSX.Element {
+}): React.JSX.Element {
   const types = useFeatures().integrationKeyTypes
   const t = types.find((t) => t.id === props.type) || {
     enabled: false,
@@ -96,7 +96,7 @@ export function IntegrationKeyDetails(props: {
 
 export default function IntegrationKeyList(props: {
   serviceID: string
-}): JSX.Element {
+}): React.JSX.Element {
   const classes = useStyles()
   const isMobile = useIsWidthDown('md')
   const [create, setCreate] = useState<boolean>(false)

--- a/web/src/app/services/ServiceAlerts.tsx
+++ b/web/src/app/services/ServiceAlerts.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles({
 
 export default function ServiceAlerts(props: {
   serviceID: string
-}): JSX.Element {
+}): React.JSX.Element {
   const classes = useStyles()
 
   const [alertStatus, setAlertStatus] = useState('')

--- a/web/src/app/services/ServiceCreateDialog.tsx
+++ b/web/src/app/services/ServiceCreateDialog.tsx
@@ -66,7 +66,7 @@ function inputVars(
 
 export default function ServiceCreateDialog(props: {
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [value, setValue] = useState<Value>({
     name: '',
     description: '',

--- a/web/src/app/services/ServiceDeleteDialog.tsx
+++ b/web/src/app/services/ServiceDeleteDialog.tsx
@@ -17,7 +17,7 @@ function DeleteForm(props: {
   error: string | undefined
   value: boolean
   onChange: (deleteEP: boolean) => void
-}): JSX.Element {
+}): React.JSX.Element {
   return (
     <FormControl error={Boolean(props.error)} style={{ width: '100%' }}>
       <FormControlLabel
@@ -60,7 +60,7 @@ const mutation = gql`
 export default function ServiceDeleteDialog(props: {
   serviceID: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [, navigate] = useLocation()
   const [deleteEP, setDeleteEP] = useState<boolean>(true)
   const [{ data, ...dataStatus }] = useQuery({

--- a/web/src/app/services/ServiceDetails.tsx
+++ b/web/src/app/services/ServiceDetails.tsx
@@ -84,7 +84,7 @@ const alertStatus = (a: AlertNode[]): LinkStatus | null => {
 
 export default function ServiceDetails(props: {
   serviceID: string
-}): JSX.Element {
+}): React.JSX.Element {
   const { serviceID } = props
   const [showEdit, setShowEdit] = useState(false)
   const [showDelete, setShowDelete] = useState(false)

--- a/web/src/app/services/ServiceEditDialog.tsx
+++ b/web/src/app/services/ServiceEditDialog.tsx
@@ -46,7 +46,7 @@ const setLabel = gql`
 export default function ServiceEditDialog(props: {
   serviceID: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [value, setValue] = useState<Value | null>(null)
   const [{ data, fetching: dataFetching, error: dataError }] = useQuery({
     query,

--- a/web/src/app/services/ServiceFilterContainer.tsx
+++ b/web/src/app/services/ServiceFilterContainer.tsx
@@ -25,7 +25,7 @@ interface ServiceFilterContainerProps {
 
 export default function ServiceFilterContainer(
   props: ServiceFilterContainerProps,
-): JSX.Element {
+): React.JSX.Element {
   const { labelKey, labelValue, integrationKey } = props.value
   return (
     <FilterContainer

--- a/web/src/app/services/ServiceForm.tsx
+++ b/web/src/app/services/ServiceForm.tsx
@@ -29,7 +29,7 @@ interface ServiceFormProps {
   epRequired?: boolean
 }
 
-export default function ServiceForm(props: ServiceFormProps): JSX.Element {
+export default function ServiceForm(props: ServiceFormProps): React.JSX.Element {
   const { epRequired, errors, ...containerProps } = props
 
   const formErrs = errors.map((e) => {

--- a/web/src/app/services/ServiceLabelCreateDialog.tsx
+++ b/web/src/app/services/ServiceLabelCreateDialog.tsx
@@ -18,7 +18,7 @@ interface ServiceLabelCreateDialogProps {
 
 export default function ServiceLabelCreateDialog(
   props: ServiceLabelCreateDialogProps,
-): JSX.Element {
+): React.JSX.Element {
   const [value, setValue] = useState<Label>({ key: '', value: '' })
 
   const [{ error }, commit] = useMutation(mutation)

--- a/web/src/app/services/ServiceLabelDeleteDialog.tsx
+++ b/web/src/app/services/ServiceLabelDeleteDialog.tsx
@@ -13,7 +13,7 @@ export default function ServiceLabelDeleteDialog(props: {
   serviceID: string
   labelKey: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const { labelKey, onClose, serviceID } = props
 
   const [deleteLabelStatus, deleteLabel] = useMutation(mutation)

--- a/web/src/app/services/ServiceLabelEditDialog.tsx
+++ b/web/src/app/services/ServiceLabelEditDialog.tsx
@@ -33,7 +33,7 @@ export default function ServiceLabelEditDialog(props: {
   serviceID: string
   labelKey: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const { onClose, labelKey, serviceID } = props
   const [value, setValue] = useState<Value | null>(null)
 

--- a/web/src/app/services/ServiceLabelList.tsx
+++ b/web/src/app/services/ServiceLabelList.tsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles({ spacing: { marginBottom: 96 } })
 
 export default function ServiceLabelList(props: {
   serviceID: string
-}): JSX.Element {
+}): React.JSX.Element {
   const [create, setCreate] = useState(false)
   const [editKey, setEditKey] = useState<string | null>(null)
   const [deleteKey, setDeleteKey] = useState<string | null>(null)

--- a/web/src/app/services/ServiceList.tsx
+++ b/web/src/app/services/ServiceList.tsx
@@ -27,7 +27,7 @@ const query = gql`
   }
 `
 const context = { suspense: false }
-export default function ServiceList(): JSX.Element {
+export default function ServiceList(): React.JSX.Element {
   const [search, setSearch] = useURLParam<string>('search', '')
   const { labelKey, labelValue, integrationKey } = getServiceFilters(search)
   const [create, setCreate] = useState(false)

--- a/web/src/app/services/ServiceMaintenanceDialog.tsx
+++ b/web/src/app/services/ServiceMaintenanceDialog.tsx
@@ -15,7 +15,7 @@ interface Props {
   onClose: () => void
 }
 
-function label(hours: number): JSX.Element {
+function label(hours: number): React.JSX.Element {
   return (
     <span>
       <Time duration={{ hours }} /> (
@@ -27,7 +27,7 @@ function label(hours: number): JSX.Element {
 function ServiceMaintenanceForm(props: {
   value: DateTime
   onChange: (val: DateTime) => void
-}): JSX.Element {
+}): React.JSX.Element {
   const [selectedOption, setSelectedOption] = useState(1)
 
   function handleOption(value: number): void {
@@ -72,7 +72,7 @@ const mutation = gql`
 
 export default function ServiceMaintenanceModeDialog(
   props: Props,
-): JSX.Element {
+): React.JSX.Element {
   const [endTime, setEndTime] = useState(DateTime.local().plus({ hours: 1 }))
   const [updateServiceStatus, updateService] = useMutation(mutation)
 

--- a/web/src/app/services/ServiceNotices.tsx
+++ b/web/src/app/services/ServiceNotices.tsx
@@ -34,7 +34,7 @@ interface ServiceMaintenanceNoticeProps {
 export default function ServiceNotices({
   serviceID,
   extraNotices = [],
-}: ServiceMaintenanceNoticeProps): JSX.Element | null {
+}: ServiceMaintenanceNoticeProps): React.JSX.Element | null {
   const [, updateService] = useMutation(mutation)
   const [{ fetching, data }] = useQuery({
     query,

--- a/web/src/app/services/UniversalKey/DeleteSecondaryTokenDialog.tsx
+++ b/web/src/app/services/UniversalKey/DeleteSecondaryTokenDialog.tsx
@@ -18,7 +18,7 @@ const mutation = gql`
 export default function DeleteSecondaryTokenDialog({
   keyID,
   onClose,
-}: DeleteSecondaryTokenDialogProps): JSX.Element {
+}: DeleteSecondaryTokenDialogProps): React.JSX.Element {
   const [status, commit] = useMutation(mutation)
   const [hasConfirmed, setHasConfirmed] = useState(false)
 

--- a/web/src/app/services/UniversalKey/GenTokenDialog.tsx
+++ b/web/src/app/services/UniversalKey/GenTokenDialog.tsx
@@ -16,7 +16,7 @@ const mutation = gql`
   }
 `
 
-function GenerateTokenText(): JSX.Element {
+function GenerateTokenText(): React.JSX.Element {
   return (
     <Typography>
       Generates an auth bearer token that can immediately be used for this
@@ -25,7 +25,7 @@ function GenerateTokenText(): JSX.Element {
   )
 }
 
-function CopyTokenText({ token }: { token: string }): JSX.Element {
+function CopyTokenText({ token }: { token: string }): React.JSX.Element {
   return (
     <Grid container spacing={2}>
       <Grid item xs={12}>
@@ -42,7 +42,7 @@ function CopyTokenText({ token }: { token: string }): JSX.Element {
 export default function GenTokenDialog({
   keyID,
   onClose,
-}: TokenCopyDialogProps): JSX.Element {
+}: TokenCopyDialogProps): React.JSX.Element {
   const [status, commit] = useMutation(mutation)
   const token = status.data?.generateKeyToken
 

--- a/web/src/app/services/UniversalKey/PromoteTokenDialog.tsx
+++ b/web/src/app/services/UniversalKey/PromoteTokenDialog.tsx
@@ -18,7 +18,7 @@ const mutation = gql`
 export default function PromoteTokenDialog({
   keyID,
   onClose,
-}: PromoteTokenDialogProps): JSX.Element {
+}: PromoteTokenDialogProps): React.JSX.Element {
   const [status, commit] = useMutation(mutation)
   const [hasConfirmed, setHasConfirmed] = useState(false)
 

--- a/web/src/app/services/UniversalKey/UniversalKeyRuleConfig.tsx
+++ b/web/src/app/services/UniversalKey/UniversalKeyRuleConfig.tsx
@@ -58,7 +58,7 @@ function truncateCond(cond: string): string {
 
 export default function UniversalKeyRuleList(
   props: UniversalKeyRuleListProps,
-): JSX.Element {
+): React.JSX.Element {
   const [create, setCreate] = useState(false)
   const [edit, setEdit] = useState('')
   const [remove, setRemove] = useState('')

--- a/web/src/app/services/UniversalKey/UniversalKeyRuleDialog.tsx
+++ b/web/src/app/services/UniversalKey/UniversalKeyRuleDialog.tsx
@@ -45,7 +45,7 @@ const mutation = gql`
 
 export default function UniversalKeyRuleDialog(
   props: UniversalKeyRuleDialogProps,
-): JSX.Element {
+): React.JSX.Element {
   const [q] = useQuery<{
     integrationKey: IntegrationKey
   }>({

--- a/web/src/app/services/UniversalKey/UniversalKeyRuleForm.tsx
+++ b/web/src/app/services/UniversalKey/UniversalKeyRuleForm.tsx
@@ -23,7 +23,7 @@ interface UniversalKeyRuleFormProps {
 
 export default function UniversalKeyRuleForm(
   props: UniversalKeyRuleFormProps,
-): JSX.Element {
+): React.JSX.Element {
   return (
     <Grid container spacing={2}>
       <Grid item xs={12}>

--- a/web/src/app/services/UniversalKey/UniversalKeyRuleRemoveDialog.tsx
+++ b/web/src/app/services/UniversalKey/UniversalKeyRuleRemoveDialog.tsx
@@ -17,7 +17,7 @@ const mutation = gql`
 
 export default function UniversalKeyRuleCreateDialogProps(
   props: UniversalKeyRuleCreateDialogProps,
-): JSX.Element {
+): React.JSX.Element {
   const [deleteRuleResult, commit] = useMutation(mutation)
 
   return (

--- a/web/src/app/theme/ThemePicker.tsx
+++ b/web/src/app/theme/ThemePicker.tsx
@@ -19,7 +19,7 @@ import DefaultColorIcon from '@mui/icons-material/Circle'
 import PaletteIcon from '@mui/icons-material/Palette'
 import { ThemeContext } from './themeConfig'
 
-export default function ThemePicker(): JSX.Element {
+export default function ThemePicker(): React.JSX.Element {
   const { themeMode, setThemeMode, sourceColor, setSourceColor } =
     useContext(ThemeContext)
   const [showMore, setShowMore] = useState(false)

--- a/web/src/app/theme/themeConfig.tsx
+++ b/web/src/app/theme/themeConfig.tsx
@@ -159,7 +159,7 @@ function loadThemeColor(): string {
   return validHexColor(savedColor) ? (savedColor as string) : blueGrey[500]
 }
 
-export function ThemeProvider(props: ThemeProviderProps): JSX.Element {
+export function ThemeProvider(props: ThemeProviderProps): React.JSX.Element {
   const [savedThemeMode, setSavedThemeMode] = useState(loadTheme())
   const [sourceColor, setSourceColor] = useState(loadThemeColor())
 

--- a/web/src/app/users/SendTestDialog.tsx
+++ b/web/src/app/users/SendTestDialog.tsx
@@ -102,7 +102,7 @@ export function SendTestContent(props: SendTestContentProps): React.ReactNode {
 
 export default function SendTestDialog(
   props: SendTestDialogProps,
-): JSX.Element {
+): React.JSX.Element {
   const { onClose, contactMethodID } = props
   const [sendTestStatus, sendTest] = useMutation(mutation)
 

--- a/web/src/app/users/UserCalendarSubscriptionList.tsx
+++ b/web/src/app/users/UserCalendarSubscriptionList.tsx
@@ -36,7 +36,7 @@ export const calendarSubscriptionsQuery = gql`
 
 export default function UserCalendarSubscriptionList(props: {
   userID: string
-}): JSX.Element {
+}): React.JSX.Element {
   const userID = props.userID
   const [creationDisabled] = useConfigValue(
     'General.DisableCalendarSubscriptions',
@@ -73,7 +73,7 @@ export default function UserCalendarSubscriptionList(props: {
   const subheaderDict: { [key: string]: boolean } = {}
   const items: FlatListListItem[] = []
 
-  function renderOtherActions(id: string): JSX.Element {
+  function renderOtherActions(id: string): React.JSX.Element {
     return (
       <OtherActions
         actions={[

--- a/web/src/app/users/UserContactMethodDeleteDialog.tsx
+++ b/web/src/app/users/UserContactMethodDeleteDialog.tsx
@@ -11,7 +11,7 @@ const mutation = gql`
 function UserContactMethodDeleteDialog(props: {
   contactMethodID: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const { contactMethodID, ...rest } = props
 
   const [deleteCMStatus, deleteCM] = useMutation(mutation)

--- a/web/src/app/users/UserContactMethodForm.tsx
+++ b/web/src/app/users/UserContactMethodForm.tsx
@@ -31,7 +31,7 @@ export type UserContactMethodFormProps = {
 
 export default function UserContactMethodForm(
   props: UserContactMethodFormProps,
-): JSX.Element {
+): React.JSX.Element {
   const { value, edit = false, ...other } = props
 
   const destinationTypes = useContactMethodTypes()

--- a/web/src/app/users/UserContactMethodList.tsx
+++ b/web/src/app/users/UserContactMethodList.tsx
@@ -92,7 +92,7 @@ export default function UserContactMethodList(
 
   const contactMethods = data.user.contactMethods
 
-  const getIcon = (cm: UserContactMethod): JSX.Element | null => {
+  const getIcon = (cm: UserContactMethod): React.JSX.Element | null => {
     if (!cm.disabled) return null
     if (props.readOnly) {
       return <Warning message='Contact method disabled' />
@@ -150,7 +150,7 @@ export default function UserContactMethodList(
     return actions
   }
 
-  function getSecondaryAction(cm: UserContactMethod): JSX.Element {
+  function getSecondaryAction(cm: UserContactMethod): React.JSX.Element {
     return (
       <Grid container spacing={2} alignItems='center' wrap='nowrap'>
         {cm.disabled && !props.readOnly && !mobile && isCurrentUser && (

--- a/web/src/app/users/UserDetails.tsx
+++ b/web/src/app/users/UserDetails.tsx
@@ -61,7 +61,7 @@ const profileQuery = gql`
 export default function UserDetails(props: {
   userID: string
   readOnly: boolean
-}): JSX.Element {
+}): React.JSX.Element {
   const userID = props.userID
   const { userID: currentUserID, isAdmin } = useSessionInfo()
 
@@ -117,10 +117,10 @@ export default function UserDetails(props: {
   }
 
   const options: (
-    | JSX.Element
+    | React.JSX.Element
     | {
         label: string
-        icon: JSX.Element
+        icon: React.JSX.Element
         handleOnClick: () => void
       }
   )[] = [

--- a/web/src/app/users/UserEditForm.tsx
+++ b/web/src/app/users/UserEditForm.tsx
@@ -22,7 +22,7 @@ export interface UserEditFormProps {
   onChange: (newValue: Value) => void
 }
 
-function UserEditForm(props: UserEditFormProps): JSX.Element {
+function UserEditForm(props: UserEditFormProps): React.JSX.Element {
   const {
     value,
     errors,

--- a/web/src/app/users/UserList.tsx
+++ b/web/src/app/users/UserList.tsx
@@ -30,7 +30,7 @@ const query = gql`
 
 const context = { suspense: false }
 
-function UserList(): JSX.Element {
+function UserList(): React.JSX.Element {
   const { isAdmin } = useSessionInfo()
   const [create, setCreate] = useState(false)
   const [search] = useURLParam<string>('search', '')

--- a/web/src/app/users/UserNotificationRuleCreateDialog.tsx
+++ b/web/src/app/users/UserNotificationRuleCreateDialog.tsx
@@ -15,7 +15,7 @@ const mutation = gql`
 export default function UserNotificationRuleCreateDialog(props: {
   onClose: () => void
   userID: string
-}): JSX.Element {
+}): React.JSX.Element {
   const [value, setValue] = useState({ contactMethodID: '', delayMinutes: 0 })
 
   const [{ fetching, error }, createNotification] = useMutation(mutation)

--- a/web/src/app/users/UserNotificationRuleDeleteDialog.tsx
+++ b/web/src/app/users/UserNotificationRuleDeleteDialog.tsx
@@ -11,7 +11,7 @@ const mutation = gql`
 export default function UserNotificationRuleDeleteDialog(props: {
   ruleID: string
   onClose: () => void
-}): JSX.Element {
+}): React.JSX.Element {
   const { ruleID, ...rest } = props
 
   const [{ fetching, error }, deleteNotification] = useMutation(mutation)

--- a/web/src/app/users/UserNotificationRuleForm.tsx
+++ b/web/src/app/users/UserNotificationRuleForm.tsx
@@ -29,7 +29,7 @@ interface Error {
 
 export default function UserNotificationRuleForm(
   props: UserNotificationRuleFormProps,
-): JSX.Element {
+): React.JSX.Element {
   const { userID, ...other } = props
   return (
     <FormContainer {...other} optionalLabels>

--- a/web/src/app/users/UserOnCallAssignmentList.tsx
+++ b/web/src/app/users/UserOnCallAssignmentList.tsx
@@ -58,7 +58,7 @@ function services(onCallSteps: OnCallServiceAssignment[] = []): Service[] {
 export default function UserOnCallAssignmentList(props: {
   userID: string
   currentUser?: boolean
-}): JSX.Element {
+}): React.JSX.Element {
   const userID = props.userID
   const [{ data, error }] = useQuery<{ user: User }>({
     query,

--- a/web/src/app/users/UserPhoneNumberFilterContainer.tsx
+++ b/web/src/app/users/UserPhoneNumberFilterContainer.tsx
@@ -12,7 +12,7 @@ interface UserPhoneNumberFilterContainerProps {
 
 export default function UserPhoneNumberFilterContainer(
   props: UserPhoneNumberFilterContainerProps,
-): JSX.Element {
+): React.JSX.Element {
   const [searchParam, setSearchParam] = useURLParam('search', '' as string)
   const [search, setSearch] = useState(searchParam)
 

--- a/web/src/app/users/UserSessionList.tsx
+++ b/web/src/app/users/UserSessionList.tsx
@@ -86,7 +86,7 @@ export type UserSessionListProps = {
 
 export default function UserSessionList({
   userID,
-}: UserSessionListProps): JSX.Element {
+}: UserSessionListProps): React.JSX.Element {
   // handles both logout all and logout individual sessions
   const [endSession, setEndSession] = useState<Session | 'all' | null>(null)
 

--- a/web/src/app/users/UserShiftsCalendar.tsx
+++ b/web/src/app/users/UserShiftsCalendar.tsx
@@ -29,7 +29,7 @@ interface UserShiftsCalendarProps {
 
 export default function UserShiftsCalendar({
   userID,
-}: UserShiftsCalendarProps): JSX.Element | null {
+}: UserShiftsCalendarProps): React.JSX.Element | null {
   const { weekly, start } = useCalendarNavigation()
 
   const queryStart = weekly

--- a/web/src/app/util/ClickableText.tsx
+++ b/web/src/app/util/ClickableText.tsx
@@ -21,7 +21,7 @@ export default function ClickableText({
   size = 'small',
   type = 'button',
   ...props
-}: ButtonProps): JSX.Element {
+}: ButtonProps): React.JSX.Element {
   const classes = useStyles()
   return (
     <Button

--- a/web/src/app/util/CopyText.tsx
+++ b/web/src/app/util/CopyText.tsx
@@ -32,7 +32,7 @@ interface CopyTextProps {
   noTypography?: boolean
 }
 
-export default function CopyText(props: CopyTextProps): JSX.Element {
+export default function CopyText(props: CopyTextProps): React.JSX.Element {
   const classes = useStyles()
   const [copied, setCopied] = useState(false)
 

--- a/web/src/app/util/CountDown.tsx
+++ b/web/src/app/util/CountDown.tsx
@@ -65,7 +65,7 @@ export function formatTimeRemaining(
   return timeString
 }
 
-function CountDown(props: CountDownProps): JSX.Element | string {
+function CountDown(props: CountDownProps): React.JSX.Element | string {
   const [timeRemaining, setTimeRemaining] = useState(
     DateTime.fromISO(props.end).toSeconds() - DateTime.local().toSeconds(),
   )

--- a/web/src/app/util/Diff.tsx
+++ b/web/src/app/util/Diff.tsx
@@ -14,7 +14,7 @@ interface DiffProps {
  * Diff displays a difference in characters
  * or words from an old and new value
  */
-export default function Diff(props: DiffProps): JSX.Element {
+export default function Diff(props: DiffProps): React.JSX.Element {
   const { oldValue, newValue, type } = props
   const theme = useTheme()
 

--- a/web/src/app/util/FromValueField.tsx
+++ b/web/src/app/util/FromValueField.tsx
@@ -10,7 +10,7 @@ export default function FromValueField(
     defaultPhone?: string | null
     defaultSID?: string | null
   },
-): JSX.Element {
+): React.JSX.Element {
   const [phoneMode, setPhoneMode] = useState(
     props.value === '' || props.value.startsWith('+'),
   )

--- a/web/src/app/util/ISOPickers.tsx
+++ b/web/src/app/util/ISOPickers.tsx
@@ -34,7 +34,7 @@ type ISOTextFieldProps = Partial<Omit<TextFieldProps, 'value' | 'onChange'>> & {
   max?: string
 }
 
-function ISOPicker(props: ISOPickerProps): JSX.Element {
+function ISOPicker(props: ISOPickerProps): React.JSX.Element {
   const {
     format,
     timeZone,
@@ -183,17 +183,17 @@ function ISOPicker(props: ISOPickerProps): JSX.Element {
   )
 }
 
-export function ISOTimePicker(props: ISOTextFieldProps): JSX.Element {
+export function ISOTimePicker(props: ISOTextFieldProps): React.JSX.Element {
   return <ISOPicker {...props} format='HH:mm' truncateTo='minute' type='time' />
 }
 
-export function ISODatePicker(props: ISOTextFieldProps): JSX.Element {
+export function ISODatePicker(props: ISOTextFieldProps): React.JSX.Element {
   return (
     <ISOPicker {...props} format='yyyy-MM-dd' truncateTo='day' type='date' />
   )
 }
 
-export function ISODateTimePicker(props: ISOTextFieldProps): JSX.Element {
+export function ISODateTimePicker(props: ISOTextFieldProps): React.JSX.Element {
   return (
     <ISOPicker
       {...props}

--- a/web/src/app/util/NumberField.tsx
+++ b/web/src/app/util/NumberField.tsx
@@ -13,7 +13,7 @@ type NumberFieldProps = TextFieldProps & {
   ) => void
 }
 
-export default function NumberField(props: NumberFieldProps): JSX.Element {
+export default function NumberField(props: NumberFieldProps): React.JSX.Element {
   const { float, min, max, step = 'any', onChange, value, ...rest } = props
 
   const [inputValue, setInputValue] = useState(value)

--- a/web/src/app/util/QuerySetFavoriteButton.tsx
+++ b/web/src/app/util/QuerySetFavoriteButton.tsx
@@ -62,7 +62,7 @@ interface QuerySetFavoriteButtonProps {
 export function QuerySetFavoriteButton({
   id,
   type,
-}: QuerySetFavoriteButtonProps): JSX.Element {
+}: QuerySetFavoriteButtonProps): React.JSX.Element {
   const [{ data, fetching }] = useQuery({
     query: queries[type],
     variables: { id },

--- a/web/src/app/util/RequireConfig.tsx
+++ b/web/src/app/util/RequireConfig.tsx
@@ -247,8 +247,8 @@ export function useDestinationType(type: DestinationType): DestinationTypeInfo {
 }
 
 export function Config(props: {
-  children: (x: ConfigData, s?: SessionInfo) => JSX.Element
-}): JSX.Element {
+  children: (x: ConfigData, s?: SessionInfo) => React.JSX.Element
+}): React.JSX.Element {
   return props.children(useConfig(), useSessionInfo()) || null
 }
 
@@ -258,14 +258,14 @@ export type RequireConfigProps = {
   test?: (x: Value) => boolean
 
   // react element to render if checks failed
-  else?: JSX.Element
+  else?: React.JSX.Element
   isAdmin?: boolean
   children?: ReactChild
 }
 
 export default function RequireConfig(
   props: RequireConfigProps,
-): JSX.Element | null {
+): React.JSX.Element | null {
   const {
     configID,
     test = isTrue,

--- a/web/src/app/util/ServiceChip.tsx
+++ b/web/src/app/util/ServiceChip.tsx
@@ -16,7 +16,7 @@ const serviceQuery = gql`
 
 type WithID<T> = { id: string } & T
 
-export function ServiceChip(props: WithID<ChipProps>): JSX.Element {
+export function ServiceChip(props: WithID<ChipProps>): React.JSX.Element {
   const { id, label, ...rest } = props
   const [, navigate] = useLocation()
 

--- a/web/src/app/util/SetFavoriteButton.tsx
+++ b/web/src/app/util/SetFavoriteButton.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }))
 
-export function FavoriteIcon(): JSX.Element {
+export function FavoriteIcon(): React.JSX.Element {
   const classes = useStyles()
   return <MUIFavoriteIcon data-cy='fav-icon' className={classes.favorited} />
 }
@@ -36,7 +36,7 @@ export function SetFavoriteButton({
   onClick,
   isFavorite,
   loading,
-}: SetFavoriteButtonProps): JSX.Element | null {
+}: SetFavoriteButtonProps): React.JSX.Element | null {
   const classes = useStyles()
 
   if (loading) {

--- a/web/src/app/util/SkipToContentLink.tsx
+++ b/web/src/app/util/SkipToContentLink.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles({
   },
 })
 
-export function SkipToContentLink(): JSX.Element {
+export function SkipToContentLink(): React.JSX.Element {
   const classes = useStyles()
   return (
     <Link className={classes.skipLink} href='#content'>

--- a/web/src/app/util/SpeedDial.tsx
+++ b/web/src/app/util/SpeedDial.tsx
@@ -38,7 +38,7 @@ interface CustomSpeedDialProps {
 
 export default function CustomSpeedDial(
   props: CustomSpeedDialProps,
-): JSX.Element {
+): React.JSX.Element {
   const [open, setOpen] = useState(false)
   const classes = useStyles()
 

--- a/web/src/app/util/TelTextField.tsx
+++ b/web/src/app/util/TelTextField.tsx
@@ -30,7 +30,7 @@ const noSuspense = { suspense: false }
 
 export default function TelTextField(
   props: TextFieldProps & { value: string },
-): JSX.Element {
+): React.JSX.Element {
   const classes = useStyles()
   const [phoneNumber, setPhoneNumber] = useState('')
 

--- a/web/src/app/util/avatars.tsx
+++ b/web/src/app/util/avatars.tsx
@@ -32,7 +32,7 @@ function useAvatar(
   otherProps: AvatarProps,
   loading = false,
   imgSrc?: string,
-): JSX.Element {
+): React.JSX.Element {
   const validImage = useValidImage(imgSrc)
 
   const av = (
@@ -53,7 +53,7 @@ function useAvatar(
   return av
 }
 
-export function UserAvatar(props: UserAvatarProps): JSX.Element {
+export function UserAvatar(props: UserAvatarProps): React.JSX.Element {
   const { userID, ...otherProps } = props
   return useAvatar(
     Person,
@@ -63,7 +63,7 @@ export function UserAvatar(props: UserAvatarProps): JSX.Element {
   )
 }
 
-export function CurrentUserAvatar(props: AvatarProps): JSX.Element {
+export function CurrentUserAvatar(props: AvatarProps): React.JSX.Element {
   const { ready, userID } = useSessionInfo()
   return useAvatar(
     Person,
@@ -73,18 +73,18 @@ export function CurrentUserAvatar(props: AvatarProps): JSX.Element {
   )
 }
 
-export function ServiceAvatar(props: AvatarProps): JSX.Element {
+export function ServiceAvatar(props: AvatarProps): React.JSX.Element {
   return useAvatar(VpnKey, props)
 }
 
-export function EPAvatar(props: AvatarProps): JSX.Element {
+export function EPAvatar(props: AvatarProps): React.JSX.Element {
   return useAvatar(Layers, props)
 }
 
-export function RotationAvatar(props: AvatarProps): JSX.Element {
+export function RotationAvatar(props: AvatarProps): React.JSX.Element {
   return useAvatar(RotateRight, props)
 }
 
-export function ScheduleAvatar(props: AvatarProps): JSX.Element {
+export function ScheduleAvatar(props: AvatarProps): React.JSX.Element {
   return useAvatar(Today, props)
 }

--- a/web/src/app/util/calendar/Calendar.tsx
+++ b/web/src/app/util/calendar/Calendar.tsx
@@ -136,7 +136,7 @@ interface CalendarEventWrapperProps extends CalendarProps {
 
 function CalendarEventWrapperWithLink(
   props: CalendarEventWrapperProps,
-): JSX.Element {
+): React.JSX.Element {
   return (
     <CalendarEventWrapper {...props} event={props.event} showScheduleLink>
       {props.children}
@@ -144,7 +144,7 @@ function CalendarEventWrapperWithLink(
   )
 }
 
-export default function Calendar(props: CalendarProps): JSX.Element {
+export default function Calendar(props: CalendarProps): React.JSX.Element {
   const classes = useStyles()
   const theme = useTheme()
 
@@ -209,7 +209,7 @@ export default function Calendar(props: CalendarProps): JSX.Element {
     }
   }
 
-  const getOverrideTitle = (o: UserOverride): JSX.Element => {
+  const getOverrideTitle = (o: UserOverride): React.JSX.Element => {
     if (o.addUser && o.removeUser) {
       // replace override
       return (

--- a/web/src/app/util/calendar/CalendarEventWrapper.tsx
+++ b/web/src/app/util/calendar/CalendarEventWrapper.tsx
@@ -40,7 +40,7 @@ const useStyles = makeStyles({
 })
 
 interface ScheduleCalendarEventWrapperProps {
-  children: JSX.Element
+  children: React.JSX.Element
   event: ScheduleCalendarEvent
   showScheduleLink?: boolean
 }
@@ -49,7 +49,7 @@ export default function ScheduleCalendarEventWrapper({
   children,
   event,
   showScheduleLink,
-}: ScheduleCalendarEventWrapperProps): JSX.Element {
+}: ScheduleCalendarEventWrapperProps): React.JSX.Element {
   const classes = useStyles()
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
 
@@ -92,7 +92,7 @@ export default function ScheduleCalendarEventWrapper({
 
   function renderTempSchedButtons(
     calEvent: TempSchedEvent | TempSchedShiftEvent,
-  ): JSX.Element {
+  ): React.JSX.Element {
     // don't display actions on events in the past
     if (DateTime.fromJSDate(calEvent.end) <= DateTime.utc()) {
       return <React.Fragment />
@@ -118,7 +118,7 @@ export default function ScheduleCalendarEventWrapper({
     )
   }
 
-  function renderOverrideButtons(calEvent: OverrideEvent): JSX.Element {
+  function renderOverrideButtons(calEvent: OverrideEvent): React.JSX.Element {
     return (
       <div className={classes.cardActionContainer}>
         <CardActions
@@ -145,7 +145,7 @@ export default function ScheduleCalendarEventWrapper({
     )
   }
 
-  function renderShiftButtons(calEvent: OnCallShiftEvent): JSX.Element {
+  function renderShiftButtons(calEvent: OnCallShiftEvent): React.JSX.Element {
     return (
       <React.Fragment>
         <Grid item className={classes.flexGrow} />
@@ -164,7 +164,7 @@ export default function ScheduleCalendarEventWrapper({
     )
   }
 
-  function renderButtons(): JSX.Element {
+  function renderButtons(): React.JSX.Element {
     if (showScheduleLink) {
       const id = event?.targetID ?? ''
       return (
@@ -194,8 +194,8 @@ export default function ScheduleCalendarEventWrapper({
     return renderShiftButtons(event as OnCallShiftEvent)
   }
 
-  function renderOverrideDescription(calEvent: OverrideEvent): JSX.Element {
-    const getDesc = (addUser?: User, removeUser?: User): JSX.Element => {
+  function renderOverrideDescription(calEvent: OverrideEvent): React.JSX.Element {
+    const getDesc = (addUser?: User, removeUser?: User): React.JSX.Element => {
       if (addUser && removeUser)
         return (
           <React.Fragment>
@@ -236,7 +236,7 @@ export default function ScheduleCalendarEventWrapper({
    * the full shift start and end date times, as
    * well as the controls relevant to the event.
    */
-  function renderShiftInfo(): JSX.Element {
+  function renderShiftInfo(): React.JSX.Element {
     const fmt = (date: Date): string =>
       DateTime.fromJSDate(date).toLocaleString(DateTime.DATETIME_FULL)
 

--- a/web/src/app/util/calendar/CalendarToolbar.tsx
+++ b/web/src/app/util/calendar/CalendarToolbar.tsx
@@ -32,7 +32,7 @@ interface ScheduleCalendarToolbarProps {
 
 function ScheduleCalendarToolbar(
   props: ScheduleCalendarToolbarProps,
-): JSX.Element {
+): React.JSX.Element {
   const classes = useStyles()
   const { weekly, start, setParams: setNavParams } = useCalendarNavigation()
 

--- a/web/src/explore/explore.tsx
+++ b/web/src/explore/explore.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
-const App = (): JSX.Element => {
+const App = (): React.JSX.Element => {
   const path = location.host + location.pathname.replace(/\/explore.*$/, '')
   const [needLogin, setNeedLogin] = useState(false)
   const classes = useStyles()


### PR DESCRIPTION
### <!--** Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- Identified the issue 
This pull request includes changes to update the return type of several React components from `JSX.Element` to `React.JSX.Element`. This is a minor but widespread update across multiple files to ensure consistency and potentially leverage newer TypeScript features.

The most important changes include:
chnge deprecated JSX namespace to React.JSX

- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.
