### PR TITLE
service: fix label error messaging for create and edit

### DIFF
--- a/web/src/app/services/ServiceEditDialog.tsx
+++ b/web/src/app/services/ServiceEditDialog.tsx
@@ -47,25 +47,20 @@ export default function ServiceEditDialog(props: {
   serviceID: string
   onClose: () => void
 }): JSX.Element {
-  const [value, setValue] = useState<Value | null>(null)
-  const [{ data, fetching: dataFetching, error: dataError }] = useQuery({
+  const [{ data, error: dataError }] = useQuery({
     query,
     variables: { id: props.serviceID },
   })
-
-  const [saveStatus, save] = useMutation(mutation)
-  const [saveLabelStatus, saveLabel] = useMutation(setLabel)
-
-  if (dataFetching && !data) {
-    return <Spinner />
-  }
-
   const defaultValue = {
     name: data?.service?.name,
     description: data?.service?.description,
     escalationPolicyID: data?.service?.ep?.id,
     labels: data?.service?.labels || [],
   }
+  const [value, setValue] = useState<Value>(defaultValue)
+
+  const [saveStatus, save] = useMutation(mutation)
+  const [saveLabelStatus, saveLabel] = useMutation(setLabel)
 
   const fieldErrs = fieldErrors(saveStatus.error).concat(
     fieldErrors(saveLabelStatus.error),
@@ -74,7 +69,7 @@ export default function ServiceEditDialog(props: {
   return (
     <FormDialog
       title='Edit Service'
-      loading={saveStatus.fetching || (!data && dataFetching)}
+      loading={saveStatus.fetching}
       errors={nonFieldErrors(saveStatus.error).concat(
         nonFieldErrors(dataError),
         nonFieldErrors(saveLabelStatus.error),
@@ -116,10 +111,8 @@ export default function ServiceEditDialog(props: {
         <ServiceForm
           epRequired
           errors={fieldErrs}
-          disabled={Boolean(
-            saveStatus.fetching || (!data && dataFetching) || dataError,
-          )}
-          value={value || defaultValue}
+          disabled={Boolean(saveStatus.fetching || !data || dataError)}
+          value={value}
           onChange={(value) => setValue(value)}
         />
       }

--- a/web/src/app/services/ServiceForm.tsx
+++ b/web/src/app/services/ServiceForm.tsx
@@ -3,7 +3,6 @@ import Grid from '@mui/material/Grid'
 import TextField from '@mui/material/TextField'
 import { EscalationPolicySelect } from '../selection/EscalationPolicySelect'
 import { FormContainer, FormField } from '../forms'
-import { FieldError } from '../util/errutil'
 import { useConfigValue } from '../util/RequireConfig'
 import { Label } from '../../schema'
 import { InputAdornment } from '@mui/material'
@@ -20,7 +19,12 @@ export interface Value {
 interface ServiceFormProps {
   value: Value
 
-  errors: FieldError[]
+  nameError?: string
+  descError?: string
+  epError?: string
+
+  labelErrorKey?: string
+  labelErrorMsg?: string
 
   onChange: (val: Value) => void
 
@@ -30,18 +34,28 @@ interface ServiceFormProps {
 }
 
 export default function ServiceForm(props: ServiceFormProps): JSX.Element {
-  const { epRequired, errors, ...containerProps } = props
+  const {
+    epRequired,
+    nameError,
+    descError,
+    epError,
+    labelErrorKey,
+    labelErrorMsg,
+    ...containerProps
+  } = props
 
-  const formErrs = errors.map((e) => {
-    if (e.field !== 'value') {
-      // label value
-      return e
-    }
-    return {
-      ...e,
-      field: 'labels',
-    }
-  })
+  const formErrs = [
+    { field: 'name', message: nameError },
+    { field: 'description', message: descError },
+    {
+      field: 'escalationPolicyID',
+      message: epError,
+    },
+    {
+      field: 'label_' + labelErrorKey,
+      message: labelErrorMsg,
+    },
+  ].filter((e) => e.message)
 
   const [reqLabels] = useConfigValue('Services.RequiredLabels') as [string[]]
 
@@ -92,6 +106,7 @@ export default function ServiceForm(props: ServiceFormProps): JSX.Element {
                 required={!epRequired} // optional when editing
                 component={TextField}
                 fieldName='labels'
+                errorName={'label_' + labelName}
                 label={
                   reqLabels.length === 1
                     ? 'Service Label'

--- a/web/src/app/util/ErrorConsumer.ts
+++ b/web/src/app/util/ErrorConsumer.ts
@@ -13,7 +13,11 @@ type ErrorStore = {
 /** ErrorConsumer is a utility class for consuming and handling errors from a CombinedError. */
 export class ErrorConsumer {
   constructor(e?: CombinedError | null | undefined) {
-    if (!e) return
+    this.append(e)
+  }
+
+  append(e?: CombinedError | null | undefined): ErrorConsumer {
+    if (!e) return this
 
     if (e.networkError) {
       this.store.errors.add({
@@ -74,7 +78,7 @@ export class ErrorConsumer {
       })
     }
 
-    this.hadErrors = this.hasErrors()
+    this._hadErrors = this._hadErrors || this.hasErrors()
 
     // Use FinalizationRegistry if available, this will allow us to raise any errors that are forgotten.
     if (
@@ -89,13 +93,18 @@ export class ErrorConsumer {
 
       r.register(this, { e: this.store }, this)
     }
+
+    return this
   }
 
   private isDone: boolean = false
   private store: ErrorStore = { errors: new Set() }
 
   /** Whether there were any errors in the original error. */
-  public readonly hadErrors: boolean = false
+  private _hadErrors: boolean = false
+  public get hadErrors(): boolean {
+    return this._hadErrors
+  }
 
   private doneCheck(): void {
     if (!this.isDone) return


### PR DESCRIPTION
**Description:**
Fixes issues where service create dialog didn't display label errors and unexpected errors didn't get displayed.

**Which issue(s) this PR fixes:**
Fixes #3623 