### PR TITLE
fix(lifecycle): skip shutdown wait on run failure

### DIFF
--- a/app/lifecycle/manager.go
+++ b/app/lifecycle/manager.go
@@ -197,7 +197,12 @@ func (m *Manager) Run(ctx context.Context) error {
 
 	err := m.runFunc(ctx)
 	close(m.runDone)
-	<-m.shutdownDone
+	s = <-m.status
+	m.status <- s
+	if s == StatusShutdown {
+		<-m.shutdownDone
+	}
+
 	return err
 }
 


### PR DESCRIPTION
**Description:**
Fixes an issue where the app would deadlock if the Run function failed outside of shutdown.

**Which issue(s) this PR fixes:**
Fixes #3868 
