### PR TITLE
engine: update rate limit rules for on-call user notifications

### DIFF
--- a/engine/message/ratelimit.go
+++ b/engine/message/ratelimit.go
@@ -26,8 +26,8 @@ func init() {
 	perCM.
 		WithMsgTypes(notification.MessageTypeScheduleOnCallUsers).
 		AddRules([]ThrottleRule{
-			{Count: 2, Per: 15 * time.Minute},
-			{Count: 4, Per: 1 * time.Hour, Smooth: true},
+			{Count: 3, Per: 1 * time.Minute},
+			{Count: 20, Per: 1 * time.Hour, Smooth: true},
 		})
 
 	// status notifications


### PR DESCRIPTION
**Description:**
Increases On-Call Status Notifications
- 3 per minute, burst (from 2 per 15-minute)
- 20 per hour, overall (from 4 per hour)

**Which issue(s) this PR fixes:**
Fixes #4188 