### PR TITLE
fix(Dockerfile): replace CMD with ENTRYPOINT

### DIFF
--- a/devtools/ci/dockerfiles/goalert/Dockerfile
+++ b/devtools/ci/dockerfiles/goalert/Dockerfile
@@ -7,7 +7,7 @@ FROM docker.io/library/alpine
 RUN apk --no-cache add ca-certificates
 ENV GOALERT_LISTEN :8081
 EXPOSE 8081
-CMD ["/usr/bin/goalert"]
+ENTRYPOINT ["/usr/bin/goalert"]
 
 COPY --from=build /build/bin/build/goalert-linux-amd64/goalert/bin/* /usr/bin/
 RUN /usr/bin/goalert self-test


### PR DESCRIPTION
Switching from CMD to ENTRYPOINT makes is easier to provide commandline flags using the args flag, without having to add goalert to the args.

<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [ ] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [ ] All new and existing tests passed.
- [ ] Added comments in the code, where necessary.
- [ ] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Switching from CMD to ENTRYPOINT makes is easier to provide commandline flags using the `args` key in Kubernetes, without having to add `goalert` to the args.

**Which issue(s) this PR fixes:**
n/a

**Out of Scope:**
n/a

**Screenshots:**
n/a

**Describe any introduced user-facing changes:**
Existing deployments which already use `args` in the following format
```yaml
args:
  - goalert
  - --public-url
  - https://goalert.example.com
```
could be facing issues with this change, since the results command line would be `/usr/bin/goalert goalert --public-url https://goalert.example.com`, which would potentially fail to start.

**Describe any introduced API changes:**
n/a

**Additional Info:**
n/a
