### PR TITLE
Jsx to tsx convert calendar subscribe jsx files

### DIFF
--- a/web/src/app/schedules/calendar-subscribe/CalendarSubscribeButton.tsx
+++ b/web/src/app/schedules/calendar-subscribe/CalendarSubscribeButton.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { useQuery } from 'urql'
-import { PropTypes as p } from 'prop-types'
 import Button from '@mui/material/Button'
 import Tooltip from '@mui/material/Tooltip'
 
@@ -8,8 +7,15 @@ import CalendarSubscribeCreateDialog from './CalendarSubscribeCreateDialog'
 import { calendarSubscriptionsQuery } from '../../users/UserCalendarSubscriptionList'
 import { useConfigValue, useSessionInfo } from '../../util/RequireConfig'
 import _ from 'lodash'
+import { UserCalendarSubscription } from '../../../schema'
 
-export default function CalendarSubscribeButton(props) {
+interface CalendarSubscribeButtonProps {
+  scheduleID: string
+}
+
+export default function CalendarSubscribeButton({
+  scheduleID,
+}: CalendarSubscribeButtonProps): JSX.Element {
   const [creationDisabled] = useConfigValue(
     'General.DisableCalendarSubscriptions',
   )
@@ -26,7 +32,8 @@ export default function CalendarSubscribeButton(props) {
   })
 
   const numSubs = _.get(data, 'user.calendarSubscriptions', []).filter(
-    (cs) => cs.scheduleID === props.scheduleID && !cs.disabled,
+    (cs: UserCalendarSubscription) =>
+      cs.scheduleID === scheduleID && !cs.disabled,
   ).length
 
   let context =
@@ -46,13 +53,14 @@ export default function CalendarSubscribeButton(props) {
         title={context}
         placement='top-start'
         PopperProps={{
+          // @ts-expect-error data-cy is not a valid prop
           'data-cy': 'subscribe-btn-context',
         }}
       >
         <Button
           data-cy='subscribe-btn'
           aria-label='Subscribe to this schedule'
-          disabled={creationDisabled}
+          disabled={Boolean(creationDisabled)}
           onClick={() => setShowDialog(true)}
           variant='contained'
         >
@@ -63,13 +71,9 @@ export default function CalendarSubscribeButton(props) {
       {showDialog && (
         <CalendarSubscribeCreateDialog
           onClose={() => setShowDialog(false)}
-          scheduleID={props.scheduleID}
+          scheduleID={scheduleID}
         />
       )}
     </React.Fragment>
   )
-}
-
-CalendarSubscribeButton.propTypes = {
-  scheduleID: p.string,
 }

--- a/web/src/app/schedules/calendar-subscribe/CalendarSubscribeCreateDialog.tsx
+++ b/web/src/app/schedules/calendar-subscribe/CalendarSubscribeCreateDialog.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useState } from 'react'
 import { useMutation, gql } from 'urql'
 import FormDialog from '../../dialogs/FormDialog'
-import CalendarSubscribeForm from './CalendarSubscribeForm'
+import CalendarSubscribeForm, { CalSubFormValue } from './CalendarSubscribeForm'
 import { fieldErrors, nonFieldErrors } from '../../util/errutil'
 import { Typography } from '@mui/material'
 import { CheckCircleOutline as SuccessIcon } from '@mui/icons-material'
@@ -37,7 +37,7 @@ export function getForm(
   data: { createUserCalendarSubscription: UserCalendarSubscription },
 ): ReactNode {
   return isComplete ? (
-    <CalenderSuccessForm url={data.createUserCalendarSubscription.url} />
+    <CalenderSuccessForm url={data.createUserCalendarSubscription.url!} />
   ) : (
     defaultForm
   )
@@ -51,7 +51,7 @@ interface CalendarSubscribeCreateDialogProps {
 export default function CalendarSubscribeCreateDialog(
   props: CalendarSubscribeCreateDialogProps,
 ): ReactNode {
-  const [value, setValue] = useState({
+  const [value, setValue] = useState<CalSubFormValue>({
     name: '',
     scheduleID: props.scheduleID || null,
     reminderMinutes: [],

--- a/web/src/app/schedules/calendar-subscribe/CalendarSubscribeEditDialog.tsx
+++ b/web/src/app/schedules/calendar-subscribe/CalendarSubscribeEditDialog.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useState } from 'react'
 import { useQuery, useMutation, gql } from 'urql'
 import FormDialog from '../../dialogs/FormDialog'
-import CalendarSubscribeForm from './CalendarSubscribeForm'
+import CalendarSubscribeForm, { CalSubFormValue } from './CalendarSubscribeForm'
 import { GenericError, ObjectNotFound } from '../../error-pages'
 import _ from 'lodash'
 import Spinner from '../../loading/components/Spinner'
@@ -36,10 +36,11 @@ export function CalendarSubscribeEditDialogContent(
   const { data, onClose } = props
 
   // set default values from retrieved data
-  const [value, setValue] = useState({
+  const [value, setValue] = useState<CalSubFormValue>({
     name: _.get(data, 'name', ''),
     scheduleID: _.get(data, 'scheduleID', null),
     fullSchedule: _.get(data, 'fullSchedule', false),
+    reminderMinutes: _.get(data, 'reminderMinutes', []),
   })
 
   // setup the mutation

--- a/web/src/app/schedules/calendar-subscribe/CalendarSubscribeForm.tsx
+++ b/web/src/app/schedules/calendar-subscribe/CalendarSubscribeForm.tsx
@@ -3,11 +3,18 @@ import { FormContainer, FormField } from '../../forms'
 import { Checkbox, FormControlLabel, Grid, TextField } from '@mui/material'
 import { ScheduleSelect } from '../../selection'
 
+export type CalSubFormValue = {
+  scheduleID: string | null
+  name: string
+  reminderMinutes: Array<number>
+  fullSchedule: boolean
+}
+
 interface CalendarSubscribeFormProps {
   loading?: boolean
-  errors?: Array<{ message: string; field: string; helpLink: string }>
-  value: { scheduleId: string; name: string; reminderMinutes: Array<string> }
-  onChange: (value: object) => void
+  errors?: Array<{ message: string; field: string; helpLink?: string }>
+  value: CalSubFormValue
+  onChange: (value: CalSubFormValue) => void
   scheduleReadOnly?: boolean
 }
 

--- a/web/src/app/schedules/calendar-subscribe/CalendarSubscribeForm.tsx
+++ b/web/src/app/schedules/calendar-subscribe/CalendarSubscribeForm.tsx
@@ -1,10 +1,19 @@
 import React from 'react'
-import { PropTypes as p } from 'prop-types'
 import { FormContainer, FormField } from '../../forms'
 import { Checkbox, FormControlLabel, Grid, TextField } from '@mui/material'
 import { ScheduleSelect } from '../../selection'
 
-export default function CalendarSubscribeForm(props) {
+interface CalendarSubscribeFormProps {
+  loading?: boolean
+  errors?: Array<{ message: string; field: string; helpLink: string }>
+  value: { scheduleId: string; name: string; reminderMinutes: Array<string> }
+  onChange: (value: object) => void
+  scheduleReadOnly?: boolean
+}
+
+export default function CalendarSubscribeForm(
+  props: CalendarSubscribeFormProps,
+): React.ReactNode {
   return (
     <FormContainer
       disabled={props.loading}
@@ -47,16 +56,4 @@ export default function CalendarSubscribeForm(props) {
       </Grid>
     </FormContainer>
   )
-}
-
-CalendarSubscribeForm.propTypes = {
-  errors: p.array,
-  loading: p.bool,
-  onChange: p.func.isRequired,
-  scheduleReadOnly: p.bool,
-  value: p.shape({
-    scheduleID: p.string,
-    name: p.string,
-    reminderMinutes: p.array,
-  }).isRequired,
 }

--- a/web/src/app/schedules/calendar-subscribe/CalendarSuccessForm.tsx
+++ b/web/src/app/schedules/calendar-subscribe/CalendarSuccessForm.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { PropTypes as p } from 'prop-types'
 import { Button, FormHelperText, Grid, Typography } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import CopyText from '../../util/CopyText'
+import { Theme } from '@mui/material/styles'
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles((theme: Theme) => ({
   caption: {
     width: '100%',
   },
@@ -18,15 +18,21 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
-export default function CalenderSuccessForm(props) {
+interface CalendarSuccessFormProps {
+  url: string
+}
+
+export default function CalenderSuccessForm({
+  url,
+}: CalendarSuccessFormProps): React.ReactNode {
   const classes = useStyles()
-  const url = props.url.replace(/^https?:\/\//, 'webcal://')
+  const convertedUrl = url.replace(/^https?:\/\//, 'webcal://')
   return (
     <Grid container spacing={2}>
       <Grid item xs={12} className={classes.subscribeButtonContainer}>
         <Button
           variant='contained'
-          href={url}
+          href={convertedUrl}
           target='_blank'
           rel='noopener noreferrer'
         >
@@ -36,12 +42,7 @@ export default function CalenderSuccessForm(props) {
       </Grid>
       <Grid item xs={12}>
         <Typography>
-          <CopyText
-            title={props.url}
-            value={props.url}
-            placement='bottom'
-            asURL
-          />
+          <CopyText title={url} value={url} placement='bottom' asURL />
         </Typography>
         <FormHelperText>
           Some applications require you copy and paste the URL directly
@@ -49,8 +50,4 @@ export default function CalenderSuccessForm(props) {
       </Grid>
     </Grid>
   )
-}
-
-CalenderSuccessForm.propTypes = {
-  url: p.string.isRequired,
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Converts the calendar subscribe jsx files to tsx to properly enforce typing.

**Out of Scope:**
Include any out of scope items here.

**Screenshots:**
N/A

**Describe any introduced user-facing changes:**
N/A

**Describe any introduced API changes:**
N/A

**Additional Info:**
N/A
