### PR TITLE
schedules: Fixes a bug where 'replace' overrides would behave as an 'add' + 'delete' rather than replace

### DIFF
--- a/engine/schedulemanager/update.go
+++ b/engine/schedulemanager/update.go
@@ -181,10 +181,17 @@ func (db *DB) update(ctx context.Context) error {
 			// temp schedule active for this ID, skip
 			continue
 		}
+		var wasOnCall bool
 		if o.RemoveUserID.Valid {
+			wasOnCall = newOnCall[gadb.SchedMgrOnCallRow{ScheduleID: o.TgtScheduleID, UserID: o.RemoveUserID.UUID}]
 			delete(newOnCall, gadb.SchedMgrOnCallRow{ScheduleID: o.TgtScheduleID, UserID: o.RemoveUserID.UUID})
 		}
 		if o.AddUserID.Valid {
+			if o.RemoveUserID.Valid && !wasOnCall {
+				// if they were not on call, don't add them
+				continue
+			}
+
 			newOnCall[gadb.SchedMgrOnCallRow{ScheduleID: o.TgtScheduleID, UserID: o.AddUserID.UUID}] = true
 		}
 	}

--- a/engine/schedulemanager/update.go
+++ b/engine/schedulemanager/update.go
@@ -188,7 +188,8 @@ func (db *DB) update(ctx context.Context) error {
 		}
 		if o.AddUserID.Valid {
 			if o.RemoveUserID.Valid && !wasOnCall {
-				// if they were not on call, don't add them
+				// Add+Remove is a Replace
+				// If the user being replaced is not on-call, we don't want to add an extra shift for thier replacement.
 				continue
 			}
 

--- a/test/smoke/scheduleoverrideadd_test.go
+++ b/test/smoke/scheduleoverrideadd_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/target/goalert/util/timeutil"
 )
 
-// TestScheduleOverrideAdd validates that an "add"  style override correctly adds an additional shift.
+// TestScheduleOverrideAdd validates that an "add" style override correctly adds an additional shift.
 //
 // - User A is always on-call
 // - User B is on-call for a specific time (via rule)

--- a/test/smoke/scheduleoverrideadd_test.go
+++ b/test/smoke/scheduleoverrideadd_test.go
@@ -1,0 +1,99 @@
+package smoke
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/target/goalert/test/smoke/harness"
+	"github.com/target/goalert/util/timeutil"
+)
+
+// TestScheduleOverrideAdd validates that an "add"  style override correctly adds an additional shift.
+//
+// - User A is always on-call
+// - User B is on-call for a specific time (via rule)
+// - User C has an override that adds them to the schedule for a specific time
+func TestScheduleOverrideAdd(t *testing.T) {
+	t.Parallel()
+
+	sql := `
+	insert into users (id, name, email) 
+	values 
+		({{uuid "u1"}}, 'bob', 'joe'),
+		({{uuid "u2"}}, 'ben', 'josh'),
+		({{uuid "u3"}}, 'tim', 'tim');
+
+	insert into escalation_policies (id, name) 
+	values
+		({{uuid "eid"}}, 'esc policy');
+
+	insert into escalation_policy_steps (id, escalation_policy_id) 
+	values
+		({{uuid "esid"}}, {{uuid "eid"}});
+
+	insert into schedules (id, name, description, time_zone)
+	values
+		({{uuid "sched"}}, 'test', 'test', 'America/Chicago');
+	
+	insert into schedule_rules (schedule_id, start_time, end_time, tgt_user_id)
+	values
+		({{uuid "sched"}}, '00:00', '00:00', {{uuid "u1"}}),
+		({{uuid "sched"}}, '09:00', '21:00', {{uuid "u2"}});
+
+	insert into escalation_policy_actions (escalation_policy_step_id, schedule_id) 
+	values 
+		({{uuid "esid"}}, {{uuid "sched"}});
+
+	insert into services (id, escalation_policy_id, name) 
+	values
+		({{uuid "sid"}}, {{uuid "eid"}}, 'service');
+
+`
+	h := harness.NewHarness(t, sql, "npcycle-indexes")
+	defer h.Close()
+
+	svcID := h.UUID("sid")
+	u1 := h.UUID("u1")
+	u2 := h.UUID("u2")
+	u3 := h.UUID("u3")
+
+	now := h.Now()
+
+	start := now.AddDate(0, 0, 2)
+	end := now.AddDate(0, 0, 6)
+
+	h.GraphQLQuery2(fmt.Sprintf(`
+	mutation{
+	createUserOverride(input:{
+		addUserID: "%s",
+		scheduleID:"%s",
+		start:"%s",
+		end:"%s"}) { id }
+	}`,
+		u3, h.UUID("sched"), start.Format(time.RFC3339), end.Format(time.RFC3339)))
+
+	h.FastForwardToTime(timeutil.NewClock(0, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1)
+	h.FastForwardToTime(timeutil.NewClock(9, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1, u2)
+	h.FastForwardToTime(timeutil.NewClock(21, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1)
+
+	h.FastForward(24 * time.Hour * 3)
+
+	h.FastForwardToTime(timeutil.NewClock(0, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1, u3)
+	h.FastForwardToTime(timeutil.NewClock(9, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1, u2, u3)
+	h.FastForwardToTime(timeutil.NewClock(21, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1, u3)
+
+	h.FastForward(24 * time.Hour * 3)
+	h.FastForwardToTime(timeutil.NewClock(0, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1)
+	h.FastForwardToTime(timeutil.NewClock(9, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1, u2)
+	h.FastForwardToTime(timeutil.NewClock(21, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1)
+}

--- a/test/smoke/scheduleoverrideremove_test.go
+++ b/test/smoke/scheduleoverrideremove_test.go
@@ -1,0 +1,97 @@
+package smoke
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/target/goalert/test/smoke/harness"
+	"github.com/target/goalert/util/timeutil"
+)
+
+// TestScheduleOverrideRemove validates that a "remove" style override correctly removes an existing shift.
+//
+// - User A is always on-call
+// - User B is on-call for a specific time (via rule)
+// - User B has an override that removes them from the schedule for a specific time.
+func TestScheduleOverrideRemove(t *testing.T) {
+	t.Parallel()
+
+	sql := `
+	insert into users (id, name, email) 
+	values 
+		({{uuid "u1"}}, 'bob', 'joe'),
+		({{uuid "u2"}}, 'ben', 'josh');
+
+	insert into escalation_policies (id, name) 
+	values
+		({{uuid "eid"}}, 'esc policy');
+
+	insert into escalation_policy_steps (id, escalation_policy_id) 
+	values
+		({{uuid "esid"}}, {{uuid "eid"}});
+
+	insert into schedules (id, name, description, time_zone)
+	values
+		({{uuid "sched"}}, 'test', 'test', 'America/Chicago');
+	
+	insert into schedule_rules (schedule_id, start_time, end_time, tgt_user_id)
+	values
+		({{uuid "sched"}}, '00:00', '00:00', {{uuid "u1"}}),
+		({{uuid "sched"}}, '09:00', '21:00', {{uuid "u2"}});
+
+	insert into escalation_policy_actions (escalation_policy_step_id, schedule_id) 
+	values 
+		({{uuid "esid"}}, {{uuid "sched"}});
+
+	insert into services (id, escalation_policy_id, name) 
+	values
+		({{uuid "sid"}}, {{uuid "eid"}}, 'service');
+
+`
+	h := harness.NewHarness(t, sql, "npcycle-indexes")
+	defer h.Close()
+
+	svcID := h.UUID("sid")
+	u1 := h.UUID("u1")
+	u2 := h.UUID("u2")
+
+	now := h.Now()
+
+	start := now.AddDate(0, 0, 2)
+	end := now.AddDate(0, 0, 6)
+
+	h.GraphQLQuery2(fmt.Sprintf(`
+	mutation{
+	createUserOverride(input:{
+		removeUserID: "%s",
+		scheduleID:"%s",
+		start:"%s",
+		end:"%s"}) { id }
+	}`,
+		u2, h.UUID("sched"), start.Format(time.RFC3339), end.Format(time.RFC3339)))
+
+	h.FastForwardToTime(timeutil.NewClock(0, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1)
+	h.FastForwardToTime(timeutil.NewClock(9, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1, u2)
+	h.FastForwardToTime(timeutil.NewClock(21, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1)
+
+	h.FastForward(24 * time.Hour * 3)
+
+	h.FastForwardToTime(timeutil.NewClock(0, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1)
+	h.FastForwardToTime(timeutil.NewClock(9, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1)
+	h.FastForwardToTime(timeutil.NewClock(21, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1)
+
+	h.FastForward(24 * time.Hour * 3)
+	h.FastForwardToTime(timeutil.NewClock(0, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1)
+	h.FastForwardToTime(timeutil.NewClock(9, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1, u2)
+	h.FastForwardToTime(timeutil.NewClock(21, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1)
+}

--- a/test/smoke/scheduleoverridereplace_test.go
+++ b/test/smoke/scheduleoverridereplace_test.go
@@ -1,0 +1,100 @@
+package smoke
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/target/goalert/test/smoke/harness"
+	"github.com/target/goalert/util/timeutil"
+)
+
+// TestScheduleOverrideAdd validates that an "add"  style override correctly adds an additional shift.
+//
+// - User A is always on-call
+// - User B is on-call for a specific time (via rule)
+// - User C has an override that replaces user B on the schedule for a specific time
+func TestScheduleOverrideReplace(t *testing.T) {
+	t.Parallel()
+
+	sql := `
+	insert into users (id, name, email) 
+	values 
+		({{uuid "u1"}}, 'bob', 'joe'),
+		({{uuid "u2"}}, 'ben', 'josh'),
+		({{uuid "u3"}}, 'tim', 'tim');
+
+	insert into escalation_policies (id, name) 
+	values
+		({{uuid "eid"}}, 'esc policy');
+
+	insert into escalation_policy_steps (id, escalation_policy_id) 
+	values
+		({{uuid "esid"}}, {{uuid "eid"}});
+
+	insert into schedules (id, name, description, time_zone)
+	values
+		({{uuid "sched"}}, 'test', 'test', 'America/Chicago');
+	
+	insert into schedule_rules (schedule_id, start_time, end_time, tgt_user_id)
+	values
+		({{uuid "sched"}}, '00:00', '00:00', {{uuid "u1"}}),
+		({{uuid "sched"}}, '09:00', '21:00', {{uuid "u2"}});
+
+	insert into escalation_policy_actions (escalation_policy_step_id, schedule_id) 
+	values 
+		({{uuid "esid"}}, {{uuid "sched"}});
+
+	insert into services (id, escalation_policy_id, name) 
+	values
+		({{uuid "sid"}}, {{uuid "eid"}}, 'service');
+
+`
+	h := harness.NewHarness(t, sql, "npcycle-indexes")
+	defer h.Close()
+
+	svcID := h.UUID("sid")
+	u1 := h.UUID("u1")
+	u2 := h.UUID("u2")
+	u3 := h.UUID("u3")
+
+	now := h.Now()
+
+	start := now.AddDate(0, 0, 2)
+	end := now.AddDate(0, 0, 6)
+
+	h.GraphQLQuery2(fmt.Sprintf(`
+	mutation{
+	createUserOverride(input:{
+		removeUserID: "%s",
+		addUserID: "%s",
+		scheduleID:"%s",
+		start:"%s",
+		end:"%s"}) { id }
+	}`,
+		u2, u3, h.UUID("sched"), start.Format(time.RFC3339), end.Format(time.RFC3339)))
+
+	h.FastForwardToTime(timeutil.NewClock(0, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1)
+	h.FastForwardToTime(timeutil.NewClock(9, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1, u2)
+	h.FastForwardToTime(timeutil.NewClock(21, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1)
+
+	h.FastForward(24 * time.Hour * 3)
+
+	h.FastForwardToTime(timeutil.NewClock(0, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1)
+	h.FastForwardToTime(timeutil.NewClock(9, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1, u3)
+	h.FastForwardToTime(timeutil.NewClock(21, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1)
+
+	h.FastForward(24 * time.Hour * 3)
+	h.FastForwardToTime(timeutil.NewClock(0, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1)
+	h.FastForwardToTime(timeutil.NewClock(9, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1, u2)
+	h.FastForwardToTime(timeutil.NewClock(21, 0), "America/Chicago")
+	h.WaitAndAssertOnCallUsers(svcID, u1)
+}

--- a/test/smoke/scheduleoverridereplace_test.go
+++ b/test/smoke/scheduleoverridereplace_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/target/goalert/util/timeutil"
 )
 
-// TestScheduleOverrideAdd validates that an "add"  style override correctly adds an additional shift.
+// TestScheduleOverrideReplace validates that a "replace" style override correctly replaces a user.
 //
 // - User A is always on-call
 // - User B is on-call for a specific time (via rule)
-// - User C has an override that replaces user B on the schedule for a specific time
+// - User C has an override that replaces user B on the schedule for a specific time.
 func TestScheduleOverrideReplace(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**Description:**
- Adds smoketests for each of the three override types
- Ensures adding a new shift only happens if the user was already on-call (for replace overrides)
