### PR TITLE
fix: Exclude disabled subscriptions from inactivity queries

### DIFF
--- a/engine/cleanupmanager/queries.sql
+++ b/engine/cleanupmanager/queries.sql
@@ -217,6 +217,7 @@ WHERE
             user_calendar_subscriptions
         WHERE
             greatest(last_access, last_update) <(now() - '1 day'::interval * sqlc.arg(inactivity_threshold_days)::int)
+            AND NOT disabled
         ORDER BY
             id
         LIMIT 100

--- a/gadb/queries.sql.go
+++ b/gadb/queries.sql.go
@@ -1074,6 +1074,7 @@ WHERE
             user_calendar_subscriptions
         WHERE
             greatest(last_access, last_update) <(now() - '1 day'::interval * $1::int)
+            AND NOT disabled
         ORDER BY
             id
         LIMIT 100


### PR DESCRIPTION
**Description:**
Fixes a bug where the API cleanup would incorrectly disable already disabled calendar subscriptions; causing the job to eventually timeout.
