### PR TITLE
twilio/sms(RCS): Fix display bugs

### DIFF
--- a/graphql2/graphqlapp/contactmethod.go
+++ b/graphql2/graphqlapp/contactmethod.go
@@ -5,8 +5,10 @@ import (
 	"database/sql"
 	"errors"
 
+	"github.com/target/goalert/config"
 	"github.com/target/goalert/graphql2"
 	"github.com/target/goalert/notification"
+	"github.com/target/goalert/notification/twilio"
 	"github.com/target/goalert/user/contactmethod"
 	"github.com/target/goalert/validation"
 	"github.com/target/goalert/validation/validate"
@@ -73,6 +75,12 @@ func (a *ContactMethod) LastTestMessageState(ctx context.Context, obj *contactme
 		return nil, nil
 	}
 
+	cfg := config.FromContext(ctx)
+	if obj.Dest.Type == twilio.DestTypeTwilioSMS && cfg.Twilio.RCSSenderID != "" && status.SrcValue == cfg.Twilio.RCSSenderID {
+		// TODO: remove this when we have a better way to get the sender name
+		status.SrcValue = cfg.ApplicationName()
+	}
+
 	return notificationStateFromSendResult(status.Status, status.SrcValue), nil
 }
 
@@ -88,6 +96,12 @@ func (a *ContactMethod) LastVerifyMessageState(ctx context.Context, obj *contact
 	}
 	if status == nil {
 		return nil, nil
+	}
+
+	cfg := config.FromContext(ctx)
+	if obj.Dest.Type == twilio.DestTypeTwilioSMS && cfg.Twilio.RCSSenderID != "" && status.SrcValue == cfg.Twilio.RCSSenderID {
+		// TODO: remove this when we have a better way to get the sender name
+		status.SrcValue = cfg.ApplicationName()
 	}
 
 	return notificationStateFromSendResult(status.Status, status.SrcValue), nil

--- a/graphql2/graphqlapp/messagelog.go
+++ b/graphql2/graphqlapp/messagelog.go
@@ -31,6 +31,8 @@ func msgStatus(stat notification.Status) string {
 		str.WriteString("Sent")
 	case notification.StateDelivered:
 		str.WriteString("Delivered")
+	case notification.StateRead:
+		str.WriteString("Read")
 	case notification.StateFailedTemp:
 		str.WriteString("Failed (temporary)")
 	case notification.StateFailedPerm:

--- a/web/src/app/admin/admin-message-logs/AdminMessageLogsLayout.tsx
+++ b/web/src/app/admin/admin-message-logs/AdminMessageLogsLayout.tsx
@@ -104,6 +104,7 @@ export default function AdminMessageLogsLayout(): React.JSX.Element {
     const s = status.toLowerCase()
     if (s.includes('deliver')) statusStyles = statusDict.success
     if (s.includes('sent')) statusStyles = statusDict.success
+    if (s.includes('read')) statusStyles = statusDict.success
     if (s.includes('fail')) statusStyles = statusDict.error
     if (s.includes('temp')) statusStyles = statusDict.warning
     if (s.includes('pend')) statusStyles = statusDict.info


### PR DESCRIPTION
**Description:**
Fixed a few remaining issues with RCS messages:
- The admin message log now displays the `Read` status correctly
- The test/verify dialog now displays the Application Name instead of the RCS sender ID, for RCS messages
- Simplified status history to only show durations of each state
- Added history to admin message logs UI

**Out of Scope**
Alert log is only updated when a message is sent, fixing this is a separate body of work
- NP cycle manager will need to migrate to job queue and add the log entry on insert
- EP manager will need to migrate to job queue and add the log entry on insert

**Screenshots**
![image](https://github.com/user-attachments/assets/9384804a-1767-42f4-85cf-3d9cc65dc3d5)
![image](https://github.com/user-attachments/assets/8a67bfaf-b909-49d9-a1d2-135de95a14d3)
