### PR TITLE
river: call `.Start()` synchronously

### DIFF
--- a/app/runapp.go
+++ b/app/runapp.go
@@ -24,12 +24,10 @@ func (app *App) _Run(ctx context.Context) error {
 		}
 	}()
 
-	go func() {
-		err := app.RiverUI.Start(ctx)
-		if err != nil {
-			app.Logger.ErrorContext(ctx, "Failed to start River UI.", slog.Any("error", err))
-		}
-	}()
+	err := app.RiverUI.Start(ctx)
+	if err != nil {
+		app.Logger.ErrorContext(ctx, "Failed to start River UI.", slog.Any("error", err))
+	}
 
 	go app.events.Run(ctx)
 
@@ -58,7 +56,7 @@ func (app *App) _Run(ctx context.Context) error {
 		slog.String("address", app.l.Addr().String()),
 		slog.String("url", app.ConfigStore.Config().PublicURL()),
 	)
-	err := app.srv.Serve(app.l)
+	err = app.srv.Serve(app.l)
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return errors.Wrap(err, "serve HTTP")
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -291,7 +291,7 @@ func (p *Engine) _resume(ctx context.Context) error {
 		return errors.Wrap(err, "resume river")
 	}
 
-	go p.startRiver()
+	p.startRiver()
 
 	return nil
 }
@@ -564,10 +564,7 @@ func (p *Engine) handlePause(ctx context.Context, respCh chan error) {
 func (p *Engine) startRiver() {
 	ctx := p.runCtx
 	err := p.cfg.River.Start(ctx)
-	// Ignore shutdown errors, they are expected.
-	// TODO: replace with errors.Is(err, river.ErrShutdown) when/if
-	// this gets merged: https://github.com/riverqueue/river/pull/830
-	if err != nil && !strings.Contains(err.Error(), "shutdown") {
+	if err != nil {
 		log.Log(ctx, errors.Wrap(err, "start river"))
 	}
 }
@@ -594,7 +591,7 @@ func (p *Engine) _run(ctx context.Context) error {
 	}
 
 	p.runCtx = ctx
-	go p.startRiver()
+	p.startRiver()
 
 	dur := p.cfg.CycleTime
 	if dur == 0 {


### PR DESCRIPTION
**Description:**
Removes unecessary goroutines surrounding river's `.Start()` methods, removing the startup race and need to check for early shutdown errors from the library.
