### PR TITLE
fix: fix override dialog extra button

### DIFF
--- a/web/src/app/schedules/ScheduleOverrideDialog.jsx
+++ b/web/src/app/schedules/ScheduleOverrideDialog.jsx
@@ -147,7 +147,7 @@ export default function ScheduleOverrideDialog(props) {
         })
       }
       disableSubmit={step === 0}
-      onNext={onNext}
+      onNext={step < 1 ? onNext : undefined}
     />
   )
 }


### PR DESCRIPTION
**Description:**
Fixes an issue where the `Next` button still appears in the override dialog after selecting the type.

If clicked, the dialog would enter a visually broken state, and the overrides would lose the added user (making them remove the user with no replacement coverage).

**Describe any introduced user-facing changes:**
N/A

**Describe any introduced API changes:**
N/A
