### PR TITLE
Correct Average Ack Time in reporting

### DIFF
--- a/graphql2/graphqlapp/service.go
+++ b/graphql2/graphqlapp/service.go
@@ -138,7 +138,7 @@ func (s *Service) AlertStats(ctx context.Context, svc *service.Service, input *g
 		end := res.AddTo(r.Bucket)
 		stats.AlertCount = append(stats.AlertCount, graphql2.TimeSeriesBucket{Start: r.Bucket, End: end, Value: float64(r.AlertCount)})
 		stats.EscalatedCount = append(stats.EscalatedCount, graphql2.TimeSeriesBucket{Start: r.Bucket, End: end, Value: float64(r.EscalatedCount)})
-		stats.AvgAckSec = append(stats.AvgAckSec, graphql2.TimeSeriesBucket{Start: r.Bucket, End: end, Value: r.AvgTimeToCloseSeconds})
+		stats.AvgAckSec = append(stats.AvgAckSec, graphql2.TimeSeriesBucket{Start: r.Bucket, End: end, Value: r.AvgTimeToAckSeconds})
 		stats.AvgCloseSec = append(stats.AvgCloseSec, graphql2.TimeSeriesBucket{Start: r.Bucket, End: end, Value: r.AvgTimeToCloseSeconds})
 	}
 	return &stats, nil


### PR DESCRIPTION
The average ack time currently returns the close time - this corrects the avgacksec to return the average acknowledge time

