### PR TITLE
refactor: streamline dataloader context management for type safety

### DIFF
--- a/dataloader/loader.go
+++ b/dataloader/loader.go
@@ -20,9 +20,20 @@ func NewStoreLoaderInt[V any](ctx context.Context, fetchMany func(context.Contex
 
 func NewStoreLoader[V any](ctx context.Context, fetchMany func(context.Context, []string) ([]V, error)) *Loader[string, V] {
 	return newLoader(ctx, loaderConfig[string, V]{
-		Max:       100,
-		Delay:     time.Millisecond,
-		IDFunc:    func(v V) string { return reflect.ValueOf(v).FieldByName("ID").String() },
+		Max:   100,
+		Delay: time.Millisecond,
+		IDFunc: func(v V) string {
+			type stringer interface {
+				String() string
+			}
+			field := reflect.ValueOf(v).FieldByName("ID")
+			if field.IsValid() && field.CanInterface() {
+				if s, ok := field.Interface().(stringer); ok {
+					return s.String()
+				}
+			}
+			return field.String()
+		},
 		FetchFunc: fetchMany,
 	})
 }

--- a/graphql2/graphqlapp/dataloaders.go
+++ b/graphql2/graphqlapp/dataloaders.go
@@ -62,6 +62,7 @@ func (a *App) registerLoaders(ctx context.Context) context.Context {
 	})
 	return ctx
 }
+
 func loadersFrom(ctx context.Context) loaders {
 	loader, ok := ctx.Value(requestLoadersKey).(*loaders)
 	if !ok {


### PR DESCRIPTION
**Description:**
This pull request refactors the `graphql2/graphqlapp/dataloaders.go` file to simplify and modernize the data loader implementation. The changes replace the old `dataLoaderKey`-based approach with a consolidated `loaders` struct to manage all data loaders. This improves maintainability, readability, and type safety.

It was common before to have loaders silently not-work because of failed type assertions.

### Key Changes:

#### Refactoring of Data Loader Management:
* Replaced the `dataLoaderKey` constants and their usage with a single `loaders` struct, which contains all data loaders as fields. This eliminates the need for multiple context keys.
* Introduced the `loadersFrom` function to retrieve the `loaders` struct from the context, simplifying access to individual loaders.

#### Updates to Loader Initialization:
* Updated the `registerLoaders` function to initialize all data loaders within the `loaders` struct and store it in the context under a single key (`requestLoadersKey`). 

#### Updates to Loader Usage:
* Refactored all `FindOne` methods (e.g., `FindOneAlertMetadata`, `FindOneNotificationMessageStatus`, etc.) to use the new `loadersFrom` function for accessing the appropriate loader. This replaces the previous pattern of retrieving loaders directly from context values. 

#### Updates to Loader Cleanup:
* Replaced the iterative cleanup of individual loaders (using `dataLoaderKey` constants) with a straightforward cleanup of each loader in the `loaders` struct. 
