### PR TITLE
fix: increase timeout in TestIDLocker_CancelQueue for better stability

### DIFF
--- a/ctxlock/idlocker_test.go
+++ b/ctxlock/idlocker_test.go
@@ -81,7 +81,7 @@ func TestIDLocker_Timeout(t *testing.T) {
 }
 
 func TestIDLocker_CancelQueue(t *testing.T) {
-	l := ctxlock.NewIDLocker[string](ctxlock.Config{MaxWait: 10, Timeout: time.Millisecond})
+	l := ctxlock.NewIDLocker[string](ctxlock.Config{MaxWait: 10, Timeout: time.Second})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
**Description:**
This pull request includes a small change to the `TestIDLocker_CancelQueue` test in the `idlocker_test.go` file. The `Timeout` configuration for the `ctxlock.NewIDLocker` instance was increased from `time.Millisecond` to `time.Second` to adjust the timeout duration.

This matches other tests and should resolve issues in CI.
