### PR TITLE
dataloader: add aggregate functions

### DIFF
--- a/dataloader/aggfetcher.go
+++ b/dataloader/aggfetcher.go
@@ -5,24 +5,62 @@ import (
 	"time"
 )
 
+// AggFetcher provides batched loading of aggregated data. Unlike the basic Fetcher
+// which returns at most one value per ID, AggFetcher collects multiple values
+// for each ID and returns them as a slice.
+//
+// This is useful for one-to-many relationships where you need to fetch all related
+// items for a set of parent IDs, such as fetching all alerts for multiple services.
+//
+// Type parameters:
+//   - K: The type of the unique identifier (key) for items being fetched
+//   - V: The type of values being aggregated
 type AggFetcher[K comparable, V any] struct {
-	*Fetcher[K, AggFetchResult[K, V]] // Fetcher for aggregated results
+	*Fetcher[K, AggFetchResult[K, V]] // Embedded Fetcher for aggregated results
 }
 
-// AggFetchFunc defines the signature for functions that fetch data with parameters and an array of results.
-// The function receives a context, parameter value, and slice of IDs to fetch.
+// AggFetchFunc defines the signature for functions that fetch aggregated data.
+// The function receives a context and slice of IDs to fetch, and should return
+// all values associated with any of those IDs (potentially multiple values per ID).
 type AggFetchFunc[K comparable, V any] func(context.Context, []K) ([]V, error)
 
+// AggFetchResult holds the aggregated results for a single ID.
+// It contains the ID and all values associated with that ID.
+type AggFetchResult[K comparable, V any] struct {
+	ID     K   // The unique identifier
+	Values []V // All values associated with this ID
+}
+
+// NewStoreLoaderAgg creates a new AggFetcher for loading aggregated data from a store.
+// This is useful for one-to-many relationships where you need to batch-load multiple
+// related items for each parent ID.
+//
+// The fetchMany function should return all values for the given IDs. Values can be
+// returned in any order and multiple values can have the same ID (as determined by idFunc).
+// The AggFetcher will automatically group them by ID.
+//
+// Example usage:
+//
+//	// Fetch all alerts for multiple services
+//	alertLoader := dataloader.NewStoreLoaderAgg(ctx,
+//		func(ctx context.Context, serviceIDs []string) ([]Alert, error) {
+//			return alertStore.FindByServiceIDs(ctx, serviceIDs)
+//		},
+//		func(alert Alert) string { return alert.ServiceID },
+//	)
+//	alerts, err := alertLoader.FetchAggregate(ctx, "service-123")
 func NewStoreLoaderAgg[V any, K comparable](ctx context.Context, fetchMany AggFetchFunc[K, V], idFunc IDFunc[K, V]) *AggFetcher[K, V] {
 	return &AggFetcher[K, V]{
 		Fetcher: &Fetcher[K, AggFetchResult[K, V]]{
 			FetchFunc: func(ctx context.Context, ids []K) ([]AggFetchResult[K, V], error) {
-
-				result := make(map[K]*AggFetchResult[K, V])
+				// Fetch all values for the requested IDs
 				values, err := fetchMany(ctx, ids)
 				if err != nil {
 					return nil, err
 				}
+
+				// Group values by their ID
+				result := make(map[K]*AggFetchResult[K, V])
 				for _, v := range values {
 					id := idFunc(v)
 					res, ok := result[id]
@@ -34,6 +72,7 @@ func NewStoreLoaderAgg[V any, K comparable](ctx context.Context, fetchMany AggFe
 					}
 				}
 
+				// Convert map to slice for return
 				resList := make([]AggFetchResult[K, V], 0, len(result))
 				for _, v := range result {
 					resList = append(resList, *v)
@@ -47,11 +86,13 @@ func NewStoreLoaderAgg[V any, K comparable](ctx context.Context, fetchMany AggFe
 	}
 }
 
-// FetchOneAggParam retrieves a single aggregated value by its ID using the specified parameters.
-// Requests with the same parameter values will be batched together, while requests
-// with different parameters will use separate batches.
+// FetchAggregate retrieves all values associated with the given ID.
+// Multiple calls within the same batch window will be batched together
+// into a single call to the underlying fetch function.
 //
-// The method lazily creates new Fetcher instances for each unique parameter combination.
+// Returns a slice of all values associated with the ID, or nil if no values
+// are found. An error is returned if the fetch operation fails or the context
+// is cancelled.
 func (af *AggFetcher[K, V]) FetchAggregate(ctx context.Context, id K) ([]V, error) {
 	res, err := af.FetchOne(ctx, id)
 	if err != nil {

--- a/dataloader/aggfetcher.go
+++ b/dataloader/aggfetcher.go
@@ -1,0 +1,64 @@
+package dataloader
+
+import (
+	"context"
+	"time"
+)
+
+type AggFetcher[K comparable, V any] struct {
+	*Fetcher[K, AggFetchResult[K, V]] // Fetcher for aggregated results
+}
+
+// AggFetchFunc defines the signature for functions that fetch data with parameters and an array of results.
+// The function receives a context, parameter value, and slice of IDs to fetch.
+type AggFetchFunc[K comparable, V any] func(context.Context, []K) ([]V, error)
+
+func NewStoreLoaderAgg[V any, K comparable](ctx context.Context, fetchMany AggFetchFunc[K, V], idFunc IDFunc[K, V]) *AggFetcher[K, V] {
+	return &AggFetcher[K, V]{
+		Fetcher: &Fetcher[K, AggFetchResult[K, V]]{
+			FetchFunc: func(ctx context.Context, ids []K) ([]AggFetchResult[K, V], error) {
+
+				result := make(map[K]*AggFetchResult[K, V])
+				values, err := fetchMany(ctx, ids)
+				if err != nil {
+					return nil, err
+				}
+				for _, v := range values {
+					id := idFunc(v)
+					res, ok := result[id]
+					if !ok {
+						res = &AggFetchResult[K, V]{ID: id, Values: []V{v}}
+						result[id] = res
+					} else {
+						res.Values = append(res.Values, v)
+					}
+				}
+
+				resList := make([]AggFetchResult[K, V], 0, len(result))
+				for _, v := range result {
+					resList = append(resList, *v)
+				}
+				return resList, nil
+			},
+			IDFunc:   func(afr AggFetchResult[K, V]) K { return afr.ID },
+			MaxBatch: 100,
+			Delay:    5 * time.Millisecond,
+		},
+	}
+}
+
+// FetchOneAggParam retrieves a single aggregated value by its ID using the specified parameters.
+// Requests with the same parameter values will be batched together, while requests
+// with different parameters will use separate batches.
+//
+// The method lazily creates new Fetcher instances for each unique parameter combination.
+func (af *AggFetcher[K, V]) FetchAggregate(ctx context.Context, id K) ([]V, error) {
+	res, err := af.FetchOne(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, nil // No results found for this ID
+	}
+	return res.Values, nil
+}

--- a/dataloader/aggfetcherparam.go
+++ b/dataloader/aggfetcherparam.go
@@ -1,0 +1,69 @@
+package dataloader
+
+import (
+	"context"
+	"time"
+)
+
+// AggFetchParamFunc defines the signature for functions that fetch data with parameters and an array of results.
+// The function receives a context, parameter value, and slice of IDs to fetch.
+type AggFetchParamFunc[K, P comparable, V any] func(context.Context, P, []K) ([]V, error)
+
+type AggFetchResult[K comparable, V any] struct {
+	ID     K
+	Values []V
+}
+
+type AggFetcherParam[K, P comparable, V any] struct {
+	*FetcherParam[K, P, AggFetchResult[K, V]] // Fetcher for aggregated results
+}
+
+func NewStoreLoaderAggParam[V any, K, P comparable](ctx context.Context, fetchMany AggFetchParamFunc[K, P, V], idFunc IDFunc[K, V]) *AggFetcherParam[K, P, V] {
+	return &AggFetcherParam[K, P, V]{
+		FetcherParam: &FetcherParam[K, P, AggFetchResult[K, V]]{
+			FetchFunc: func(ctx context.Context, p P, k []K) ([]AggFetchResult[K, V], error) {
+				values, err := fetchMany(ctx, p, k)
+				if err != nil {
+					return nil, err
+				}
+
+				result := make(map[K]*AggFetchResult[K, V])
+				for _, v := range values {
+					id := idFunc(v)
+					res, ok := result[id]
+					if !ok {
+						res = &AggFetchResult[K, V]{ID: id, Values: []V{v}}
+						result[id] = res
+					} else {
+						res.Values = append(res.Values, v)
+					}
+				}
+
+				resList := make([]AggFetchResult[K, V], 0, len(result))
+				for _, v := range result {
+					resList = append(resList, *v)
+				}
+				return resList, nil
+			},
+			IDFunc:   func(afr AggFetchResult[K, V]) K { return afr.ID },
+			MaxBatch: 100,
+			Delay:    5 * time.Millisecond,
+		},
+	}
+}
+
+// FetchOneAggParam retrieves a single aggregated value by its ID using the specified parameters.
+// Requests with the same parameter values will be batched together, while requests
+// with different parameters will use separate batches.
+//
+// The method lazily creates new Fetcher instances for each unique parameter combination.
+func (af *AggFetcherParam[K, P, V]) FetchAggregateParam(ctx context.Context, id K, param P) ([]V, error) {
+	res, err := af.FetcherParam.FetchOneParam(ctx, id, param)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, nil // No results found for this ID
+	}
+	return res.Values, nil
+}

--- a/dataloader/aggfetcherparam.go
+++ b/dataloader/aggfetcherparam.go
@@ -5,28 +5,58 @@ import (
 	"time"
 )
 
-// AggFetchParamFunc defines the signature for functions that fetch data with parameters and an array of results.
-// The function receives a context, parameter value, and slice of IDs to fetch.
+// AggFetchParamFunc defines the signature for functions that fetch aggregated data with parameters.
+// The function receives a context, parameter value, and slice of IDs to fetch, and should return
+// all values associated with any of those IDs for the given parameters.
 type AggFetchParamFunc[K, P comparable, V any] func(context.Context, P, []K) ([]V, error)
 
-type AggFetchResult[K comparable, V any] struct {
-	ID     K
-	Values []V
-}
-
+// AggFetcherParam provides batched loading of aggregated data with parameters.
+// Unlike AggFetcher, this allows you to pass additional parameters that modify
+// the fetch behavior. It maintains separate Fetcher instances for each unique
+// parameter combination.
+//
+// This is useful for parameterized one-to-many relationships, such as fetching
+// all active alerts for multiple services, or all escalation policies for
+// multiple teams with specific filters.
+//
+// Type parameters:
+//   - K: The type of the unique identifier (key) for items being fetched
+//   - P: The type of additional parameters that can be passed to modify fetch behavior
+//   - V: The type of values being aggregated
 type AggFetcherParam[K, P comparable, V any] struct {
-	*FetcherParam[K, P, AggFetchResult[K, V]] // Fetcher for aggregated results
+	*FetcherParam[K, P, AggFetchResult[K, V]] // Embedded FetcherParam for aggregated results
 }
 
+// NewStoreLoaderAggParam creates a new AggFetcherParam for loading aggregated data
+// from a store with parameters. This allows you to batch requests not just by ID,
+// but also by parameter values, while still aggregating multiple results per ID.
+//
+// The fetchMany function should handle the parameter and return all values for
+// the given IDs that match the parameter criteria. Values can be returned in any
+// order and multiple values can have the same ID (as determined by idFunc).
+// The AggFetcherParam will automatically group them by ID.
+//
+// Example usage:
+//
+//	type AlertParams struct { Status string }
+//	alertLoader := dataloader.NewStoreLoaderAggParam(ctx,
+//		func(ctx context.Context, params AlertParams, serviceIDs []string) ([]Alert, error) {
+//			return alertStore.FindByServiceIDsAndStatus(ctx, serviceIDs, params.Status)
+//		},
+//		func(alert Alert) string { return alert.ServiceID },
+//	)
+//	openAlerts, err := alertLoader.FetchAggregateParam(ctx, "service-123", AlertParams{Status: "open"})
 func NewStoreLoaderAggParam[V any, K, P comparable](ctx context.Context, fetchMany AggFetchParamFunc[K, P, V], idFunc IDFunc[K, V]) *AggFetcherParam[K, P, V] {
 	return &AggFetcherParam[K, P, V]{
 		FetcherParam: &FetcherParam[K, P, AggFetchResult[K, V]]{
 			FetchFunc: func(ctx context.Context, p P, k []K) ([]AggFetchResult[K, V], error) {
+				// Fetch all values for the requested IDs with the given parameters
 				values, err := fetchMany(ctx, p, k)
 				if err != nil {
 					return nil, err
 				}
 
+				// Group values by their ID
 				result := make(map[K]*AggFetchResult[K, V])
 				for _, v := range values {
 					id := idFunc(v)
@@ -39,6 +69,7 @@ func NewStoreLoaderAggParam[V any, K, P comparable](ctx context.Context, fetchMa
 					}
 				}
 
+				// Convert map to slice for return
 				resList := make([]AggFetchResult[K, V], 0, len(result))
 				for _, v := range result {
 					resList = append(resList, *v)
@@ -52,11 +83,14 @@ func NewStoreLoaderAggParam[V any, K, P comparable](ctx context.Context, fetchMa
 	}
 }
 
-// FetchOneAggParam retrieves a single aggregated value by its ID using the specified parameters.
+// FetchAggregateParam retrieves all values associated with the given ID using the specified parameters.
 // Requests with the same parameter values will be batched together, while requests
 // with different parameters will use separate batches.
 //
 // The method lazily creates new Fetcher instances for each unique parameter combination.
+// Returns a slice of all values associated with the ID for the given parameters,
+// or nil if no values are found. An error is returned if the fetch operation fails
+// or the context is cancelled.
 func (af *AggFetcherParam[K, P, V]) FetchAggregateParam(ctx context.Context, id K, param P) ([]V, error) {
 	res, err := af.FetcherParam.FetchOneParam(ctx, id, param)
 	if err != nil {

--- a/gadb/queries.sql.go
+++ b/gadb/queries.sql.go
@@ -5196,22 +5196,24 @@ func (q *Queries) SequenceNames(ctx context.Context) ([]string, error) {
 const serviceAlertCounts = `-- name: ServiceAlertCounts :many
 SELECT
   COUNT(*),
-  status
+  status,
+  service_id
 FROM
   alerts
 WHERE
-  service_id = $1
+  service_id = ANY ($1::uuid[])
 GROUP BY
   status
 `
 
 type ServiceAlertCountsRow struct {
-	Count  int64
-	Status EnumAlertStatus
+	Count     int64
+	Status    EnumAlertStatus
+	ServiceID uuid.NullUUID
 }
 
-func (q *Queries) ServiceAlertCounts(ctx context.Context, serviceID uuid.NullUUID) ([]ServiceAlertCountsRow, error) {
-	rows, err := q.db.QueryContext(ctx, serviceAlertCounts, serviceID)
+func (q *Queries) ServiceAlertCounts(ctx context.Context, serviceIds []uuid.UUID) ([]ServiceAlertCountsRow, error) {
+	rows, err := q.db.QueryContext(ctx, serviceAlertCounts, pq.Array(serviceIds))
 	if err != nil {
 		return nil, err
 	}
@@ -5219,7 +5221,7 @@ func (q *Queries) ServiceAlertCounts(ctx context.Context, serviceID uuid.NullUUI
 	var items []ServiceAlertCountsRow
 	for rows.Next() {
 		var i ServiceAlertCountsRow
-		if err := rows.Scan(&i.Count, &i.Status); err != nil {
+		if err := rows.Scan(&i.Count, &i.Status, &i.ServiceID); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -5235,37 +5237,36 @@ func (q *Queries) ServiceAlertCounts(ctx context.Context, serviceID uuid.NullUUI
 
 const serviceAlertStats = `-- name: ServiceAlertStats :many
 SELECT
-  date_bin($2::interval, closed_at,
-    $3::timestamptz)::timestamptz AS bucket,
-  coalesce(EXTRACT(EPOCH FROM AVG(time_to_ack)), 0)::double precision AS
-    avg_time_to_ack_seconds,
-  coalesce(EXTRACT(EPOCH FROM AVG(time_to_close)), 0)::double precision AS
-    avg_time_to_close_seconds,
+  date_bin($1::interval, closed_at, $2::timestamptz)::timestamptz AS bucket,
+  coalesce(EXTRACT(EPOCH FROM AVG(time_to_ack)), 0)::double precision AS avg_time_to_ack_seconds,
+  coalesce(EXTRACT(EPOCH FROM AVG(time_to_close)), 0)::double precision AS avg_time_to_close_seconds,
   coalesce(COUNT(*), 0)::bigint AS alert_count,
   coalesce(SUM(
       CASE WHEN escalated THEN
         1
       ELSE
         0
-      END), 0)::bigint AS escalated_count
+      END), 0)::bigint AS escalated_count,
+  service_id
 FROM
   alert_metrics
 WHERE
-  service_id = $1
+  service_id = ANY ($3::uuid[])
   AND (closed_at BETWEEN $4
     AND $5)
 GROUP BY
+  service_id,
   bucket
 ORDER BY
   bucket
 `
 
 type ServiceAlertStatsParams struct {
-	ServiceID uuid.UUID
-	Stride    sqlutil.Interval
-	Origin    time.Time
-	StartTime time.Time
-	EndTime   time.Time
+	Stride     sqlutil.Interval
+	Origin     time.Time
+	ServiceIds []uuid.UUID
+	StartTime  time.Time
+	EndTime    time.Time
 }
 
 type ServiceAlertStatsRow struct {
@@ -5274,14 +5275,15 @@ type ServiceAlertStatsRow struct {
 	AvgTimeToCloseSeconds float64
 	AlertCount            int64
 	EscalatedCount        int64
+	ServiceID             uuid.UUID
 }
 
 // ServiceAlertStats returns statistics about alerts for a service.
 func (q *Queries) ServiceAlertStats(ctx context.Context, arg ServiceAlertStatsParams) ([]ServiceAlertStatsRow, error) {
 	rows, err := q.db.QueryContext(ctx, serviceAlertStats,
-		arg.ServiceID,
 		arg.Stride,
 		arg.Origin,
+		pq.Array(arg.ServiceIds),
 		arg.StartTime,
 		arg.EndTime,
 	)
@@ -5298,6 +5300,7 @@ func (q *Queries) ServiceAlertStats(ctx context.Context, arg ServiceAlertStatsPa
 			&i.AvgTimeToCloseSeconds,
 			&i.AlertCount,
 			&i.EscalatedCount,
+			&i.ServiceID,
 		); err != nil {
 			return nil, err
 		}

--- a/graphql2/graphqlapp/service.go
+++ b/graphql2/graphqlapp/service.go
@@ -122,13 +122,12 @@ func (s *Service) AlertStats(ctx context.Context, svc *service.Service, input *g
 	}
 
 	var stats graphql2.AlertStats
-	rows, err := gadb.New(s.DB).ServiceAlertStats(ctx, gadb.ServiceAlertStatsParams{
+	rows, err := (*App)(s).FindAlertStats(ctx, AlertStatsParam{
+		Stride:    res.PGXInterval(),
+		Origin:    origin,
 		StartTime: start,
 		EndTime:   end,
-		ServiceID: uuid.MustParse(svc.ID),
-		Origin:    origin,
-		Stride:    res.PGXInterval(),
-	})
+	}, uuid.MustParse(svc.ID))
 	if errors.Is(err, sql.ErrNoRows) {
 		return &stats, nil
 	}

--- a/graphql2/graphqlapp/service.go
+++ b/graphql2/graphqlapp/service.go
@@ -146,7 +146,7 @@ func (s *Service) AlertStats(ctx context.Context, svc *service.Service, input *g
 }
 
 func (s *Service) AlertsByStatus(ctx context.Context, svc *service.Service) (*graphql2.AlertsByStatus, error) {
-	rows, err := gadb.New(s.DB).ServiceAlertCounts(ctx, uuid.NullUUID{UUID: uuid.MustParse(svc.ID), Valid: true})
+	rows, err := (*App)(s).FindAlertCountByStatus(ctx, uuid.MustParse(svc.ID))
 	if errors.Is(err, sql.ErrNoRows) {
 		return &graphql2.AlertsByStatus{}, nil
 	}


### PR DESCRIPTION
**Description:**
Adds aggregate functions for batching queries that fetch multiple rows.

- Updated `Service.AlertsByStatus` and `Service.AlertStats` to batch results via dataloader.

**Describe any introduced user-facing changes:**
N/A

**Describe any introduced API changes:**
N/A

**Additional Info:**
Fetching alert status, or counts, on multiple services during a query will now result in a single call to the DB.
