### PR TITLE
service details: Add "Recent Events" as an aggregated alert log

### DIFF
--- a/graphql2/generated.go
+++ b/graphql2/generated.go
@@ -140,6 +140,7 @@ type ComplexityRoot struct {
 	}
 
 	AlertLogEntry struct {
+		AlertID   func(childComplexity int) int
 		ID        func(childComplexity int) int
 		Message   func(childComplexity int) int
 		MessageID func(childComplexity int) int
@@ -730,6 +731,7 @@ type ComplexityRoot struct {
 		Name                 func(childComplexity int) int
 		Notices              func(childComplexity int) int
 		OnCallUsers          func(childComplexity int) int
+		RecentEvents         func(childComplexity int, input *AlertRecentEventsOptions) int
 	}
 
 	ServiceConnection struct {
@@ -1106,6 +1108,7 @@ type ServiceResolver interface {
 	Labels(ctx context.Context, obj *service.Service) ([]label.Label, error)
 	HeartbeatMonitors(ctx context.Context, obj *service.Service) ([]heartbeat.Monitor, error)
 	Notices(ctx context.Context, obj *service.Service) ([]notice.Notice, error)
+	RecentEvents(ctx context.Context, obj *service.Service, input *AlertRecentEventsOptions) (*AlertLogEntryConnection, error)
 	AlertStats(ctx context.Context, obj *service.Service, input *ServiceAlertStatsOptions) (*AlertStats, error)
 	AlertsByStatus(ctx context.Context, obj *service.Service) (*AlertsByStatus, error)
 }
@@ -1347,6 +1350,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.AlertDataPoint.Timestamp(childComplexity), true
+
+	case "AlertLogEntry.alertID":
+		if e.complexity.AlertLogEntry.AlertID == nil {
+			break
+		}
+
+		return e.complexity.AlertLogEntry.AlertID(childComplexity), true
 
 	case "AlertLogEntry.id":
 		if e.complexity.AlertLogEntry.ID == nil {
@@ -4637,6 +4647,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Service.OnCallUsers(childComplexity), true
+
+	case "Service.recentEvents":
+		if e.complexity.Service.RecentEvents == nil {
+			break
+		}
+
+		args, err := ec.field_Service_recentEvents_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Service.RecentEvents(childComplexity, args["input"].(*AlertRecentEventsOptions)), true
 
 	case "ServiceConnection.nodes":
 		if e.complexity.ServiceConnection.Nodes == nil {
@@ -8706,6 +8728,34 @@ func (ec *executionContext) field_Service_alertStats_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Service_recentEvents_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Service_recentEvents_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Service_recentEvents_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*AlertRecentEventsOptions, error) {
+	if _, ok := rawArgs["input"]; !ok {
+		var zeroVal *AlertRecentEventsOptions
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalOAlertRecentEventsOptions2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐAlertRecentEventsOptions(ctx, tmp)
+	}
+
+	var zeroVal *AlertRecentEventsOptions
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field___Directive_args_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -9292,6 +9342,8 @@ func (ec *executionContext) fieldContext_Alert_service(_ context.Context, field 
 				return ec.fieldContext_Service_heartbeatMonitors(ctx, field)
 			case "notices":
 				return ec.fieldContext_Service_notices(ctx, field)
+			case "recentEvents":
+				return ec.fieldContext_Service_recentEvents(ctx, field)
 			case "alertStats":
 				return ec.fieldContext_Service_alertStats(ctx, field)
 			case "alertsByStatus":
@@ -9913,6 +9965,50 @@ func (ec *executionContext) fieldContext_AlertLogEntry_id(_ context.Context, fie
 	return fc, nil
 }
 
+func (ec *executionContext) _AlertLogEntry_alertID(ctx context.Context, field graphql.CollectedField, obj *alertlog.Entry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AlertLogEntry_alertID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AlertID(), nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AlertLogEntry_alertID(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AlertLogEntry",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _AlertLogEntry_timestamp(ctx context.Context, field graphql.CollectedField, obj *alertlog.Entry) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_AlertLogEntry_timestamp(ctx, field)
 	if err != nil {
@@ -10132,6 +10228,8 @@ func (ec *executionContext) fieldContext_AlertLogEntryConnection_nodes(_ context
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_AlertLogEntry_id(ctx, field)
+			case "alertID":
+				return ec.fieldContext_AlertLogEntry_alertID(ctx, field)
 			case "timestamp":
 				return ec.fieldContext_AlertLogEntry_timestamp(ctx, field)
 			case "message":
@@ -20186,6 +20284,8 @@ func (ec *executionContext) fieldContext_Mutation_createService(ctx context.Cont
 				return ec.fieldContext_Service_heartbeatMonitors(ctx, field)
 			case "notices":
 				return ec.fieldContext_Service_notices(ctx, field)
+			case "recentEvents":
+				return ec.fieldContext_Service_recentEvents(ctx, field)
 			case "alertStats":
 				return ec.fieldContext_Service_alertStats(ctx, field)
 			case "alertsByStatus":
@@ -24293,6 +24393,8 @@ func (ec *executionContext) fieldContext_Query_service(ctx context.Context, fiel
 				return ec.fieldContext_Service_heartbeatMonitors(ctx, field)
 			case "notices":
 				return ec.fieldContext_Service_notices(ctx, field)
+			case "recentEvents":
+				return ec.fieldContext_Service_recentEvents(ctx, field)
 			case "alertStats":
 				return ec.fieldContext_Service_alertStats(ctx, field)
 			case "alertsByStatus":
@@ -30220,6 +30322,67 @@ func (ec *executionContext) fieldContext_Service_notices(_ context.Context, fiel
 	return fc, nil
 }
 
+func (ec *executionContext) _Service_recentEvents(ctx context.Context, field graphql.CollectedField, obj *service.Service) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Service_recentEvents(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Service().RecentEvents(rctx, obj, fc.Args["input"].(*AlertRecentEventsOptions))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*AlertLogEntryConnection)
+	fc.Result = res
+	return ec.marshalNAlertLogEntryConnection2ᚖgithubᚗcomᚋtargetᚋgoalertᚋgraphql2ᚐAlertLogEntryConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Service_recentEvents(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Service",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "nodes":
+				return ec.fieldContext_AlertLogEntryConnection_nodes(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_AlertLogEntryConnection_pageInfo(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AlertLogEntryConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Service_recentEvents_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Service_alertStats(ctx context.Context, field graphql.CollectedField, obj *service.Service) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Service_alertStats(ctx, field)
 	if err != nil {
@@ -30400,6 +30563,8 @@ func (ec *executionContext) fieldContext_ServiceConnection_nodes(_ context.Conte
 				return ec.fieldContext_Service_heartbeatMonitors(ctx, field)
 			case "notices":
 				return ec.fieldContext_Service_notices(ctx, field)
+			case "recentEvents":
+				return ec.fieldContext_Service_recentEvents(ctx, field)
 			case "alertStats":
 				return ec.fieldContext_Service_alertStats(ctx, field)
 			case "alertsByStatus":
@@ -36794,7 +36959,7 @@ func (ec *executionContext) unmarshalInputAlertRecentEventsOptions(ctx context.C
 		asMap["after"] = ""
 	}
 
-	fieldsInOrder := [...]string{"limit", "after"}
+	fieldsInOrder := [...]string{"limit", "after", "since"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -36815,6 +36980,13 @@ func (ec *executionContext) unmarshalInputAlertRecentEventsOptions(ctx context.C
 				return it, err
 			}
 			it.After = data
+		case "since":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("since"))
+			data, err := ec.unmarshalOISOTimestamp2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Since = data
 		}
 	}
 
@@ -41622,6 +41794,11 @@ func (ec *executionContext) _AlertLogEntry(ctx context.Context, sel ast.Selectio
 			out.Values[i] = graphql.MarshalString("AlertLogEntry")
 		case "id":
 			out.Values[i] = ec._AlertLogEntry_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "alertID":
+			out.Values[i] = ec._AlertLogEntry_alertID(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -48164,6 +48341,42 @@ func (ec *executionContext) _Service(ctx context.Context, sel ast.SelectionSet, 
 					}
 				}()
 				res = ec._Service_notices(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "recentEvents":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Service_recentEvents(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/graphql2/graphqlapp/alert.go
+++ b/graphql2/graphqlapp/alert.go
@@ -479,12 +479,13 @@ func (m *Mutation) SetAlertNoiseReason(ctx context.Context, input graphql2.SetAl
 }
 
 func (a *Alert) RecentEvents(ctx context.Context, obj *alert.Alert, opts *graphql2.AlertRecentEventsOptions) (*graphql2.AlertLogEntryConnection, error) {
+	return (*App)(a).RecentAlertEvents(ctx, opts, alertlog.SearchOptions{FilterAlertIDs: []int{obj.ID}})
+}
+
+func (a *App) RecentAlertEvents(ctx context.Context, opts *graphql2.AlertRecentEventsOptions, s alertlog.SearchOptions) (*graphql2.AlertLogEntryConnection, error) {
 	if opts == nil {
 		opts = new(graphql2.AlertRecentEventsOptions)
 	}
-
-	var s alertlog.SearchOptions
-	s.FilterAlertIDs = append(s.FilterAlertIDs, obj.ID)
 
 	if opts.After != nil && *opts.After != "" {
 		err := search.ParseCursor(*opts.After, &s)

--- a/graphql2/graphqlapp/alert.go
+++ b/graphql2/graphqlapp/alert.go
@@ -499,6 +499,7 @@ func (a *Alert) RecentEvents(ctx context.Context, obj *alert.Alert, opts *graphq
 	if s.Limit == 0 {
 		s.Limit = search.DefaultMaxResults
 	}
+	s.Since = opts.Since
 
 	s.Limit++
 

--- a/graphql2/graphqlapp/service.go
+++ b/graphql2/graphqlapp/service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/target/goalert/alert/alertlog"
 	"github.com/target/goalert/assignment"
 	"github.com/target/goalert/escalation"
 	"github.com/target/goalert/gadb"
@@ -91,6 +92,10 @@ func (q *Query) Services(ctx context.Context, opts *graphql2.ServiceSearchOption
 	}
 	conn.Nodes = svcs
 	return conn, err
+}
+func (s *Service) RecentEvents(ctx context.Context, obj *service.Service, opts *graphql2.AlertRecentEventsOptions) (*graphql2.AlertLogEntryConnection, error) {
+	id := uuid.MustParse(obj.ID)
+	return (*App)(s).RecentAlertEvents(ctx, opts, alertlog.SearchOptions{FilterServiceID: &id})
 }
 
 func (s *Service) AlertStats(ctx context.Context, svc *service.Service, input *graphql2.ServiceAlertStatsOptions) (*graphql2.AlertStats, error) {

--- a/graphql2/models_gen.go
+++ b/graphql2/models_gen.go
@@ -68,8 +68,9 @@ type AlertPendingNotification struct {
 }
 
 type AlertRecentEventsOptions struct {
-	Limit *int    `json:"limit,omitempty"`
-	After *string `json:"after,omitempty"`
+	Limit *int       `json:"limit,omitempty"`
+	After *string    `json:"after,omitempty"`
+	Since *time.Time `json:"since,omitempty"`
 }
 
 type AlertSearchOptions struct {

--- a/graphql2/schema.graphql
+++ b/graphql2/schema.graphql
@@ -1044,6 +1044,7 @@ type AlertPendingNotification {
 input AlertRecentEventsOptions {
   limit: Int
   after: String = ""
+  since: ISOTimestamp
 }
 
 type AlertLogEntryConnection {
@@ -1052,7 +1053,15 @@ type AlertLogEntryConnection {
 }
 
 type AlertLogEntry {
+  """
+  The unique ID of the log entry.
+  """
   id: Int!
+
+  """
+  The ID of the alert this log entry is associated with.
+  """
+  alertID: Int!
   timestamp: ISOTimestamp!
   message: String!
   state: NotificationState
@@ -1101,6 +1110,11 @@ type Service {
   heartbeatMonitors: [HeartbeatMonitor!]!
 
   notices: [Notice!]!
+
+  """
+  Recent log entries for all alerts belonging to the service.
+  """
+  recentEvents(input: AlertRecentEventsOptions): AlertLogEntryConnection!
 }
 
 input CreateIntegrationKeyInput {

--- a/test/integration/service.spec.ts
+++ b/test/integration/service.spec.ts
@@ -121,7 +121,7 @@ test('Alerts', async ({ page, isMobile }) => {
   await createService(page, name, description)
 
   // Ensure recent events are empty
-  await expect(page.getByTestId('service-recent-events')).toHaveText(
+  await expect(page.getByTestId('service-recent-events')).toContainText(
     'No recent events in the selected time range',
   )
 
@@ -176,11 +176,15 @@ test('Alerts', async ({ page, isMobile }) => {
     await page.getByRole('link', { name, exact: true }).click()
   }
 
-  await expect(page.getByTestId('service-recent-events')).toHaveText('Created')
-  await expect(page.getByTestId('service-recent-events')).toHaveText(
+  await expect(page.getByTestId('service-recent-events')).toContainText(
+    'Created',
+  )
+  await expect(page.getByTestId('service-recent-events')).toContainText(
     'Acknowledged',
   )
-  await expect(page.getByTestId('service-recent-events')).toHaveText('Closed')
+  await expect(page.getByTestId('service-recent-events')).toContainText(
+    'Closed',
+  )
 })
 
 test('Metric', async ({ page, isMobile }) => {

--- a/test/integration/service.spec.ts
+++ b/test/integration/service.spec.ts
@@ -120,6 +120,11 @@ test('Alerts', async ({ page, isMobile }) => {
   name = 'pw-service ' + c.name()
   await createService(page, name, description)
 
+  // Ensure recent events are empty
+  await expect(page.getByTestId('service-recent-events')).toHaveText(
+    'No recent events in the selected time range',
+  )
+
   // Go to the alerts page
   await page
     .getByRole('link', {
@@ -170,6 +175,12 @@ test('Alerts', async ({ page, isMobile }) => {
   } else {
     await page.getByRole('link', { name, exact: true }).click()
   }
+
+  await expect(page.getByTestId('service-recent-events')).toHaveText('Created')
+  await expect(page.getByTestId('service-recent-events')).toHaveText(
+    'Acknowledged',
+  )
+  await expect(page.getByTestId('service-recent-events')).toHaveText('Closed')
 })
 
 test('Metric', async ({ page, isMobile }) => {

--- a/web/src/app/services/ServiceDetails.tsx
+++ b/web/src/app/services/ServiceDetails.tsx
@@ -2,7 +2,7 @@ import React, { Suspense, useState } from 'react'
 import { gql, useQuery } from 'urql'
 import { Redirect } from 'wouter'
 import _ from 'lodash'
-import { Button } from '@mui/material'
+import { Button, Grid } from '@mui/material'
 import { Edit, Delete } from '@mui/icons-material'
 
 import DetailsPage, { LinkStatus } from '../details/DetailsPage'
@@ -17,6 +17,7 @@ import { ServiceAvatar } from '../util/avatars'
 import ServiceMaintenanceModeDialog from './ServiceMaintenanceDialog'
 import ServiceNotices from './ServiceNotices'
 import type { HeartbeatMonitor, Label } from '../../schema'
+import ServiceRecentEvents from './ServiceRecentEvents'
 
 interface AlertNode {
   id: string
@@ -123,7 +124,16 @@ export default function ServiceDetails(props: {
           </React.Fragment>
         }
         details={data.service.description}
-        pageContent={<ServiceOnCallList serviceID={serviceID} />}
+        pageContent={
+          <Grid container spacing={2}>
+            <Grid item xs={12}>
+              <ServiceOnCallList serviceID={serviceID} />
+            </Grid>
+            <Grid item xs={12}>
+              <ServiceRecentEvents serviceID={serviceID} />
+            </Grid>
+          </Grid>
+        }
         primaryActions={[
           <Button
             color='primary'

--- a/web/src/app/services/ServiceRecentEvents.tsx
+++ b/web/src/app/services/ServiceRecentEvents.tsx
@@ -1,0 +1,133 @@
+import React, { useState } from 'react'
+import {
+  Card,
+  CardHeader,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+} from '@mui/material'
+import { gql, useQuery } from 'urql'
+import { GenericError } from '../error-pages'
+import CompList from '../lists/CompList'
+import { CompListItemNav } from '../lists/CompListItems'
+import { AlertLogEntry } from '../../schema'
+import { DateTime } from 'luxon'
+import { Time } from '../util/Time'
+
+const query = gql`
+  query ServiceRecentEvents($serviceID: ID!, $since: ISOTimestamp) {
+    service(id: $serviceID) {
+      id
+      recentEvents(input: { since: $since, limit: 5 }) {
+        nodes {
+          id
+          alertID
+          timestamp
+          message
+        }
+      }
+    }
+  }
+`
+
+export interface ServiceRecentEventsProps {
+  serviceID: string
+}
+
+type TimeRange = '1h' | '1d' | '1w'
+
+const timeRangeOptions = [
+  { value: '1h' as TimeRange, label: '1 hour' },
+  { value: '1d' as TimeRange, label: '1 day' },
+  { value: '1w' as TimeRange, label: '1 week' },
+]
+
+function getTimestamp(range: TimeRange): string {
+  const now = DateTime.now().startOf('minute')
+  switch (range) {
+    case '1h':
+      return now.plus({ hour: -1 }).toISO()
+    case '1d':
+      return now.plus({ day: -1 }).toISO()
+    case '1w':
+      return now.plus({ week: -1 }).toISO()
+    default:
+      throw new Error(`Unknown time range: ${range}`)
+  }
+}
+
+function formatEventMessage(entry: AlertLogEntry): string {
+  // Extract the alert ID and format a simple message
+  return `Alert ${entry.alertID}: ${entry.message}`
+}
+
+const noSuspense = {
+  suspense: false,
+}
+export default function ServiceRecentEvents({
+  serviceID,
+}: ServiceRecentEventsProps): React.JSX.Element {
+  const [timeRange, setTimeRange] = useState<TimeRange>('1h')
+
+  const [{ data, error, fetching }] = useQuery({
+    query,
+    variables: {
+      serviceID,
+      since: getTimestamp(timeRange),
+    },
+    context: noSuspense,
+  })
+
+  const handleTimeRangeChange = (event: SelectChangeEvent<TimeRange>): void => {
+    setTimeRange(event.target.value as TimeRange)
+  }
+
+  if (error) {
+    return <GenericError error={error.message} />
+  }
+
+  const events = data?.service?.recentEvents?.nodes || []
+
+  return (
+    <Card>
+      <CardHeader
+        title='Most recent events'
+        action={
+          <FormControl size='small' sx={{ minWidth: 120 }}>
+            <InputLabel>Time Range</InputLabel>
+            <Select
+              value={timeRange}
+              label='Time Range'
+              onChange={handleTimeRangeChange}
+            >
+              {timeRangeOptions.map((option) => (
+                <MenuItem key={option.value} value={option.value}>
+                  {option.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        }
+      />
+      <CompList
+        data-cy='service-recent-events'
+        emptyMessage={
+          fetching
+            ? 'Loading events...'
+            : 'No recent events in the selected time range'
+        }
+      >
+        {events.map((event: AlertLogEntry) => (
+          <CompListItemNav
+            key={event.id}
+            title={formatEventMessage(event)}
+            subText={<Time time={event.timestamp} format='relative' />}
+            url={`/alerts/${event.alertID}`}
+          />
+        ))}
+      </CompList>
+    </Card>
+  )
+}

--- a/web/src/app/services/ServiceRecentEvents.tsx
+++ b/web/src/app/services/ServiceRecentEvents.tsx
@@ -91,7 +91,7 @@ export default function ServiceRecentEvents({
   const events = data?.service?.recentEvents?.nodes || []
 
   return (
-    <Card>
+    <Card data-testid='service-recent-events'>
       <CardHeader
         title='Most recent events'
         action={

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -39,6 +39,7 @@ export interface AlertDataPoint {
 }
 
 export interface AlertLogEntry {
+  alertID: number
   id: number
   message: string
   messageID?: null | string
@@ -80,6 +81,7 @@ export interface AlertPendingNotification {
 export interface AlertRecentEventsOptions {
   after?: null | string
   limit?: null | number
+  since?: null | ISOTimestamp
 }
 
 export interface AlertSearchOptions {
@@ -1078,6 +1080,7 @@ export interface Service {
   name: string
   notices: Notice[]
   onCallUsers: ServiceOnCallUser[]
+  recentEvents: AlertLogEntryConnection
 }
 
 export interface ServiceAlertStatsOptions {


### PR DESCRIPTION
**Description:**
Adds a `Recent Events` section to the service details page that shows the 5 most recent events from the alert log (any alert owned by the service).

This is intended to help debugging issues, especially "duplicate suppressed" messages which would previously require the user to open all active alerts and look at their individual logs.

- Note: the log entries are clickable and take you to the alert

**Screenshots:**
<img width="1296" height="995" alt="image" src="https://github.com/user-attachments/assets/4ad4ee67-586e-476e-99dd-652868c1d756" />

**Describe any introduced user-facing changes:**
- New section under the on-call card on the service details page

**Describe any introduced API changes:**
- `recentEvents` under `Service` with the same types/functionality as the one under `Alert` (but limited to a single service ID instead of alert ID)
