### PR TITLE
engine/schedulemanager: refactor schedule calculation for maintainability and job queue migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ postgres:
 		--name goalert-postgres \
 		--shm-size 1g \
 		-p 5432:5432 \
-		docker.io/library/postgres:$(PG_VERSION)-alpine && $(WAITFOR) "$(DB_URL)" && make regendb) || ($(CONTAINER_TOOL) start goalert-postgres && $(WAITFOR) "$(DB_URL)")
+		docker.io/library/postgres:$(PG_VERSION)-alpine postgres -N 500 && $(WAITFOR) "$(DB_URL)" && make regendb) || ($(CONTAINER_TOOL) start goalert-postgres && $(WAITFOR) "$(DB_URL)")
 
 regendb: bin/goalert config.json.bak ## Reset the database and fill it with random data
 	go tool resetdb -with-rand-data -admin-id=00000000-0000-0000-0000-000000000001 -mult $(SIZE)

--- a/dataloader/fetcher_test.go
+++ b/dataloader/fetcher_test.go
@@ -3,6 +3,7 @@ package dataloader
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -64,13 +65,16 @@ func TestFetcher_FetchOne_Extra(t *testing.T) {
 func TestFetcher_MaxBatch(t *testing.T) {
 	type example struct{ ID string }
 
+	var mx sync.Mutex
 	var batchSizes []int
 	l := &Fetcher[string, example]{
 		MaxBatch: 3,
 		Delay:    time.Millisecond,
 		IDFunc:   func(v example) string { return v.ID },
 		FetchFunc: func(ctx context.Context, ids []string) ([]example, error) {
+			mx.Lock()
 			batchSizes = append(batchSizes, len(ids))
+			mx.Unlock()
 			var results []example
 			for _, id := range ids {
 				results = append(results, example{ID: id})

--- a/engine/schedulemanager/calcupdates.go
+++ b/engine/schedulemanager/calcupdates.go
@@ -19,7 +19,7 @@ type updateInfo struct {
 	ScheduleData    schedule.Data
 	CurrentOnCall   mapset.Set[uuid.UUID]
 	Rules           []gadb.SchedMgrRulesRow
-	Overrides       []gadb.SchedMgrOverridesRow
+	ActiveOverrides []gadb.SchedMgrOverridesRow
 }
 
 type updateResult struct {
@@ -44,7 +44,7 @@ func (info updateInfo) calcLatestOnCall(now time.Time) mapset.Set[uuid.UUID] {
 		}
 	}
 
-	for _, o := range info.Overrides {
+	for _, o := range info.ActiveOverrides {
 		if o.RemoveUserID.Valid {
 			if !newOnCall.Contains(o.RemoveUserID.UUID) {
 				// if the user to be removed is not currently on-call, skip

--- a/engine/schedulemanager/calcupdates.go
+++ b/engine/schedulemanager/calcupdates.go
@@ -108,11 +108,7 @@ func (info updateInfo) calcUpdates(now time.Time) (*updateResult, error) {
 
 	if dataNeedsUpdate {
 		info.ScheduleData.V1.OnCallNotificationRules = newRules
-		data, err := json.Marshal(info.ScheduleData)
-		if err != nil {
-			return nil, fmt.Errorf("marshal schedule data: %w", err)
-		}
-		jsonData, err := jsonutil.Apply(info.RawScheduleData, data)
+		jsonData, err := jsonutil.Apply(info.RawScheduleData, info.ScheduleData)
 		if err != nil {
 			return nil, fmt.Errorf("apply schedule data: %w", err)
 		}

--- a/engine/schedulemanager/calcupdates.go
+++ b/engine/schedulemanager/calcupdates.go
@@ -63,6 +63,9 @@ func (info updateInfo) calcLatestOnCall(now time.Time) mapset.Set[uuid.UUID] {
 }
 
 func (info updateInfo) calcUpdates(now time.Time) (*updateResult, error) {
+	if info.CurrentOnCall == nil {
+		info.CurrentOnCall = mapset.NewThreadUnsafeSet[uuid.UUID]()
+	}
 	result := updateResult{
 		ScheduleID: info.ScheduleID,
 		// since we do this in a single thread, we can use a thread-unsafe set and avoid the cost of locking

--- a/engine/schedulemanager/calcupdates.go
+++ b/engine/schedulemanager/calcupdates.go
@@ -1,0 +1,119 @@
+package schedulemanager
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/google/uuid"
+	"github.com/target/goalert/gadb"
+	"github.com/target/goalert/schedule"
+	"github.com/target/goalert/util/jsonutil"
+)
+
+type updateInfo struct {
+	ScheduleID      uuid.UUID
+	TimeZone        *time.Location
+	RawScheduleData json.RawMessage
+	ScheduleData    schedule.Data
+	CurrentOnCall   mapset.Set[uuid.UUID]
+	Rules           []gadb.SchedMgrRulesRow
+	Overrides       []gadb.SchedMgrOverridesRow
+}
+
+type updateResult struct {
+	ScheduleID           uuid.UUID
+	UsersToStart         mapset.Set[uuid.UUID]
+	UsersToStop          mapset.Set[uuid.UUID]
+	NewRawScheduleData   json.RawMessage       // no update necessary if nil
+	NotificationChannels mapset.Set[uuid.UUID] // channels to notify, empty if no notifications
+}
+
+func (info updateInfo) calcLatestOnCall(now time.Time) mapset.Set[uuid.UUID] {
+	if isActive, users := info.ScheduleData.TempOnCall(now); isActive {
+		// temporary schedule config takes precedence over anything else and makes this easy
+		// we use a thread-unsafe set here to avoid the cost of locking since this is only called in a single thread
+		return mapset.NewThreadUnsafeSet(users...)
+	}
+	now = now.In(info.TimeZone)
+	newOnCall := mapset.NewThreadUnsafeSet[uuid.UUID]()
+	for _, r := range info.Rules {
+		if ruleRowIsActive(r, now) {
+			newOnCall.Add(r.ResolvedUserID)
+		}
+	}
+
+	for _, o := range info.Overrides {
+		switch {
+		case o.AddUserID.Valid && o.RemoveUserID.Valid: // replace
+			if !newOnCall.Contains(o.RemoveUserID.UUID) {
+				break // if the user to be removed is not currently on-call, skip
+			}
+			newOnCall.Remove(o.RemoveUserID.UUID)
+			newOnCall.Add(o.AddUserID.UUID)
+		case o.AddUserID.Valid: // add
+			newOnCall.Add(o.AddUserID.UUID)
+		case o.RemoveUserID.Valid: // remove
+			newOnCall.Remove(o.RemoveUserID.UUID)
+		}
+	}
+
+	return newOnCall
+}
+
+func (info updateInfo) calcUpdates(now time.Time) (*updateResult, error) {
+	result := updateResult{
+		ScheduleID: info.ScheduleID,
+		// since we do this in a single thread, we can use a thread-unsafe set and avoid the cost of locking
+		UsersToStart:         mapset.NewThreadUnsafeSet[uuid.UUID](),
+		UsersToStop:          mapset.NewThreadUnsafeSet[uuid.UUID](),
+		NotificationChannels: mapset.NewThreadUnsafeSet[uuid.UUID](),
+	}
+	now = now.In(info.TimeZone)
+
+	newOnCall := info.calcLatestOnCall(now)
+	onCallChanged := !newOnCall.Equal(info.CurrentOnCall)
+	if onCallChanged {
+		result.UsersToStart = info.CurrentOnCall.Difference(newOnCall)
+		result.UsersToStop = newOnCall.Difference(info.CurrentOnCall)
+	}
+
+	var dataNeedsUpdate bool
+	newRules := make([]schedule.OnCallNotificationRule, len(info.ScheduleData.V1.OnCallNotificationRules))
+	// we copy the rules to avoid modifying the original slice
+	copy(newRules, info.ScheduleData.V1.OnCallNotificationRules)
+	for i, r := range newRules {
+		if r.Time == nil { // if time is not set, then it is a "when schedule changes" rule
+			if onCallChanged {
+				result.NotificationChannels.Add(r.ChannelID)
+			}
+			continue
+		}
+		if r.NextNotification != nil && !r.NextNotification.After(now) {
+			result.NotificationChannels.Add(r.ChannelID)
+		}
+		newTime := nextOnCallNotification(now, r)
+		if equalTimePtr(r.NextNotification, newTime) {
+			// no change, skip
+			continue
+		}
+		dataNeedsUpdate = true
+		newRules[i].NextNotification = newTime
+	}
+
+	if dataNeedsUpdate {
+		info.ScheduleData.V1.OnCallNotificationRules = newRules
+		data, err := json.Marshal(info.ScheduleData)
+		if err != nil {
+			return nil, fmt.Errorf("marshal schedule data: %w", err)
+		}
+		jsonData, err := jsonutil.Apply(info.RawScheduleData, data)
+		if err != nil {
+			return nil, fmt.Errorf("apply schedule data: %w", err)
+		}
+		result.NewRawScheduleData = jsonData
+	}
+
+	return &result, nil
+}

--- a/engine/schedulemanager/calcupdates_test.go
+++ b/engine/schedulemanager/calcupdates_test.go
@@ -14,12 +14,11 @@ import (
 )
 
 func TestUpdateInfo_calcUpdates_NotifyOnChange(t *testing.T) {
-	channelID := uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+	channelID1 := uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+	channelID2 := uuid.MustParse("123e4567-e89b-12d3-a456-426614174001")
 	var sData schedule.Data
 	sData.V1.OnCallNotificationRules = []schedule.OnCallNotificationRule{
-		{
-			ChannelID: channelID,
-		},
+		{ChannelID: channelID1}, {ChannelID: channelID2},
 	}
 	data, err := json.Marshal(sData)
 	require.NoError(t, err)
@@ -35,7 +34,7 @@ func TestUpdateInfo_calcUpdates_NotifyOnChange(t *testing.T) {
 
 	result, err := info.calcUpdates(time.Now())
 	require.NoError(t, err)
-	require.EqualValues(t, []uuid.UUID{channelID}, result.NotificationChannels.ToSlice())
+	require.EqualValues(t, []uuid.UUID{channelID1, channelID2}, result.NotificationChannels.ToSlice())
 }
 
 func TestUpdateInfo_calcUpdates_NotifyAtTime(t *testing.T) {

--- a/engine/schedulemanager/calcupdates_test.go
+++ b/engine/schedulemanager/calcupdates_test.go
@@ -1,0 +1,90 @@
+package schedulemanager
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/gadb"
+	"github.com/target/goalert/schedule"
+	"github.com/target/goalert/util/timeutil"
+)
+
+func TestUpdateInfo_calcUpdates_NotifyOnChange(t *testing.T) {
+	channelID := uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+	var sData schedule.Data
+	sData.V1.OnCallNotificationRules = []schedule.OnCallNotificationRule{
+		{
+			ChannelID: channelID,
+		},
+	}
+	data, err := json.Marshal(sData)
+	require.NoError(t, err)
+	info := updateInfo{
+		ScheduleID:      uuid.New(),
+		TimeZone:        time.UTC,
+		RawScheduleData: data,
+		ScheduleData:    sData,
+		CurrentOnCall:   mapset.NewThreadUnsafeSet(uuid.New()), // no rules, so no longer on-call
+		Rules:           []gadb.SchedMgrRulesRow{},
+		ActiveOverrides: []gadb.SchedMgrOverridesRow{},
+	}
+
+	result, err := info.calcUpdates(time.Now())
+	require.NoError(t, err)
+	require.EqualValues(t, []uuid.UUID{channelID}, result.NotificationChannels.ToSlice())
+}
+
+func TestUpdateInfo_calcUpdates_NotifyAtTime(t *testing.T) {
+	channelID := uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+	var sData schedule.Data
+	everyDay := timeutil.EveryDay()
+	at9am := timeutil.NewClock(9, 0)
+	nextRun := time.Date(2023, 10, 1, 9, 0, 0, 0, time.UTC)
+	sData.V1.OnCallNotificationRules = []schedule.OnCallNotificationRule{
+		{
+			ChannelID:        channelID,
+			NextNotification: &nextRun,
+			WeekdayFilter:    &everyDay,
+			Time:             &at9am,
+		},
+	}
+	data, err := json.Marshal(sData)
+	require.NoError(t, err)
+	info := updateInfo{
+		ScheduleID:      uuid.New(),
+		TimeZone:        time.UTC,
+		RawScheduleData: data,
+		ScheduleData:    sData,
+		CurrentOnCall:   mapset.NewThreadUnsafeSet[uuid.UUID](),
+		Rules:           []gadb.SchedMgrRulesRow{},
+		ActiveOverrides: []gadb.SchedMgrOverridesRow{},
+	}
+
+	result, err := info.calcUpdates(nextRun.Add(-1 * time.Hour))
+	require.NoError(t, err)
+	require.Empty(t, result.NotificationChannels.ToSlice()) // 8 am, no notification yet
+
+	require.Empty(t, result.NewRawScheduleData) // no update necessary
+
+	result, err = info.calcUpdates(nextRun)
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{channelID}, result.NotificationChannels.ToSlice())
+
+	var expected schedule.Data
+	expectedNext := nextRun.AddDate(0, 0, 1)
+	expected.V1.OnCallNotificationRules = []schedule.OnCallNotificationRule{
+		{
+			ChannelID:        channelID,
+			NextNotification: &expectedNext,
+			WeekdayFilter:    &everyDay,
+			Time:             &at9am,
+		},
+	}
+	expectedData, err := json.Marshal(expected)
+	require.NoError(t, err)
+	require.JSONEq(t, string(expectedData), string(result.NewRawScheduleData))
+}

--- a/engine/schedulemanager/update.go
+++ b/engine/schedulemanager/update.go
@@ -21,6 +21,45 @@ import (
 	"github.com/target/goalert/util/timeutil"
 )
 
+type set[T comparable] map[T]struct{}
+
+func (s set[T]) Add(v T) {
+	if s == nil {
+		s = make(set[T])
+	}
+	s[v] = struct{}{}
+}
+func (s set[T]) Has(v T) bool {
+	if s == nil {
+		return false
+	}
+	_, ok := s[v]
+	return ok
+}
+func (s set[T]) MissingFrom(other set[T]) set[T] {
+	if s == nil {
+		return other
+	}
+	if other == nil {
+		return nil
+	}
+
+	missing := make(set[T])
+	for v := range other {
+		if !s.Has(v) {
+			missing.Add(v)
+		}
+	}
+	return missing
+}
+
+type updateInfo struct {
+	ScheduleID    uuid.UUID
+	TimeZone      time.Location
+	ScheduleData  schedule.Data
+	OnCallUserIDs set[uuid.UUID]
+}
+
 // UpdateAll will update all schedule rules.
 func (db *DB) UpdateAll(ctx context.Context) error {
 	err := permission.LimitCheckAny(ctx, permission.System)

--- a/engine/schedulemanager/update.go
+++ b/engine/schedulemanager/update.go
@@ -175,7 +175,7 @@ updateLoop:
 			continue
 		}
 
-		for userID := range result.UsersToStart.Each {
+		for _, userID := range result.UsersToStart.ToSlice() {
 			err = q.SchedMgrStartOnCall(ctx, gadb.SchedMgrStartOnCallParams{
 				ScheduleID: info.ScheduleID,
 				UserID:     userID,
@@ -189,7 +189,7 @@ updateLoop:
 				return errors.Wrapf(err, "record shift start for user %s on schedule %s", userID, info.ScheduleID)
 			}
 		}
-		for userID := range result.UsersToStop.Each {
+		for _, userID := range result.UsersToStop.ToSlice() {
 			err = q.SchedMgrEndOnCall(ctx, gadb.SchedMgrEndOnCallParams{
 				ScheduleID: info.ScheduleID,
 				UserID:     userID,
@@ -215,7 +215,7 @@ updateLoop:
 			}
 		}
 
-		for chanID := range result.NotificationChannels.Each {
+		for _, chanID := range result.NotificationChannels.ToSlice() {
 			err = q.SchedMgrInsertMessage(ctx, gadb.SchedMgrInsertMessageParams{
 				ID:         uuid.New(),
 				ChannelID:  uuid.NullUUID{UUID: chanID, Valid: true},

--- a/engine/schedulemanager/update.go
+++ b/engine/schedulemanager/update.go
@@ -175,7 +175,7 @@ updateLoop:
 			continue
 		}
 
-		for _, userID := range result.UsersToStart.ToSlice() {
+		for userID := range mapset.Elements(result.UsersToStart) {
 			err = q.SchedMgrStartOnCall(ctx, gadb.SchedMgrStartOnCallParams{
 				ScheduleID: info.ScheduleID,
 				UserID:     userID,
@@ -189,7 +189,7 @@ updateLoop:
 				return errors.Wrapf(err, "record shift start for user %s on schedule %s", userID, info.ScheduleID)
 			}
 		}
-		for _, userID := range result.UsersToStop.ToSlice() {
+		for userID := range mapset.Elements(result.UsersToStop) {
 			err = q.SchedMgrEndOnCall(ctx, gadb.SchedMgrEndOnCallParams{
 				ScheduleID: info.ScheduleID,
 				UserID:     userID,
@@ -215,7 +215,7 @@ updateLoop:
 			}
 		}
 
-		for _, chanID := range result.NotificationChannels.ToSlice() {
+		for chanID := range mapset.Elements(result.NotificationChannels) {
 			err = q.SchedMgrInsertMessage(ctx, gadb.SchedMgrInsertMessageParams{
 				ID:         uuid.New(),
 				ChannelID:  uuid.NullUUID{UUID: chanID, Valid: true},

--- a/engine/schedulemanager/update.go
+++ b/engine/schedulemanager/update.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/target/goalert/gadb"
@@ -103,7 +104,8 @@ func (db *DB) update(ctx context.Context) error {
 			return info
 		}
 		info := &updateInfo{
-			ScheduleID: schedID,
+			ScheduleID:    schedID,
+			CurrentOnCall: mapset.NewThreadUnsafeSet[uuid.UUID](),
 		}
 		updateData[schedID] = info
 		return info

--- a/engine/schedulemanager/update.go
+++ b/engine/schedulemanager/update.go
@@ -135,7 +135,7 @@ func (db *DB) update(ctx context.Context) error {
 	}
 	for _, o := range overrides {
 		info := getInfo(o.TgtScheduleID)
-		info.Overrides = append(info.Overrides, o)
+		info.ActiveOverrides = append(info.ActiveOverrides, o)
 	}
 
 	rules, err := q.SchedMgrRules(ctx)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.14.1
 	github.com/creack/pty/v2 v2.0.1
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
+	github.com/deckarep/golang-set/v2 v2.8.0
 	github.com/emersion/go-smtp v0.23.0
 	github.com/expr-lang/expr v1.17.5
 	github.com/fatih/color v1.18.0
@@ -112,8 +113,6 @@ require (
 	github.com/curioswitch/go-reassign v0.3.0 // indirect
 	github.com/daixiang0/gci v0.13.6 // indirect
 	github.com/dave/dst v0.27.3 // indirect
-	github.com/deckarep/golang-set v1.8.0 // indirect
-	github.com/deckarep/golang-set/v2 v2.8.0 // indirect
 	github.com/denis-tingaikin/go-header v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -112,6 +112,8 @@ require (
 	github.com/curioswitch/go-reassign v0.3.0 // indirect
 	github.com/daixiang0/gci v0.13.6 // indirect
 	github.com/dave/dst v0.27.3 // indirect
+	github.com/deckarep/golang-set v1.8.0 // indirect
+	github.com/deckarep/golang-set/v2 v2.8.0 // indirect
 	github.com/denis-tingaikin/go-header v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,10 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set v1.8.0 h1:sk9/l/KqpunDwP7pSjUg0keiOOLEnOBHzykLrsPppp4=
+github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS383rP6+o6qqo=
+github.com/deckarep/golang-set/v2 v2.8.0 h1:swm0rlPCmdWn9mESxKOjWk8hXSqoxOp+ZlfuyaAdFlQ=
+github.com/deckarep/golang-set/v2 v2.8.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/denis-tingaikin/go-header v0.5.0 h1:SRdnP5ZKvcO9KKRP1KJrhFR3RrlGuD+42t4429eC9k8=
 github.com/denis-tingaikin/go-header v0.5.0/go.mod h1:mMenU5bWrok6Wl2UsZjy+1okegmwQ3UgWl4V1D8gjlY=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deckarep/golang-set v1.8.0 h1:sk9/l/KqpunDwP7pSjUg0keiOOLEnOBHzykLrsPppp4=
-github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS383rP6+o6qqo=
 github.com/deckarep/golang-set/v2 v2.8.0 h1:swm0rlPCmdWn9mESxKOjWk8hXSqoxOp+ZlfuyaAdFlQ=
 github.com/deckarep/golang-set/v2 v2.8.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/denis-tingaikin/go-header v0.5.0 h1:SRdnP5ZKvcO9KKRP1KJrhFR3RrlGuD+42t4429eC9k8=

--- a/test/smoke/harness/email.go
+++ b/test/smoke/harness/email.go
@@ -52,7 +52,7 @@ func isListening(addr string) bool {
 }
 
 func newEmailServer(h *Harness) *emailServer {
-	mp := newMailpit(h.t, 5)
+	mp := newMailpit(h.t)
 
 	h.t.Logf("mailpit: smtp: %s", mp.smtpAddr)
 	h.t.Logf("mailpit: api: %s", mp.apiAddr)

--- a/test/smoke/harness/harness.go
+++ b/test/smoke/harness/harness.go
@@ -181,7 +181,7 @@ func NewStoppedHarnessWithFlags(t *testing.T, initSQL string, sqlData interface{
 	t.Logf("Using DB URL: %s", dbURL)
 	name := strings.ReplaceAll("smoketest_"+time.Now().Format("2006_01_02_15_04_05")+uuid.New().String(), "-", "")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
 	conn, err := pgx.Connect(ctx, DBURL(""))
@@ -314,7 +314,7 @@ func (h *Harness) StartWithAppCfgHook(fn func(*app.Config)) {
 	appCfg.JSON = true
 	appCfg.DBURL = h.dbURL
 	appCfg.TwilioBaseURL = h.twS.URL
-	appCfg.DBMaxOpen = 3
+	appCfg.DBMaxOpen = 5
 	appCfg.SlackBaseURL = h.slackS.URL
 	appCfg.SMTPListenAddr = "localhost:0"
 	appCfg.EmailIntegrationDomain = "smoketest.example.com"
@@ -333,7 +333,7 @@ func (h *Harness) StartWithAppCfgHook(fn func(*app.Config)) {
 	if err != nil {
 		h.t.Fatalf("failed to parse db url: %v", err)
 	}
-	poolCfg.MaxConns = 3
+	poolCfg.MaxConns = 5
 
 	h.appPool, err = pgxpool.NewWithConfig(ctx, poolCfg)
 	require.NoError(h.t, err, "create pgx pool")

--- a/test/smoke/harness/mailpit_test.go
+++ b/test/smoke/harness/mailpit_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewMailpit(t *testing.T) {
-	mp := newMailpit(t, 5)
+	mp := newMailpit(t)
 
 	err := smtp.SendMail(mp.smtpAddr, nil, "example@example.com", []string{"foo@bar.com"}, []byte("Subject: Hello\nTo: foo@bar.com\n\nWorld!"))
 	require.NoError(t, err, "expected to be able to send email")

--- a/test/smoke/harness/slack.go
+++ b/test/smoke/harness/slack.go
@@ -309,7 +309,7 @@ func (ch *slackChannel) expectMessageFunc(desc string, test func(mockslack.Messa
 			return true
 		}
 		return false
-	}, 30*time.Second, time.Second, "expected to find Slack %s: Channel=%s; ID=%s; keywords=%v", desc, ch.name, ch.id, keywords)
+	}, 30*time.Second, 100*time.Millisecond, "expected to find Slack %s: Channel=%s; ID=%s; keywords=%v", desc, ch.name, ch.id, keywords)
 	return found
 }
 

--- a/test/smoke/harness/slack.go
+++ b/test/smoke/harness/slack.go
@@ -276,6 +276,7 @@ func (ch *slackChannel) ExpectEphemeralMessage(keywords ...string) SlackMessage 
 		return msg.ToUserID != ""
 	}, keywords...)
 }
+
 func containsAllKeywords(text string, keywords ...string) bool {
 	for _, w := range keywords {
 		if !strings.Contains(text, w) {
@@ -288,8 +289,8 @@ func containsAllKeywords(text string, keywords ...string) bool {
 func (ch *slackChannel) expectMessageFunc(desc string, test func(mockslack.Message) bool, keywords ...string) (found *slackMessage) {
 	ch.h.t.Helper()
 
-	ch.h.Trigger()
 	require.Eventually(ch.h.t, func() bool {
+		ch.h.Trigger()
 		for _, msg := range ch.h.slack.Messages(ch.id) {
 			if !test(msg) {
 				continue


### PR DESCRIPTION
**Description:**
This PR updates the schedule manager to:
- reactors logic to focus on a single schedule at a time, greatly simplifying the flow
- separates fetching data from calculating desired state, in prep for job queue migration
- fixes a few flaky test issues

**Which issue(s) this PR fixes:**
Part of #4245

**Describe any introduced user-facing changes:**
N/A

**Describe any introduced API changes:**
N/A
