### PR TITLE
fix various HTTP response codes

### DIFF
--- a/genericapi/handler.go
+++ b/genericapi/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/target/goalert/permission"
 	"github.com/target/goalert/retry"
 	"github.com/target/goalert/util/errutil"
+	"github.com/target/goalert/validation"
 	"github.com/target/goalert/validation/validate"
 )
 
@@ -100,7 +101,7 @@ func (h *Handler) ServeCreateAlert(w http.ResponseWriter, r *http.Request) {
 			Meta                            map[string]string
 		}
 		err = json.Unmarshal(data, &b)
-		if errutil.HTTPError(ctx, w, err) {
+		if errutil.HTTPError(ctx, w, validation.WrapError(err)) {
 			return
 		}
 

--- a/genericapi/handler.go
+++ b/genericapi/handler.go
@@ -91,8 +91,7 @@ func (h *Handler) ServeCreateAlert(w http.ResponseWriter, r *http.Request) {
 	ct, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 	if ct == "application/json" {
 		data, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+		if errutil.HTTPError(ctx, w, err) {
 			return
 		}
 
@@ -101,8 +100,7 @@ func (h *Handler) ServeCreateAlert(w http.ResponseWriter, r *http.Request) {
 			Meta                            map[string]string
 		}
 		err = json.Unmarshal(data, &b)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+		if errutil.HTTPError(ctx, w, err) {
 			return
 		}
 

--- a/test/smoke/maxbodyresponse_test.go
+++ b/test/smoke/maxbodyresponse_test.go
@@ -1,0 +1,57 @@
+package smoke
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/test/smoke/harness"
+)
+
+func TestMaxBodyResponse(t *testing.T) {
+	t.Parallel()
+
+	const sql = `
+	insert into escalation_policies (id, name)
+	values
+		({{uuid "eid"}}, 'esc policy');
+
+	insert into services (id, escalation_policy_id, name)
+	values
+		({{uuid "sid"}}, {{uuid "eid"}}, 'service');
+
+	insert into integration_keys (id, type, name, service_id)
+	values
+		({{uuid "int_key"}}, 'generic', 'my key', {{uuid "sid"}});
+	`
+
+	h := harness.NewHarness(t, sql, "add-generic-integration-key")
+	defer h.Close()
+
+	u := h.URL() + "/v1/api/alerts?key=" + h.UUID("int_key")
+
+	// Create a 1MB payload (1024 * 1024 bytes = 1MB)
+	// This exceeds the default 256KB limit
+	largePayload := strings.Repeat("x", 1024*1024)
+	payload := `{"summary": "large payload", "details": "` + largePayload + `"}`
+
+	resp, err := http.Post(u, "application/json", bytes.NewBufferString(payload))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Should get 413 Request Entity Too Large
+	// Let's first check what we actually got and the response body for debugging
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	t.Logf("Status Code: %d, Body: %s", resp.StatusCode, string(body))
+
+	require.Equal(t, 413, resp.StatusCode, "expected 413 Request Entity Too Large")
+
+	bodyStr := string(body)
+	require.Contains(t, bodyStr, "Request Entity Too Large")
+	require.Contains(t, bodyStr, "max body:")
+}

--- a/util/errutil/httperror.go
+++ b/util/errutil/httperror.go
@@ -71,7 +71,7 @@ func HTTPError(ctx context.Context, w http.ResponseWriter, err error) bool {
 		// Similar to above, but that we timed out waiting in the queue.
 		http.Error(w, http.StatusText(http.StatusRequestTimeout), http.StatusRequestTimeout)
 	case isCancel(err):
-		// Client disconnected, send 400 back so logs reflect that this
+		// Client disconnected, send 499 back so logs reflect that this
 		// was a client-side problem.
 		http.Error(w, "Client disconnected.", 499)
 	case permission.IsUnauthorized(err):

--- a/util/errutil/httperror.go
+++ b/util/errutil/httperror.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/target/goalert/ctxlock"
@@ -49,26 +50,30 @@ func HTTPError(ctx context.Context, w http.ResponseWriter, err error) bool {
 	}
 
 	err = MapDBError(err)
+	var bodyLimit *http.MaxBytesError
 	switch {
-	case errors.Is(err, ctxlock.ErrQueueFull), errors.Is(err, ctxlock.ErrTimeout), IsLimitError(err):
-		// Either the queue is full or the lock timed out. Either way
-		// we are waiting on concurrent requests for this source, so
-		// send them back with a 429 because we are rate limiting them
-		// due to being at/beyond capacity.
+	case errors.As(err, &bodyLimit):
+		http.Error(w, fmt.Sprintf("%s (max body: %v bytes)", http.StatusText(http.StatusRequestEntityTooLarge), bodyLimit.Limit), http.StatusRequestEntityTooLarge)
+	case errors.Is(err, ctxlock.ErrQueueFull):
+		// The queue is full meaning we have over 100 requests from the
+		// same source.
 		//
 		// Because of the way the lock works, we can guarantee that
 		// we will process one request at a time (per source), but we
 		// may have to wait for a previous request to finish before we
 		// can start processing the next one.
 		//
-		// This means only concurrent requests (per process) have the
-		// possibility to be rate limited, and not sequential requests,
+		// This means only concurrent requests (per process/per key) have
+		// the possibility to be rate limited, and not sequential requests,
 		// even in the worst case scenario.
-		http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+		http.Error(w, "Too many concurrent requests for this key or session", http.StatusTooManyRequests)
+	case errors.Is(err, ctxlock.ErrTimeout):
+		// Similar to above, but that we timed out waiting in the queue.
+		http.Error(w, http.StatusText(http.StatusRequestTimeout), http.StatusRequestTimeout)
 	case isCancel(err):
 		// Client disconnected, send 400 back so logs reflect that this
 		// was a client-side problem.
-		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		http.Error(w, "Client disconnected.", 499)
 	case permission.IsUnauthorized(err):
 		http.Error(w, unwrapAll(err).Error(), http.StatusUnauthorized)
 	case permission.IsPermissionError(err):


### PR DESCRIPTION
**Description:**
Fixes various incorrect status code responses
- Hitting a limit (like too many unacked alerts) now correctly responds with [409 Conflict](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/409) fixing a regression.
- Body size limit errors now respond with [413 Content Too Large](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/413)
- Aborted/disconnected requests will be sent a 499 to distinguish from 400
- Requests in the queue that timeout will now get [408 Request Timeout](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/408) (as opposed to the [429 Too Many Requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/429) when the queue is full)

Also a test was added for the body size limit, as prior to this change they would incorrectly result in 500 errors.

