### PR TITLE
Allow multiple user selection in Temp Schedules

### DIFF
--- a/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedAddNewShift.tsx
@@ -171,7 +171,7 @@ export default function TempSchedAddNewShift({
               label='Select Users'
               multiple
               value={selectedUsers}
-              name="userID"
+              name='userID'
               onChange={(newValue: string[]) => setSelectedUsers(newValue)}
             />
           </Grid>


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Please include a description of the proposed changes.
Currently, temporary schedules allow selecting only one user at a time. However, there are situations where multiple people need to be included in the same schedule. This change enables that capability.
**Which issue(s) this PR fixes:**
Fixes #4422 


**Screenshot:**
<img width="894" height="694" alt="Screenshot 2025-10-27 at 9 19 51 PM" src="https://github.com/user-attachments/assets/70a224cc-4a20-4dd1-a186-ac12c3754f19" />


