### PR TITLE
fixed daily rotation participation distribution for schedules with day restrictions

### DIFF
--- a/oncall/singlerulecalculator.go
+++ b/oncall/singlerulecalculator.go
@@ -63,32 +63,11 @@ func (t *TimeIterator) NewSingleRuleCalculator(loc *time.Location, rule Resolved
 			rotCopy := *rule.Rotation
 			rotCopy.Users = append([]string{}, rule.Rotation.Users...)
 
-			// For daily rotations with day restrictions, we need to pause the rotation
+			// for daily rotations with day restrictions, we need to pause the rotation
 			// on inactive days to ensure fair distribution (otherwise some participants
 			// would never appear if their turn always falls on inactive days).
 			if !rule.IsAlways() && rotCopy.Type == rotation.TypeDaily {
-				// For daily rotation with day restrictions, advance position per active day
-				activeStart := rule.StartTime(t.Start().In(loc))
-				currentIndex := rotCopy.CurrentIndex
-
-				for activeStart.Before(t.End()) && limit() {
-					activeEnd := rule.EndTime(activeStart)
-					if activeEnd.After(t.End()) {
-						activeEnd = t.End()
-					}
-
-					userID := rotCopy.Users[currentIndex%len(rotCopy.Users)]
-					calc.rot.SetSpan(activeStart, activeEnd, userID)
-
-					currentIndex++
-
-					nextActiveStart := rule.StartTime(activeEnd)
-					if nextActiveStart.Equal(activeEnd) || nextActiveStart.Before(activeEnd) {
-						break
-					}
-
-					activeStart = nextActiveStart
-				}
+				calc.setDailyRotationSpans(rotCopy, rule, loc, limit)
 			} else {
 				cur := t.Start().In(loc)
 				// loop through rotations
@@ -136,3 +115,64 @@ func (rCalc *SingleRuleCalculator) ActiveUser() string { return rCalc.userID }
 
 // Changed will return true if the ActiveUser has changed this tick.
 func (rCalc *SingleRuleCalculator) Changed() bool { return rCalc.changed }
+
+// setDailyRotationSpans calculates rotation spans for daily rotations with weekday/time restrictions.
+// It counts active days from the rotation origin to ensure consistent user assignment across query windows.
+func (calc *SingleRuleCalculator) setDailyRotationSpans(rot ResolvedRotation, rule ResolvedRule, loc *time.Location, limit func() bool) {
+	// find the first active day at or after rotation start
+	origin := rot.Start.In(loc)
+	firstActive := rule.StartTime(origin)
+
+	// process each active period in the query window
+	start := rule.StartTime(calc.Start().In(loc))
+
+	for start.Before(calc.End()) && limit() {
+		end := rule.EndTime(start)
+		if end.After(calc.End()) {
+			end = calc.End()
+		}
+
+		// count active days from rotation origin to determine the correct user
+		days := calc.countActiveDays(firstActive, start, rule, loc, limit)
+
+		// calculate user index based on days elapsed from rotation origin
+		idx := days % len(rot.Users)
+		userID := rot.Users[idx]
+
+		calc.rot.SetSpan(start, end, userID)
+
+		next := rule.StartTime(end)
+		if next.Equal(end) || next.Before(end) {
+			break
+		}
+
+		start = next
+	}
+}
+
+// countActiveDays counts the number of active days from start up to (but not including) end.
+// Times are normalized to midnight for pure calendar day comparison to ensure consistency across query windows.
+func (calc *SingleRuleCalculator) countActiveDays(start, end time.Time, rule ResolvedRule, loc *time.Location, limit func() bool) int {
+	n := 0
+	cur := start
+
+	// normalize end to midnight for comparison
+	endMidnight := time.Date(end.Year(), end.Month(), end.Day(), 0, 0, 0, 0, loc)
+
+	for limit() {
+		// normalize cur to midnight for pure calendar day comparison
+		curMidnight := time.Date(cur.Year(), cur.Month(), cur.Day(), 0, 0, 0, 0, loc)
+		if !curMidnight.Before(endMidnight) {
+			break
+		}
+
+		next := rule.StartTime(rule.EndTime(cur))
+		if next.Equal(cur) || next.Before(cur) {
+			break
+		}
+		n++
+		cur = next
+	}
+
+	return n
+}

--- a/oncall/singlerulecalculator_test.go
+++ b/oncall/singlerulecalculator_test.go
@@ -170,4 +170,81 @@ func TestDailyRotationWithDayRestrictions(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("ConsistentAcrossQueryWindows", func(t *testing.T) {
+		userIDs := []string{
+			"user-0", "user-1", "user-2", "user-3", "user-4", "user-5", "user-6",
+			"user-7", "user-8", "user-9", "user-10", "user-11", "user-12", "user-13",
+			"user-14", "user-15",
+		}
+
+		rotStart := time.Date(2025, 12, 10, 8, 0, 0, 0, time.UTC)
+
+		rot := &oncall.ResolvedRotation{
+			Rotation: rotation.Rotation{
+				ID:          "test-rotation",
+				Type:        rotation.TypeDaily,
+				ShiftLength: 1,
+				Start:       rotStart,
+			},
+			CurrentIndex: 0,
+			CurrentStart: rotStart,
+			Users:        userIDs,
+		}
+
+		testRule := oncall.ResolvedRule{
+			Rule: rule.Rule{
+				WeekdayFilter: timeutil.WeekdayFilter{0, 1, 1, 1, 1, 1, 0},
+				Start:         timeutil.NewClock(9, 0),
+				End:           timeutil.NewClock(17, 0),
+			},
+			Rotation: rot,
+		}
+
+		start1 := time.Date(2025, 11, 30, 0, 0, 0, 0, loc)
+		end1 := time.Date(2026, 1, 4, 0, 0, 0, 0, loc)
+		iter1 := oncall.NewTimeIterator(start1, end1, time.Minute).NewSingleRuleCalculator(loc, testRule)
+
+		shifts1 := make(map[string]string)
+		var currentUser1 string
+		for iter1.Next() {
+			user := iter1.ActiveUser()
+			t := time.Unix(iter1.Unix(), 0).In(loc)
+			date := t.Format("2006-01-02")
+			if user != "" && user != currentUser1 {
+				shifts1[date] = user
+				currentUser1 = user
+			}
+		}
+
+		start2 := time.Date(2025, 12, 28, 0, 0, 0, 0, loc)
+		end2 := time.Date(2026, 2, 1, 0, 0, 0, 0, loc)
+		iter2 := oncall.NewTimeIterator(start2, end2, time.Minute).NewSingleRuleCalculator(loc, testRule)
+
+		shifts2 := make(map[string]string)
+		var currentUser2 string
+		for iter2.Next() {
+			user := iter2.ActiveUser()
+			t := time.Unix(iter2.Unix(), 0).In(loc)
+			date := t.Format("2006-01-02")
+			if user != "" && user != currentUser2 {
+				shifts2[date] = user
+				currentUser2 = user
+			}
+		}
+
+		testDates := []string{"2025-12-29", "2025-12-30", "2025-12-31", "2026-01-01", "2026-01-02"}
+		for _, date := range testDates {
+			user1, ok1 := shifts1[date]
+			user2, ok2 := shifts2[date]
+
+			if ok1 != ok2 {
+				t.Errorf("Date %s: one query found shift, other didn't (query1=%v, query2=%v)", date, ok1, ok2)
+			}
+
+			if ok1 && ok2 && user1 != user2 {
+				t.Errorf("Date %s: inconsistent user assignment: query1=%s, query2=%s", date, user1, user2)
+			}
+		}
+	})
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and ~existing tests passed~.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**

When a daily rotation is combined with a schedule which has restriction(eg: active only on weekdays) the rotation advances through calendar time and not with active days. Due to this some participants fell on the inactivate days and never appeared on the schedule.

This PR fixes it by advancing rotations based on active day instead of calendar time.

**Which issue(s) this PR fixes:**

Fixes #4447 

**Out of Scope:**

**Screenshots:**

**Describe any introduced user-facing changes:**

**Describe any introduced API changes:**

**Additional Info:**
