### PR TITLE
temp sched: guarantee every day header is rendered

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "transform": {
       "^.+\\.(j|t)sx?$": "esbuild-jest"
     },
-    "rootDir": "web/src"
+    "rootDir": "web/src",
+    "transformIgnorePatterns": [
+      "node_modules/(?!wouter)"
+    ]
   },
   "standard": {
     "parser": "babel-eslint",

--- a/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
+++ b/web/src/app/schedules/temp-sched/TempSchedShiftsList.tsx
@@ -124,12 +124,7 @@ export default function TempSchedShiftsList({
       zone,
       handleCoverageGapClick,
     )
-    const subheaderItems = getSubheaderItems(
-      schedInterval,
-      shifts,
-      shiftDur as Duration,
-      zone,
-    )
+    const subheaderItems = getSubheaderItems(schedInterval, shifts, zone)
 
     const outOfBoundsItems = getOutOfBoundsItems(schedInterval, shifts, zone)
 

--- a/web/src/app/schedules/temp-sched/shiftsListUtil.test.ts
+++ b/web/src/app/schedules/temp-sched/shiftsListUtil.test.ts
@@ -28,11 +28,7 @@ describe('getSubheaderItems', () => {
       const schedInterval = Interval.fromISO(tc.schedIntervalISO, {
         zone: tc.zone,
       })
-      const result = getSubheaderItems(
-        schedInterval,
-        tc.shifts,
-        tc.zone,
-      )
+      const result = getSubheaderItems(schedInterval, tc.shifts, tc.zone)
 
       expect(result).toHaveLength(tc.expected.length)
       expect(_.uniq(result.map((r) => r.id))).toHaveLength(tc.expected.length)

--- a/web/src/app/schedules/temp-sched/shiftsListUtil.test.ts
+++ b/web/src/app/schedules/temp-sched/shiftsListUtil.test.ts
@@ -31,7 +31,6 @@ describe('getSubheaderItems', () => {
       const result = getSubheaderItems(
         schedInterval,
         tc.shifts,
-        tc.shiftDuration as Duration,
         tc.zone,
       )
 
@@ -87,7 +86,7 @@ describe('getSubheaderItems', () => {
     schedIntervalISO: `${'2021-08-13T00:00:00.000-05:00'}/${'2021-08-14T01:00:00.000-05:00'}`,
     shifts: [],
     shiftDuration: Duration.fromObject({ hours: 25 }),
-    expected: ['Friday, August 13'],
+    expected: ['Friday, August 13', 'Saturday, August 14'],
     zone: chicago,
   })
 
@@ -96,7 +95,7 @@ describe('getSubheaderItems', () => {
     schedIntervalISO: `${'2021-08-13T00:00:00.000-05:00'}/${'2021-08-15T02:00:00.000-05:00'}`,
     shifts: [],
     shiftDuration: Duration.fromObject({ hours: 50 }),
-    expected: ['Friday, August 13'],
+    expected: ['Friday, August 13', 'Saturday, August 14', 'Sunday, August 15'],
     zone: chicago,
   })
 
@@ -177,7 +176,7 @@ describe('getSubheaderItems', () => {
       },
     ],
     shiftDuration: Duration.fromObject({ hours: 30 }),
-    expected: ['Friday, August 13', 'Saturday, August 14'],
+    expected: ['Friday, August 13', 'Saturday, August 14', 'Sunday, August 15'],
     zone: chicago,
   })
 })

--- a/web/src/app/schedules/temp-sched/shiftsListUtil.tsx
+++ b/web/src/app/schedules/temp-sched/shiftsListUtil.tsx
@@ -31,7 +31,6 @@ export type Sortable<T> = T & {
 export function getSubheaderItems(
   schedInterval: Interval,
   shifts: Shift[],
-  shiftDur: Duration,
   zone: ExplicitZone,
 ): Sortable<FlatListSub>[] {
   if (!schedInterval.isValid) {
@@ -49,10 +48,14 @@ export function getSubheaderItems(
     ...shifts.map((s) => DateTime.fromISO(s.end, { zone })),
   )
 
-  const dayInvs = splitShift(
-    Interval.fromDateTimes(lowerBound, upperBound),
-    shiftDur,
-  )
+  const dayInvs: Interval[] = []
+  let currentDay = lowerBound.startOf('day')
+
+  while (currentDay < upperBound) {
+    const nextDay = currentDay.plus({ days: 1 })
+    dayInvs.push(Interval.fromDateTimes(currentDay, nextDay))
+    currentDay = nextDay
+  }
 
   return dayInvs.map((day) => {
     const at = day.start.startOf('day')


### PR DESCRIPTION
Fixes an issue where the day subheader sometimes isn't rendered on a temporary schedule