### PR TITLE
fix: use applicationName config in nav bar and login page

### DIFF
--- a/web/src/app/main/NavBar.tsx
+++ b/web/src/app/main/NavBar.tsx
@@ -4,6 +4,7 @@ import List from '@mui/material/List'
 import Typography from '@mui/material/Typography'
 import makeStyles from '@mui/styles/makeStyles'
 import { styles as globalStyles } from '../styles/materialStyles'
+import { applicationName } from '../env'
 import {
   Group,
   Layers,
@@ -73,7 +74,7 @@ export default function NavBar(): React.JSX.Element {
           {logo}
         </a>
         <Typography variant='h5' sx={{ pl: 1 }}>
-          <b>GoAlert</b>
+          <b>{applicationName}</b>
         </Typography>
       </div>
       <Divider />

--- a/web/src/app/main/components/Login.tsx
+++ b/web/src/app/main/components/Login.tsx
@@ -9,7 +9,7 @@ import Divider from '@mui/material/Divider'
 import makeStyles from '@mui/styles/makeStyles'
 import { Theme, useTheme } from '@mui/material'
 import { getParameterByName } from '../../util/query_param'
-import { pathPrefix } from '../../env'
+import { pathPrefix, applicationName } from '../../env'
 
 import logoImgSrc from '../../public/logos/lightmode_logo.svg'
 import darkModeLogoImgSrc from '../../public/logos/darkmode_logo.svg'
@@ -232,7 +232,7 @@ export default function Login(): React.JSX.Element {
                 <Grid item>{logo}</Grid>
                 <Grid item sx={{ display: 'flex', alignItems: 'center' }}>
                   <Typography variant='h5' sx={{ pl: 1 }}>
-                    <b>GoAlert</b>
+                    <b>{applicationName}</b>
                   </Typography>
                 </Grid>
               </Grid>


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
The application name was hardcoded as "GoAlert" in NavBar.tsx and Login.tsx. These components now read from the applicationName value already exported by env.ts, which is populated from the server-side General.ApplicationName config. The browser tab title already used this value correctly; this makes the top-left display consistent.

**Which issue(s) this PR fixes:**
Fixes #4481 

**Describe any introduced user-facing changes:**
Results in expected behavior when modifying the Application Name config value. 
