### PR TITLE
Add Google Chat notification destination

### DIFF
--- a/app/startup.go
+++ b/app/startup.go
@@ -8,6 +8,7 @@ import (
 	"github.com/target/goalert/app/lifecycle"
 	"github.com/target/goalert/expflag"
 	"github.com/target/goalert/notification/email"
+	"github.com/target/goalert/notification/googlechat"
 	"github.com/target/goalert/notification/webhook"
 	"github.com/target/goalert/retry"
 
@@ -95,6 +96,7 @@ func (app *App) startup(ctx context.Context) error {
 	app.DestRegistry.RegisterProvider(ctx, app.slackChan.DMSender())
 	app.DestRegistry.RegisterProvider(ctx, app.slackChan.UserGroupSender())
 	app.DestRegistry.RegisterProvider(ctx, webhook.NewSender(ctx, app.httpClient))
+	app.DestRegistry.RegisterProvider(ctx, googlechat.NewSender(ctx, app.httpClient))
 	if app.cfg.StubNotifiers {
 		app.DestRegistry.StubNotifiers()
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -141,6 +141,10 @@ type Config struct {
 		AllowedURLs []string `public:"true" info:"If set, allows webhooks for these domains only."`
 	}
 
+	GoogleChat struct {
+		Enable bool `public:"true" info:"Enables Google Chat as a notification destination."`
+	}
+
 	Feedback struct {
 		Enable      bool   `public:"true" info:"Enables Feedback link in nav bar."`
 		OverrideURL string `public:"true" info:"Use a custom URL for Feedback link in nav bar."`

--- a/graphql2/mapconfig.go
+++ b/graphql2/mapconfig.go
@@ -89,6 +89,7 @@ func MapConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "SMTP.Password", Type: ConfigTypeString, Description: "Password for authentication.", Value: cfg.SMTP.Password, Password: true},
 		{ID: "Webhook.Enable", Type: ConfigTypeBoolean, Description: "Enables webhook as a contact method.", Value: fmt.Sprintf("%t", cfg.Webhook.Enable)},
 		{ID: "Webhook.AllowedURLs", Type: ConfigTypeStringList, Description: "If set, allows webhooks for these domains only.", Value: strings.Join(cfg.Webhook.AllowedURLs, "\n")},
+		{ID: "GoogleChat.Enable", Type: ConfigTypeBoolean, Description: "Enables Google Chat as a notification destination.", Value: fmt.Sprintf("%t", cfg.GoogleChat.Enable)},
 		{ID: "Feedback.Enable", Type: ConfigTypeBoolean, Description: "Enables Feedback link in nav bar.", Value: fmt.Sprintf("%t", cfg.Feedback.Enable)},
 		{ID: "Feedback.OverrideURL", Type: ConfigTypeString, Description: "Use a custom URL for Feedback link in nav bar.", Value: cfg.Feedback.OverrideURL},
 	}
@@ -124,6 +125,7 @@ func MapPublicConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "SMTP.From", Type: ConfigTypeString, Description: "The email address messages should be sent from.", Value: cfg.SMTP.From},
 		{ID: "Webhook.Enable", Type: ConfigTypeBoolean, Description: "Enables webhook as a contact method.", Value: fmt.Sprintf("%t", cfg.Webhook.Enable)},
 		{ID: "Webhook.AllowedURLs", Type: ConfigTypeStringList, Description: "If set, allows webhooks for these domains only.", Value: strings.Join(cfg.Webhook.AllowedURLs, "\n")},
+		{ID: "GoogleChat.Enable", Type: ConfigTypeBoolean, Description: "Enables Google Chat as a notification destination.", Value: fmt.Sprintf("%t", cfg.GoogleChat.Enable)},
 		{ID: "Feedback.Enable", Type: ConfigTypeBoolean, Description: "Enables Feedback link in nav bar.", Value: fmt.Sprintf("%t", cfg.Feedback.Enable)},
 		{ID: "Feedback.OverrideURL", Type: ConfigTypeString, Description: "Use a custom URL for Feedback link in nav bar.", Value: cfg.Feedback.OverrideURL},
 	}
@@ -383,6 +385,12 @@ func ApplyConfigValues(cfg config.Config, vals []ConfigValueInput) (config.Confi
 			cfg.Webhook.Enable = val
 		case "Webhook.AllowedURLs":
 			cfg.Webhook.AllowedURLs = parseStringList(v.Value)
+		case "GoogleChat.Enable":
+			val, err := parseBool(v.ID, v.Value)
+			if err != nil {
+				return cfg, err
+			}
+			cfg.GoogleChat.Enable = val
 		case "Feedback.Enable":
 			val, err := parseBool(v.ID, v.Value)
 			if err != nil {

--- a/graphql2/mapconfig_test.go
+++ b/graphql2/mapconfig_test.go
@@ -1,0 +1,44 @@
+package graphql2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/config"
+)
+
+func TestMapConfigValues_CustomWebhookProviders(t *testing.T) {
+	var cfg config.Config
+	cfg.GoogleChat.Enable = true
+	cfg.CustomWebhook.Enable = true
+
+	values := MapConfigValues(cfg)
+	publicValues := MapPublicConfigValues(cfg)
+
+	assertConfigValue := func(t *testing.T, vals []ConfigValue, id string, want string) {
+		t.Helper()
+		for _, v := range vals {
+			if v.ID == id {
+				assert.Equal(t, want, v.Value)
+				return
+			}
+		}
+		require.Failf(t, "missing config value", "expected %s to be present", id)
+	}
+
+	assertConfigValue(t, values, "GoogleChat.Enable", "true")
+	assertConfigValue(t, values, "CustomWebhook.Enable", "true")
+	assertConfigValue(t, publicValues, "GoogleChat.Enable", "true")
+	assertConfigValue(t, publicValues, "CustomWebhook.Enable", "true")
+}
+
+func TestApplyConfigValues_CustomWebhookProviders(t *testing.T) {
+	cfg, err := ApplyConfigValues(config.Config{}, []ConfigValueInput{
+		{ID: "GoogleChat.Enable", Value: "true"},
+		{ID: "CustomWebhook.Enable", Value: "true"},
+	})
+	require.NoError(t, err)
+	assert.True(t, cfg.GoogleChat.Enable)
+	assert.True(t, cfg.CustomWebhook.Enable)
+}

--- a/notification/googlechat/sender.go
+++ b/notification/googlechat/sender.go
@@ -1,0 +1,316 @@
+package googlechat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/target/goalert/config"
+	"github.com/target/goalert/gadb"
+	"github.com/target/goalert/notification"
+	"github.com/target/goalert/notification/nfydest"
+	"github.com/target/goalert/validation"
+	"github.com/target/goalert/validation/validate"
+)
+
+const (
+	DestTypeGoogleChat = "builtin-google-chat"
+	FieldWebhookURL    = "webhook_url"
+
+	FallbackIconURL = "builtin://googlechat"
+)
+
+var googleChatWebhookPath = regexp.MustCompile(`^/v1/spaces/[^/]+/messages$`)
+
+type Sender struct {
+	Client *http.Client
+}
+
+type ChatMessage struct {
+	Text string `json:"text"`
+}
+
+var _ nfydest.Provider = (*Sender)(nil)
+var _ nfydest.MessageSender = (*Sender)(nil)
+
+func NewSender(_ context.Context, client *http.Client) *Sender {
+	return &Sender{Client: client}
+}
+
+func NewGoogleChatDest(webhookURL string) gadb.DestV1 {
+	return gadb.NewDestV1(DestTypeGoogleChat, FieldWebhookURL, webhookURL)
+}
+
+func (Sender) ID() string { return DestTypeGoogleChat }
+
+func (Sender) TypeInfo(ctx context.Context) (*nfydest.TypeInfo, error) {
+	cfg := config.FromContext(ctx)
+	return &nfydest.TypeInfo{
+		Type:                       DestTypeGoogleChat,
+		Name:                       "Google Chat",
+		Enabled:                    cfg.GoogleChat.Enable,
+		IconURL:                    FallbackIconURL,
+		IconAltText:                "Google Chat",
+		UserDisclaimer:             "Google Chat webhooks support alert and on-call change notifications.",
+		SupportsAlertNotifications: true,
+		SupportsStatusUpdates:      true,
+		SupportsOnCallNotify:       true,
+		RequiredFields: []nfydest.FieldConfig{{
+			FieldID:            FieldWebhookURL,
+			Label:              "Webhook URL",
+			PlaceholderText:    "https://chat.googleapis.com/v1/spaces/.../messages?key=...&token=...",
+			InputType:          "url",
+			SupportsValidation: true,
+		}},
+	}, nil
+}
+
+func (s *Sender) ValidateField(ctx context.Context, fieldID, value string) error {
+	cfg := config.FromContext(ctx)
+
+	switch fieldID {
+	case FieldWebhookURL:
+		err := validate.AbsoluteURL(FieldWebhookURL, value)
+		if err != nil {
+			return err
+		}
+
+		if err := validateGoogleChatWebhookURL(value); err != nil {
+			return err
+		}
+
+		if !cfg.ValidWebhookURL(value) {
+			return validation.NewGenericError("url is not allowed by administrator")
+		}
+
+		return nil
+	}
+
+	return validation.NewGenericError("unknown field ID")
+}
+
+func (s *Sender) DisplayInfo(ctx context.Context, args map[string]string) (*nfydest.DisplayInfo, error) {
+	if args == nil {
+		args = make(map[string]string)
+	}
+
+	if err := validateGoogleChatWebhookURL(args[FieldWebhookURL]); err != nil {
+		return nil, err
+	}
+
+	return &nfydest.DisplayInfo{
+		IconURL:     FallbackIconURL,
+		IconAltText: "Google Chat",
+		Text:        "Google Chat",
+	}, nil
+}
+
+func (s *Sender) SendMessage(ctx context.Context, msg notification.Message) (*notification.SentMessage, error) {
+	cfg := config.FromContext(ctx)
+	webhookURL := msg.DestArg(FieldWebhookURL)
+
+	if err := validateGoogleChatWebhookURL(webhookURL); err != nil {
+		return &notification.SentMessage{
+			State:        notification.StateFailedPerm,
+			StateDetails: err.Error(),
+		}, nil
+	}
+
+	if !cfg.ValidWebhookURL(webhookURL) {
+		return &notification.SentMessage{
+			State:        notification.StateFailedPerm,
+			StateDetails: "invalid or not allowed URL",
+		}, nil
+	}
+
+	payload, err := json.Marshal(ChatMessage{Text: formatGoAlertMessage(ctx, msg)})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+
+	resp, err := s.client().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return &notification.SentMessage{State: notification.StateSent}, nil
+	}
+
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+	if readErr != nil {
+		return nil, readErr
+	}
+
+	details := strings.TrimSpace(string(body))
+	if details != "" {
+		details = fmt.Sprintf("%s: %s", resp.Status, details)
+	} else {
+		details = resp.Status
+	}
+
+	state := notification.StateFailedPerm
+	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+		state = notification.StateFailedTemp
+	}
+
+	return &notification.SentMessage{
+		State:        state,
+		StateDetails: details,
+	}, nil
+}
+
+func (s *Sender) client() *http.Client {
+	if s != nil && s.Client != nil {
+		return s.Client
+	}
+	return http.DefaultClient
+}
+
+func formatGoAlertMessage(ctx context.Context, msg notification.Message) string {
+	cfg := config.FromContext(ctx)
+
+	switch t := msg.(type) {
+	case notification.Test:
+		return "This is a test message from GoAlert."
+	case notification.Alert:
+		return formatAlertMessage(cfg, t)
+	case notification.AlertBundle:
+		return formatAlertBundleMessage(cfg, t)
+	case notification.AlertStatus:
+		return formatAlertStatusMessage(cfg, t)
+	case notification.ScheduleOnCallUsers:
+		return formatScheduleOnCallUsers(t)
+	default:
+		return fmt.Sprintf("unsupported message type: %T", t)
+	}
+}
+
+func formatAlertMessage(cfg config.Config, a notification.Alert) string {
+	var parts []string
+	parts = append(parts,
+		"GoAlert alert",
+		fmt.Sprintf("Alert: #%d %s", a.AlertID, a.Summary),
+		fmt.Sprintf("Service: %s", a.ServiceName),
+	)
+	if a.Details != "" {
+		parts = append(parts, fmt.Sprintf("Details: %s", a.Details))
+	}
+	parts = append(parts, fmt.Sprintf("Link: %s", alertURL(cfg, a.AlertID)))
+
+	return strings.Join(parts, "\n")
+}
+
+func formatAlertBundleMessage(cfg config.Config, a notification.AlertBundle) string {
+	return strings.Join([]string{
+		"GoAlert alert bundle",
+		fmt.Sprintf("Service: %s", a.ServiceName),
+		fmt.Sprintf("Count: %d unacknowledged alerts", a.Count),
+		fmt.Sprintf("Link: %s", serviceAlertsURL(cfg, a.ServiceID)),
+	}, "\n")
+}
+
+func formatAlertStatusMessage(cfg config.Config, a notification.AlertStatus) string {
+	state := alertStateText(a.NewAlertState)
+	if state == "" {
+		state = "updated"
+	}
+
+	var parts []string
+	parts = append(parts,
+		"GoAlert alert update",
+		fmt.Sprintf("Alert: #%d %s", a.AlertID, a.Summary),
+		fmt.Sprintf("State: %s", state),
+	)
+	if a.LogEntry != "" {
+		parts = append(parts, fmt.Sprintf("Log: %s", a.LogEntry))
+	}
+	parts = append(parts, fmt.Sprintf("Link: %s", alertURL(cfg, a.AlertID)))
+
+	return strings.Join(parts, "\n")
+}
+
+func alertStateText(state notification.AlertState) string {
+	switch state {
+	case notification.AlertStateUnacknowledged:
+		return "unacknowledged"
+	case notification.AlertStateAcknowledged:
+		return "acknowledged"
+	case notification.AlertStateClosed:
+		return "closed"
+	default:
+		return ""
+	}
+}
+
+func alertURL(cfg config.Config, id int) string {
+	return cfg.CallbackURL(fmt.Sprintf("/alerts/%d", id))
+}
+
+func serviceAlertsURL(cfg config.Config, serviceID string) string {
+	return cfg.CallbackURL(fmt.Sprintf("/services/%s/alerts", serviceID))
+}
+
+func formatScheduleOnCallUsers(n notification.ScheduleOnCallUsers) string {
+	users := "Nobody"
+	if len(n.Users) > 0 {
+		sorted := make([]notification.User, len(n.Users))
+		copy(sorted, n.Users)
+		sort.Slice(sorted, func(i, j int) bool {
+			if sorted[i].Name == sorted[j].Name {
+				return sorted[i].ID < sorted[j].ID
+			}
+			return sorted[i].Name < sorted[j].Name
+		})
+
+		names := make([]string, 0, len(sorted))
+		for _, u := range sorted {
+			names = append(names, u.Name)
+		}
+		users = strings.Join(names, ", ")
+	}
+
+	return fmt.Sprintf(
+		"GoAlert on-call shift changed\nSchedule: %s\nNow on-call: %s\nLink: %s",
+		n.ScheduleName,
+		users,
+		n.ScheduleURL,
+	)
+}
+
+func validateGoogleChatWebhookURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return validation.WrapError(err)
+	}
+
+	if u.Scheme != "https" {
+		return validation.NewFieldError(FieldWebhookURL, "must use https")
+	}
+	if u.Hostname() != "chat.googleapis.com" {
+		return validation.NewFieldError(FieldWebhookURL, "must be a Google Chat incoming webhook URL")
+	}
+	if !googleChatWebhookPath.MatchString(u.Path) {
+		return validation.NewFieldError(FieldWebhookURL, "must be a Google Chat incoming webhook URL")
+	}
+	q := u.Query()
+	if q.Get("key") == "" || q.Get("token") == "" {
+		return validation.NewFieldError(FieldWebhookURL, "must include key and token query parameters")
+	}
+
+	return nil
+}

--- a/web/src/app/documentation/Documentation.tsx
+++ b/web/src/app/documentation/Documentation.tsx
@@ -16,15 +16,16 @@ const useStyles = makeStyles({
 })
 
 export default function Documentation(): React.JSX.Element {
-  const [publicURL, webhookEnabled] = useConfigValue(
+  const [publicURL, webhookEnabled, googleChatEnabled] = useConfigValue(
     'General.PublicURL',
     'Webhook.Enable',
+    'GoogleChat.Enable',
   )
   const classes = useStyles()
 
   // NOTE list markdown documents here
   let markdownDocs = [{ doc: integrationKeys, id: 'integration-keys' }]
-  if (webhookEnabled) {
+  if (webhookEnabled || googleChatEnabled) {
     markdownDocs.push({ doc: webhooks, id: 'webhooks' })
   }
 
@@ -44,7 +45,7 @@ export default function Documentation(): React.JSX.Element {
     if (!el) return
 
     el.scrollIntoView()
-  }, [webhookEnabled, publicURL])
+  }, [webhookEnabled, googleChatEnabled, publicURL])
 
   return (
     <React.Fragment>

--- a/web/src/app/util/DestinationAvatar.tsx
+++ b/web/src/app/util/DestinationAvatar.tsx
@@ -3,6 +3,7 @@ import { Avatar, CircularProgress } from '@mui/material'
 
 import {
   BrokenImage,
+  Chat,
   Notifications as AlertIcon,
   RotateRight as RotationIcon,
   Today as ScheduleIcon,
@@ -15,6 +16,7 @@ const builtInIcons: { [key: string]: React.ReactNode } = {
   'builtin://rotation': <RotationIcon />,
   'builtin://schedule': <ScheduleIcon />,
   'builtin://webhook': <WebhookIcon />,
+  'builtin://googlechat': <Chat />,
   'builtin://email': <Email />,
 }
 

--- a/web/src/app/util/DestinationChip.stories.tsx
+++ b/web/src/app/util/DestinationChip.stories.tsx
@@ -17,6 +17,7 @@ const meta = {
         'builtin://schedule',
         'builtin://rotation',
         'builtin://webhook',
+        'builtin://googlechat',
         'builtin://slack',
       ],
     },

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -1678,5 +1678,6 @@ type ConfigID =
   | 'SMTP.Password'
   | 'Webhook.Enable'
   | 'Webhook.AllowedURLs'
+  | 'GoogleChat.Enable'
   | 'Feedback.Enable'
   | 'Feedback.OverrideURL'


### PR DESCRIPTION
**Description:**
Google Chat incoming webhooks do not accept GoAlert’s generic webhook payload directly. Google Chat expects a Chat message payload, so sending GoAlert’s JSON as-is results in a payload shape mismatch.

This PR adds:
- native Google Chat notification support that formats messages into the `{"text":"..."}` payload Google Chat expects


**Which issue(s) this PR fixes:**
Add configurable Google Chat notification destinations(https://github.com/target/goalert/issues/4485)

**Screenshots:**

**Admin configuration**
![Admin configuration showing Google Chat and Custom Webhook enabled](https://github.com/user-attachments/assets/6313e44f-9722-4554-b065-ead812d55eea)

**Google Chat Escalation step setup**
![Escalation step setup](https://github.com/user-attachments/assets/b7d04825-4c4a-4327-9bf9-b2d8bac554d0)
**Escalation steps showing Google Chat destination chip**
![Escalation steps showing Google Chat destination chip](https://github.com/user-attachments/assets/1f8e3238-db0d-49cb-8788-21e9cc532579)
**Notification rule with Google Chat**
![Notification rule with Google Chat ](https://github.com/user-attachments/assets/60041016-d9fd-4115-8a86-ead06ec4cfd4)
**Notification rule showing Google Chat destination chip**
![Escalation steps showing Google Chat destination chip](https://github.com/user-attachments/assets/cc4a8833-1d43-49f6-a87d-4d8af4948c95)

**Message previews**
**Escalation**
![Google chat message preview1](https://github.com/user-attachments/assets/dca0c4cb-8c31-4732-9dce-a8a450532dc8)
**Notification rule**
![Google chat message preview2](https://github.com/user-attachments/assets/6f57380e-e8f1-4bee-a5f9-fd0eebd920fc)

**Describe any introduced user-facing changes:**
- Adds a new `Google Chat` destination type
- Sends Google Chat incoming webhooks using a Chat-compatible JSON payload
- Adds a config toggle to enable or disable Google Chat independently

**Describe any introduced API changes:**
- Adds the `GoogleChat.Enable` config key

**Additional Info:**
This PR is part of a split change set. The Custom Webhook and notification test coverage are handled in separate PRs.

Verified with:
- `go test ./config ./graphql2 ./notification/googlechat ./app -count=1`
- `node_modules/.bin/tsc -p web/src/app/tsconfig.json --noEmit`