### PR TITLE
fix(genericapi): update summary, details and metadata on dedup match

### DIFF
--- a/alert/store.go
+++ b/alert/store.go
@@ -34,6 +34,7 @@ type Store struct {
 	createUpdNew   *sql.Stmt
 	createUpdAck   *sql.Stmt
 	createUpdClose *sql.Stmt
+	updateExistingByDedup *sql.Stmt
 
 	updateByStatusAndService *sql.Stmt
 	updateByIDAndStatus      *sql.Stmt
@@ -117,6 +118,12 @@ func NewStore(ctx context.Context, db *sql.DB, logDB *alertlog.Store) (*Store, e
 				dedup_key = $2 and
 				status != 'closed'
 			RETURNING id, summary, details, created_at
+		`),
+
+		updateExistingByDedup: p(`
+		UPDATE alerts
+		SET summary = $1, details = $2
+		WHERE service_id = $3 AND dedup_key = $4 AND status != 'closed'
 		`),
 
 		getServiceID: p("SELECT service_id FROM alerts WHERE id = $1"),
@@ -234,7 +241,7 @@ func (s *Store) canTouchAlert(ctx context.Context, alertID int) error {
 // in maintenance mode, there are no steps on the escalation policy, or if the
 // alert has already been escalated since the given time.
 func (s *Store) EscalateAsOf(ctx context.Context, id int, t time.Time) error {
-	err := permission.LimitCheckAny(ctx, permission.System, permission.User)
+	err := permission.LimitCheckAny(ctx, permission.System, permission.User, permission.Service)
 	if err != nil {
 		return err
 	}
@@ -251,6 +258,16 @@ func (s *Store) EscalateAsOf(ctx context.Context, id int, t time.Time) error {
 	}
 	if err != nil {
 		return fmt.Errorf("lock alert: %w", err)
+	}
+	if permission.Service(ctx) {
+		var svcID string
+		err = tx.StmtContext(ctx, s.getServiceID).QueryRowContext(ctx, id).Scan(&svcID)
+		if err != nil {
+			return fmt.Errorf("get service for alert: %w", err)
+		}
+		if err = permission.LimitCheckAny(ctx, permission.MatchService(svcID)); err != nil {
+			return err
+		}
 	}
 	if lck.Status == gadb.EnumAlertStatusClosed {
 		return logError{isAlreadyClosed: true, alertID: id, _type: alertlog.TypeClosed, logDB: s.logDB}
@@ -553,11 +570,24 @@ func (s *Store) CreateOrUpdateTx(ctx context.Context, tx *sql.Tx, a *Alert) (*Al
 	switch n.Status {
 	case StatusTriggered:
 		var m alertlog.CreatedMetaData
+		newSummary, newDetails := n.Summary, n.Details
 		err = tx.Stmt(s.createUpdNew).
 			QueryRowContext(ctx, n.Summary, n.Details, n.ServiceID, n.Source, n.DedupKey()).
 			Scan(&n.ID, &n.Summary, &n.Details, &n.Status, &n.Source, &n.CreatedAt, &inserted)
 		if !inserted {
 			logType = alertlog.TypeDuplicateSupressed
+			if newSummary != "" || newDetails != "" {
+				_, err =  tx.Stmt(s.updateExistingByDedup).ExecContext(ctx, newSummary, newDetails, n.ServiceID, n.DedupKey())
+				if err != nil {
+					return nil, false, err
+				}
+				if newSummary != "" {
+					n.Summary = newSummary
+				}
+				if newDetails != "" {
+					n.Details = newDetails
+				}
+			}
 		} else {
 			logType = alertlog.TypeCreated
 			hasSteps, err := gadb.New(tx).Alert_ServiceEPHasSteps(ctx, uuid.MustParse(n.ServiceID))
@@ -632,7 +662,7 @@ func (s *Store) createOrUpdate(ctx context.Context, a *Alert, meta map[string]st
 	}
 
 	// Set metadata only if meta is not nil and isNew is true
-	if meta != nil && isNew {
+	if meta != nil && n != nil {
 		err = s.SetMetadataTx(ctx, tx, n.ID, meta)
 		if err != nil {
 			return nil, false, err

--- a/alert/store.go
+++ b/alert/store.go
@@ -661,8 +661,7 @@ func (s *Store) createOrUpdate(ctx context.Context, a *Alert, meta map[string]st
 		return nil, false, err
 	}
 
-	// Set metadata only if meta is not nil and isNew is true
-	if meta != nil && n != nil {
+	if len(meta) > 0 && n != nil {
 		err = s.SetMetadataTx(ctx, tx, n.ID, meta)
 		if err != nil {
 			return nil, false, err

--- a/genericapi/handler.go
+++ b/genericapi/handler.go
@@ -79,6 +79,7 @@ func (h *Handler) ServeCreateAlert(w http.ResponseWriter, r *http.Request) {
 	details := r.FormValue("details")
 	action := r.FormValue("action")
 	dedup := r.FormValue("dedup")
+	escalate := r.FormValue("escalate") == "true"
 
 	meta := make(map[string]string)
 	for _, v := range r.Form["meta"] {
@@ -99,6 +100,7 @@ func (h *Handler) ServeCreateAlert(w http.ResponseWriter, r *http.Request) {
 		var b struct {
 			Summary, Details, Action, Dedup *string
 			Meta                            map[string]string
+			Escalate 						*bool
 		}
 		err = json.Unmarshal(data, &b)
 		if errutil.HTTPError(ctx, w, validation.WrapError(err)) {
@@ -116,6 +118,9 @@ func (h *Handler) ServeCreateAlert(w http.ResponseWriter, r *http.Request) {
 		}
 		if b.Action != nil {
 			action = *b.Action
+		}
+		if b.Escalate != nil {
+			escalate = *b.Escalate
 		}
 		if b.Meta != nil {
 			meta = b.Meta
@@ -160,6 +165,12 @@ func (h *Handler) ServeCreateAlert(w http.ResponseWriter, r *http.Request) {
 	)
 	if errutil.HTTPError(ctx, w, errors.Wrap(err, "create alert")) {
 		return
+	}
+	if escalate && !resp.IsNew && resp.AlertID != 0 && action != "close" {
+		err = h.c.AlertStore.EscalateAsOf(ctx, resp.AlertID, time.Time{})
+		if errutil.HTTPError(ctx, w, errors.Wrap(err, "escalate alert")){
+			return
+		}
 	}
 
 	if r.Header.Get("Accept") != "application/json" {

--- a/test/smoke/genericapiupdate_test.go
+++ b/test/smoke/genericapiupdate_test.go
@@ -1,0 +1,122 @@
+package smoke
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/test/smoke/harness"
+)
+
+func TestGenericAPIUpdate(t *testing.T) {
+	t.Parallel()
+
+	const sql = `
+	insert into escalation_policies (id, name)
+	values
+		({{uuid "ep1"}}, 'policy1');
+
+	insert into escalation_policy_steps (id, escalation_policy_id)
+	values
+		({{uuid "eps1"}}, {{uuid "ep1"}});
+
+	insert into users (id, name, email)
+	values
+		({{uuid "u1"}}, 'bob', 'bob@example.com');
+
+	insert into user_contact_methods (id, user_id, name, type, value)
+	values
+		({{uuid "cm1"}}, {{uuid "u1"}}, 'personal', 'SMS', {{phone "1"}});
+
+	insert into user_notification_rules (user_id, contact_method_id, delay_minutes)
+	values
+		({{uuid "u1"}}, {{uuid "cm1"}}, 0);
+
+	insert into escalation_policy_actions (escalation_policy_step_id, user_id)
+	values
+		({{uuid "eps1"}}, {{uuid "u1"}});
+
+	insert into services (id, escalation_policy_id, name)
+	values
+		({{uuid "s1"}}, {{uuid "ep1"}}, 'service1');
+
+	insert into integration_keys (id, type, name, service_id)
+	values
+		({{uuid "i1"}}, 'generic', 'my key', {{uuid "s1"}});
+	`
+
+	h := harness.NewHarness(t, sql, "")
+	defer h.Close()
+
+	tw := h.Twilio(t)
+	d1 := tw.Device(h.Phone("1"))
+
+	fire := func(summary, dedup string, meta map[string]string, escalate bool) {
+		body := map[string]interface{}{
+			"summary":  summary,
+			"dedup":    dedup,
+			"escalate": escalate,
+			"meta":     meta,
+		}
+		data, err := json.Marshal(body)
+		require.NoError(t, err)
+
+		resp, err := http.Post(
+			h.URL()+"/api/v2/generic/incoming?token="+h.UUID("i1"),
+			"application/json",
+			bytes.NewReader(data),
+		)
+		require.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	}
+
+	// Create initial alert — user gets notified
+	fire("original summary", "dedup1", map[string]string{"sev": "2"}, false)
+	d1.ExpectSMS("original summary")
+
+	// Update summary and metadata on existing alert via same dedup key
+	fire("updated summary", "dedup1", map[string]string{"sev": "1"}, false)
+
+	// Verify updated values are stored via GraphQL
+	res := h.GraphQLQuery2(`query {
+		alerts {
+			nodes {
+				summary
+				meta { key value }
+			}
+		}
+	}`)
+
+	var result struct {
+		Alerts struct {
+			Nodes []struct {
+				Summary string
+				Meta    []struct {
+					Key   string
+					Value string
+				}
+			}
+		}
+	}
+	require.NoError(t, json.Unmarshal(res.Data, &result))
+	require.Len(t, result.Alerts.Nodes, 1, "expected exactly one alert")
+
+	alert := result.Alerts.Nodes[0]
+	assert.Equal(t, "updated summary", alert.Summary, "summary should be updated")
+
+	var sev string
+	for _, m := range alert.Meta {
+		if m.Key == "sev" {
+			sev = m.Value
+		}
+	}
+	assert.Equal(t, "1", sev, "metadata sev should be updated to 1")
+
+	// Re-escalate the existing alert — user gets notified again with updated summary
+	fire("updated summary", "dedup1", map[string]string{"sev": "1"}, true)
+	d1.ExpectSMS("updated summary")
+}


### PR DESCRIPTION
## Problem

Fixes #4374

When the Generic Alert Ingestion API receives a POST with a dedup key matching an existing alert, it returns `200 IsNew:false` but silently discards the incoming `summary`, `details`, and `metadata`.

## Root Cause

Two bugs in `alert/store.go`:

1. `CreateOrUpdateTx` — the `createUpdNew` SQL CTE returns the existing row unchanged. New `summary`/`details` are only used in the INSERT branch; the existing-alert branch ignores them entirely.

2. `createOrUpdate` — `SetMetadataTx` was guarded by `&& isNew`, so metadata was only written for brand-new alerts.

## Changes

- **`alert/store.go`**: After a dedup match on a non-closed alert, run a second UPDATE statement to apply new `summary`/`details`. Remove `&& isNew` guard on metadata so it updates for existing alerts too.
- **`alert/store.go`**: Extend `EscalateAsOf` to accept `permission.Service` with an ownership check, so services can re-escalate their own alerts via the API.
- **`genericapi/handler.go`**: Add `escalate` parameter (form value, query string, or JSON body). When `true` on an existing alert, re-triggers the escalation policy.
- **`test/smoke/genericapiupdate_test.go`**: Smoke test covering summary + metadata update via dedup key, and re-escalation via `escalate:true`.

## Testing

```
go test ./test/smoke/ -run TestGenericAPIUpdate -v -timeout 120s
--- PASS: TestGenericAPIUpdate (11.38s)
```

## Notes

- Alert metadata is not currently rendered in the UI. It is stored in the DB and accessible via GraphQL but has no UI surface — worth a follow-up issue.
- JSON body requires `"escalate":true` (boolean). Form-encoded requests accept `escalate=true` (string).