### PR TITLE
notification/teams: add Microsoft Teams notification destination

### DIFF
--- a/app/startup.go
+++ b/app/startup.go
@@ -8,6 +8,7 @@ import (
 	"github.com/target/goalert/app/lifecycle"
 	"github.com/target/goalert/expflag"
 	"github.com/target/goalert/notification/email"
+	"github.com/target/goalert/notification/teams"
 	"github.com/target/goalert/notification/webhook"
 	"github.com/target/goalert/retry"
 
@@ -95,6 +96,7 @@ func (app *App) startup(ctx context.Context) error {
 	app.DestRegistry.RegisterProvider(ctx, app.slackChan.DMSender())
 	app.DestRegistry.RegisterProvider(ctx, app.slackChan.UserGroupSender())
 	app.DestRegistry.RegisterProvider(ctx, webhook.NewSender(ctx, app.httpClient))
+	app.DestRegistry.RegisterProvider(ctx, teams.NewSender(ctx, app.httpClient))
 	if app.cfg.StubNotifiers {
 		app.DestRegistry.StubNotifiers()
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -103,6 +103,11 @@ type Config struct {
 		DisableBroadcastThreadReplies bool `info:"Disable broadcasting alert status updates in threads to the main channel." public:"true"`
 	}
 
+	Teams struct {
+		Enable              bool     `public:"true" info:"Enables sending notifications to Microsoft Teams channels via Power Automate Workflow webhooks."`
+		AllowedWorkflowURLs []string `public:"true" info:"If set, allows Teams workflow webhook URLs for these domains only."`
+	}
+
 	Twilio struct {
 		Enable bool `public:"true" info:"Enables sending and processing of Voice and SMS messages through the Twilio notification provider."`
 
@@ -332,6 +337,24 @@ func (cfg Config) ValidWebhookURL(testURL string) bool {
 		return true
 	}
 	for _, baseU := range cfg.Webhook.AllowedURLs {
+		matched, err := MatchURL(baseU, testURL)
+		if err != nil {
+			return false
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidTeamsWorkflowURL returns true if the URL is an allowed Microsoft Teams
+// workflow webhook target.
+func (cfg Config) ValidTeamsWorkflowURL(testURL string) bool {
+	if len(cfg.Teams.AllowedWorkflowURLs) == 0 {
+		return true
+	}
+	for _, baseU := range cfg.Teams.AllowedWorkflowURLs {
 		matched, err := MatchURL(baseU, testURL)
 		if err != nil {
 			return false

--- a/graphql2/mapconfig.go
+++ b/graphql2/mapconfig.go
@@ -69,6 +69,8 @@ func MapConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "Slack.SigningSecret", Type: ConfigTypeString, Description: "Signing secret to verify requests from slack.", Value: cfg.Slack.SigningSecret, Password: true},
 		{ID: "Slack.InteractiveMessages", Type: ConfigTypeBoolean, Description: "Enable interactive messages (e.g. buttons).", Value: fmt.Sprintf("%t", cfg.Slack.InteractiveMessages)},
 		{ID: "Slack.DisableBroadcastThreadReplies", Type: ConfigTypeBoolean, Description: "Disable broadcasting alert status updates in threads to the main channel.", Value: fmt.Sprintf("%t", cfg.Slack.DisableBroadcastThreadReplies)},
+		{ID: "Teams.Enable", Type: ConfigTypeBoolean, Description: "Enables sending notifications to Microsoft Teams channels via Power Automate Workflow webhooks.", Value: fmt.Sprintf("%t", cfg.Teams.Enable)},
+		{ID: "Teams.AllowedWorkflowURLs", Type: ConfigTypeStringList, Description: "If set, allows Teams workflow webhook URLs for these domains only.", Value: strings.Join(cfg.Teams.AllowedWorkflowURLs, "\n")},
 		{ID: "Twilio.Enable", Type: ConfigTypeBoolean, Description: "Enables sending and processing of Voice and SMS messages through the Twilio notification provider.", Value: fmt.Sprintf("%t", cfg.Twilio.Enable)},
 		{ID: "Twilio.VoiceName", Type: ConfigTypeString, Description: "The Twilio voice to use for Text To Speech for phone calls. See https://www.twilio.com/docs/voice/twiml/say/text-speech#polly-standard-and-neural-voices", Value: cfg.Twilio.VoiceName},
 		{ID: "Twilio.VoiceLanguage", Type: ConfigTypeString, Description: "The Twilio voice language to use for Text To Speech for phone calls. See https://www.twilio.com/docs/voice/twiml/say/text-speech#polly-standard-and-neural-voices", Value: cfg.Twilio.VoiceLanguage},
@@ -119,6 +121,8 @@ func MapPublicConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "Mailgun.Enable", Type: ConfigTypeBoolean, Description: "", Value: fmt.Sprintf("%t", cfg.Mailgun.Enable)},
 		{ID: "Slack.Enable", Type: ConfigTypeBoolean, Description: "", Value: fmt.Sprintf("%t", cfg.Slack.Enable)},
 		{ID: "Slack.DisableBroadcastThreadReplies", Type: ConfigTypeBoolean, Description: "Disable broadcasting alert status updates in threads to the main channel.", Value: fmt.Sprintf("%t", cfg.Slack.DisableBroadcastThreadReplies)},
+		{ID: "Teams.Enable", Type: ConfigTypeBoolean, Description: "Enables sending notifications to Microsoft Teams channels via Power Automate Workflow webhooks.", Value: fmt.Sprintf("%t", cfg.Teams.Enable)},
+		{ID: "Teams.AllowedWorkflowURLs", Type: ConfigTypeStringList, Description: "If set, allows Teams workflow webhook URLs for these domains only.", Value: strings.Join(cfg.Teams.AllowedWorkflowURLs, "\n")},
 		{ID: "Twilio.Enable", Type: ConfigTypeBoolean, Description: "Enables sending and processing of Voice and SMS messages through the Twilio notification provider.", Value: fmt.Sprintf("%t", cfg.Twilio.Enable)},
 		{ID: "Twilio.FromNumber", Type: ConfigTypeString, Description: "The Twilio number to use for outgoing notifications.", Value: cfg.Twilio.FromNumber},
 		{ID: "Twilio.MessagingServiceSID", Type: ConfigTypeString, Description: "If set, replaces the use of From Number for SMS notifications.", Value: cfg.Twilio.MessagingServiceSID},
@@ -321,6 +325,14 @@ func ApplyConfigValues(cfg config.Config, vals []ConfigValueInput) (config.Confi
 				return cfg, err
 			}
 			cfg.Slack.DisableBroadcastThreadReplies = val
+		case "Teams.Enable":
+			val, err := parseBool(v.ID, v.Value)
+			if err != nil {
+				return cfg, err
+			}
+			cfg.Teams.Enable = val
+		case "Teams.AllowedWorkflowURLs":
+			cfg.Teams.AllowedWorkflowURLs = parseStringList(v.Value)
 		case "Twilio.Enable":
 			val, err := parseBool(v.ID, v.Value)
 			if err != nil {

--- a/notification/teams/card.go
+++ b/notification/teams/card.go
@@ -1,0 +1,195 @@
+package teams
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/target/goalert/config"
+	"github.com/target/goalert/notification"
+)
+
+// Adaptive Card color values (https://adaptivecards.io/explorer/TextBlock.html).
+const (
+	colorClosed  = "Good"
+	colorUnacked = "Attention"
+	colorAcked   = "Warning"
+)
+
+// CardVersion is the Adaptive Card schema version used for all outgoing
+// cards. 1.2 is the safest widely-supported version in Microsoft Teams,
+// including cards posted through Power Automate Workflows.
+const CardVersion = "1.2"
+
+const maxDetailsLen = 2000
+
+// AdaptiveCard is a minimal Adaptive Card representation, limited to the
+// conservative subset of the schema that Microsoft Teams supports when cards
+// are posted via a Power Automate Workflow webhook.
+type AdaptiveCard struct {
+	Type    string       `json:"type"`
+	Schema  string       `json:"$schema"`
+	Version string       `json:"version"`
+	Body    []any        `json:"body"`
+	Actions []CardAction `json:"actions,omitempty"`
+	MSTeams *MSTeams     `json:"msteams,omitempty"`
+}
+
+// MSTeams contains Teams-specific rendering properties.
+type MSTeams struct {
+	Width string `json:"width,omitempty"`
+}
+
+// TextBlock is an Adaptive Card TextBlock element.
+type TextBlock struct {
+	Type     string `json:"type"`
+	Text     string `json:"text"`
+	Wrap     bool   `json:"wrap,omitempty"`
+	Weight   string `json:"weight,omitempty"`
+	Size     string `json:"size,omitempty"`
+	Color    string `json:"color,omitempty"`
+	IsSubtle bool   `json:"isSubtle,omitempty"`
+	Spacing  string `json:"spacing,omitempty"`
+}
+
+// FactSet is an Adaptive Card FactSet element.
+type FactSet struct {
+	Type  string `json:"type"`
+	Facts []Fact `json:"facts"`
+}
+
+// Fact is a single title/value pair within a FactSet.
+type Fact struct {
+	Title string `json:"title"`
+	Value string `json:"value"`
+}
+
+// CardAction is an Adaptive Card action; only Action.OpenUrl is used since
+// submit-style actions require a bot to receive them.
+type CardAction struct {
+	Type  string `json:"type"`
+	Title string `json:"title"`
+	URL   string `json:"url,omitempty"`
+}
+
+func newCard(body []any, actions ...CardAction) AdaptiveCard {
+	return AdaptiveCard{
+		Type:    "AdaptiveCard",
+		Schema:  "http://adaptivecards.io/schemas/adaptive-card.json",
+		Version: CardVersion,
+		Body:    body,
+		Actions: actions,
+		MSTeams: &MSTeams{Width: "Full"},
+	}
+}
+
+func openURLAction(title, url string) CardAction {
+	return CardAction{Type: "Action.OpenUrl", Title: title, URL: url}
+}
+
+func title(text string) TextBlock {
+	return TextBlock{Type: "TextBlock", Text: text, Wrap: true, Weight: "Bolder", Size: "Medium"}
+}
+
+func body(text string) TextBlock {
+	return TextBlock{Type: "TextBlock", Text: text, Wrap: true}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+func stateInfo(state notification.AlertState) (color, defaultText string) {
+	switch state {
+	case notification.AlertStateAcknowledged:
+		return colorAcked, "Acknowledged"
+	case notification.AlertStateClosed:
+		return colorClosed, "Closed"
+	default:
+		return colorUnacked, "Unacknowledged"
+	}
+}
+
+// alertCard renders an alert notification or status update as an Adaptive
+// Card, colored by the current alert state (matching Slack's color scheme).
+func alertCard(ctx context.Context, alertID int, summary, details, serviceName, logEntry string, state notification.AlertState) AdaptiveCard {
+	cfg := config.FromContext(ctx)
+
+	color, defaultText := stateInfo(state)
+	if logEntry == "" {
+		logEntry = defaultText
+	}
+
+	elements := []any{
+		title(fmt.Sprintf("Alert #%d: %s", alertID, summary)),
+		TextBlock{Type: "TextBlock", Text: logEntry, Wrap: true, Color: color, Weight: "Bolder"},
+	}
+
+	var facts []Fact
+	if serviceName != "" {
+		facts = append(facts, Fact{Title: "Service", Value: serviceName})
+	}
+	if len(facts) > 0 {
+		elements = append(elements, FactSet{Type: "FactSet", Facts: facts})
+	}
+
+	if details != "" {
+		elements = append(elements, TextBlock{
+			Type: "TextBlock", Text: truncate(details, maxDetailsLen),
+			Wrap: true, IsSubtle: true, Spacing: "Medium",
+		})
+	}
+
+	return newCard(elements,
+		openURLAction("Open Alert", cfg.CallbackURL(fmt.Sprintf("/alerts/%d", alertID))),
+	)
+}
+
+// alertBundleCard renders a bundled-alerts notification for a service.
+func alertBundleCard(ctx context.Context, serviceID, serviceName string, count int) AdaptiveCard {
+	cfg := config.FromContext(ctx)
+
+	return newCard([]any{
+		title(fmt.Sprintf("Service '%s' has %d unacknowledged alerts.", serviceName, count)),
+	},
+		openURLAction("Open Alerts", cfg.CallbackURL("/services/"+serviceID+"/alerts")),
+	)
+}
+
+// onCallCard renders a schedule on-call notification.
+func onCallCard(_ context.Context, m notification.ScheduleOnCallUsers) AdaptiveCard {
+	var text string
+	if len(m.Users) == 0 {
+		text = fmt.Sprintf("No one is on-call for %s.", m.ScheduleName)
+	} else {
+		names := make([]string, len(m.Users))
+		for i, u := range m.Users {
+			names[i] = fmt.Sprintf("[%s](%s)", u.Name, u.URL)
+		}
+		text = fmt.Sprintf("On-call for %s: %s", m.ScheduleName, strings.Join(names, ", "))
+	}
+
+	return newCard([]any{
+		title(fmt.Sprintf("On-Call Notification: %s", m.ScheduleName)),
+		body(text),
+	},
+		openURLAction("Open Schedule", m.ScheduleURL),
+	)
+}
+
+// testCard renders a test notification.
+func testCard(ctx context.Context) AdaptiveCard {
+	cfg := config.FromContext(ctx)
+	return newCard([]any{
+		title(fmt.Sprintf("%s Test Notification", cfg.ApplicationName())),
+		body("This is a test message."),
+	})
+}
+
+// signalCard renders a dynamic-action signal message.
+func signalCard(_ context.Context, message string) AdaptiveCard {
+	return newCard([]any{body(message)})
+}

--- a/notification/teams/card_test.go
+++ b/notification/teams/card_test.go
@@ -1,0 +1,98 @@
+package teams
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/config"
+	"github.com/target/goalert/notification"
+)
+
+func testCtx() context.Context {
+	var cfg config.Config
+	cfg.General.PublicURL = "http://example.com"
+	cfg.Teams.Enable = true
+	return cfg.Context(context.Background())
+}
+
+func toJSON(t *testing.T, v any) string {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(data)
+}
+
+func TestAlertCard(t *testing.T) {
+	ctx := testCtx()
+
+	card := alertCard(ctx, 123, "Example Summary", "Example Details", "Example Service", "", notification.AlertStateUnacknowledged)
+	doc := toJSON(t, card)
+
+	assert.Contains(t, doc, `"Alert #123: Example Summary"`)
+	assert.Contains(t, doc, `"Unacknowledged"`)
+	assert.Contains(t, doc, `"color":"Attention"`)
+	assert.Contains(t, doc, `"Example Details"`)
+	assert.Contains(t, doc, `"Example Service"`)
+	assert.Contains(t, doc, `"url":"http://example.com/alerts/123"`)
+	assert.Contains(t, doc, `"version":"1.2"`)
+
+	card = alertCard(ctx, 123, "Example Summary", "", "", "Acknowledged by Joe", notification.AlertStateAcknowledged)
+	doc = toJSON(t, card)
+	assert.Contains(t, doc, `"Acknowledged by Joe"`)
+	assert.Contains(t, doc, `"color":"Warning"`)
+
+	card = alertCard(ctx, 123, "Example Summary", "", "", "", notification.AlertStateClosed)
+	doc = toJSON(t, card)
+	assert.Contains(t, doc, `"Closed"`)
+	assert.Contains(t, doc, `"color":"Good"`)
+}
+
+func TestAlertCard_TruncatesDetails(t *testing.T) {
+	long := strings.Repeat("x", maxDetailsLen+100)
+	card := alertCard(testCtx(), 1, "s", long, "", "", notification.AlertStateUnacknowledged)
+	doc := toJSON(t, card)
+
+	assert.NotContains(t, doc, long)
+	assert.Contains(t, doc, strings.Repeat("x", maxDetailsLen)+"…")
+}
+
+func TestAlertBundleCard(t *testing.T) {
+	card := alertBundleCard(testCtx(), "svc-id", "Example Service", 6)
+	doc := toJSON(t, card)
+
+	assert.Contains(t, doc, `"Service 'Example Service' has 6 unacknowledged alerts."`)
+	assert.Contains(t, doc, `"url":"http://example.com/services/svc-id/alerts"`)
+}
+
+func TestOnCallCard(t *testing.T) {
+	card := onCallCard(testCtx(), notification.ScheduleOnCallUsers{
+		ScheduleName: "Example Schedule",
+		ScheduleURL:  "http://example.com/schedules/sched-id",
+		Users: []notification.User{
+			{Name: "Alice", URL: "http://example.com/users/alice"},
+			{Name: "Bob", URL: "http://example.com/users/bob"},
+		},
+	})
+	doc := toJSON(t, card)
+
+	assert.Contains(t, doc, "[Alice](http://example.com/users/alice)")
+	assert.Contains(t, doc, "[Bob](http://example.com/users/bob)")
+	assert.Contains(t, doc, `"url":"http://example.com/schedules/sched-id"`)
+
+	card = onCallCard(testCtx(), notification.ScheduleOnCallUsers{
+		ScheduleName: "Example Schedule",
+		ScheduleURL:  "http://example.com/schedules/sched-id",
+	})
+	doc = toJSON(t, card)
+	assert.Contains(t, doc, "No one is on-call")
+}
+
+func TestTestCard(t *testing.T) {
+	doc := toJSON(t, testCard(testCtx()))
+	assert.Contains(t, doc, "GoAlert Test Notification")
+	assert.Contains(t, doc, "This is a test message.")
+}

--- a/notification/teams/nfydest.go
+++ b/notification/teams/nfydest.go
@@ -1,0 +1,103 @@
+package teams
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/target/goalert/config"
+	"github.com/target/goalert/gadb"
+	"github.com/target/goalert/notification/nfydest"
+	"github.com/target/goalert/validation"
+	"github.com/target/goalert/validation/validate"
+)
+
+const (
+	DestTypeTeamsWorkflow = "builtin-teams-workflow"
+	FieldWebhookURL       = "teams_webhook_url"
+	ParamMessage          = "message"
+	FallbackIconURL       = "builtin://msteams"
+)
+
+// NewTeamsWorkflowDest creates a new Teams workflow webhook destination.
+func NewTeamsWorkflowDest(url string) gadb.DestV1 {
+	return gadb.NewDestV1(DestTypeTeamsWorkflow, FieldWebhookURL, url)
+}
+
+var _ nfydest.Provider = (*Sender)(nil)
+
+func (Sender) ID() string { return DestTypeTeamsWorkflow }
+
+func (Sender) TypeInfo(ctx context.Context) (*nfydest.TypeInfo, error) {
+	cfg := config.FromContext(ctx)
+	return &nfydest.TypeInfo{
+		Type:                       DestTypeTeamsWorkflow,
+		Name:                       "Microsoft Teams",
+		Enabled:                    cfg.Teams.Enable,
+		SupportsAlertNotifications: true,
+		SupportsStatusUpdates:      true,
+		SupportsOnCallNotify:       true,
+		SupportsSignals:            true,
+		StatusUpdatesRequired:      true,
+		RequiredFields: []nfydest.FieldConfig{{
+			FieldID:            FieldWebhookURL,
+			Label:              "Workflow Webhook URL",
+			PlaceholderText:    "https://example.westus.logic.azure.com/workflows/...",
+			InputType:          "url",
+			Hint:               "Teams Documentation",
+			HintURL:            "/docs#teams",
+			SupportsValidation: true,
+		}},
+		DynamicParams: []nfydest.DynamicParamConfig{{
+			ParamID: ParamMessage,
+			Label:   "Message",
+			Hint:    "The text of the message to send.",
+		}},
+	}, nil
+}
+
+func validateWebhookURL(ctx context.Context, value string) error {
+	cfg := config.FromContext(ctx)
+
+	err := validate.AbsoluteURL(FieldWebhookURL, value)
+	if err != nil {
+		return err
+	}
+
+	u, err := url.Parse(value)
+	if err != nil {
+		return validation.WrapError(err)
+	}
+	if u.Scheme != "https" {
+		return validation.NewGenericError("url must use https")
+	}
+	if !cfg.ValidTeamsWorkflowURL(value) {
+		return validation.NewGenericError("url is not allowed by administrator")
+	}
+
+	return nil
+}
+
+func (s *Sender) ValidateField(ctx context.Context, fieldID, value string) error {
+	switch fieldID {
+	case FieldWebhookURL:
+		return validateWebhookURL(ctx, value)
+	}
+
+	return validation.NewGenericError("unknown field ID")
+}
+
+func (s *Sender) DisplayInfo(ctx context.Context, args map[string]string) (*nfydest.DisplayInfo, error) {
+	if args == nil {
+		args = make(map[string]string)
+	}
+
+	u, err := url.Parse(args[FieldWebhookURL])
+	if err != nil {
+		return nil, validation.WrapError(err)
+	}
+	return &nfydest.DisplayInfo{
+		IconURL:     FallbackIconURL,
+		IconAltText: "Microsoft Teams",
+		Text:        u.Hostname(),
+	}, nil
+}

--- a/notification/teams/sender.go
+++ b/notification/teams/sender.go
@@ -1,0 +1,125 @@
+package teams
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/target/goalert/config"
+	"github.com/target/goalert/notification"
+	"github.com/target/goalert/notification/nfydest"
+)
+
+// Sender posts Adaptive Card messages to Microsoft Teams channels using
+// Power Automate Workflow webhook URLs.
+type Sender struct {
+	client *http.Client
+}
+
+// NewSender creates a new Sender using the given HTTP client.
+func NewSender(ctx context.Context, client *http.Client) *Sender {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &Sender{client: client}
+}
+
+var _ nfydest.MessageSender = &Sender{}
+
+// workflowMessage is the payload format expected by the Teams
+// "post a card in a chat or channel" Workflow trigger.
+type workflowMessage struct {
+	Type        string       `json:"type"`
+	Attachments []attachment `json:"attachments"`
+}
+
+type attachment struct {
+	ContentType string       `json:"contentType"`
+	ContentURL  *string      `json:"contentUrl"`
+	Content     AdaptiveCard `json:"content"`
+}
+
+// NewWorkflowMessage wraps an Adaptive Card in the message envelope expected
+// by a Teams Workflow webhook.
+func NewWorkflowMessage(card AdaptiveCard) any {
+	return workflowMessage{
+		Type: "message",
+		Attachments: []attachment{{
+			ContentType: "application/vnd.microsoft.card.adaptive",
+			Content:     card,
+		}},
+	}
+}
+
+// SendMessage renders the message as an Adaptive Card and posts it to the
+// destination's workflow webhook URL.
+func (s *Sender) SendMessage(ctx context.Context, msg notification.Message) (*notification.SentMessage, error) {
+	cfg := config.FromContext(ctx)
+
+	var card AdaptiveCard
+	switch m := msg.(type) {
+	case notification.Test:
+		card = testCard(ctx)
+	case notification.Alert:
+		// Workflow webhooks cannot update existing messages, so
+		// re-notifications post a fresh card.
+		card = alertCard(ctx, m.AlertID, m.Summary, m.Details, m.ServiceName, "", notification.AlertStateUnacknowledged)
+	case notification.AlertStatus:
+		card = alertCard(ctx, m.AlertID, m.Summary, m.Details, m.ServiceName, m.LogEntry, m.NewAlertState)
+	case notification.AlertBundle:
+		card = alertBundleCard(ctx, m.ServiceID, m.ServiceName, m.Count)
+	case notification.SignalMessage:
+		card = signalCard(ctx, m.Param(ParamMessage))
+	case notification.ScheduleOnCallUsers:
+		card = onCallCard(ctx, m)
+	default:
+		return nil, fmt.Errorf("message type '%T' not supported", m)
+	}
+
+	webURL := msg.DestArg(FieldWebhookURL)
+	if !cfg.ValidTeamsWorkflowURL(webURL) {
+		// fail permanently if the URL is not currently valid/allowed
+		return &notification.SentMessage{
+			State:        notification.StateFailedPerm,
+			StateDetails: "invalid or not allowed URL",
+		}, nil
+	}
+
+	data, err := json.Marshal(NewWorkflowMessage(card))
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", webURL, bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
+
+	switch {
+	case resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500:
+		// temporary failure; return an error so the message is retried
+		return nil, fmt.Errorf("post to teams workflow: %s", resp.Status)
+	case resp.StatusCode >= 400:
+		return &notification.SentMessage{
+			State:        notification.StateFailedPerm,
+			StateDetails: fmt.Sprintf("teams workflow responded with %s", resp.Status),
+		}, nil
+	}
+
+	return &notification.SentMessage{State: notification.StateSent}, nil
+}

--- a/notification/teams/sender_test.go
+++ b/notification/teams/sender_test.go
@@ -1,0 +1,127 @@
+package teams
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/config"
+	"github.com/target/goalert/notification"
+	"github.com/target/goalert/notification/nfymsg"
+)
+
+func TestSender_SendMessage(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		data, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(data, &body))
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	ctx := testCtx()
+	s := NewSender(ctx, srv.Client())
+
+	res, err := s.SendMessage(ctx, notification.Alert{
+		Base: nfymsg.Base{
+			ID:   "msg-id",
+			Dest: NewTeamsWorkflowDest(srv.URL),
+		},
+		AlertID:     123,
+		Summary:     "Example Summary",
+		ServiceName: "Example Service",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, notification.StateSent, res.State)
+
+	assert.Equal(t, "message", body["type"])
+	atts, ok := body["attachments"].([]any)
+	require.True(t, ok)
+	require.Len(t, atts, 1)
+	att, ok := atts[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "application/vnd.microsoft.card.adaptive", att["contentType"])
+	card, ok := att["content"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "AdaptiveCard", card["type"])
+}
+
+func TestSender_SendMessage_PermanentFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	ctx := testCtx()
+	s := NewSender(ctx, srv.Client())
+
+	res, err := s.SendMessage(ctx, notification.Test{
+		Base: nfymsg.Base{Dest: NewTeamsWorkflowDest(srv.URL)},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, notification.StateFailedPerm, res.State)
+}
+
+func TestSender_SendMessage_TemporaryFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	ctx := testCtx()
+	s := NewSender(ctx, srv.Client())
+
+	_, err := s.SendMessage(ctx, notification.Test{
+		Base: nfymsg.Base{Dest: NewTeamsWorkflowDest(srv.URL)},
+	})
+	require.Error(t, err)
+}
+
+func TestSender_SendMessage_DisallowedURL(t *testing.T) {
+	var cfg config.Config
+	cfg.General.PublicURL = "http://example.com"
+	cfg.Teams.Enable = true
+	cfg.Teams.AllowedWorkflowURLs = []string{"https://allowed.example.com"}
+	ctx := cfg.Context(context.Background())
+
+	s := NewSender(ctx, nil)
+
+	res, err := s.SendMessage(ctx, notification.Test{
+		Base: nfymsg.Base{Dest: NewTeamsWorkflowDest("https://evil.example.com/hook")},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, notification.StateFailedPerm, res.State)
+}
+
+func TestSender_ValidateField(t *testing.T) {
+	ctx := testCtx()
+	var s Sender
+
+	assert.NoError(t, s.ValidateField(ctx, FieldWebhookURL, "https://example.westus.logic.azure.com/workflows/abc"))
+	assert.Error(t, s.ValidateField(ctx, FieldWebhookURL, "http://example.com/insecure"), "http URLs should be rejected")
+	assert.Error(t, s.ValidateField(ctx, FieldWebhookURL, "not-a-url"))
+	assert.Error(t, s.ValidateField(ctx, "unknown_field", "value"))
+
+	var cfg config.Config
+	cfg.Teams.AllowedWorkflowURLs = []string{"https://allowed.example.com"}
+	restrictedCtx := cfg.Context(context.Background())
+	assert.NoError(t, s.ValidateField(restrictedCtx, FieldWebhookURL, "https://allowed.example.com/hook"))
+	assert.Error(t, s.ValidateField(restrictedCtx, FieldWebhookURL, "https://other.example.com/hook"))
+}
+
+func TestSender_DisplayInfo(t *testing.T) {
+	var s Sender
+	info, err := s.DisplayInfo(testCtx(), map[string]string{
+		FieldWebhookURL: "https://example.westus.logic.azure.com/workflows/abc",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "example.westus.logic.azure.com", info.Text)
+	assert.Equal(t, FallbackIconURL, info.IconURL)
+}

--- a/test/smoke/harness/harness.go
+++ b/test/smoke/harness/harness.go
@@ -282,6 +282,8 @@ func (h *Harness) StartWithAppCfgHook(fn func(*app.Config)) {
 
 	cfg.Webhook.Enable = true
 
+	cfg.Teams.Enable = true
+
 	cfg.Mailgun.Enable = true
 	cfg.Mailgun.APIKey = mailgunAPIKey
 	cfg.Mailgun.EmailDomain = "smoketest.example.com"

--- a/test/smoke/teamsworkflow_test.go
+++ b/test/smoke/teamsworkflow_test.go
@@ -1,0 +1,100 @@
+package smoke
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/test/smoke/harness"
+)
+
+type teamsWorkflowMessage struct {
+	Type        string
+	Attachments []struct {
+		ContentType string
+		Content     json.RawMessage
+	}
+}
+
+// TestTeamsWorkflow tests that alert notifications and status updates are
+// posted to a Microsoft Teams workflow webhook as Adaptive Cards.
+func TestTeamsWorkflow(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan teamsWorkflowMessage, 10)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var msg teamsWorkflowMessage
+
+		data, err := io.ReadAll(r.Body)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		err = json.Unmarshal(data, &msg)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		ch <- msg
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer ts.Close()
+
+	sql := `
+	insert into escalation_policies (id, name)
+	values
+		({{uuid "eid"}}, 'esc policy');
+	insert into escalation_policy_steps (id, escalation_policy_id)
+	values
+		({{uuid "esid"}}, {{uuid "eid"}});
+
+	insert into notification_channels (id, name, dest)
+	values
+		({{uuid "chan"}}, 'teams chan', '{"Type": "builtin-teams-workflow", "Args": {"teams_webhook_url": "` + ts.URL + `"}}');
+
+	insert into escalation_policy_actions (escalation_policy_step_id, channel_id)
+	values
+		({{uuid "esid"}}, {{uuid "chan"}});
+
+	insert into services (id, escalation_policy_id, name)
+	values
+		({{uuid "sid"}}, {{uuid "eid"}}, 'service');
+`
+	h := harness.NewHarness(t, sql, "schedule-rotation-ep-labels")
+	defer h.Close()
+
+	expectCard := func(contains ...string) {
+		t.Helper()
+		timeout := time.After(15 * time.Second)
+		select {
+		case msg := <-ch:
+			assert.Equal(t, "message", msg.Type)
+			require.Len(t, msg.Attachments, 1)
+			assert.Equal(t, "application/vnd.microsoft.card.adaptive", msg.Attachments[0].ContentType)
+			card := string(msg.Attachments[0].Content)
+			for _, s := range contains {
+				assert.Contains(t, card, s)
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for teams workflow message")
+		}
+	}
+
+	a := h.CreateAlertWithDetails(h.UUID("sid"), "testing summary", "testing details")
+	h.Trigger()
+	expectCard("testing summary", "testing details", "Attention")
+
+	a.Ack()
+	h.Trigger()
+	expectCard("testing summary", "Warning")
+
+	a.Close()
+	h.Trigger()
+	expectCard("testing summary", "Good")
+}

--- a/web/src/app/documentation/Documentation.tsx
+++ b/web/src/app/documentation/Documentation.tsx
@@ -4,6 +4,7 @@ import CardContent from '@mui/material/CardContent'
 import Typography from '@mui/material/Typography'
 import integrationKeys from './sections/IntegrationKeys.md'
 import webhooks from './sections/Webhooks.md'
+import teams from './sections/Teams.md'
 import Markdown from '../util/Markdown'
 import { useConfigValue } from '../util/RequireConfig'
 import { pathPrefix } from '../env'
@@ -16,9 +17,10 @@ const useStyles = makeStyles({
 })
 
 export default function Documentation(): React.JSX.Element {
-  const [publicURL, webhookEnabled] = useConfigValue(
+  const [publicURL, webhookEnabled, teamsEnabled] = useConfigValue(
     'General.PublicURL',
     'Webhook.Enable',
+    'Teams.Enable',
   )
   const classes = useStyles()
 
@@ -26,6 +28,9 @@ export default function Documentation(): React.JSX.Element {
   let markdownDocs = [{ doc: integrationKeys, id: 'integration-keys' }]
   if (webhookEnabled) {
     markdownDocs.push({ doc: webhooks, id: 'webhooks' })
+  }
+  if (teamsEnabled) {
+    markdownDocs.push({ doc: teams, id: 'teams' })
   }
 
   markdownDocs = markdownDocs.map((md) => ({
@@ -44,7 +49,7 @@ export default function Documentation(): React.JSX.Element {
     if (!el) return
 
     el.scrollIntoView()
-  }, [webhookEnabled, publicURL])
+  }, [webhookEnabled, teamsEnabled, publicURL])
 
   return (
     <React.Fragment>

--- a/web/src/app/documentation/sections/Teams.md
+++ b/web/src/app/documentation/sections/Teams.md
@@ -1,0 +1,37 @@
+# Microsoft Teams
+
+GoAlert can post alert notifications, status updates, on-call notifications, and test messages to Microsoft Teams channels as Adaptive Cards.
+
+Messages are delivered through a Power Automate Workflow webhook (the supported replacement for the retired Office 365 connectors).
+
+### Creating a Workflow Webhook URL
+
+1. In Microsoft Teams, open the channel you want notifications in and choose **Workflows** (or start from the Power Automate "Post to a channel when a webhook request is received" template).
+2. Create the workflow **"Post to a channel when a webhook request is received"** and select the target team and channel.
+3. Copy the generated HTTP POST URL.
+4. In GoAlert, create a notification destination of type **Microsoft Teams** (e.g. as an escalation policy step or schedule on-call notification) and paste the URL.
+
+### Notes
+
+- Cards are posted by the workflow's Flow bot identity, not by GoAlert itself.
+- Alert status updates are posted as new cards; existing cards are not edited.
+- Acknowledge/close from within Teams is not supported with workflow webhooks; use the card's **Open Alert** button to act on an alert in GoAlert.
+- Treat the workflow webhook URL as a secret: anyone with the URL can post to the channel.
+- Administrators may restrict allowed webhook domains with the `Teams.AllowedWorkflowURLs` setting.
+
+### Payload
+
+Each message is a standard Teams message envelope containing a single Adaptive Card attachment:
+
+```
+{
+    "type": "message",
+    "attachments": [
+        {
+            "contentType": "application/vnd.microsoft.card.adaptive",
+            "contentUrl": null,
+            "content": { ...Adaptive Card... }
+        }
+    ]
+}
+```

--- a/web/src/app/icons/components/Icons.tsx
+++ b/web/src/app/icons/components/Icons.tsx
@@ -6,6 +6,7 @@ import WarningIcon from '@mui/icons-material/Warning'
 import slackIcon from '../../public/icons/slack.svg'
 import slackIconBlack from '../../public/icons/slack_monochrome_black.svg'
 import slackIconWhite from '../../public/icons/slack_monochrome_white.svg'
+import msTeamsIcon from '../../public/icons/msteams.svg'
 import makeStyles from '@mui/styles/makeStyles'
 import { useTheme } from '@mui/material'
 import { Webhook } from '@mui/icons-material'
@@ -87,6 +88,10 @@ export function SlackBW(): React.JSX.Element {
       alt='Slack'
     />
   )
+}
+
+export function Teams(): React.JSX.Element {
+  return <img src={msTeamsIcon} width={20} height={20} alt='Microsoft Teams' />
 }
 
 export function WebhookBW(): React.JSX.Element {

--- a/web/src/app/public/icons/msteams.svg
+++ b/web/src/app/public/icons/msteams.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="25" cy="8.5" r="3.5" fill="#5059c9"/>
+  <path fill="#5059c9" d="M20.5 14h9.7a.8.8 0 0 1 .8.8v6.7a5.5 5.5 0 0 1-5.5 5.5h-.1a5.4 5.4 0 0 1-4.9-3.1z"/>
+  <circle cx="17.5" cy="7.5" r="4.5" fill="#7b83eb"/>
+  <path fill="#7b83eb" d="M12 14h11a1 1 0 0 1 1 1v7.5a6.5 6.5 0 0 1-6.5 6.5h-.1A6.4 6.4 0 0 1 12 24.6z"/>
+  <rect x="1" y="8" width="17" height="17" rx="2" fill="#4b53bc"/>
+  <path fill="#fff" d="M5.5 12.5h9v2.3h-3.3v7.7H8.8v-7.7H5.5z"/>
+</svg>

--- a/web/src/app/util/DestinationAvatar.tsx
+++ b/web/src/app/util/DestinationAvatar.tsx
@@ -9,6 +9,7 @@ import {
   Webhook as WebhookIcon,
   Email,
 } from '@mui/icons-material'
+import { Teams as TeamsIcon } from '../icons/components/Icons'
 
 const builtInIcons: { [key: string]: React.ReactNode } = {
   'builtin://alert': <AlertIcon />,
@@ -16,6 +17,7 @@ const builtInIcons: { [key: string]: React.ReactNode } = {
   'builtin://schedule': <ScheduleIcon />,
   'builtin://webhook': <WebhookIcon />,
   'builtin://email': <Email />,
+  'builtin://msteams': <TeamsIcon />,
 }
 
 export type DestinationAvatarProps = {

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -1671,6 +1671,8 @@ type ConfigID =
   | 'Slack.SigningSecret'
   | 'Slack.InteractiveMessages'
   | 'Slack.DisableBroadcastThreadReplies'
+  | 'Teams.Enable'
+  | 'Teams.AllowedWorkflowURLs'
   | 'Twilio.Enable'
   | 'Twilio.VoiceName'
   | 'Twilio.VoiceLanguage'


### PR DESCRIPTION
- [ ] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [ ] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Adds Microsoft Teams as a first-party notification destination. Since Office 365 connectors were retired, the supported webhook-style path into Teams is a Power Automate Workflow webhook ("Post to a channel when a webhook request is received"). This PR adds a `builtin-teams-workflow` destination type that renders GoAlert notifications as Adaptive Cards and posts them to such a webhook.

- New `notification/teams` package implementing `nfydest.Provider` and `nfydest.MessageSender`, following the existing `notification/webhook` and `notification/slack` patterns.
- Adaptive Cards (schema 1.2, the conservative version Teams supports through workflow webhooks) for alert notifications, alert status updates, alert bundles, schedule on-call notifications, universal-key signal messages, and test messages. Alert cards are colored by state (Attention/Warning/Good) to match the Slack color scheme, include service name and truncated details, and carry an "Open Alert" button that deep-links into GoAlert.
- Error classification in the sender: 429/5xx responses are retried, other 4xx and disallowed URLs fail permanently.
- Status updates are posted as new cards (workflow webhooks cannot edit previously posted messages).
- `/docs` gains a "Microsoft Teams" section (shown when Teams is enabled) with setup steps for creating the workflow webhook.

**Which issue(s) this PR fixes:**
N/A — no associated issue.

**Out of Scope:**
Interactive Ack/Close buttons inside Teams cards. Microsoft does not deliver card actions back to the sender for workflow-webhook posts; that requires a Bot Framework integration (bot registration, conversation reference storage, inbound activity endpoints, and identity linking). The card renderer is structured so a future bot-backed sender can reuse it and add `Action.Execute` buttons.

**Screenshots:**
N/A

**Describe any introduced user-facing changes:**
- New admin config settings: `Teams.Enable` and `Teams.AllowedWorkflowURLs` (optional domain allow-list, mirroring `Webhook.AllowedURLs`).
- When enabled, a "Microsoft Teams" destination becomes available for escalation policy steps, schedule on-call notifications, and universal integration key actions, with a required "Workflow Webhook URL" field (https-only, validated against the allow-list).
- New Teams icon for destination chips and a "Microsoft Teams" section on the `/docs` page.

**Describe any introduced API changes:**
- New destination type `builtin-teams-workflow` with required field `teams_webhook_url` and dynamic param `message`, exposed automatically through the existing `destinationTypes` GraphQL API.
- New config keys `Teams.Enable` and `Teams.AllowedWorkflowURLs` in the config GraphQL API.

**Additional Info:**
Unit tests cover card rendering per message type, details truncation, URL validation, error classification, and display info. A smoke test (`test/smoke/teamsworkflow_test.go`) verifies alert → ack → close card delivery end-to-end; it compiles cleanly but was authored on a Windows machine without a local Postgres, so it has not been executed locally — please let CI validate it. `make check` was likewise not run locally (Windows); Go vet, gofmt, `go test ./notification/... ./graphql2/... ./config/... ./app/...`, TypeScript typecheck, eslint, and prettier all pass.