### PR TITLE
Fix auto closing

### DIFF
--- a/integrationkey/uik/handler.go
+++ b/integrationkey/uik/handler.go
@@ -63,6 +63,7 @@ func (h *Handler) handleAction(ctx context.Context, act gadb.UIKActionV1) (inser
 			Details:   act.Param("details"),
 			Source:    alert.SourceUniversal,
 			Status:    status,
+			Dedup:     alert.NewUserDedup(act.Param("dedup")),
 		})
 		if err != nil {
 			return false, err

--- a/test/smoke/uikdedupclose_test.go
+++ b/test/smoke/uikdedupclose_test.go
@@ -1,0 +1,136 @@
+package smoke
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/expflag"
+	"github.com/target/goalert/test/smoke/harness"
+)
+
+// TestUIKDedupClose verifies that a universal integration key's builtin-alert
+// action uses an explicit `dedup` param -- instead of summary/details -- to
+// match an existing alert for de-duplication and closing.
+func TestUIKDedupClose(t *testing.T) {
+	t.Parallel()
+
+	const sql = `
+		insert into escalation_policies (id, name) values
+			({{uuid "eid"}}, 'esc policy');
+		insert into services (id, escalation_policy_id, name) values
+			({{uuid "sid"}}, {{uuid "eid"}}, 'service');
+	`
+
+	h := harness.NewHarnessWithFlags(t, sql, "", expflag.FlagSet{expflag.UnivKeys})
+	defer h.Close()
+
+	resp := h.GraphQLQuery2(fmt.Sprintf(`mutation{ createIntegrationKey(input: {name: "key", type: universal, serviceID: "%s"}){ id, href } }`, h.UUID("sid")))
+	require.Empty(t, resp.Errors)
+
+	var respData struct {
+		CreateIntegrationKey struct {
+			ID   uuid.UUID
+			Href string
+		}
+	}
+	require.NoError(t, json.Unmarshal(resp.Data, &respData))
+
+	resp = h.GraphQLQuery2(fmt.Sprintf(`
+		mutation{
+			updateKeyConfig(input: {
+				keyID: "%s",
+				defaultActions: [
+					{dest: {type: "builtin-alert"},
+						params: {
+							summary: "req.body['summary']",
+							dedup: "req.body['dedup']",
+							close: "req.body['close']"
+						}}
+				]
+			})
+		}`, respData.CreateIntegrationKey.ID))
+	require.Empty(t, resp.Errors)
+
+	resp = h.GraphQLQuery2(fmt.Sprintf(`mutation{ generateKeyToken(id: "%s")}`, respData.CreateIntegrationKey.ID))
+	require.Empty(t, resp.Errors)
+	var gen struct{ GenerateKeyToken string }
+	require.NoError(t, json.Unmarshal(resp.Data, &gen))
+
+	post := func(body string) {
+		t.Helper()
+		req, err := http.NewRequest("POST", respData.CreateIntegrationKey.Href, strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+gen.GenerateKeyToken)
+		req.Header.Set("Content-Type", "application/json")
+		r, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer r.Body.Close()
+		data, _ := io.ReadAll(r.Body)
+		require.Equalf(t, http.StatusNoContent, r.StatusCode, "response: %s", data)
+	}
+
+	type alertNode struct {
+		ID      string
+		Summary string
+		Status  string
+	}
+	getAlerts := func() []alertNode {
+		t.Helper()
+		res := h.GraphQLQuery2(fmt.Sprintf(`query{ alerts(input: {filterByServiceID: ["%s"]}){ nodes { id summary status } } }`, h.UUID("sid")))
+		require.Empty(t, res.Errors)
+		var data struct {
+			Alerts struct{ Nodes []alertNode }
+		}
+		require.NoError(t, json.Unmarshal(res.Data, &data))
+		return data.Alerts.Nodes
+	}
+
+	// Trigger two distinct alerts, each with its own explicit dedup key.
+	post(`{"summary": "first summary", "dedup": "alert-a"}`)
+	post(`{"summary": "second alert", "dedup": "alert-b"}`)
+
+	alerts := getAlerts()
+	require.Len(t, alerts, 2, "expected two distinct alerts")
+
+	// Re-triggering with the same dedup key but a different summary must be
+	// suppressed as a duplicate of the existing alert
+	post(`{"summary": "this should be ignored", "dedup": "alert-a"}`)
+	alerts = getAlerts()
+	require.Len(t, alerts, 2, "duplicate trigger (same dedup key) should not create a new alert")
+
+	var alertA, alertB alertNode
+	for _, a := range alerts {
+		switch a.Summary {
+		case "first summary":
+			alertA = a
+		case "second alert":
+			alertB = a
+		}
+	}
+	require.NotEmpty(t, alertA.ID, "alert A not found")
+	require.NotEmpty(t, alertB.ID, "alert B not found")
+	assert.Equal(t, "StatusUnacknowledged", alertA.Status)
+	assert.Equal(t, "StatusUnacknowledged", alertB.Status)
+
+	// Closing by dedup key "alert-a" must close only that alert, using a
+	// different summary than the one it was originally triggered with
+	post(`{"summary": "irrelevant close summary", "dedup": "alert-a", "close": true}`)
+
+	alerts = getAlerts()
+	require.Len(t, alerts, 2)
+	for _, a := range alerts {
+		switch a.ID {
+		case alertA.ID:
+			assert.Equal(t, "StatusClosed", a.Status, "alert A should be closed")
+		case alertB.ID:
+			assert.Equal(t, "StatusUnacknowledged", a.Status, "alert B should be unaffected")
+		}
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
When creating an alert with a universal integration key the config allows for setting a dedup key based on the received alert payload, but the key was never passed into the created alert config on create/update so any alerts created via UIK used the default dedup hash created from the summary + details. 

This surfaced as upstream systems unable to close alerts automatically due to the dedupe hash of the opened alert not matching the cleared alert request.

This pr adds the uik configured dedup key to the alert on create/update.
