### PR TITLE
feat: adds support for color on uik messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ PUBLIC_URL := http://localhost:3030$(HTTP_PREFIX)
 export GOALERT_PUBLIC_URL := $(PUBLIC_URL)
 
 # used to enable experimental features, use `goalert --list-experimental` to see available features or check the expflag package
-EXPERIMENTAL :=
-export GOALERT_EXPERIMENTAL := $(EXPERIMENTAL)
+EXPERIMENTAL ?=
+export GOALERT_EXPERIMENTAL ?= $(EXPERIMENTAL)
 
 ifeq ($(CI), 1)
 PROD_CY_PROC = Procfile.cypress.ci

--- a/docs/universal-integration-keys.md
+++ b/docs/universal-integration-keys.md
@@ -30,6 +30,33 @@ The Expr language is chosen for its safety, performance, and Go integration capa
 
 Data mapping is part of the action definition in UIKs. Helper functions like `sprintf` can be used to construct messages based on the input data. This allows users to customize the content of sent messages based on the incoming JSON payload.
 
+#### Slack Signal Actions
+
+A UIK action that targets a Slack Channel sends a signal as a colored Slack attachment. Its dynamic parameters are expressions that resolve to strings from the incoming request.
+
+| Parameter | Description |
+| --- | --- |
+| `message` | The Slack mrkdwn message body. For an incoming JSON payload, use `req.body['message']`. |
+| `color` | The attachment color. Use `good`, `warning`, `danger`, or a six-digit hex value such as `#439FE0`. For an incoming JSON payload, use `req.body['color']`. |
+
+GoAlert resolves the named colors before sending the Slack message: `good` becomes `#218626`, `warning` becomes `#867321`, and `danger` becomes `#862421`. A valid `#RRGGBB` value is used unchanged. Missing or unsupported values use neutral blue (`#439FE0`).
+
+For example, configure the Slack action's dynamic parameters as:
+
+```text
+message: req.body['message']
+color: req.body['color']
+```
+
+Then send a payload such as:
+
+```json
+{
+  "message": "*Deployment validation*\n• Verify the alert route\n• Check <https://example.com|the runbook>",
+  "color": "danger"
+}
+```
+
 There will be limits (TBD) on the number of output actions for a single key, total number of rules, and size of the Expr expression to enforce some level of bounding on request complexity. This feature will inherit the 1-request-per-process-per-key rule that other integration keys adopt, ensuring no "noisy neighbor" issues with isolation.
 
 ### 3.5 Max Pending Messages Per Service

--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -53,8 +54,9 @@ const (
 )
 
 var (
-	_ nfydest.MessageSender       = &ChannelSender{}
-	_ notification.ReceiverSetter = &ChannelSender{}
+	_          nfydest.MessageSender       = &ChannelSender{}
+	_          notification.ReceiverSetter = &ChannelSender{}
+	hexColorRx                             = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)
 )
 
 func NewChannelSender(ctx context.Context, cfg Config) (*ChannelSender, error) {
@@ -456,17 +458,7 @@ func signalAttachmentColor(color string) string {
 }
 
 func isHexColor(color string) bool {
-	if len(color) != len("#000000") || color[0] != '#' {
-		return false
-	}
-
-	for _, r := range color[1:] {
-		if !('0' <= r && r <= '9' || 'a' <= r && r <= 'f' || 'A' <= r && r <= 'F') {
-			return false
-		}
-	}
-
-	return true
+	return hexColorRx.MatchString(color)
 }
 
 func chanTS(origChannelID, externalID string) (channelID, ts string) {

--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -450,15 +450,11 @@ func signalAttachmentColor(color string) string {
 	case "":
 		return signalColorDefault
 	default:
-		if isHexColor(color) {
+		if hexColorRx.MatchString(color) {
 			return color
 		}
 		return signalColorDefault
 	}
-}
-
-func isHexColor(color string) bool {
-	return hexColorRx.MatchString(color)
 }
 
 func chanTS(origChannelID, externalID string) (channelID, ts string) {

--- a/notification/slack/channel.go
+++ b/notification/slack/channel.go
@@ -46,6 +46,12 @@ const (
 	colorAcked   = "#867321"
 )
 
+const (
+	signalParamMessage = "message"
+	signalParamColor   = "color"
+	signalColorDefault = "#439FE0"
+)
+
 var (
 	_ nfydest.MessageSender       = &ChannelSender{}
 	_ notification.ReceiverSetter = &ChannelSender{}
@@ -419,6 +425,50 @@ func alertMsgOption(ctx context.Context, callbackID string, id int, summary, log
 	)
 }
 
+func signalMsgOption(message, color string) slack.MsgOption {
+	attachment := slack.Attachment{
+		Color:    signalAttachmentColor(color),
+		Fallback: message,
+		Blocks: slack.Blocks{BlockSet: []slack.Block{
+			slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", message, false, false), nil, nil),
+		}},
+	}
+
+	return slack.MsgOptionAttachments(attachment)
+}
+
+func signalAttachmentColor(color string) string {
+	switch color {
+	case "good":
+		return colorClosed
+	case "warning":
+		return colorAcked
+	case "danger":
+		return colorUnacked
+	case "":
+		return signalColorDefault
+	default:
+		if isHexColor(color) {
+			return color
+		}
+		return signalColorDefault
+	}
+}
+
+func isHexColor(color string) bool {
+	if len(color) != len("#000000") || color[0] != '#' {
+		return false
+	}
+
+	for _, r := range color[1:] {
+		if !('0' <= r && r <= '9' || 'a' <= r && r <= 'f' || 'A' <= r && r <= 'F') {
+			return false
+		}
+	}
+
+	return true
+}
+
 func chanTS(origChannelID, externalID string) (channelID, ts string) {
 	ts = externalID
 	if strings.Contains(ts, ":") {
@@ -485,7 +535,7 @@ func (s *ChannelSender) SendMessage(ctx context.Context, msg notification.Messag
 			fmt.Sprintf("Service '%s' has %d unacknowledged alerts.\n\n<%s>", slackutilsx.EscapeMessage(t.ServiceName), t.Count, cfg.CallbackURL("/services/"+t.ServiceID+"/alerts")),
 			false))
 	case notification.SignalMessage:
-		opts = append(opts, slack.MsgOptionText(t.Param("message"), false))
+		opts = append(opts, signalMsgOption(t.Param(signalParamMessage), t.Param(signalParamColor)))
 	case notification.ScheduleOnCallUsers:
 		opts = append(opts, slack.MsgOptionText(s.onCallNotificationText(ctx, t), false))
 	default:

--- a/notification/slack/nfydestchannel.go
+++ b/notification/slack/nfydestchannel.go
@@ -40,11 +40,18 @@ func (s *ChannelSender) TypeInfo(ctx context.Context) (*nfydest.TypeInfo, error)
 			SupportsSearch: true,
 			Hint:           fmt.Sprintf("If your channel doesn't appear in search results, invite %s (bot) to the channel and allow a minute for it to appear.", botName),
 		}},
-		DynamicParams: []nfydest.DynamicParamConfig{{
-			ParamID: "message",
-			Label:   "Message",
-			Hint:    "The text of the message to send.",
-		}},
+		DynamicParams: []nfydest.DynamicParamConfig{
+			{
+				ParamID: signalParamMessage,
+				Label:   "Message",
+				Hint:    "The text of the message to send.",
+			},
+			{
+				ParamID: signalParamColor,
+				Label:   "Color",
+				Hint:    "GoAlert resolves `good`, `warning`, and `danger` to green, yellow, and red hex values. A `#RRGGBB` value is used unchanged; missing or unsupported values use neutral blue (`#439FE0`).",
+			},
+		},
 	}, nil
 }
 

--- a/notification/slack/nfydestchannel.go
+++ b/notification/slack/nfydestchannel.go
@@ -44,12 +44,12 @@ func (s *ChannelSender) TypeInfo(ctx context.Context) (*nfydest.TypeInfo, error)
 			{
 				ParamID: signalParamMessage,
 				Label:   "Message",
-				Hint:    "The text of the message to send.",
+				Hint:    "The text of the message to send; supports markdown formatting.",
 			},
 			{
 				ParamID: signalParamColor,
 				Label:   "Color",
-				Hint:    "GoAlert resolves `good`, `warning`, and `danger` to green, yellow, and red hex values. A `#RRGGBB` value is used unchanged; missing or unsupported values use neutral blue (`#439FE0`).",
+				Hint:    "GoAlert resolves `good`, `warning`, and `danger` or `#RRGGBB` hex values; defaults to neutral blue (`#439FE0`).",
 			},
 		},
 	}, nil

--- a/test/smoke/sendsignal_test.go
+++ b/test/smoke/sendsignal_test.go
@@ -9,18 +9,24 @@ import (
 	"github.com/target/goalert/test/smoke/harness"
 )
 
-// TestSendSignal tests the sendSignal mutation with a builtin-slack-channel destination.
-func TestSendSignal(t *testing.T) {
-	t.Parallel()
-
-	const sql = `
+const (
+	signalTestSQL = `
 		insert into escalation_policies (id, name) values
 			({{uuid "ep"}}, 'esc policy');
 		insert into services (id, name, escalation_policy_id) values
 			({{uuid "svc"}}, 'service', {{uuid "ep"}});
 	`
+	signalColorDanger  = "#862421"
+	signalColorGood    = "#218626"
+	signalColorWarning = "#867321"
+	signalColorDefault = "#439FE0"
+)
 
-	h := harness.NewHarnessWithFlags(t, sql, "nc-duplicate-table", expflag.FlagSet{expflag.UnivKeys})
+// TestSendSignal tests the sendSignal mutation with a builtin-slack-channel destination.
+func TestSendSignal(t *testing.T) {
+	t.Parallel()
+
+	h := harness.NewHarnessWithFlags(t, signalTestSQL, "nc-duplicate-table", expflag.FlagSet{expflag.UnivKeys})
 	defer h.Close()
 
 	chanID := h.Slack().Channel("chan1").ID()
@@ -34,5 +40,45 @@ func TestSendSignal(t *testing.T) {
 	}`, h.UUID("svc"), chanID))
 	require.Empty(t, resp.Errors)
 
-	h.Slack().Channel("chan1").ExpectMessage("test-signal-message")
+	msg := h.Slack().Channel("chan1").ExpectMessage("test-signal-message")
+	msg.AssertColor(signalColorDefault)
+	msg.AssertActions()
+}
+
+func TestSendSignalColors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		signalColor string
+		wantColor   string
+	}{
+		{name: "Danger", signalColor: "danger", wantColor: signalColorDanger},
+		{name: "Good", signalColor: "good", wantColor: signalColorGood},
+		{name: "Warning", signalColor: "warning", wantColor: signalColorWarning},
+		{name: "Hex", signalColor: "#439FE0", wantColor: "#439FE0"},
+		{name: "Unsupported", signalColor: "unsupported", wantColor: signalColorDefault},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			h := harness.NewHarnessWithFlags(t, signalTestSQL, "nc-duplicate-table", expflag.FlagSet{expflag.UnivKeys})
+			defer h.Close()
+
+			channel := h.Slack().Channel("chan1")
+			message := "test-" + test.name + "-signal"
+			resp := h.GraphQLQuery2(fmt.Sprintf(`mutation {
+				sendSignal(input: {
+					serviceID: "%s",
+					dest: {type: "builtin-slack-channel", args: {slack_channel_id: "%s"}},
+					params: {message: "%s", color: "%s"}
+				})
+			}`, h.UUID("svc"), channel.ID(), message, test.signalColor))
+			require.Empty(t, resp.Errors)
+
+			msg := channel.ExpectMessage(message)
+			msg.AssertColor(test.wantColor)
+			msg.AssertActions()
+		})
+	}
 }

--- a/test/smoke/signal_test.go
+++ b/test/smoke/signal_test.go
@@ -88,7 +88,7 @@ func TestSignal(t *testing.T) {
 					{dest: {type: "builtin-webhook", args: {webhook_url: "%s"}},
 						params: {body: "req.body['webhook-body']"}},
 					{dest: {type: "builtin-slack-channel", args: {slack_channel_id: "%s"}},
-						params: {message: "req.body['slack-text']"}}
+						params: {message: "req.body['slack-text']", color: "'danger'"}}
 				]
 			})
 		}`, respData.CreateIntegrationKey.ID, srv.URL+"/test-path", h.Slack().Channel("chan1").ID()))
@@ -112,6 +112,8 @@ func TestSignal(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, r.StatusCode)
 
 	assert.True(t, gotTestMessage, "expected webhook test message")
-	h.Slack().Channel("chan1").ExpectMessage("slack-text-data")
+	msg := h.Slack().Channel("chan1").ExpectMessage("slack-text-data")
+	msg.AssertColor("#862421")
+	msg.AssertActions()
 	h.Twilio(t).Device(h.Phone("1")).ExpectSMS("test-summary")
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Please include a description of the proposed changes.
This should include details if the user experience is impacted.

- Adds optional color to UIK slack configuration. Supports the same inputs as slack - 3 keywords or hex values.
- Updates makefile to support passing experimental flags as `EXPERIMENTAL` or `GOALERT_EXPERIMENTAL` (as documented)

**Which issue(s) this PR fixes:**
For significant amounts of work, it is best to start an issue first, preferably before the work is started.
For large pull requests, be sure to reference the associated GitHub issue(s).

No direct issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

**Out of Scope:**
Include any out of scope items here.

**Screenshots:**
If applicable, add some screenshots here.

<img width="916" height="628" alt="Screenshot 2026-08-04 at 2 35 17 PM" src="https://github.com/user-attachments/assets/7b597a20-8927-42be-bbb3-e24e311068a5" />

<img width="618" height="441" alt="Screenshot 2026-08-04 at 2 36 05 PM" src="https://github.com/user-attachments/assets/75d5a1d9-8694-4ec5-8fe4-6b11baeaa9f1" />

```
curl -X POST http://localhost:3030/api/v2/uik -H "Authorization: Bearer <bearer>" -H "Content-Type: application/json" -d '{
    "name": "test",
    "color": "warning",
    "message": "*Deployment validation*\n\n*Checklist*\n• Verify the alert route\n• Confirm the attachment color\n• Check <https://example.com|the runbook>\n\n*Steps*\n1. Send this signal\n2. Inspect the Slack message\n3. Confirm formatting\n\n*Example payload*\n```json\n{\n  \"status\": \"healthy\",\n \"latency_ms\": 42\n}\n```\n\n> This is a quoted note."
  }'
```

**Describe any introduced user-facing changes:**
If introducing any user-facing changes, provide a clear description of them.

Users can now choose to set a field to parse for color when sending slack messages through UIK. If the message doesn't contain a color it will be rendered with a default blue color. 

**Describe any introduced API changes:**
If introducing any API changes, provide a clear description of them.

**Additional Info:**
Any additional information or context.
