### PR TITLE
chore: update pr size labeler workflow 

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,16 +15,20 @@ jobs:
       - uses: actions/checkout@v6
         with: # checkout the base branch, where we run the script from
           path: base
-      - uses: actions/checkout@v6
-        with: # checkout the merge commit, where the PR changes are
-          ref: refs/pull/${{ github.event.number }}/merge
-          path: merge
-          # we need full history
-          fetch-depth: 0
+
+      # fetch the PR merge commit as a Git object, but do not check it out
+      - name: Fetch PR merge ref
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          git fetch --no-tags origin \
+            "refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge"
+
       - name: Run labeler script from base
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
           FAIL_IF_XL: '1'
           MAIN_BRANCH: ${{ github.event.pull_request.base.ref }}
-        run: cd merge && ../base/devtools/scripts/github-set-pr-label.sh
+          DIFF_HEAD_REF: refs/remotes/pull/${{ github.event.number }}/merge
+        run: cd base && devtools/scripts/github-set-pr-label.sh

--- a/devtools/scripts/git-diff-label-calc.sh
+++ b/devtools/scripts/git-diff-label-calc.sh
@@ -72,7 +72,9 @@ done < <(cat "$IGNORE_PATTERN_FILE" 2>/dev/null)
 # $IGNORE_ARGS[@]: list of `:(exclude)file` patterns to ignore
 OUTPUT=$(
     if [ "$DEBUG" = "1" ]; then set -x; fi
-    git diff --ignore-blank-lines --numstat -w --diff-filter=d --minimal --merge-base "origin/$MAIN_BRANCH" -- "${IGNORE_ARGS[@]}"
+    git diff --ignore-blank-lines --numstat -w --diff-filter=d --minimal \
+    "origin/$MAIN_BRANCH...${DIFF_HEAD_REF:-HEAD}" \
+    -- "${IGNORE_ARGS[@]}"
 )
 
 debug


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [ ] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [ ] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [ ] All new and existing tests passed.
- [ ] Added comments in the code, where necessary.
- [ ] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Updates the labeler workflow to fetch the pr ref without checking out in order to determine pr size for prs created via forks.


**Which issue(s) this PR fixes:**
For significant amounts of work, it is best to start an issue first, preferably before the work is started.
For large pull requests, be sure to reference the associated GitHub issue(s).

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

**Out of Scope:**
Include any out of scope items here.

**Screenshots:**
If applicable, add some screenshots here.

**Describe any introduced user-facing changes:**
If introducing any user-facing changes, provide a clear description of them.

**Describe any introduced API changes:**
If introducing any API changes, provide a clear description of them.

**Additional Info:**
Any additional information or context.
