### PR TITLE
feat: add configurable markdown support for ntfy notifications

### DIFF
--- a/app/startup.go
+++ b/app/startup.go
@@ -8,6 +8,7 @@ import (
 	"github.com/target/goalert/app/lifecycle"
 	"github.com/target/goalert/expflag"
 	"github.com/target/goalert/notification/email"
+	"github.com/target/goalert/notification/ntfy"
 	"github.com/target/goalert/notification/webhook"
 	"github.com/target/goalert/retry"
 
@@ -95,6 +96,7 @@ func (app *App) startup(ctx context.Context) error {
 	app.DestRegistry.RegisterProvider(ctx, app.slackChan.DMSender())
 	app.DestRegistry.RegisterProvider(ctx, app.slackChan.UserGroupSender())
 	app.DestRegistry.RegisterProvider(ctx, webhook.NewSender(ctx, app.httpClient))
+	app.DestRegistry.RegisterProvider(ctx, ntfy.NewSender(ctx, app.httpClient))
 	if app.cfg.StubNotifiers {
 		app.DestRegistry.StubNotifiers()
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -141,6 +141,12 @@ type Config struct {
 		AllowedURLs []string `public:"true" info:"If set, allows webhooks for these domains only."`
 	}
 
+	Ntfy struct {
+		Enable    bool   `public:"true" info:"Enables ntfy as a contact method."`
+		ServerURL string `public:"true" info:"Base URL of the ntfy server (e.g. https://ntfy.sh)."`
+		Token     string `password:"true" info:"Access token used to publish. Required if the server restricts publishing."`
+	}
+
 	Feedback struct {
 		Enable      bool   `public:"true" info:"Enables Feedback link in nav bar."`
 		OverrideURL string `public:"true" info:"Use a custom URL for Feedback link in nav bar."`
@@ -560,7 +566,17 @@ func (cfg Config) Validate() error {
 			"From", cfg.SMTP.From,
 			"Address", cfg.SMTP.Address,
 		),
+		validateEnable("Ntfy", cfg.Ntfy.Enable,
+			"ServerURL", cfg.Ntfy.ServerURL,
+		),
 	)
+
+	if cfg.Ntfy.ServerURL != "" {
+		err = validate.Many(
+			err,
+			validate.AbsoluteURL("Ntfy.ServerURL", cfg.Ntfy.ServerURL),
+		)
+	}
 
 	if cfg.Feedback.OverrideURL != "" {
 		err = validate.Many(

--- a/config/config.go
+++ b/config/config.go
@@ -146,6 +146,7 @@ type Config struct {
 		Enable    bool   `public:"true" info:"Enables ntfy as a contact method."`
 		ServerURL string `public:"true" info:"Base URL of the ntfy server (e.g. https://ntfy.sh)."`
 		Token     string `password:"true" info:"Access token used to publish. Required if the server restricts publishing."`
+		Markdown  bool   `public:"true" info:"Enables markdown formatting for ntfy notifications."`
 	}
 
 	Feedback struct {

--- a/graphql2/mapconfig.go
+++ b/graphql2/mapconfig.go
@@ -93,6 +93,7 @@ func MapConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "Ntfy.Enable", Type: ConfigTypeBoolean, Description: "Enables ntfy as a contact method.", Value: fmt.Sprintf("%t", cfg.Ntfy.Enable)},
 		{ID: "Ntfy.ServerURL", Type: ConfigTypeString, Description: "Base URL of the ntfy server (e.g. https://ntfy.sh).", Value: cfg.Ntfy.ServerURL},
 		{ID: "Ntfy.Token", Type: ConfigTypeString, Description: "Access token used to publish. Required if the server restricts publishing.", Value: cfg.Ntfy.Token, Password: true},
+		{ID: "Ntfy.Markdown", Type: ConfigTypeBoolean, Description: "Enables markdown formatting for ntfy notifications.", Value: fmt.Sprintf("%t", cfg.Ntfy.Markdown)},
 		{ID: "Feedback.Enable", Type: ConfigTypeBoolean, Description: "Enables Feedback link in nav bar.", Value: fmt.Sprintf("%t", cfg.Feedback.Enable)},
 		{ID: "Feedback.OverrideURL", Type: ConfigTypeString, Description: "Use a custom URL for Feedback link in nav bar.", Value: cfg.Feedback.OverrideURL},
 	}
@@ -131,6 +132,7 @@ func MapPublicConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "Webhook.AllowedURLs", Type: ConfigTypeStringList, Description: "If set, allows webhooks for these domains only.", Value: strings.Join(cfg.Webhook.AllowedURLs, "\n")},
 		{ID: "Ntfy.Enable", Type: ConfigTypeBoolean, Description: "Enables ntfy as a contact method.", Value: fmt.Sprintf("%t", cfg.Ntfy.Enable)},
 		{ID: "Ntfy.ServerURL", Type: ConfigTypeString, Description: "Base URL of the ntfy server (e.g. https://ntfy.sh).", Value: cfg.Ntfy.ServerURL},
+		{ID: "Ntfy.Markdown", Type: ConfigTypeBoolean, Description: "Enables markdown formatting for ntfy notifications.", Value: fmt.Sprintf("%t", cfg.Ntfy.Markdown)},
 		{ID: "Feedback.Enable", Type: ConfigTypeBoolean, Description: "Enables Feedback link in nav bar.", Value: fmt.Sprintf("%t", cfg.Feedback.Enable)},
 		{ID: "Feedback.OverrideURL", Type: ConfigTypeString, Description: "Use a custom URL for Feedback link in nav bar.", Value: cfg.Feedback.OverrideURL},
 	}
@@ -406,6 +408,12 @@ func ApplyConfigValues(cfg config.Config, vals []ConfigValueInput) (config.Confi
 			cfg.Ntfy.ServerURL = v.Value
 		case "Ntfy.Token":
 			cfg.Ntfy.Token = v.Value
+		case "Ntfy.Markdown":
+			val, err := parseBool(v.ID, v.Value)
+			if err != nil {
+				return cfg, err
+			}
+			cfg.Ntfy.Markdown = val
 		case "Feedback.Enable":
 			val, err := parseBool(v.ID, v.Value)
 			if err != nil {

--- a/graphql2/mapconfig.go
+++ b/graphql2/mapconfig.go
@@ -89,6 +89,9 @@ func MapConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "SMTP.Password", Type: ConfigTypeString, Description: "Password for authentication.", Value: cfg.SMTP.Password, Password: true},
 		{ID: "Webhook.Enable", Type: ConfigTypeBoolean, Description: "Enables webhook as a contact method.", Value: fmt.Sprintf("%t", cfg.Webhook.Enable)},
 		{ID: "Webhook.AllowedURLs", Type: ConfigTypeStringList, Description: "If set, allows webhooks for these domains only.", Value: strings.Join(cfg.Webhook.AllowedURLs, "\n")},
+		{ID: "Ntfy.Enable", Type: ConfigTypeBoolean, Description: "Enables ntfy as a contact method.", Value: fmt.Sprintf("%t", cfg.Ntfy.Enable)},
+		{ID: "Ntfy.ServerURL", Type: ConfigTypeString, Description: "Base URL of the ntfy server (e.g. https://ntfy.sh).", Value: cfg.Ntfy.ServerURL},
+		{ID: "Ntfy.Token", Type: ConfigTypeString, Description: "Access token used to publish. Required if the server restricts publishing.", Value: cfg.Ntfy.Token, Password: true},
 		{ID: "Feedback.Enable", Type: ConfigTypeBoolean, Description: "Enables Feedback link in nav bar.", Value: fmt.Sprintf("%t", cfg.Feedback.Enable)},
 		{ID: "Feedback.OverrideURL", Type: ConfigTypeString, Description: "Use a custom URL for Feedback link in nav bar.", Value: cfg.Feedback.OverrideURL},
 	}
@@ -124,6 +127,8 @@ func MapPublicConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "SMTP.From", Type: ConfigTypeString, Description: "The email address messages should be sent from.", Value: cfg.SMTP.From},
 		{ID: "Webhook.Enable", Type: ConfigTypeBoolean, Description: "Enables webhook as a contact method.", Value: fmt.Sprintf("%t", cfg.Webhook.Enable)},
 		{ID: "Webhook.AllowedURLs", Type: ConfigTypeStringList, Description: "If set, allows webhooks for these domains only.", Value: strings.Join(cfg.Webhook.AllowedURLs, "\n")},
+		{ID: "Ntfy.Enable", Type: ConfigTypeBoolean, Description: "Enables ntfy as a contact method.", Value: fmt.Sprintf("%t", cfg.Ntfy.Enable)},
+		{ID: "Ntfy.ServerURL", Type: ConfigTypeString, Description: "Base URL of the ntfy server (e.g. https://ntfy.sh).", Value: cfg.Ntfy.ServerURL},
 		{ID: "Feedback.Enable", Type: ConfigTypeBoolean, Description: "Enables Feedback link in nav bar.", Value: fmt.Sprintf("%t", cfg.Feedback.Enable)},
 		{ID: "Feedback.OverrideURL", Type: ConfigTypeString, Description: "Use a custom URL for Feedback link in nav bar.", Value: cfg.Feedback.OverrideURL},
 	}
@@ -383,6 +388,16 @@ func ApplyConfigValues(cfg config.Config, vals []ConfigValueInput) (config.Confi
 			cfg.Webhook.Enable = val
 		case "Webhook.AllowedURLs":
 			cfg.Webhook.AllowedURLs = parseStringList(v.Value)
+		case "Ntfy.Enable":
+			val, err := parseBool(v.ID, v.Value)
+			if err != nil {
+				return cfg, err
+			}
+			cfg.Ntfy.Enable = val
+		case "Ntfy.ServerURL":
+			cfg.Ntfy.ServerURL = v.Value
+		case "Ntfy.Token":
+			cfg.Ntfy.Token = v.Value
 		case "Feedback.Enable":
 			val, err := parseBool(v.ID, v.Value)
 			if err != nil {

--- a/notification/ntfy/nfydest.go
+++ b/notification/ntfy/nfydest.go
@@ -1,0 +1,111 @@
+package ntfy
+
+import (
+	"context"
+	"strings"
+
+	"github.com/target/goalert/config"
+	"github.com/target/goalert/gadb"
+	"github.com/target/goalert/notification/nfydest"
+	"github.com/target/goalert/validation"
+	"github.com/target/goalert/validation/validate"
+)
+
+const (
+	DestTypeNtfy   = "builtin-ntfy"
+	FieldNtfyTopic = "ntfy_topic"
+
+	// FallbackIconURL reuses the webhook icon. The UI resolves builtin icons from a fixed map and
+	// renders anything else as an image URL, so an unknown builtin value shows as a broken image.
+	FallbackIconURL = "builtin://webhook"
+
+	// maxTopicLen is ntfy's limit on a topic name.
+	maxTopicLen = 64
+)
+
+// NewNtfyDest returns a destination for the given ntfy topic.
+func NewNtfyDest(topic string) gadb.DestV1 {
+	return gadb.NewDestV1(DestTypeNtfy, FieldNtfyTopic, topic)
+}
+
+var _ (nfydest.Provider) = (*Sender)(nil)
+
+func (Sender) ID() string { return DestTypeNtfy }
+
+func (Sender) TypeInfo(ctx context.Context) (*nfydest.TypeInfo, error) {
+	cfg := config.FromContext(ctx)
+	return &nfydest.TypeInfo{
+		Type:                       DestTypeNtfy,
+		Name:                       "Ntfy",
+		IconURL:                    FallbackIconURL,
+		IconAltText:                "Ntfy",
+		Enabled:                    cfg.Ntfy.Enable,
+		SupportsUserVerification:   true,
+		SupportsOnCallNotify:       true,
+		SupportsStatusUpdates:      true,
+		SupportsAlertNotifications: true,
+		RequiredFields: []nfydest.FieldConfig{{
+			FieldID:            FieldNtfyTopic,
+			Label:              "Topic",
+			PlaceholderText:    "alerts-jane",
+			InputType:          "text",
+			Hint:               "Subscribe to this topic in the ntfy app to receive notifications.",
+			SupportsValidation: true,
+		}},
+	}, nil
+}
+
+func (s *Sender) ValidateField(ctx context.Context, fieldID, value string) error {
+	switch fieldID {
+	case FieldNtfyTopic:
+		return validateTopic(value)
+	}
+
+	return validation.NewGenericError("unknown field ID")
+}
+
+func (s *Sender) DisplayInfo(ctx context.Context, args map[string]string) (*nfydest.DisplayInfo, error) {
+	if args == nil {
+		args = make(map[string]string)
+	}
+
+	topic := args[FieldNtfyTopic]
+	if err := validateTopic(topic); err != nil {
+		return nil, validation.WrapError(err)
+	}
+
+	return &nfydest.DisplayInfo{
+		IconURL:     FallbackIconURL,
+		IconAltText: "Ntfy",
+		Text:        topic,
+		LinkURL:     topicURL(config.FromContext(ctx).Ntfy.ServerURL, topic),
+	}, nil
+}
+
+// validateTopic enforces ntfy's topic charset. A topic is a URL path segment on the ntfy server, so
+// anything outside this set either changes the path or is rejected on publish.
+func validateTopic(topic string) error {
+	if err := validate.ASCII(FieldNtfyTopic, topic, 1, maxTopicLen); err != nil {
+		return err
+	}
+
+	for _, r := range topic {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+		default:
+			return validation.NewFieldError(FieldNtfyTopic,
+				"may only contain letters, numbers, dashes and underscores")
+		}
+	}
+
+	return nil
+}
+
+// topicURL is the publish endpoint for a topic, and also the page a browser can subscribe from.
+func topicURL(serverURL, topic string) string {
+	if serverURL == "" || topic == "" {
+		return ""
+	}
+
+	return strings.TrimSuffix(serverURL, "/") + "/" + topic
+}

--- a/notification/ntfy/sender.go
+++ b/notification/ntfy/sender.go
@@ -1,0 +1,245 @@
+package ntfy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/target/goalert/config"
+	"github.com/target/goalert/notification/nfydest"
+	"github.com/target/goalert/notification/nfymsg"
+)
+
+// requestTimeout matches the webhook sender: a page that has not left the building within a few
+// seconds is better retried than held.
+const requestTimeout = 3 * time.Second
+
+// ntfy priority levels. Alerts publish at max so they break through Do Not Disturb on the phone;
+// everything else is informational.
+const (
+	priorityDefault = 3
+	priorityHigh    = 4
+	priorityMax     = 5
+)
+
+// MetaClickURL is the alert metadata key whose value becomes the notification's tap target. A caller
+// that creates alerts with a link into its own system -- a chat thread, a runbook -- sets it there,
+// because the payload GoAlert builds has no other way to carry one.
+const MetaClickURL = "click"
+
+// maxTitleLen caps the title, which travels as an HTTP header rather than in the body.
+const maxTitleLen = 250
+
+type Sender struct {
+	Client *http.Client
+}
+
+func NewSender(ctx context.Context, client *http.Client) *Sender {
+	return &Sender{Client: client}
+}
+
+var _ nfydest.MessageSender = &Sender{}
+
+// message is one ntfy publish: a body, plus the headers ntfy renders it with.
+type message struct {
+	Title    string
+	Body     string
+	Priority int
+	ClickURL string
+	Tags     string
+}
+
+// SendMessage publishes a notification to the destination's ntfy topic.
+func (s *Sender) SendMessage(ctx context.Context, msg nfymsg.Message) (*nfymsg.SentMessage, error) {
+	cfg := config.FromContext(ctx)
+
+	topic := msg.DestArg(FieldNtfyTopic)
+	if err := validateTopic(topic); err != nil {
+		return &nfymsg.SentMessage{
+			State:        nfymsg.StateFailedPerm,
+			StateDetails: "invalid ntfy topic",
+		}, nil
+	}
+
+	endpoint := topicURL(cfg.Ntfy.ServerURL, topic)
+	if endpoint == "" {
+		return &nfymsg.SentMessage{
+			State:        nfymsg.StateFailedPerm,
+			StateDetails: "no ntfy server URL configured",
+		}, nil
+	}
+
+	m, err := buildMessage(cfg, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(m.Body))
+	if err != nil {
+		return nil, err
+	}
+
+	if title := headerValue(m.Title, maxTitleLen); title != "" {
+		req.Header.Set("X-Title", title)
+	}
+	req.Header.Set("X-Priority", strconv.Itoa(m.Priority))
+	if m.ClickURL != "" {
+		req.Header.Set("X-Click", m.ClickURL)
+	}
+	if m.Tags != "" {
+		req.Header.Set("X-Tags", m.Tags)
+	}
+	if cfg.Ntfy.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+cfg.Ntfy.Token)
+	}
+
+	client := s.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// A 4xx fails the same way on a retry: a rejected token, or a topic the server will not accept.
+	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		return &nfymsg.SentMessage{
+			State:        nfymsg.StateFailedPerm,
+			StateDetails: fmt.Sprintf("ntfy returned %d", resp.StatusCode),
+		}, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ntfy returned %d", resp.StatusCode)
+	}
+
+	return &nfymsg.SentMessage{State: nfymsg.StateSent}, nil
+}
+
+// buildMessage renders a notification into the fields ntfy publishes.
+func buildMessage(cfg config.Config, msg nfymsg.Message) (message, error) {
+	switch m := msg.(type) {
+	case nfymsg.Test:
+		return message{
+			Title:    cfg.ApplicationName(),
+			Body:     "Test message.",
+			Priority: priorityDefault,
+		}, nil
+
+	case nfymsg.Verification:
+		return message{
+			Title:    cfg.ApplicationName(),
+			Body:     fmt.Sprintf("Verification code: %s", m.Code),
+			Priority: priorityHigh,
+			Tags:     "key",
+		}, nil
+
+	case nfymsg.Alert:
+		return message{
+			Title:    m.Summary,
+			Body:     m.Details,
+			Priority: priorityMax,
+			ClickURL: alertClickURL(cfg, m.Meta, m.AlertID),
+			Tags:     "rotating_light",
+		}, nil
+
+	case nfymsg.AlertBundle:
+		return message{
+			Title:    m.ServiceName,
+			Body:     fmt.Sprintf("%d unacknowledged alerts.", m.Count),
+			Priority: priorityMax,
+			ClickURL: cfg.CallbackURL(fmt.Sprintf("/services/%s/alerts", m.ServiceID)),
+			Tags:     "rotating_light",
+		}, nil
+
+	case nfymsg.AlertStatus:
+		return message{
+			Title:    alertStatusTitle(m),
+			Body:     m.LogEntry,
+			Priority: priorityDefault,
+			ClickURL: alertClickURL(cfg, nil, m.AlertID),
+		}, nil
+
+	case nfymsg.ScheduleOnCallUsers:
+		return message{
+			Title:    fmt.Sprintf("On call for %s", m.ScheduleName),
+			Body:     onCallBody(m.Users),
+			Priority: priorityDefault,
+			ClickURL: m.ScheduleURL,
+			Tags:     "calendar",
+		}, nil
+	}
+
+	return message{}, fmt.Errorf("message type '%T' not supported", msg)
+}
+
+// alertClickURL is where tapping the notification lands. Alert metadata wins, so the system that
+// raised the alert can point at itself; otherwise the alert in GoAlert.
+func alertClickURL(cfg config.Config, meta map[string]string, alertID int) string {
+	if u, ok := meta[MetaClickURL]; ok && isAbsoluteURL(u) {
+		return u
+	}
+
+	return cfg.CallbackURL(fmt.Sprintf("/alerts/%d", alertID))
+}
+
+// alertStatusTitle falls back to the alert number, because the summary is not always carried on a
+// status update.
+func alertStatusTitle(m nfymsg.AlertStatus) string {
+	if m.Summary != "" {
+		return m.Summary
+	}
+
+	return fmt.Sprintf("Alert #%d", m.AlertID)
+}
+
+func onCallBody(users []nfymsg.User) string {
+	if len(users) == 0 {
+		return "Nobody is on call."
+	}
+
+	names := make([]string, len(users))
+	for i, u := range users {
+		names[i] = u.Name
+	}
+
+	return strings.Join(names, ", ")
+}
+
+func isAbsoluteURL(s string) bool {
+	if s == "" {
+		return false
+	}
+
+	u, err := url.Parse(s)
+
+	return err == nil && u.IsAbs()
+}
+
+// headerValue flattens a value for use as an HTTP header. ntfy takes the title as a header, and a
+// newline in an alert summary would otherwise make the request unsendable.
+func headerValue(s string, maxLen int) string {
+	s = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return ' '
+		}
+
+		return r
+	}, s)
+
+	s = strings.TrimSpace(s)
+	if len(s) > maxLen {
+		s = strings.TrimSpace(s[:maxLen])
+	}
+
+	return s
+}

--- a/notification/ntfy/sender.go
+++ b/notification/ntfy/sender.go
@@ -90,6 +90,9 @@ func (s *Sender) SendMessage(ctx context.Context, msg nfymsg.Message) (*nfymsg.S
 		req.Header.Set("X-Title", title)
 	}
 	req.Header.Set("X-Priority", strconv.Itoa(m.Priority))
+	if cfg.Ntfy.Markdown {
+		req.Header.Set("X-Markdown", "yes")
+	}
 	if m.ClickURL != "" {
 		req.Header.Set("X-Click", m.ClickURL)
 	}

--- a/notification/ntfy/sender_test.go
+++ b/notification/ntfy/sender_test.go
@@ -37,7 +37,7 @@ func alertMsg(meta map[string]string) nfymsg.Alert {
 }
 
 func TestSendMessage_Alert(t *testing.T) {
-	var gotPath, gotTitle, gotPriority, gotClick, gotAuth, gotBody string
+	var gotPath, gotTitle, gotPriority, gotClick, gotAuth, gotMarkdown, gotBody string
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
@@ -46,6 +46,7 @@ func TestSendMessage_Alert(t *testing.T) {
 		gotPriority = r.Header.Get("X-Priority")
 		gotClick = r.Header.Get("X-Click")
 		gotAuth = r.Header.Get("Authorization")
+		gotMarkdown = r.Header.Get("X-Markdown")
 	}))
 	defer srv.Close()
 
@@ -64,6 +65,24 @@ func TestSendMessage_Alert(t *testing.T) {
 	assert.Equal(t, "5", gotPriority)
 	assert.Equal(t, "https://chat.example.com/demo/pl/abc123", gotClick)
 	assert.Equal(t, "Bearer tok-123", gotAuth)
+	assert.Empty(t, gotMarkdown)
+}
+
+func TestSendMessage_MarkdownEnabled(t *testing.T) {
+	var gotMarkdown string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMarkdown = r.Header.Get("X-Markdown")
+	}))
+	defer srv.Close()
+
+	cfg := testConfig(srv.URL)
+	cfg.Ntfy.Markdown = true
+	s := NewSender(context.Background(), srv.Client())
+
+	_, err := s.SendMessage(cfg.Context(context.Background()), alertMsg(nil))
+	require.NoError(t, err)
+	assert.Equal(t, "yes", gotMarkdown)
 }
 
 func TestSendMessage_ClickFallsBackToGoAlert(t *testing.T) {

--- a/notification/ntfy/sender_test.go
+++ b/notification/ntfy/sender_test.go
@@ -1,0 +1,204 @@
+package ntfy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/config"
+	"github.com/target/goalert/notification/nfymsg"
+)
+
+// testConfig points at the given ntfy server and gives CallbackURL something to build on.
+func testConfig(serverURL string) config.Config {
+	var cfg config.Config
+	cfg.General.PublicURL = "https://goalert.example.com"
+	cfg.Ntfy.Enable = true
+	cfg.Ntfy.ServerURL = serverURL
+	cfg.Ntfy.Token = "tok-123"
+
+	return cfg
+}
+
+func alertMsg(meta map[string]string) nfymsg.Alert {
+	return nfymsg.Alert{
+		Base:        nfymsg.Base{ID: "msg-1", Dest: NewNtfyDest("alerts-jane")},
+		AlertID:     42,
+		Summary:     "Disk full",
+		Details:     "Root volume is at 98%.",
+		ServiceID:   "svc-1",
+		ServiceName: "demo",
+		Meta:        meta,
+	}
+}
+
+func TestSendMessage_Alert(t *testing.T) {
+	var gotPath, gotTitle, gotPriority, gotClick, gotAuth, gotBody string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotPath, gotBody = r.URL.Path, string(body)
+		gotTitle = r.Header.Get("X-Title")
+		gotPriority = r.Header.Get("X-Priority")
+		gotClick = r.Header.Get("X-Click")
+		gotAuth = r.Header.Get("Authorization")
+	}))
+	defer srv.Close()
+
+	cfg := testConfig(srv.URL)
+	s := NewSender(context.Background(), srv.Client())
+
+	res, err := s.SendMessage(cfg.Context(context.Background()),
+		alertMsg(map[string]string{MetaClickURL: "https://chat.example.com/demo/pl/abc123"}))
+	require.NoError(t, err)
+	assert.Equal(t, nfymsg.StateSent, res.State)
+
+	assert.Equal(t, "/alerts-jane", gotPath)
+	assert.Equal(t, "Disk full", gotTitle)
+	assert.Equal(t, "Root volume is at 98%.", gotBody)
+	// Alerts page at max priority so they break through Do Not Disturb.
+	assert.Equal(t, "5", gotPriority)
+	assert.Equal(t, "https://chat.example.com/demo/pl/abc123", gotClick)
+	assert.Equal(t, "Bearer tok-123", gotAuth)
+}
+
+func TestSendMessage_ClickFallsBackToGoAlert(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		meta map[string]string
+	}{
+		{"no meta", nil},
+		{"empty value", map[string]string{MetaClickURL: ""}},
+		{"not absolute", map[string]string{MetaClickURL: "/demo/pl/abc123"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotClick string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotClick = r.Header.Get("X-Click")
+			}))
+			defer srv.Close()
+
+			cfg := testConfig(srv.URL)
+			s := NewSender(context.Background(), srv.Client())
+
+			_, err := s.SendMessage(cfg.Context(context.Background()), alertMsg(tc.meta))
+			require.NoError(t, err)
+			assert.Equal(t, "https://goalert.example.com/alerts/42", gotClick)
+		})
+	}
+}
+
+// A summary spanning lines would otherwise make the request unsendable, since the title is a header.
+func TestSendMessage_MultilineSummary(t *testing.T) {
+	var gotTitle string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTitle = r.Header.Get("X-Title")
+	}))
+	defer srv.Close()
+
+	cfg := testConfig(srv.URL)
+	s := NewSender(context.Background(), srv.Client())
+
+	msg := alertMsg(nil)
+	msg.Summary = "Disk full\non node-1\r\nagain"
+
+	res, err := s.SendMessage(cfg.Context(context.Background()), msg)
+	require.NoError(t, err)
+	assert.Equal(t, nfymsg.StateSent, res.State)
+	assert.Equal(t, "Disk full on node-1  again", gotTitle)
+}
+
+func TestSendMessage_Verification(t *testing.T) {
+	var gotBody, gotPriority string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		gotPriority = r.Header.Get("X-Priority")
+	}))
+	defer srv.Close()
+
+	cfg := testConfig(srv.URL)
+	s := NewSender(context.Background(), srv.Client())
+
+	_, err := s.SendMessage(cfg.Context(context.Background()), nfymsg.Verification{
+		Base: nfymsg.Base{ID: "msg-1", Dest: NewNtfyDest("alerts-jane")},
+		Code: "123456",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, gotBody, "123456")
+	assert.Equal(t, "4", gotPriority)
+}
+
+func TestSendMessage_RejectsPermanentlyOn4xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	cfg := testConfig(srv.URL)
+	s := NewSender(context.Background(), srv.Client())
+
+	res, err := s.SendMessage(cfg.Context(context.Background()), alertMsg(nil))
+	require.NoError(t, err)
+	assert.Equal(t, nfymsg.StateFailedPerm, res.State)
+}
+
+// A 5xx may succeed on a retry, so it must surface as an error rather than a permanent failure.
+func TestSendMessage_RetriesOn5xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	cfg := testConfig(srv.URL)
+	s := NewSender(context.Background(), srv.Client())
+
+	_, err := s.SendMessage(cfg.Context(context.Background()), alertMsg(nil))
+	assert.Error(t, err)
+}
+
+func TestSendMessage_NoServerURLConfigured(t *testing.T) {
+	cfg := testConfig("")
+	s := NewSender(context.Background(), http.DefaultClient)
+
+	res, err := s.SendMessage(cfg.Context(context.Background()), alertMsg(nil))
+	require.NoError(t, err)
+	assert.Equal(t, nfymsg.StateFailedPerm, res.State)
+}
+
+func TestValidateTopic(t *testing.T) {
+	for _, tc := range []struct {
+		topic string
+		ok    bool
+	}{
+		{"alerts-jane", true},
+		{"a_b-C9", true},
+		{"", false},
+		{"has space", false},
+		{"has/slash", false},
+		{"dots.not.allowed", false},
+		{"ünïcode", false},
+	} {
+		t.Run(tc.topic, func(t *testing.T) {
+			err := validateTopic(tc.topic)
+			if tc.ok {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestTopicURL(t *testing.T) {
+	assert.Equal(t, "https://ntfy.example.com/alerts-jane",
+		topicURL("https://ntfy.example.com", "alerts-jane"))
+	assert.Equal(t, "https://ntfy.example.com/alerts-jane",
+		topicURL("https://ntfy.example.com/", "alerts-jane"))
+	assert.Empty(t, topicURL("", "alerts-jane"))
+	assert.Empty(t, topicURL("https://ntfy.example.com", ""))
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [x] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Adds a configurable `Ntfy.Markdown` setting to allow users to toggle Markdown rendering for ntfy notifications. When enabled, GoAlert sends the `X-Markdown: yes` header with outgoing publish requests, enabling rich text formatting in ntfy client apps and web interfaces.

**Which issue(s) this PR fixes:**
N/A (Feature addition for ntfy contact method integration)

**Out of Scope:**
- Automatic Markdown formatting changes to message bodies themselves (relies on ntfy's server/client Markdown rendering of text).

**Screenshots:**
N/A

**Describe any introduced user-facing changes:**
Introduces a new toggle (`Ntfy.Markdown`) in the GoAlert Admin Configuration UI under the Ntfy notification provider settings, allowing administrators to enable or disable Markdown formatting for ntfy notifications.

**Describe any introduced API changes:**
Exposes the new configuration key `Ntfy.Markdown` (boolean) in both public and admin GraphQL configuration mappings (`MapConfigValues` and `MapPublicConfigValues`).

**Additional Info:**
- Fully backward compatible: defaults to `false` (preserving existing plain text behavior unless explicitly enabled).
- Covered by unit tests in `notification/ntfy`.
---

*PR sponsored by [Obmondo](https://obmondo.com)*

---

**Note:** Since this is a company-paid contribution, we fork to the company
account repo on GitHub. GitHub does not support "allow maintainer to edit
in repo" for organization accounts.

- Maintainers can either provide feedback for required changes before merging, OR
- Pull our branch, make changes in their repo, and create a new PR including our commits.