### PR TITLE
feat: allow acknowledge through generic API

### DIFF
--- a/genericapi/handler.go
+++ b/genericapi/handler.go
@@ -123,8 +123,11 @@ func (h *Handler) ServeCreateAlert(w http.ResponseWriter, r *http.Request) {
 	}
 
 	status := alert.StatusTriggered
-	if action == "close" {
+	switch action {
+	case "close":
 		status = alert.StatusClosed
+	case "acknowledge":
+		status = alert.StatusActive
 	}
 
 	summary = validate.SanitizeText(summary, alert.MaxSummaryLength)

--- a/web/src/app/documentation/sections/IntegrationKeys.md
+++ b/web/src/app/documentation/sections/IntegrationKeys.md
@@ -9,7 +9,7 @@
 | `token`   | **Required** | The integration key to use.                                                                                                                                         |
 | `summary` | **Required** | Short description of the alert sent as SMS and voice.                                                                                                               |
 | `details` | _optional_   | Additional information about the alert, supports markdown.                                                                                                          |
-| `action`  | _optional_   | If set to `close`, it will close any matching alerts.                                                                                                               |
+| `action`  | _optional_   | If set to `acknowledge` or `close`, it will acknowledge or close any matching alerts.                                                                                                               |
 | `dedup`   | _optional_   | All calls for the same service with the same `dedup` string will update the same alert (if open) or create a new one. Defaults to using summary & details together. |
 | `meta`    | _optional_   | Additional key/value metadata to attach to the alert.                                                                                                               |
 


### PR DESCRIPTION
<!-- Thank you for your contribution to GoAlert. -->
<!-- Before submitting this PR, please make sure that you have: -->

- [x] Identified the issue which this PR solves.
- [x] Read the [**CONTRIBUTING**](https://github.com/target/goalert/blob/master/CONTRIBUTING.md) document.
- [x] Code builds clean without any errors or warnings.
- [ ] Added appropriate tests for any new functionality.
- [x] All new and existing tests passed.
- [x] Added comments in the code, where necessary.
- [x] Ran `make check` to catch common errors. Fixed any that came up.

**Description:**
Allow acknowledging alerts through the generic API. This can be helpful for some services to stop unnecessary escalation.

**Describe any introduced API changes:**
`/api/v2/generic/incoming?dedup=foo&action=acknowledge` will now acknowledge matching alerts. `action=close` remains unchanged.
