### PR TITLE
Address deprecated methods

### DIFF
--- a/app/initriver.go
+++ b/app/initriver.go
@@ -118,7 +118,7 @@ func (app *App) initRiver(ctx context.Context) error {
 			river.QueueDefault: {MaxWorkers: 100},
 		},
 		RescueStuckJobsAfter: 5 * time.Minute,
-		WorkerMiddleware: []rivertype.WorkerMiddleware{
+		Middleware: []rivertype.Middleware{
 			workerMiddlewareFunc(func(ctx context.Context, doInner func(ctx context.Context) error) error {
 				// Ensure config is set in the context for all workers.
 				return doInner(app.ConfigStore.Config().Context(ctx))

--- a/devtools/sendit/server.go
+++ b/devtools/sendit/server.go
@@ -74,13 +74,13 @@ func NewServer(authSecret []byte, prefix string) *Server {
 	transport.DialContext = s.DialContext
 
 	s.proxy = &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			req.URL.Scheme = "http"
-			req.URL.Host = req.Context().Value(serverContextValueHost).(string)
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.Out.URL.Scheme = "http"
+			r.Out.URL.Host = r.In.Context().Value(serverContextValueHost).(string)
 
-			if _, ok := req.Header["User-Agent"]; !ok {
+			if _, ok := r.Out.Header["User-Agent"]; !ok {
 				// explicitly disable User-Agent so it's not set to default value
-				req.Header.Set("User-Agent", "")
+				r.Out.Header.Set("User-Agent", "")
 			}
 		},
 		Transport: transport,


### PR DESCRIPTION
addressing the following deprecated methods:

```text
app/initriver.go:121:3: SA1019: (github.com/riverqueue/river.Config).WorkerMiddleware is deprecated: Prefer the use of Middleware instead (which may contain instances of rivertype.WorkerMiddleware). (staticcheck)
                WorkerMiddleware: []rivertype.WorkerMiddleware{
                ^
devtools/sendit/server.go:77:3: SA1019: (net/http/httputil.ReverseProxy).Director has been deprecated since Go 1.26 and an alternative has been available since Go 1.20: Use Rewrite instead. (staticcheck)
                Director: func(req *http.Request) {
```

## Actions Taken

- `rivertype.WorkerMiddleware` changed to `rivertype.Middleware`
- `httputil.ReverseProxy{Director}` changed to `httputil.ReverseProxy{Rewrite}` 