### PR TITLE
webhook: add opt-in blocking of private network destinations

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -55,6 +55,7 @@ import (
 	"github.com/target/goalert/user/notificationrule"
 	"github.com/target/goalert/util/calllimiter"
 	"github.com/target/goalert/util/log"
+	"github.com/target/goalert/util/privnet"
 	"github.com/target/goalert/util/sqlutil"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
@@ -209,7 +210,7 @@ func NewApp(c Config, pool *pgxpool.Pool) (*App, error) {
 		doneCh: make(chan struct{}),
 		Logger: c.Logger,
 		httpClient: &http.Client{
-			Transport: calllimiter.RoundTripper(http.DefaultTransport),
+			Transport: calllimiter.RoundTripper(privnet.RoundTripper(http.DefaultTransport.(*http.Transport).Clone())),
 		},
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -138,8 +138,9 @@ type Config struct {
 	}
 
 	Webhook struct {
-		Enable      bool     `public:"true" info:"Enables webhook as a contact method."`
-		AllowedURLs []string `public:"true" info:"If set, allows webhooks for these domains only."`
+		Enable                bool     `public:"true" info:"Enables webhook as a contact method."`
+		AllowedURLs           []string `public:"true" info:"If set, allows webhooks for these domains only. If empty, any URL is allowed, including internal/private network addresses."`
+		BlockPrivateAddresses bool     `info:"If enabled, webhook requests to private, loopback, and link-local addresses (e.g., 10.0.0.0/8, 127.0.0.1, 169.254.169.254) are rejected. The check is applied at connection time, so it also covers DNS names and redirects that resolve to such addresses. If requests are routed through an HTTP proxy, destination policy must be enforced at the proxy."`
 	}
 
 	Feedback struct {

--- a/graphql2/mapconfig.go
+++ b/graphql2/mapconfig.go
@@ -89,7 +89,8 @@ func MapConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "SMTP.Username", Type: ConfigTypeString, Description: "Username for authentication.", Value: cfg.SMTP.Username},
 		{ID: "SMTP.Password", Type: ConfigTypeString, Description: "Password for authentication.", Value: cfg.SMTP.Password, Password: true},
 		{ID: "Webhook.Enable", Type: ConfigTypeBoolean, Description: "Enables webhook as a contact method.", Value: fmt.Sprintf("%t", cfg.Webhook.Enable)},
-		{ID: "Webhook.AllowedURLs", Type: ConfigTypeStringList, Description: "If set, allows webhooks for these domains only.", Value: strings.Join(cfg.Webhook.AllowedURLs, "\n")},
+		{ID: "Webhook.AllowedURLs", Type: ConfigTypeStringList, Description: "If set, allows webhooks for these domains only. If empty, any URL is allowed, including internal/private network addresses.", Value: strings.Join(cfg.Webhook.AllowedURLs, "\n")},
+		{ID: "Webhook.BlockPrivateAddresses", Type: ConfigTypeBoolean, Description: "If enabled, webhook requests to private, loopback, and link-local addresses (e.g., 10.0.0.0/8, 127.0.0.1, 169.254.169.254) are rejected. The check is applied at connection time, so it also covers DNS names and redirects that resolve to such addresses. If requests are routed through an HTTP proxy, destination policy must be enforced at the proxy.", Value: fmt.Sprintf("%t", cfg.Webhook.BlockPrivateAddresses)},
 		{ID: "Feedback.Enable", Type: ConfigTypeBoolean, Description: "Enables Feedback link in nav bar.", Value: fmt.Sprintf("%t", cfg.Feedback.Enable)},
 		{ID: "Feedback.OverrideURL", Type: ConfigTypeString, Description: "Use a custom URL for Feedback link in nav bar.", Value: cfg.Feedback.OverrideURL},
 	}
@@ -125,7 +126,7 @@ func MapPublicConfigValues(cfg config.Config) []ConfigValue {
 		{ID: "SMTP.Enable", Type: ConfigTypeBoolean, Description: "Enables email as a contact method.", Value: fmt.Sprintf("%t", cfg.SMTP.Enable)},
 		{ID: "SMTP.From", Type: ConfigTypeString, Description: "The email address messages should be sent from.", Value: cfg.SMTP.From},
 		{ID: "Webhook.Enable", Type: ConfigTypeBoolean, Description: "Enables webhook as a contact method.", Value: fmt.Sprintf("%t", cfg.Webhook.Enable)},
-		{ID: "Webhook.AllowedURLs", Type: ConfigTypeStringList, Description: "If set, allows webhooks for these domains only.", Value: strings.Join(cfg.Webhook.AllowedURLs, "\n")},
+		{ID: "Webhook.AllowedURLs", Type: ConfigTypeStringList, Description: "If set, allows webhooks for these domains only. If empty, any URL is allowed, including internal/private network addresses.", Value: strings.Join(cfg.Webhook.AllowedURLs, "\n")},
 		{ID: "Feedback.Enable", Type: ConfigTypeBoolean, Description: "Enables Feedback link in nav bar.", Value: fmt.Sprintf("%t", cfg.Feedback.Enable)},
 		{ID: "Feedback.OverrideURL", Type: ConfigTypeString, Description: "Use a custom URL for Feedback link in nav bar.", Value: cfg.Feedback.OverrideURL},
 	}
@@ -391,6 +392,12 @@ func ApplyConfigValues(cfg config.Config, vals []ConfigValueInput) (config.Confi
 			cfg.Webhook.Enable = val
 		case "Webhook.AllowedURLs":
 			cfg.Webhook.AllowedURLs = parseStringList(v.Value)
+		case "Webhook.BlockPrivateAddresses":
+			val, err := parseBool(v.ID, v.Value)
+			if err != nil {
+				return cfg, err
+			}
+			cfg.Webhook.BlockPrivateAddresses = val
 		case "Feedback.Enable":
 			val, err := parseBool(v.ID, v.Value)
 			if err != nil {

--- a/notification/webhook/sender.go
+++ b/notification/webhook/sender.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/target/goalert/config"
 	"github.com/target/goalert/notification"
 	"github.com/target/goalert/notification/nfydest"
+	"github.com/target/goalert/util/privnet"
 )
 
 type Sender struct {
@@ -27,7 +29,7 @@ type POSTDataAlert struct {
 	ServiceID   string
 	ServiceName string
 	Meta        map[string]string
-	GoAlertURL string
+	GoAlertURL  string
 }
 
 // POSTDataAlertBundle represents fields in outgoing alert bundle notification.
@@ -188,6 +190,10 @@ func (s *Sender) SendMessage(ctx context.Context, msg notification.Message) (*no
 		}, nil
 	}
 
+	if cfg.Webhook.BlockPrivateAddresses {
+		ctx = privnet.WithBlockPrivate(ctx)
+	}
+
 	req, err := http.NewRequestWithContext(ctx, "POST", webURL, bytes.NewReader(data))
 	if err != nil {
 		return nil, err
@@ -195,10 +201,18 @@ func (s *Sender) SendMessage(ctx context.Context, msg notification.Message) (*no
 
 	req.Header.Add("Content-Type", "application/json")
 
-	_, err = http.DefaultClient.Do(req)
+	resp, err := s.Client.Do(req)
+	if errors.Is(err, privnet.ErrPrivateAddress) {
+		// fail permanently; the destination is blocked by the administrator
+		return &notification.SentMessage{
+			State:        notification.StateFailedPerm,
+			StateDetails: "destination address is not allowed by administrator",
+		}, nil
+	}
 	if err != nil {
 		return nil, err
 	}
+	resp.Body.Close()
 
 	return &notification.SentMessage{State: notification.StateSent}, nil
 }

--- a/notification/webhook/sender_test.go
+++ b/notification/webhook/sender_test.go
@@ -1,0 +1,43 @@
+package webhook
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/target/goalert/config"
+	"github.com/target/goalert/notification"
+	"github.com/target/goalert/notification/nfymsg"
+	"github.com/target/goalert/util/privnet"
+)
+
+func TestSender_BlockPrivateAddresses(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+	}))
+	defer srv.Close()
+
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	base.Proxy = nil
+	s := NewSender(context.Background(), &http.Client{Transport: privnet.RoundTripper(base)})
+	msg := notification.Test{Base: nfymsg.Base{Dest: NewWebhookDest(srv.URL)}}
+
+	// allowed by default
+	var cfg config.Config
+	cfg.Webhook.Enable = true
+	res, err := s.SendMessage(cfg.Context(context.Background()), msg)
+	require.NoError(t, err)
+	assert.Equal(t, notification.StateSent, res.State)
+	assert.Equal(t, 1, calls)
+
+	// blocked when enabled (test server listens on 127.0.0.1)
+	cfg.Webhook.BlockPrivateAddresses = true
+	res, err = s.SendMessage(cfg.Context(context.Background()), msg)
+	require.NoError(t, err)
+	assert.Equal(t, notification.StateFailedPerm, res.State)
+	assert.Equal(t, 1, calls, "request should not have been sent")
+}

--- a/util/privnet/privnet.go
+++ b/util/privnet/privnet.go
@@ -1,0 +1,121 @@
+// Package privnet provides an http.RoundTripper that can block outbound
+// connections to private, loopback, and link-local addresses on a
+// per-request basis.
+//
+// Requests opt in by carrying a context flag set with WithBlockPrivate. For
+// those requests, the destination is checked at connection time, using the
+// IP address actually being dialed, so DNS names and redirects that resolve
+// to internal addresses are covered.
+//
+// When a request is routed through an HTTP proxy, the proxy performs the DNS
+// lookup and connection, so only a best-effort pre-resolution check is
+// possible. In that case, destination policy must be enforced at the proxy.
+package privnet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"syscall"
+	"time"
+)
+
+// ErrPrivateAddress is returned when a request destination resolves to a
+// private, loopback, or link-local address and blocking is enabled.
+var ErrPrivateAddress = errors.New("destination resolves to a private, loopback, or link-local address")
+
+type contextKey struct{}
+
+// WithBlockPrivate returns a context that causes requests made with it to be
+// rejected if the destination is a private, loopback, or link-local address.
+func WithBlockPrivate(ctx context.Context) context.Context {
+	return context.WithValue(ctx, contextKey{}, true)
+}
+
+func blockPrivate(ctx context.Context) bool {
+	v, _ := ctx.Value(contextKey{}).(bool)
+	return v
+}
+
+// IsPrivateAddr reports whether addr is anything other than a globally
+// routable unicast address (private, loopback, link-local, multicast, etc.).
+func IsPrivateAddr(addr netip.Addr) bool {
+	addr = addr.Unmap()
+	return addr.IsPrivate() || !addr.IsGlobalUnicast()
+}
+
+// control is invoked for every connection attempt on the guarded transport,
+// after DNS resolution, with the actual address being connected to.
+func control(_ context.Context, _, address string, _ syscall.RawConn) error {
+	ap, err := netip.ParseAddrPort(address)
+	if err != nil {
+		return fmt.Errorf("parse dial address %q: %w", address, err)
+	}
+	if IsPrivateAddr(ap.Addr()) {
+		return ErrPrivateAddress
+	}
+
+	return nil
+}
+
+type roundTripper struct {
+	plain   *http.Transport
+	guarded *http.Transport
+}
+
+// RoundTripper wraps base so that requests flagged with WithBlockPrivate are
+// sent over a separate, guarded copy of the transport that rejects private
+// destinations at dial time. The guarded copy keeps its own connection pool
+// so a connection established without the check is never reused by a
+// flagged request. Unflagged requests use base unchanged.
+func RoundTripper(base *http.Transport) http.RoundTripper {
+	guarded := base.Clone()
+	guarded.DialContext = (&net.Dialer{
+		Timeout:        30 * time.Second,
+		KeepAlive:      30 * time.Second,
+		ControlContext: control,
+	}).DialContext
+
+	return &roundTripper{plain: base, guarded: guarded}
+}
+
+func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !blockPrivate(req.Context()) {
+		return rt.plain.RoundTrip(req)
+	}
+
+	if rt.guarded.Proxy != nil {
+		proxyURL, err := rt.guarded.Proxy(req)
+		if err != nil {
+			return nil, err
+		}
+		if proxyURL != nil {
+			// The proxy will resolve and connect on our behalf, so the dial
+			// check applies to the proxy address. Do a best-effort check of
+			// the destination hostname here.
+			err = checkHost(req.Context(), req.URL.Hostname())
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return rt.guarded.RoundTrip(req)
+}
+
+func checkHost(ctx context.Context, host string) error {
+	addrs, err := net.DefaultResolver.LookupNetIP(ctx, "ip", host)
+	if err != nil {
+		return fmt.Errorf("resolve %q: %w", host, err)
+	}
+	for _, addr := range addrs {
+		if IsPrivateAddr(addr) {
+			return ErrPrivateAddress
+		}
+	}
+
+	return nil
+}

--- a/util/privnet/privnet_test.go
+++ b/util/privnet/privnet_test.go
@@ -1,0 +1,85 @@
+package privnet
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsPrivateAddr(t *testing.T) {
+	check := func(private bool, addr string) {
+		t.Helper()
+		assert.Equalf(t, private, IsPrivateAddr(netip.MustParseAddr(addr)), "IsPrivateAddr(%q)", addr)
+	}
+
+	check(false, "8.8.8.8")
+	check(false, "2001:4860:4860::8888")
+
+	check(true, "10.0.0.1")
+	check(true, "172.16.0.1")
+	check(true, "192.168.1.1")
+	check(true, "127.0.0.1")
+	check(true, "0.0.0.0")
+	check(true, "169.254.169.254")
+	check(true, "224.0.0.1")
+	check(true, "::1")
+	check(true, "::")
+	check(true, "fe80::1")
+	check(true, "fd00::1")
+	check(true, "ff02::1")
+	check(true, "::ffff:10.0.0.1") // IPv4-mapped IPv6
+}
+
+func TestRoundTripper(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+	}))
+	defer srv.Close()
+
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	base.Proxy = nil
+	client := &http.Client{Transport: RoundTripper(base)}
+
+	// unflagged requests are allowed (test server listens on 127.0.0.1)
+	req, err := http.NewRequestWithContext(context.Background(), "GET", srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, 1, calls)
+
+	// flagged requests are rejected at dial time
+	req, err = http.NewRequestWithContext(WithBlockPrivate(context.Background()), "GET", srv.URL, nil)
+	require.NoError(t, err)
+	_, err = client.Do(req)
+	require.ErrorIs(t, err, ErrPrivateAddress)
+	assert.Equal(t, 1, calls, "request should not have been sent")
+}
+
+func TestRoundTripper_Proxy(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+	}))
+	defer srv.Close()
+
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	base.Proxy = func(*http.Request) (*url.URL, error) { return url.Parse(srv.URL) }
+	client := &http.Client{Transport: RoundTripper(base)}
+
+	// flagged request to a private destination is rejected before the proxy
+	// is contacted
+	req, err := http.NewRequestWithContext(WithBlockPrivate(context.Background()), "GET", "http://localhost/", nil)
+	require.NoError(t, err)
+	_, err = client.Do(req)
+	require.True(t, errors.Is(err, ErrPrivateAddress), "expected ErrPrivateAddress, got: %v", err)
+	assert.Equal(t, 0, calls, "proxy should not have been contacted")
+}

--- a/web/src/app/documentation/sections/Webhooks.md
+++ b/web/src/app/documentation/sections/Webhooks.md
@@ -2,6 +2,13 @@
 
 Webhooks are POST requests to specified endpoints with a content type of `application/json`. Webhook calls must complete within 3 seconds.
 
+### Restricting Destinations (Administrators)
+
+By default, any user who can add a webhook may point it at any URL reachable from the GoAlert server, including internal or private network addresses. Administrators can restrict this from the Admin page under **Webhook**:
+
+- **Allowed URLs**: if set, only webhook URLs matching one of the listed URL prefixes are accepted. If empty, all URLs are allowed.
+- **Block Private Addresses**: if enabled, requests to private, loopback, and link-local addresses (e.g., `10.0.0.0/8`, `127.0.0.1`, `169.254.169.254`) are rejected. The check is applied at connection time, so it also covers DNS names and redirects that resolve to such addresses. If requests are routed through an HTTP proxy, destination policy must be enforced at the proxy.
+
 Below are example payloads:
 
 ### Verification Message

--- a/web/src/schema.d.ts
+++ b/web/src/schema.d.ts
@@ -1695,5 +1695,6 @@ type ConfigID =
   | 'SMTP.Password'
   | 'Webhook.Enable'
   | 'Webhook.AllowedURLs'
+  | 'Webhook.BlockPrivateAddresses'
   | 'Feedback.Enable'
   | 'Feedback.OverrideURL'


### PR DESCRIPTION
**Description:**
Adds a `Webhook.BlockPrivateAddresses` admin setting. When enabled, webhook deliveries to private, loopback, and link-local addresses (e.g., `10.0.0.0/8`, `127.0.0.1`, `169.254.169.254`) are rejected. The check runs at connection time against the resolved IP, so DNS names and redirects that resolve to internal addresses are covered too.

Strictly opt-in, default off. Also clarifies in the `Webhook.AllowedURLs` description and the webhook docs that an empty allowlist permits any destination, including internal ones -- an admin enabling webhooks may not realize that.

Prompted by an external report; we're treating it as hardening rather than a vulnerability (webhooks are off by default, the request shape is fixed, and the response is never read).

**Out of Scope:**
- Changing the default of `AllowedURLs` from allow-all to allow-none
- Applying the block to other outbound calls (UIK actions, etc.) -- the context flag makes that a one-liner later if we want it

**Describe any introduced user-facing changes:**
- New **Block Private Addresses** toggle in the admin Webhook section
- Blocked deliveries fail permanently with "destination address is not allowed by administrator" instead of retrying

**Additional Info:**
- New `util/privnet` package: `RoundTripper(base)` keeps the base transport for normal requests and a guarded clone (own connection pool, dialer `ControlContext` check) for requests flagged via `privnet.WithBlockPrivate(ctx)`. Separate pools mean a connection established without the check is never reused by a flagged request
- The shared `app.httpClient` is now `calllimiter -> privnet -> transport`, so the call limiter still counts everything
- The webhook sender now actually uses the client passed to `NewSender` (it was using `http.DefaultClient` before) and closes the response body
- When a request is routed through an HTTP proxy, the proxy does the dial, so the guard falls back to a best-effort hostname resolution check. Destination policy must be enforced at the proxy in that case; the setting description says so

